### PR TITLE
fix: use a range for lit-html version to avoid duplicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
       "workbox-precaching": "5.1.4",
       "webpack-manifest-plugin": "2.2.0"
     },
-    "hash": "73eb1061976ee848763dd2beb832f412be0fc3ae27032efafcc827ad83e65f96"
+    "hash": "c2c87cfcbb2e59c02637afc3e76b0708116455970390548c8677976a6d40d606"
   },
   "dependencies": {
     "@polymer/iron-icon": "3.0.1",
@@ -158,7 +158,7 @@
     "lint-staged": "^10.5.1",
     "lit-css-loader": "0.0.4",
     "lit-element": "2.3.1",
-    "lit-html": "1.2.1",
+    "lit-html": "^1.2.1",
     "prettier": "^1.19.1",
     "progress-webpack-plugin": "0.0.24",
     "raw-loader": "4.0.0",


### PR DESCRIPTION
Vaadin generates a package.json file that depends on a fixed version of lit-html (1.2.1). Starting up the project runs `npm install` and results in 2 different lit-html versions installed.

<img width="375" alt="Screenshot 2021-02-05 at 10 26 15" src="https://user-images.githubusercontent.com/1222264/107016673-e76f5f80-67a6-11eb-9f2b-2d6b023ac8eb.png">

The conflicting versions cause problems in examples that use lit-html to render content. Currently, they use `render` imported from `lit-html` and `html` tag imported from `lit-element` which uses a different version of `lit-html` internally.

```js
import { render } from 'lit-html';
import { html, ... } from 'lit-element';

...

render(html`<div>Financial report generated</div>`, root);
```

One solution would be to also import `html` (with a different name) from `lit-html`:

```js
import { render, html as htmlTag } from 'lit-html';
import { html } from 'lit-element';
```

...but that gets messy when `html` is used for the root level (and possibly interpolated content) and `htmlTag` for `render`'ed content.

This PR changes the explicit `lit-html` dependency from `1.2.1` to `^1.2.1` to ensure that only one version of `lit-html` is installed.

<img width="376" alt="Screenshot 2021-02-05 at 11 42 01" src="https://user-images.githubusercontent.com/1222264/107016911-2ef5eb80-67a7-11eb-8a66-1a58c6760015.png">
