### PR TITLE
Fix heading case and formatting

### DIFF
--- a/articles/fusion/routing/nested-views.asciidoc
+++ b/articles/fusion/routing/nested-views.asciidoc
@@ -73,7 +73,7 @@ export const router = new Router(outlet);
 ...
 ----
 
-== Import theme global styles
+== Import Theme Global Styles
 
 In Vaadin, themes have some global styles that need to be applied to the page. With server-side main layout in Java, these are automatically applied for convenience. With TypeScript main layout, though, they need to be imported manually to make sure consistent styling between server-side and client-side views.
 
@@ -88,7 +88,7 @@ import '@vaadin/vaadin-lumo-styles/all-imports';
 ...
 ----
 
-== Establish an application layout
+== Establish an Application Layout
 
 The most prominent feature of the main layout is to define the layout for the application. This could be done using the `<vaadin-app-layout>` component:
 
@@ -126,7 +126,7 @@ export class MainLayoutElement extends LitElement {
 [NOTE]
 Keep the `<slot>` in the main layout template returned from the `render()` method. Vaadin Router adds views as children in the main layout.
 
-== Create navigation menu
+== Create Navigation Menu
 
 The main layout usually contains a navigation bar with the menu. Here we create the navigation bar with the menu using `<vaadin-tabs>`:
 
@@ -159,11 +159,11 @@ export class MainLayoutElement extends LitElement {
 }
 ----
 
-== Highlighting the active menu link
+== Highlighting the Active Menu Link
 
 Vaadin client-side router does not provide link highlighting itself, instead this is done with template bindings and helper methods.
 
-=== When not using `<vaadin-tabs>`
+=== When Not Using the Tabs Component
 
 When not using `<vaadin-tabs>`, you can style active links by binding the `active` attribute. In this example, we start by define the `location` property, then add a helper method `isCurrentLocation` for determining active links, and use it in the template binding in `render()`:
 
@@ -202,7 +202,7 @@ export class MainLayoutElement extends LitElement {
 }
 ----
 
-=== Using `<vaadin-tabs>`
+=== Using the Tabs Component
 
 When using `<vaadin-tabs>`, we need to bind the `selected` property to the index of selected tab.
 


### PR DESCRIPTION
Convert all headings to Title Case, and avoid using code formatting.