### PR TITLE
doc: improve live reload documentation

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -13,12 +13,15 @@ Figma
 Gradle
 [gG]rayscale
 Gretty
+[hH]otpatch(ed|ing)?
+http
 Karaf
 Lumo
 [mM]iddleware
 [nN]avbar
-Netbeans
+NetBeans
 npm
+Payara
 [pP]olyfills?
 [pP]ortlets?
 [rR]enderers?
@@ -30,6 +33,7 @@ repo
 [sS]upertype
 [tT]odos?
 [tT]oolchain
+TravaOpenJDK
 URIs
 Vaadin
 [vV]alidate

--- a/articles/guide/workflow/jetty-scaninterval.asciidoc
+++ b/articles/guide/workflow/jetty-scaninterval.asciidoc
@@ -27,7 +27,7 @@ For instance:
 
 [NOTE]
 We recommend using Jetty Maven Plugin `9.4.27.v20200227` or higher.
-There is a known issue in the previous versions that causes `RouteNotFoundException` when trying to reload Java changes automatically.
+A known issue in older versions causes `RouteNotFoundException` when reloading.
 
 Since the plugin performs a full server restart, all Java changes are picked up.
 This includes modifications to server startup listeners as well as changes to code that connects frontend and backend components, such as adding a new `LitTemplate` class, or adding a new CSS import and using it in Java via `@CssImport` annotation.

--- a/articles/guide/workflow/jetty-scaninterval.asciidoc
+++ b/articles/guide/workflow/jetty-scaninterval.asciidoc
@@ -6,9 +6,8 @@ layout: page
 
 = Automatic Restart with Jetty Maven Plugin
 
-The https://www.eclipse.org/jetty/documentation/current/jetty-maven-plugin.html[Jetty Maven plugin]
-with the `scanIntervalSeconds` configuration set to a positive value performs complete application restart
-when the given number of seconds have elapsed since the last Java change. For instance:
+The https://www.eclipse.org/jetty/documentation/jetty-9/index.html#jetty-maven-plugin[Jetty Maven plugin] with the `scanIntervalSeconds` configuration set to a positive value performs complete application restart when the given number of seconds have elapsed since the last Java change.
+For instance:
 
 [source,xml]
 ----
@@ -28,18 +27,9 @@ when the given number of seconds have elapsed since the last Java change. For in
 
 [NOTE]
 We recommend using Jetty Maven Plugin `9.4.27.v20200227` or higher.
-There is a known issue in the previous versions that causes `RouteNotFoundException` when trying to reload
-Java changes automatically.
+There is a known issue in the previous versions that causes `RouteNotFoundException` when trying to reload Java changes automatically.
 
 Since the plugin performs a full server restart, all Java changes are picked up.
-In addition, it is possible to add a new `PolymerTemplate` class to an existing JS template module or add
-a new JS module (see <<{articles}/flow/templates/basic#,Creating A Simple Component Using the Template API>>).
-Other working scenarios are:
+This includes modifications to server startup listeners as well as changes to code that connects frontend and backend components, such as adding a new `LitTemplate` class, or adding a new CSS import and using it in Java via `@CssImport` annotation.
 
-- adding a new CSS import (as a frontend resource and use it in Java via `@CssImport` annotation)
-- adding a new frontend JS module file (and use it with a Java class)
-- modifying the existing frontend resource (JS module or imported CSS file)
-
-In the latter case webpack dev server cares about changes made in the JS module only.
-
-Note that the session is not preserved during the restart.
+However, the session is not preserved during the restart.

--- a/articles/guide/workflow/overview.asciidoc
+++ b/articles/guide/workflow/overview.asciidoc
@@ -7,42 +7,36 @@ layout: page
 = Application Development Workflow
 
 This guide explains how to streamline your Vaadin application development workflow for productivity.
-It covers setting up third-party Java hotpatching tools to redeploy Java changes without server restarts, and having Vaadin automatically reload the browser for immediate feedback.
+It covers setting up Live Reload to automatically redeploy and display Java and frontend changes during development.
 It also explains how to run your Vaadin application on a server, such as Tomcat, directly from your IDE.
 
 == Live Reload
 
-Live Reload means automatically reloading the application in the browser, in order to see the effects of the last change to Java or frontend code.
-Vaadin Live Reload combines the power of Webpack and existing hotpatching technologies for Java, making it a perfect tool for boosting productivity during development.
-It is enabled by default for frontend code and with minor additional configuration for Java code (see below).
+Live Reload means automatically reloading the application in the browser after modifying its code, instead of manually restarting the server and refreshing the browser page.
+In Vaadin projects, Live Reload is supported out of the box for frontend code changes, and for Java changes in Spring Boot projects.
+For the latter, it also integrates with popular third-party Java hotpatching tools.
 
-=== Frontend code
+=== Frontend changes
 
-Code in the application's `frontend` folder, such as JS/TS template and CSS files, are monitored out of the box by the Webpack dev-server when running a Vaadin application in development mode.
-Any addition/modification/removal of a file in this folder triggers a recompilation of the application bundle followed by a browser refresh.
+Code in the application's `frontend` folder (JS/TS/CSS files) is monitored by `webpack-dev-server` when running the application in development mode.
+Adding, modifying or removing a file in this folder triggers recompilation of the frontend bundle and subsequent a browser reload.
 
-=== Java code
-On the Java side, Live Reload requires recompiling the code modifications and patching the resulting bytecode into the running server.
-Vaadin Live Reload integrates with Spring Boot developer tools (available out of the box for Spring Boot-based Vaadin applications), JRebel (commercial tool for any Vaadin application) and HotswapAgent (open-source tool for any Vaadin application).
-See the corresponding sections for setting up the desired technology:
+=== Java changes
+On the Java side, Live Reload means first compiling the modified code, then updating the running server (either by restarting it, or by hotpatching the runtime), and finally refreshing the browser.
+Live Reload can use Spring Boot Developer Tools automatic server restart feature (enabled by default in Spring Boot-based Vaadin applications), as well as two hotpatching tools: JRebel (commercial, for all Vaadin applications) and HotswapAgent (open-source, for all Vaadin applications).
+See the below sections for details on setting up the chosen technology:
 
-** <<setup-live-reload-springboot#, Spring Boot Developer tools>>
+** <<setup-live-reload-springboot#, Spring Boot Developer Tools>>
 ** <<setup-live-reload-jrebel#, JRebel>>
 ** <<setup-live-reload-hotswap-agent#, HotswapAgent>>
 
-When using hotpatching notice that:
-
-* Supported hotpatching tools are designed to be run exclusively.
-Simultaneous use of multiple tools might have undesired consequences.
-
-* Hotpatching works best for small, incremental changes to UI code.
-Changes to class loading or application startup typically require a server restart.
-
-* With  <<{articles}/flow/advanced/preserving-state-on-refresh#,`@PreserveOnRefresh`>>, view instances are reused when reloaded in the browser; hence, hotpatched changes to the view constructor will not be reflected until the view is opened in another window or tab.
+Note that only one of these technologies should be configured in the project at a time to avoid interference.
+In general, hotpatching is faster than automatic restarts and works best for small, incremental changes.
+Larger changes, such as class level modifications or changes to code that affect the whole application lifecycle (startup, shutdown, mapping between frontend and backend components), usually necessitate a server restart regardless.
 
 === Automatic server restart using Jetty and TomeEE Maven plugins
-Alternatively, the Jetty and TomEE Maven plugins facilitate automatic server restart on Java changes.
-These do not require installing third-party tools, but have the disadvantage that server restarts are slower and the browser will also not refresh automatically.
+As an alternative to Live Reload, the Jetty and TomEE Maven plugins facilitate automatic server restart on Java changes.
+These do not require installing third-party tools, but have the disadvantage that server restarts are slower and the browser will not refresh automatically.
 
 ** <<jetty-scaninterval#, Automatic Restart with Jetty Maven Plugin>>
 ** <<cdi-reloadonupdate#, Automatic Restart with TomEE Maven Plugin>>

--- a/articles/guide/workflow/overview.asciidoc
+++ b/articles/guide/workflow/overview.asciidoc
@@ -16,12 +16,12 @@ Live Reload means automatically reloading the application in the browser after m
 In Vaadin projects, Live Reload is supported out of the box for frontend code changes, and for Java changes in Spring Boot projects.
 For the latter, it also integrates with popular third-party Java hotpatching tools.
 
-=== Frontend changes
+=== Frontend Changes
 
 Code in the application's `frontend` folder (JS/TS/CSS files) is monitored by `webpack-dev-server` when running the application in development mode.
 Adding, modifying or removing a file in this folder triggers recompilation of the frontend bundle and subsequent a browser reload.
 
-=== Java changes
+=== Java Changes
 On the Java side, Live Reload means first compiling the modified code, then updating the running server (either by restarting it, or by hotpatching the runtime), and finally refreshing the browser.
 Live Reload can use Spring Boot Developer Tools automatic server restart feature (enabled by default in Spring Boot-based Vaadin applications), as well as two hotpatching tools: JRebel (commercial, for all Vaadin applications) and HotswapAgent (open-source, for all Vaadin applications).
 See the below sections for details on setting up the chosen technology:
@@ -34,7 +34,7 @@ Note that only one of these technologies should be configured in the project at 
 In general, hotpatching is faster than automatic restarts and works best for small, incremental changes.
 Larger changes, such as class level modifications or changes to code that affect the whole application lifecycle (startup, shutdown, mapping between frontend and backend components), usually necessitate a server restart regardless.
 
-=== Automatic server restart using Jetty and TomeEE Maven plugins
+=== Automatic Server Restart Using Jetty and TomeEE Maven Plugins
 As an alternative to Live Reload, the Jetty and TomEE Maven plugins facilitate automatic server restart on Java changes.
 These do not require installing third-party tools, but have the disadvantage that server restarts are slower and the browser will not refresh automatically.
 

--- a/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
@@ -23,7 +23,7 @@ If you want to know more about the features of HotswapAgent, the documentation i
 == [#configuration]#Additional Configuration#
 
 * HotswapAgent by default swaps in code changes automatically in Java debug mode.
-  To hot swap code in run mode, add the line `autoHotswap=true` to `hotswap-agent.properties` (in Spring Boot projects), or add the following JVM parameter: `-javaagent:__<JAVA_HOME>__/lib/hotswap-agent.jar=autoHotswap=true` where `JAVA_HOME` is the Java home of the TravaOpenJDK installation.
+  To hot swap code in run mode, add the line `autoHotswap=true` to `hotswap-agent.properties` (in Spring Boot projects), or add the JVM parameter `-javaagent:__<JAVA_HOME>__/lib/hotswap-agent.jar=autoHotswap=true`, where `JAVA_HOME` is the Java home of the TravaOpenJDK installation.
   Explicitly enabling automatic hotswapping may also be required with some older IDEs (such as NetBeans), or when running a Spring Boot application with Maven in forked mode.
 * When using the Jetty Maven plugin together with HotswapAgent, ensure automatic restart is disabled (omit or set `<scanIntervalSeconds>` to a value of  `0` or less).
 * The Live Reload quiet time (milliseconds since last Java change before refreshing the browser) can be adjusted with the parameter `vaadin.liveReloadQuietTime` in `hotswap-agent.properties`.
@@ -38,5 +38,4 @@ Modifications to routes are, however, picked up.
 * With <<{articles}/flow/advanced/preserving-state-on-refresh#,`@PreserveOnRefresh`>>, view instances are reused when reloaded in the browser; hence, hotpatched changes to the view constructor will not be reflected until the view is opened in another browser window or tab.
 * The Vaadin plugin included in the bundled HotswapAgent (1.4.1) does not work with servers that use application class loaders, for instance WildFly, TomEE or Payara.
 This bug is fixed in a https://github.com/HotswapProjects/HotswapAgent/releases/tag/1.4.2-SNAPSHOT[prerelease version of HotswapAgent].
-To use it, download the JAR and pass the following JVM parameters to replace the bundled HotswapAgent with the corrected version:
-`-XX:+DisableHotswapAgent -javaagent:__<path/to/hotswap-agent.jar>__`
+To use it, download the JAR and pass the JVM parameter `-XX:+DisableHotswapAgent -javaagent:__<path/to/hotswap-agent.jar>__` to replace the bundled HotswapAgent with the fixed version.

--- a/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
@@ -22,9 +22,11 @@ If you want to know more about the features of HotswapAgent, the documentation i
 
 == [#configuration]#Additional Configuration#
 
-* HotswapAgent by default swaps in code changes automatically in Java debug mode.
-  To hot swap code in run mode, add the line `autoHotswap=true` to `hotswap-agent.properties` (in Spring Boot projects), or add the JVM parameter `-javaagent:__<JAVA_HOME>__/lib/hotswap-agent.jar=autoHotswap=true`, where `JAVA_HOME` is the Java home of the TravaOpenJDK installation.
-  Explicitly enabling automatic hotswapping may also be required with some older IDEs (such as NetBeans), or when running a Spring Boot application with Maven in forked mode.
+* HotswapAgent swaps in code changes automatically only when the JVM is running in debug mode.
+  The `spring-boot-maven-plugin` goal `spring-boot:run` by default forks a separate JVM without debugger attached, meaning that HotswapAgent will not work.
+  You can disable forked mode by adding `<fork>false</fork>` to the plugin's `<configuration>` section.
+* To hot swap code when the JVM is not in debug mode, you can add the line `autoHotswap=true` to `hotswap-agent.properties` (in Spring Boot projects), or add the JVM parameter `-javaagent:__<JAVA_HOME>__/lib/hotswap-agent.jar=autoHotswap=true`, where `JAVA_HOME` is the Java home of the TravaOpenJDK installation.
+  Explicitly enabling automatic hotswapping may also be required with some older IDEs (such as NetBeans).
 * When using the Jetty Maven plugin together with HotswapAgent, ensure automatic restart is disabled (omit or set `<scanIntervalSeconds>` to a value of  `0` or less).
 * The Live Reload quiet time (milliseconds since last Java change before refreshing the browser) can be adjusted with the parameter `vaadin.liveReloadQuietTime` in `hotswap-agent.properties`.
   The default is 1000 ms.

--- a/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
@@ -35,7 +35,7 @@ If you want to know more about the features of HotswapAgent, the documentation i
 
 == Current Limitations
 
-* Since the server does not restart, modifications to startup listeners and code that connects front-end and backend components, such as adding a new `LitTemplate` class, are not reflected.
+* Since the server does not restart, modifications to startup listeners and code that connects frontend and backend components, such as adding a new `LitTemplate` class, are not reflected.
 Modifications to routes are, however, picked up.
 * With <<{articles}/flow/advanced/preserving-state-on-refresh#,`@PreserveOnRefresh`>>, view instances are reused when reloaded in the browser; hence, hotpatched changes to the view constructor will not be reflected until the view is opened in another browser window or tab.
 * The Vaadin plugin included in the bundled HotswapAgent (1.4.1) does not work with servers that use application class loaders, for instance WildFly, TomEE or Payara.

--- a/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
@@ -4,14 +4,14 @@ order: 4
 layout: page
 ---
 
-= Live Reload with HotswapAgent
+= Live Reload With HotswapAgent
 
 Live Reload works seamlessly in development mode using HotswapAgent for runtime class and resource redefinition.
 We suggest running your Vaadin project with https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases[TravaOpenJDK DCEVM], version 11.0.7+2 or later, which includes HotswapAgent with full Live Reload support.
 Setup is in most cases as easy as downloading the JDK and configuring your IDE to use it.
 If you want to know more about the features of HotswapAgent, the documentation in the http://hotswapagent.org/[HotswapAgent webpage] is a good resource.
 
-== Step-by-step guide
+== Step-by-Step Guide
 
 . Download and unpack the latest version of https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases[DCEVM JDK], add the JDK to your IDE, and set your project / run configuration to use it.
   Alternatively set `JAVA_HOME` to its location.
@@ -20,21 +20,23 @@ If you want to know more about the features of HotswapAgent, the documentation i
 . Using your IDE's debug command, start the Vaadin application in development mode.
 . Navigate to a view in your application, edit any Java file in the project, recompile, and the browser will automatically reload the page with the changes.
 
-== [#configuration]#Additional configuration#
+== [#configuration]#Additional Configuration#
 
 * HotswapAgent by default swaps in code changes automatically in Java debug mode.
-  To hot swap code in run mode, add the line `autoHotswap=true` to `hotswap-agent.properties` (in Spring Boot projects), or add the following JVM parameter: `-javaagent:__<JAVA_HOME>__/lib/hotswap-agent.jar=autoHotswap=true` where `JAVA_HOME` is the Java home of the Trava JDK installation.
-  Explicitly enabling automatic hotswapping may also be required with some older IDEs (e.g., NetBeans), or when running a Spring Boot application with Maven in forked mode.
+  To hot swap code in run mode, add the line `autoHotswap=true` to `hotswap-agent.properties` (in Spring Boot projects), or add the following JVM parameter: `-javaagent:__<JAVA_HOME>__/lib/hotswap-agent.jar=autoHotswap=true` where `JAVA_HOME` is the Java home of the TravaOpenJDK installation.
+  Explicitly enabling automatic hotswapping may also be required with some older IDEs (such as NetBeans), or when running a Spring Boot application with Maven in forked mode.
 * When using the Jetty Maven plugin together with HotswapAgent, ensure automatic restart is disabled (omit or set `<scanIntervalSeconds>` to a value of  `0` or less).
-* The Live Reload quiet time (milliseconds since last Java change before refreshing the browser) can be adjusted by the parameter `vaadin.liveReloadQuietTime` in `hotswap-agent.properties`.
-  The default is 1000 ms. Increase this value if you notice the browser refreshing before modified Java files have been fully compiled.
-* Intellij IDEA: avoid using the `Build project automatically` and `compiler.automake.allow.when.app.running` options simultaneously, since this may trigger automatic reload before classes are hotswapped properly.
+* The Live Reload quiet time (milliseconds since last Java change before refreshing the browser) can be adjusted with the parameter `vaadin.liveReloadQuietTime` in `hotswap-agent.properties`.
+  The default is 1000 ms.
+  Increase this value if you notice the browser refreshing before modified Java files have been fully compiled.
+* IntelliJ IDEA: avoid using the `Build project automatically` and `compiler.automake.allow.when.app.running` options simultaneously, since this may trigger automatic reload before classes are hotswapped properly.
 
-== Current limitations
+== Current Limitations
 
 * Since the server does not restart, modifications to startup listeners and code that connects front-end and backend components, such as adding a new `LitTemplate` class, are not reflected.
 Modifications to routes are, however, picked up.
 * With <<{articles}/flow/advanced/preserving-state-on-refresh#,`@PreserveOnRefresh`>>, view instances are reused when reloaded in the browser; hence, hotpatched changes to the view constructor will not be reflected until the view is opened in another browser window or tab.
-* The Vaadin plugin included in the bundled HotswapAgent (1.4.1) does not work with servers that use application classloaders, for instance Wildfly, TomEE or Payara.
+* The Vaadin plugin included in the bundled HotswapAgent (1.4.1) does not work with servers that use application class loaders, for instance WildFly, TomEE or Payara.
 This bug is fixed in a https://github.com/HotswapProjects/HotswapAgent/releases/tag/1.4.2-SNAPSHOT[prerelease version of HotswapAgent].
-To use it, download the JAR and pass the following JVM parameters to replace the bundled HotswapAgent with the corrected version: `-XX:+DisableHotswapAgent -javaagent:__<path/to/hotswap-agent.jar>__`
+To use it, download the JAR and pass the following JVM parameters to replace the bundled HotswapAgent with the corrected version:
+`-XX:+DisableHotswapAgent -javaagent:__<path/to/hotswap-agent.jar>__`

--- a/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-hotswap-agent.asciidoc
@@ -1,38 +1,40 @@
 ---
-title: Setting Up Live Reload Using HotswapAgent
+title: Live Reload with HotswapAgent
 order: 4
 layout: page
 ---
 
-= Setting Up Live Reload Using HotswapAgent
+= Live Reload with HotswapAgent
 
-Live Reload works seamlessly on development mode using HotswapAgent for runtime class and resource redefinition.
-If you want to know more about the features of HotswapAgent, the documentation in the http://hotswapagent.org/[HotswapAgent webpage] is a good resource.
-
-We suggest running your Vaadin project with https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases[TravaOpenJDK DCEVM] (JDK for enhanced class redefinition), version 11.0.7+2 or later.
-This JDK bundles HotswapAgent version 1.4.1 with full Live Reload support.
+Live Reload works seamlessly in development mode using HotswapAgent for runtime class and resource redefinition.
+We suggest running your Vaadin project with https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases[TravaOpenJDK DCEVM], version 11.0.7+2 or later, which includes HotswapAgent with full Live Reload support.
 Setup is in most cases as easy as downloading the JDK and configuring your IDE to use it.
+If you want to know more about the features of HotswapAgent, the documentation in the http://hotswapagent.org/[HotswapAgent webpage] is a good resource.
 
 == Step-by-step guide
 
 . Download and unpack the latest version of https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases[DCEVM JDK], add the JDK to your IDE, and set your project / run configuration to use it.
   Alternatively set `JAVA_HOME` to its location.
-. Depending on your project technology stack, you might have to apply <<configuration, additional configuration>>.
-. Using your IDE's debug command, start the Vaadin application (development deployment mode).
+. In DCEVM 11.0.9 and later, HotswapAgent is disabled by default and needs the JVM parameter `-XX:HotswapAgent=fatjar` to work with Vaadin.
+  Depending on your project technology stack, you may also want to apply <<configuration, additional configuration>>.
+. Using your IDE's debug command, start the Vaadin application in development mode.
 . Navigate to a view in your application, edit any Java file in the project, recompile, and the browser will automatically reload the page with the changes.
 
 == [#configuration]#Additional configuration#
 
-* HotswapAgent relies on the IDE to auto-reload compiled classes, which normally occurs automatically in debug mode.
-  To use HotswapAgent in run mode, add the line `autoHotswap=true` to `hotswap-agent.properties`, or add the following JVM parameter: `-javaagent:__<path/to/hotswap-agent.jar>__=autoHotswap=true`.
-* Jetty: ensure automatic restart based on resource scanning is disabled (if using the Jetty Maven plugin, omit or set `<scanIntervalSeconds>` to a value of  `0` or less).
+* HotswapAgent by default swaps in code changes automatically in Java debug mode.
+  To hot swap code in run mode, add the line `autoHotswap=true` to `hotswap-agent.properties` (in Spring Boot projects), or add the following JVM parameter: `-javaagent:__<JAVA_HOME>__/lib/hotswap-agent.jar=autoHotswap=true` where `JAVA_HOME` is the Java home of the Trava JDK installation.
+  Explicitly enabling automatic hotswapping may also be required with some older IDEs (e.g., NetBeans), or when running a Spring Boot application with Maven in forked mode.
+* When using the Jetty Maven plugin together with HotswapAgent, ensure automatic restart is disabled (omit or set `<scanIntervalSeconds>` to a value of  `0` or less).
 * The Live Reload quiet time (milliseconds since last Java change before refreshing the browser) can be adjusted by the parameter `vaadin.liveReloadQuietTime` in `hotswap-agent.properties`.
   The default is 1000 ms. Increase this value if you notice the browser refreshing before modified Java files have been fully compiled.
-* NetBeans: adding the configuration parameter `autoHotswap=true` might be needed for Live Reload to work.
-  Add the line `autoHotswap=true` to `hotswap-agent.properties` in your project's resources folder or set the following debug property (available at `Project Properties > Actions > Actions: Debug project > Set Properties`): `Env.MAVEN_OPTS=-XXaltjvm=dcevm -javaagent:``_<path/to/hotswap-agent.jar>_``=autoHotswap=true`.
 * Intellij IDEA: avoid using the `Build project automatically` and `compiler.automake.allow.when.app.running` options simultaneously, since this may trigger automatic reload before classes are hotswapped properly.
 
 == Current limitations
+
+* Since the server does not restart, modifications to startup listeners and code that connects front-end and backend components, such as adding a new `LitTemplate` class, are not reflected.
+Modifications to routes are, however, picked up.
+* With <<{articles}/flow/advanced/preserving-state-on-refresh#,`@PreserveOnRefresh`>>, view instances are reused when reloaded in the browser; hence, hotpatched changes to the view constructor will not be reflected until the view is opened in another browser window or tab.
 * The Vaadin plugin included in the bundled HotswapAgent (1.4.1) does not work with servers that use application classloaders, for instance Wildfly, TomEE or Payara.
 This bug is fixed in a https://github.com/HotswapProjects/HotswapAgent/releases/tag/1.4.2-SNAPSHOT[prerelease version of HotswapAgent].
 To use it, download the JAR and pass the following JVM parameters to replace the bundled HotswapAgent with the corrected version: `-XX:+DisableHotswapAgent -javaagent:__<path/to/hotswap-agent.jar>__`

--- a/articles/guide/workflow/setup-live-reload-jrebel.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-jrebel.asciidoc
@@ -1,20 +1,26 @@
 ---
-title: Setting Up Live Reload using JRebel
+title: Live Reload with JRebel
 order: 3
 layout: page
 ---
 
-= Setting Up Live Reload using JRebel
+= Live Reload with JRebel
 
-Live Reload works with JRebel allowing for code changes to affect Vaadin applications in real time, skipping rebuilds and redeploys.
-More information about JRebel is available at https://www.jrebel.com/products/jrebel.
+https://www.jrebel.com/products/jrebel[JRebel] is a commercial developer productivity tool for automatic, real-time update of Java code in the running application.
+Vaadin detects the JRebel Agent and automatically reloads the application in the browser after the Java changes have been hotpatched.
 
 == Step-by-step guide
 
-. Setup and activate JRebel in your favorite IDE by following the Quick Start guides available at https://www.jrebel.com/products/jrebel/learn. Use at least `2020.2.1` version which contains built-in Live Reload integration.
+. Set up and activate JRebel in your IDE by following the Quick Start guides available at https://www.jrebel.com/products/jrebel/learn. Use at least `2020.2.1` version which contains built-in Live Reload integration.
 . Run or debug your Vaadin application using the JRebel Agent.
-. Navigate to your Vaadin application on the browser, make and save some changes, and the browser will reload automatically
+. Navigate to your Vaadin application on the browser, make and save some changes, and the browser will reload automatically.
 
 == Additional configuration
 
-* For Jetty make sure to disable resource scanning and automatic restarts (if using the Maven Plugin, omit or set `<scanIntervalSeconds>` to a value of  `0` or less).
+* When using the Jetty Maven plugin together with JRebel, ensure automatic restart is disabled (omit or set `<scanIntervalSeconds>` to a value of  `0` or less).
+
+== Current limitations
+
+* Since the server does not restart, modifications to startup listeners and code that connects front-end and backend components, such as adding a new `LitTemplate` class, are not reflected.
+Modifications to routes are, however, picked up.
+* With <<{articles}/flow/advanced/preserving-state-on-refresh#,`@PreserveOnRefresh`>>, view instances are reused when reloaded in the browser; hence, hotpatched changes to the view constructor will not be reflected until the view is opened in another browser window or tab.

--- a/articles/guide/workflow/setup-live-reload-jrebel.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-jrebel.asciidoc
@@ -4,22 +4,22 @@ order: 3
 layout: page
 ---
 
-= Live Reload with JRebel
+= Live Reload With JRebel
 
 https://www.jrebel.com/products/jrebel[JRebel] is a commercial developer productivity tool for automatic, real-time update of Java code in the running application.
 Vaadin detects the JRebel Agent and automatically reloads the application in the browser after the Java changes have been hotpatched.
 
-== Step-by-step guide
+== Step-by-Step Guide
 
 . Set up and activate JRebel in your IDE by following the Quick Start guides available at https://www.jrebel.com/products/jrebel/learn. Use at least `2020.2.1` version which contains built-in Live Reload integration.
 . Run or debug your Vaadin application using the JRebel Agent.
 . Navigate to your Vaadin application on the browser, make and save some changes, and the browser will reload automatically.
 
-== Additional configuration
+== Additional Configuration
 
 * When using the Jetty Maven plugin together with JRebel, ensure automatic restart is disabled (omit or set `<scanIntervalSeconds>` to a value of  `0` or less).
 
-== Current limitations
+== Current Limitations
 
 * Since the server does not restart, modifications to startup listeners and code that connects front-end and backend components, such as adding a new `LitTemplate` class, are not reflected.
 Modifications to routes are, however, picked up.

--- a/articles/guide/workflow/setup-live-reload-springboot.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-springboot.asciidoc
@@ -1,17 +1,21 @@
 ---
-title: Setting Up Live Reload using Spring Boot
+title: Live Reload with Spring Boot Developer Tools
 order: 2
 layout: page
 ---
 
-= Setting Up Live Reload using Spring Boot
+= Live Reload with Spring Boot Developer Tools
 
-If your Vaadin application uses Spring Boot, Live Reload can make use of Spring Boot Developer tools to automatically restart whenever files on the classpath change.
-More information about Spring Boot Automatic Restart and other developer tools is available at https://docs.spring.io/spring-boot/docs/2.2.0.RELEASE/reference/html/using-spring-boot.html#using-boot-devtools.
+For Vaadin application based on Spring Boot, Live Reload by default uses https://docs.spring.io/spring-boot/docs/2.4.0.RELEASE/reference/html/using-spring-boot.html#using-boot-devtools[Spring Boot Developer Tools] to automatically restart the server whenever classpath entries are updated.
+
+The restart is significantly faster than a manual restart, as it uses a customized classloader that reloads only the application's own classes.
+Basically all Java code modifications are applied, including changes in the internal application logic, route modification (adding / removing / updating routes), and changes made to custom components (`PolymerTemplate` subclasses).
+The session is also preserved during the restart.
+Modifications which rely on updated classpath dependencies require a full application restart.
 
 == Step-by-step guide
 
-. Verify if `spring-boot-devtools` is added as a dependency in your Vaadin application `pom.xml`. If not add it like so:
+. Ensure that `spring-boot-devtools` is a dependency in the application's `pom.xml`:
 +
 [source,xml]
 ----
@@ -24,38 +28,24 @@ More information about Spring Boot Automatic Restart and other developer tools i
     </dependency>
 </dependencies>
 ----
-. Run the application using `mvn spring-boot:run` or by running the `Application` class directly from your IDE
-. Navigate to your Vaadin application on the browser, make some changes, recompile and the browser will reload automatically
+. Run the application using `mvn spring-boot:run` (requires forking the JVM, which is the default mode) or via the `Application` class.
+. Open the application in the browser, make some Java code changes, recompile, and the browser will refresh automatically.
 +
 [NOTE]
 ====
-If you have some browser extension that triggers Spring Dev Tools reloads on the browser, we recommend disabling such tools as Vaadin handles reloads automatically once the server has restarted.
-Having these enabled when using Live Reload might cause unexpected behaviour.
+Uninstall or disable any other browser extensions that refresh on Spring Dev Tools reload.
+As the Vaadin client also refreshes, having both active might lead to unexpected behaviour.
 ====
 
 == [#configuration]#Additional configuration#
 
-* If after changing code and reloading the browser page, you cannot access a view in your application,
-but instead get an error page with message like `Could not navigate to ...` or `Error creating bean with name ...`,
-you need to adjust the dev tools configuration to ensure code changes get picked up. You can do this by
-adding the following lines to your `application.properties` file:
+If during server restart you notice spurious errors like `Could not navigate to ...` or `Error creating bean with name ...`,  or you frequently see multiple restarts from a single code change, the problem may be file monitoring triggering the restart prematurely, before all updated files have been written.
+The polling interval and quiet time can be configured in the `application.properties` file:
 
 ----
 spring.devtools.restart.poll-interval=2s
 spring.devtools.restart.quiet-period=1s
 ----
 
-== Which changes work?
+Higher values improve stability at the cost of a higher-latency restart cycle.
 
-Basically all Java code modifications are applied automatically:
-- changes in the internal application logic
-- routes modification (such as add a new view (route), update the route path, remove a view)
-- changes made to custom components (`PolymerTemplate` subclasses): add/change/remove
-
-During those changes the session is preserved.
-
-=== Changes that require application restart
-
-All changes described above applied automatically only assuming you don't add
-new dependencies to the project. The modifications which rely anyhow on updated
-classpath dependencies require an application restart.

--- a/articles/guide/workflow/setup-live-reload-springboot.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-springboot.asciidoc
@@ -4,16 +4,16 @@ order: 2
 layout: page
 ---
 
-= Live Reload with Spring Boot Developer Tools
+= Live Reload With Spring Boot Developer Tools
 
 For Vaadin application based on Spring Boot, Live Reload by default uses https://docs.spring.io/spring-boot/docs/2.4.0.RELEASE/reference/html/using-spring-boot.html#using-boot-devtools[Spring Boot Developer Tools] to automatically restart the server whenever classpath entries are updated.
 
-The restart is significantly faster than a manual restart, as it uses a customized classloader that reloads only the application's own classes.
+The restart is significantly faster than a manual restart, as it uses a customized class loader that reloads only the application's own classes.
 Basically all Java code modifications are applied, including changes in the internal application logic, route modification (adding / removing / updating routes), and changes made to custom components (`PolymerTemplate` subclasses).
 The session is also preserved during the restart.
 Modifications which rely on updated classpath dependencies require a full application restart.
 
-== Step-by-step guide
+== Step-by-Step Guide
 
 . Ensure that `spring-boot-devtools` is a dependency in the application's `pom.xml`:
 +
@@ -33,11 +33,11 @@ Modifications which rely on updated classpath dependencies require a full applic
 +
 [NOTE]
 ====
-Uninstall or disable any other browser extensions that refresh on Spring Dev Tools reload.
+Uninstall or disable any other browser extensions that refresh on Spring Developer Tools reload.
 As the Vaadin client also refreshes, having both active might lead to unexpected behaviour.
 ====
 
-== [#configuration]#Additional configuration#
+== [#configuration]#Additional Configuration#
 
 If during server restart you notice spurious errors like `Could not navigate to ...` or `Error creating bean with name ...`,  or you frequently see multiple restarts from a single code change, the problem may be file monitoring triggering the restart prematurely, before all updated files have been written.
 The polling interval and quiet time can be configured in the `application.properties` file:

--- a/articles/guide/workflow/setup-live-reload-springboot.asciidoc
+++ b/articles/guide/workflow/setup-live-reload-springboot.asciidoc
@@ -8,10 +8,9 @@ layout: page
 
 For Vaadin application based on Spring Boot, Live Reload by default uses https://docs.spring.io/spring-boot/docs/2.4.0.RELEASE/reference/html/using-spring-boot.html#using-boot-devtools[Spring Boot Developer Tools] to automatically restart the server whenever classpath entries are updated.
 
-The restart is significantly faster than a manual restart, as it uses a customized class loader that reloads only the application's own classes.
+The restart is faster than a manual restart, as it uses a customized class loader that reloads only the application's own classes.
 Basically all Java code modifications are applied, including changes in the internal application logic, route modification (adding / removing / updating routes), and changes made to custom components (`PolymerTemplate` subclasses).
 The session is also preserved during the restart.
-Modifications which rely on updated classpath dependencies require a full application restart.
 
 == Step-by-Step Guide
 
@@ -49,3 +48,8 @@ spring.devtools.restart.quiet-period=1s
 
 Higher values improve stability at the cost of a higher-latency restart cycle.
 
+== Current Limitations
+
+* Modifications which rely on updated classpath dependencies require a full application restart.
+* The Vaadin client connects from the browser to the Spring Boot Live Reload server default port (35729).
+  The port number to use cannot be changed in the client currently.


### PR DESCRIPTION
This PR contains a number of smaller fixes:
* Streamline the description of live reload and setup instructions
* Simplify section headers
* Clarify the pros and cons between server restarts and hotpatching
* Update external links and modernise (`PolymerTemplate` to `LitTemplate`)
* Fix https://github.com/vaadin/flow-and-components-documentation/issues/1401
* Align with Vale rules