### PR TITLE
Filter paths ending with ../ as ../index.html

### DIFF
--- a/src/main/java/com/vaadin/demo/ResourcesFilter.java
+++ b/src/main/java/com/vaadin/demo/ResourcesFilter.java
@@ -35,6 +35,8 @@ public class ResourcesFilter implements Filter {
           String uri = request.getRequestURI();
           if (uri.endsWith("/")) {
             uri = uri + "index.html";
+          } else if (!uri.contains(".")) {
+            uri = uri + "/index.html";
           }
           filterConfig.getServletContext().getRequestDispatcher(uri).forward(request, response);
         }


### PR DESCRIPTION
Serving the static gatsby build using the docs app WebFilter doesn't work when the page is refreshed under a path other than root. This fixes the issue by filtering paths ending with `../` as `../index.html`