### PR TITLE
Limitation of custom theme for styling the loading indicator

### DIFF
--- a/articles/theming/css-loading-order.asciidoc
+++ b/articles/theming/css-loading-order.asciidoc
@@ -41,3 +41,6 @@ html {
     --lumo-font-size-m: 0.875rem;
 }
 ----
+
+[WARNING]
+By default, a <<../flow/advanced/tutorial-loading-indicator#,loading indicator>> is shown at the top of the viewport after a delay. If a theme modifies the loading indicator style, the new style is applied in the middle of the loading progress. To avoid that, style for the loading indicator should be defined in `frontend/index.html` explicitly via `.v-loading-indicator` CSS selector.

--- a/articles/theming/css-loading-order.asciidoc
+++ b/articles/theming/css-loading-order.asciidoc
@@ -43,4 +43,4 @@ html {
 ----
 
 [WARNING]
-By default, a <<../flow/advanced/tutorial-loading-indicator#,loading indicator>> is shown at the top of the viewport after a delay. If a theme modifies the loading indicator style, the new style is applied in the middle of the loading progress. To avoid that, style for the loading indicator should be defined in `frontend/index.html` explicitly via `.v-loading-indicator` CSS selector.
+By default, a <<{articles}/flow/advanced/tutorial-loading-indicator#,loading indicator>> is shown at the top of the viewport after a delay. If a theme modifies the loading indicator style, the new style is applied in the middle of the loading progress. To avoid that, style for the loading indicator should be defined in `frontend/index.html` explicitly via `.v-loading-indicator` CSS selector.


### PR DESCRIPTION
Related to https://github.com/vaadin/flow/issues/9630.