### PR TITLE
CE: add config auto-detection and setDataDir

### DIFF
--- a/articles/ce/going-to-production.asciidoc
+++ b/articles/ce/going-to-production.asciidoc
@@ -53,20 +53,42 @@ You can set the path as a system property in a `VaadinServiceInitListener`, whic
 
 ==== Spring Applications
 
-If you have a Spring application, you can register a `VaadinServiceInitListener` by implementing the interface and annotating the class as a `@SpringComponent`.
-In the `serviceInit` method, you can then set `vaadin.ce.dataDir` as a system property.
+If you have a Spring application, you can provide a bean of type `CollaborationEngineConfiguration` from your main Spring class by annotating a method with the `@Bean` annotation and returning a configuration instance with the data directory path set using the `setDataDir` method.
 
-.`com.company.myapp.MyVaadinInitListener.java`
-[source, Java]
+.`com.company.myapp.Application.java`
+[source, Java, subs="+macros"]
 ----
-include::{root}/src/main/java/com/vaadin/demo/ce/MyVaadinInitListener.java[tags=init-listener;!*,indent=0]
+@SpringBootApplication
+public class Application {
+
+    public static void main(String... args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public CollaborationEngineConfiguration ceConfigBean() {
+        CollaborationEngineConfiguration configuration = new CollaborationEngineConfiguration(
+                licenseEvent -> {
+                    // See <<ce.production.license-events>>
+                });
+        configuration.setDataDir("/Users/steve/vaadin/collaboration-engine/");
+        return configuration;
+    }
+}
 ----
 
 ==== Other Applications
 
-If you have a non-Spring application, you can implement the `VaadinServiceInitListener` in the same way as seen above, except that you can't use the `@SpringComponent` annotation.
-Instead, you need to register it through the Java Service Provider Interface (SPI) loading facility.
-You can do that by providing a file, `src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener` with a fully qualified class name to your listener as content, for example, `com.company.myapp.MyVaadinInitListener`.
+If you have a non-Spring application, you can implement a `VaadinServiceInitListener` where you create a `CollaborationEngineConfiguration` instance and set it using the `CollaborationEngine.configure()` method.
+
+.`com.company.myapp.MyVaadinInitListener.java`
+[source, Java, subs="+macros"]
+----
+include::{root}/src/main/java/com/vaadin/demo/ce/MyVaadinInitListener.java[tags=init-listener;configuration;event-handler;event-handler-ref;!*,indent=0]
+----
+
+Then, you need to register the listener via Java SPI loading facility.
+You do this by providing a file, `src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener` with a fully qualified class name to your listener as content, for example, `com.company.myapp.MyVaadinInitListener`.
 
 .The location of the configuration file
 image::images/service-init-listener.png[The location of the configuration file]
@@ -175,16 +197,11 @@ One potential way to handle the event is to send a message to any existing appli
 Another option is to send an email to the relevant people, for example, those who maintain the deployment and those who are responsible of the Collaboration Engine license.
 You need to ensure that your application notices and handles the events.
 
-The listener can be configured in a `VaadinServiceInitListener` in the same way as the `vaadin.ce.dataDir` property,
-if you're setting that property in Java code, as described earlier.
+The listener can be configured when creating the `CollaborationEngineConfiguration` as described earlier in <<ce.production.data-dir-in-project-files>>.
 
-The following example is a Spring project, so the `VaadinServiceInitListener` is registered by adding the `@SpringComponent` annotation.
-If you are not using Spring, you can register the service init listener in the same way as described in <<ce.production.data-dir-in-project-files>>.
-
-.`com.company.myapp.MyVaadinInitListener.java`
 [source, Java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/ce/MyVaadinInitListener.java[tags=init-listener;!send-email,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/ce/MyVaadinInitListener.java[tags=event-handler;!event-handler-ref,indent=0]
 ----
 
 In the above example, the license event handler logs the event messages using the SLF4J logging API, and sends an email.

--- a/articles/ce/going-to-production.asciidoc
+++ b/articles/ce/going-to-production.asciidoc
@@ -55,26 +55,9 @@ You can set the path as a system property in a `VaadinServiceInitListener`, whic
 
 If you have a Spring application, you can provide a bean of type `CollaborationEngineConfiguration` from your main Spring class by annotating a method with the `@Bean` annotation and returning a configuration instance with the data directory path set using the `setDataDir` method.
 
-.`com.company.myapp.Application.java`
 [source, Java, subs="+macros"]
 ----
-@SpringBootApplication
-public class Application {
-
-    public static void main(String... args) {
-        SpringApplication.run(Application.class, args);
-    }
-
-    @Bean
-    public CollaborationEngineConfiguration ceConfigBean() {
-        CollaborationEngineConfiguration configuration = new CollaborationEngineConfiguration(
-                licenseEvent -> {
-                    // See <<ce.production.license-events>>
-                });
-        configuration.setDataDir("/Users/steve/vaadin/collaboration-engine/");
-        return configuration;
-    }
-}
+include::{root}/src/main/java/com/vaadin/demo/ce/SpringBeanProvider.java[tags=spring-bean,indent=0]
 ----
 
 ==== Other Applications

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>collaboration-engine</artifactId>
+            <version>3.1-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/vaadin/demo/ce/MyVaadinInitListener.java
+++ b/src/main/java/com/vaadin/demo/ce/MyVaadinInitListener.java
@@ -20,10 +20,8 @@ import com.vaadin.collaborationengine.LicenseEventHandler;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
-import com.vaadin.flow.spring.annotation.SpringComponent;
 
 // tag::init-listener[]
-@SpringComponent
 public class MyVaadinInitListener implements VaadinServiceInitListener {
     // tag::logger[]
     private static final Logger LOGGER = LoggerFactory
@@ -32,12 +30,15 @@ public class MyVaadinInitListener implements VaadinServiceInitListener {
 
     @Override
     public void serviceInit(ServiceInitEvent serviceEvent) {
-        System.setProperty("vaadin.ce.dataDir",
-                "/Users/steve/vaadin/collaboration-engine/");
         // tag::configuration[]
         VaadinService service = serviceEvent.getSource();
 
+        // tag::event-handler[]
         LicenseEventHandler licenseEventHandler = licenseEvent -> {
+            // tag::event-handler-ref[]
+            // See <<ce.production.license-events>>
+            // end::event-handler-ref[]
+            // tag::event-handler-switch[]
             switch (licenseEvent.getType()) {
             case GRACE_PERIOD_STARTED:
             case LICENSE_EXPIRES_SOON:
@@ -50,10 +51,13 @@ public class MyVaadinInitListener implements VaadinServiceInitListener {
             }
             sendEmail("Vaadin Collaboration Engine license needs to be updated",
                     licenseEvent.getMessage());
+            // end::event-handler-switch[]
         };
+        // end::event-handler[]
 
         CollaborationEngineConfiguration configuration = new CollaborationEngineConfiguration(
                 licenseEventHandler);
+        configuration.setDataDir("/Users/steve/vaadin/collaboration-engine/");
         CollaborationEngine.configure(service, configuration);
         // end::configuration[]
     }

--- a/src/main/java/com/vaadin/demo/ce/SpringBeanProvider.java
+++ b/src/main/java/com/vaadin/demo/ce/SpringBeanProvider.java
@@ -1,0 +1,21 @@
+package com.vaadin.demo.ce;
+
+import org.springframework.context.annotation.Bean;
+
+import com.vaadin.collaborationengine.CollaborationEngineConfiguration;
+
+public class SpringBeanProvider {
+
+    // tag::spring-bean[]
+    @Bean
+    public CollaborationEngineConfiguration ceConfigBean() {
+        CollaborationEngineConfiguration configuration = new CollaborationEngineConfiguration(
+                licenseEvent -> {
+                    // See <<ce.production.license-events>>
+                });
+        configuration.setDataDir("/Users/steve/vaadin/collaboration-engine/");
+        return configuration;
+    }
+    // end::spring-bean[]
+
+}


### PR DESCRIPTION
Update `ce-next` with latest changes and depend on CE snapshot.

Closes https://github.com/vaadin/collaboration-engine-internal/issues/512