### PR TITLE
Add versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "title": "Latest",
+    "shortTitle": "Latest",
+    "description": "New features since the current LTS version",
+    "url": "/docs/latest/"
+  },
+  {
+    "title": "Vaadin 14",
+    "shortTitle": "v14",
+    "description": "Current long-term supported version (LTS)",
+    "url": "/docs/v14/"
+  },
+  {
+    "title": "Vaadin 10",
+    "shortTitle": "v10",
+    "url": "/docs/v10/",
+    "secondary": true
+  },
+  {
+    "title": "Vaadin 8",
+    "shortTitle": "v8",
+    "url": "/docs/v8/",
+    "secondary": true
+  }
+]


### PR DESCRIPTION
Let’s add this to the master branch, so that we can update the build scripts to use it and see if it actually works in production (even though we don’t yet have the other versions deployed).

I’m not sure if this belongs in the root folder of the repo, though, or if the file name is descriptive enough – maybe use `docs-versions.json`?