### PR TITLE
Fixed typo ('the the' -> 'the)

### DIFF
--- a/articles/fusion/security/fusion-security-configuring.asciidoc
+++ b/articles/fusion/security/fusion-security-configuring.asciidoc
@@ -30,7 +30,7 @@ public class CounterEndpoint {
 ----
 
 Vaadin access control features is enabled by default for any endpoint method:
-if not specified in Java code explicitly, before invoking an endpoint method, the presence of `Principal` object in the the request is required.
+if not specified in Java code explicitly, before invoking an endpoint method, the presence of `Principal` object in the request is required.
 The `HttpServletRequest#getUserPrincipal()` Java API is used for the check.
 
 At this point, the servlet container or the application needs to be configured appropriately to handle user authentication.


### PR DESCRIPTION
See title.