### PR TITLE
fix broken link and typo

### DIFF
--- a/articles/flow/cdi/basic.asciidoc
+++ b/articles/flow/cdi/basic.asciidoc
@@ -57,7 +57,7 @@ An instance of the CDI-enabled Vaadin servlet, `com.vaadin.cdi.CdiVaadinServlet`
 use the `@WebServlet` annotation. You can also customize `CdiVaadinServlet` to suit your setup.
 
 [NOTE]
-See <<../advanced/tutorial-flow-runtime-configuration#,Changing Vaadin Behavior with Runtime Configuration>> for more about about Vaadin servlet configuration.
+See <<../advanced/flow-runtime-configuration#,Changing Vaadin Behavior with Runtime Configuration>> for more information about Vaadin servlet configuration.
 
 == Getting Started with CDI and Vaadin Tutorial
 


### PR DESCRIPTION
I swapped "about about" to "information about" and removed "tutorial-" from the link since it didn't load.