### PR TITLE
Remove the --shamefully-hoist requirement for V19

### DIFF
--- a/articles/guide/installing/frontend.asciidoc
+++ b/articles/guide/installing/frontend.asciidoc
@@ -97,17 +97,19 @@ To install a custom frontend package into your project with pnpm, install Node.j
 For example, to install the `mobx` package into `node_modules`, run the following command in the project directory:
 
 ```
-npx pnpm i mobx --shamefully-hoist
+npx pnpm i mobx
 ```
 
 If you have installed pnpm globally, you can alternatively call it directly:
 
 ```
-pnpm i mobx --shamefully-hoist
+pnpm i mobx
 ```
 
 Vaadin requires pnpm 5 or newer.
 If you have already installed an older version of pnpm globally the above command runs the old version; either upgrade pnpm or pass a version specifier to npx, for example `pnpm@5.15.2` instead of `pnpm`.
-The `--shamefully-hoist` flag is required because Vaadin expects transitive platform dependencies to be available directly under `node_modules`.
-This requirement may be relaxed in the future.
 pnpm accepts other common npm flags, such as `--save` and `--save-dev` for saving the dependency to `package.json`.
+
+[NOTE]
+Vaadin expects transitive platform dependencies to be available directly under `node_modules`.
+In Vaadin versions earlier than 19 that use pnpm, the `--shamefully-hoist` flag must be explicitly given to pnpm during package installation: `pnpm i --shamefully-hoist mobx`.


### PR DESCRIPTION
V19 generates the .npmrc file with this flag.