### PR TITLE
fix: stress that endpoint methods should be public

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -26,6 +26,7 @@ NetBeans
 npm
 npx
 Payara
+performant
 [pP]olyfills?
 [pP]ortlets?
 [rR]enderers?

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -16,6 +16,7 @@ Gradle
 [gG]rayscale
 Gretty
 [hH]otpatch(ed|ing)?
+Javadoc
 Karaf
 Lumo
 Maven

--- a/articles/fusion/application/accessing-backend.asciidoc
+++ b/articles/fusion/application/accessing-backend.asciidoc
@@ -62,7 +62,7 @@ This syntax has the following properties:
 
 The following example demonstrates the `City.ts` module:
 
-.City.ts
+.`City.ts`
 [source,typescript]
 ----
 // Declare and export an interface
@@ -71,7 +71,7 @@ export default interface City {
 }
 ----
 
-.index.ts
+.`index.ts`
 [source,typescript]
 ----
 // Import and use a declaration from another module
@@ -93,7 +93,7 @@ Each such module exports all the methods in the endpoint.
 You can either import an entire module at once or select individual endpoint methods.
 For example, the `CounterEndpoint.ts` could be used as in the following snippets:
 
-.index.ts (import the whole endpoint module)
+.`index.ts` (import the whole endpoint module)
 [[index.ts]]
 [source,typescript]
 ----
@@ -104,7 +104,7 @@ import * as counterEndpoint from './generated/CounterEndpoint';
 counterEndpoint.addOne(1).then(result => console.log(result));
 ----
 
-.index.ts (import a single endpoint method)
+.`index.ts` (import a single endpoint method)
 [source,typescript]
 ----
 // Other imports
@@ -127,8 +127,8 @@ For more information about supported types, see <<../advanced/fusion-advanced-ty
 For example, the generated TypeScript module for the Java endpoint defined in
  <<accessing-backend#how-to-create-vaadin-endpoint,CounterEndpoint.java>> would look as follows:
 
+.`CounterEndpoint.ts`
 [source,typescript]
-.CounterEndpoint.ts
 ----
 /**
  * A Vaadin endpoint that counts numbers.

--- a/articles/fusion/application/accessing-backend.asciidoc
+++ b/articles/fusion/application/accessing-backend.asciidoc
@@ -7,14 +7,16 @@ layout: page
 
 = Accessing Java Backend
 
-A server-side Java endpoint is a back-end method that is exposed for calling from client-side TypeScript code.
+A server-side Java endpoint is a backend method that is exposed for calling from client-side TypeScript code.
 An endpoint in Vaadin is a class that defines one or more public methods.
 
-Vaadin bridges Java backend endpoints and a TypeScript frontend. It generates
-TypeScript clients to call the Java backend in a type-checkable way.
+Vaadin bridges Java backend endpoints and a TypeScript frontend.
+It generates TypeScript clients to call the Java backend in a type-checkable way.
 
+.Vaadin endpoints depend on Spring Boot auto configuration.
 [WARNING]
-Vaadin endpoints depend on Spring Boot auto-configuration. It does not work if the auto-configuration is disabled, for example, when you use `@EnableWebMvc`. As a workaround, remove the `@EnableWebMvc` annotation, as stated in link:https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/spring-boot-features.html#boot-features-spring-mvc-auto-configuration[Spring Boot documentation].
+They do not work if the auto configuration is disabled, for example, when you use `@EnableWebMvc`.
+As a workaround, remove the `@EnableWebMvc` annotation, as stated in link:https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/reference/html/spring-boot-features.html#boot-features-spring-mvc-auto-configuration[Spring Boot documentation].
 If you have an idea how to make it more useful for you, please share it on link:https://github.com/vaadin/flow/issues/new/[GitHub^].
 
 == Creating an Endpoint
@@ -41,9 +43,9 @@ public class CounterEndpoint {
 }
 ----
 
-When the application starts, Vaadin analyzes such classes in order to be able to process the requests made to such endpoints, and to appropriately verify user access.
-For each request that is trying to access the method in the corresponding Vaadin endpoint, a permission check is carried on.
-`@AnonymousAllowed` means that it permits anyone to call the method via the request without the authorization
+When the application starts, Vaadin scans the classpath for `@Endpoint`-annotated classes.
+For each request to access a public method in a Vaadin endpoint, a permission check is carried out.
+`@AnonymousAllowed` means that Vaadin permits anyone to call the method from the client-side.
 
 Please refer to the <<../security/overview#, Security>> for configuring endpoint access.
 
@@ -83,16 +85,15 @@ const cityObject: City = {
 
 In Vaadin applications, the `index.ts` (or, optionally, `index.js`) file is also a module.
 
-== Modules Generated from Vaadin Endpoints
+== Modules Generated From Vaadin Endpoints
 
-Fusion generates a TypeScript module for every Vaadin endpoint on the back end.
+Fusion generates a TypeScript module for every Vaadin endpoint on the backend.
 Each such module exports all the methods in the endpoint.
 
-You can either import an entire generated module as an endpoint, or import the
-methods from the module separately.
+You can either import an entire module at once or select individual endpoint methods.
 For example, the `CounterEndpoint.ts` could be used as in the following snippets:
 
-.index.ts (import the whole module)
+.index.ts (import the whole endpoint module)
 [[index.ts]]
 [source,typescript]
 ----
@@ -103,7 +104,7 @@ import * as counterEndpoint from './generated/CounterEndpoint';
 counterEndpoint.addOne(1).then(result => console.log(result));
 ----
 
-.index.ts (only import the needed method)
+.index.ts (import a single endpoint method)
 [source,typescript]
 ----
 // Other imports

--- a/articles/fusion/application/accessing-backend.asciidoc
+++ b/articles/fusion/application/accessing-backend.asciidoc
@@ -8,7 +8,7 @@ layout: page
 = Accessing Java Backend
 
 A server-side Java endpoint is a back-end method that is exposed for calling from client-side TypeScript code.
-An endpoint in Vaadin is a class that defines one or more API methods.
+An endpoint in Vaadin is a class that defines one or more public methods.
 
 Vaadin bridges Java backend endpoints and a TypeScript frontend. It generates
 TypeScript clients to call the Java backend in a type-checkable way.

--- a/articles/fusion/quick-start-tutorial.asciidoc
+++ b/articles/fusion/quick-start-tutorial.asciidoc
@@ -710,7 +710,9 @@ image::images/quickstart-running-2.png[Running project]
 == Next Steps and Helpful Links
 
 pass:[<!-- vale Google.Exclamation = NO -->]
+
 Congratulations on finishing the tutorial!
+
 pass:[<!-- vale Google.Exclamation = YES -->]
 
 In the following are some helpful links to continue your learning:

--- a/articles/fusion/quick-start-tutorial.asciidoc
+++ b/articles/fusion/quick-start-tutorial.asciidoc
@@ -42,7 +42,7 @@ The pre-configured starter project includes:
 
 Unzip the downloaded file and open the project  in your IDE.
 The instructions in this tutorial assume you use https://code.visualstudio.com/[VS Code].
-See the instructions for <<{articles}/guide/getting-started/intellij#,IntelliJ IDEA>>, <<{articles}/guide/getting-started/getting-started-eclipse#,Eclipse>>, and <<{articles}/guide/getting-started/getting-started-netbeans#,Netbeans>> if you prefer to use another IDE.
+See the instructions for <<{articles}/guide/getting-started/intellij#,IntelliJ IDEA>>, <<{articles}/guide/getting-started/getting-started-eclipse#,Eclipse>>, and <<{articles}/guide/getting-started/getting-started-netbeans#,NetBeans>> if you prefer to use another IDE.
 
 Open the project by either:
 
@@ -147,7 +147,7 @@ public class Todo extends AbstractEntity { // <2>
 <3> Add a `@NotBlank` Java bean validation annotation to enforce validity both in the view and on the server.
 
 Next, create a _repository_ for accessing the database.
-You only need to provide an interface with type information, Spring Data will take care of the implementation.
+You only need to provide an interface with type information, Spring Data takes care of the implementation.
 
 Create a new file, `TodoRepository.java`, in `src/main/java/com/example/application/data/service` with the following contents:
 
@@ -175,7 +175,7 @@ mvn
 ----
 
 **The first time you run `mvn`, it may take up to a few minutes** as it downloads all dependencies and builds a frontend bundle.
-The next time you start the app, it will be much faster.
+On the following builds `mvn` does not download dependencies and builds are much faster.
 
 When the build has finished, you should see the application running on http://localhost:8080.
 
@@ -223,7 +223,7 @@ public class TodoEndpoint {
 <1> Annotating a class with `@Endpoint` exposes it as a service for client-side views.
 All *public* methods of an endpoint are callable from TypeScript.
 <2> By default, endpoint access requires an authenticated user. `@AnonymousAllowed` enables access for anyone. See <<configuring-security,Configuring Security>> for more information on endpoint security.
-<3> Use Spring to autowire the `TodoRepository` for database access.
+<3> Use Spring to automatically inject the `TodoRepository` dependency for database access.
 
 Save the file and ensure the change is loaded.
 You should see log output from the reload (that ends with a `Frontend compiled successfully` message) in the console.
@@ -245,7 +245,7 @@ The UI always reflects that state.
 As a concrete example, consider a form with a submit button that should be disabled whenever the form is invalid.
 With an imperative model, you need to track the form state and set the button state whenever the form state changes.
 With a reactive model, your UI template defines that the button should be disabled whenever the form is invalid.
-You therefore only need to update the form state, the UI is updated automatically.
+That means only need to update the form state, the UI is updated automatically.
 
 == LitElement Basics
 
@@ -269,7 +269,7 @@ export class TodoView extends LitElement {
 
 LitElement uses _properties_ to track component state.
 Use `@property()` for properties that make up the public API and `@internalProperty()` for internal state properties.
-The HTML template will be re-rendered every time a property changes.
+The HTML template is re-rendered every time a property changes.
 
 [source,typescript]
 ----
@@ -285,7 +285,7 @@ Consider the properties as immutable data and remember to always create a new ob
 JavaScript https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax[spread syntax] is a convenient way to create copies of objects and arrays.
 It may take some getting used to if you haven't used it before.
 
-As an example, here are three properties we can use to understand how property-change detection works:
+As an example, here are three properties you can use to understand how property-change detection works:
 
 [source,typescript]
 ----
@@ -401,7 +401,7 @@ The component is shielded from outside CSS.
 For more about scoping styles, see <<{articles}/theming/style-scopes, Style Scopes>>.
 
 Web Components are `display: inline` by default.
-This is rarely what you want. `block`, `flex`, or `grid` are often more appropriate for building views.
+For application views `display: block`, `flex`, or `grid` is often more appropriate.
 Use the  https://developer.mozilla.org/en-US/docs/Web/CSS/:host()[`:host` selector] to target the component you are in.
 
 
@@ -416,7 +416,7 @@ static styles = css`
 
 === Component Lifecycle
 
-LitElement components support all standard web component lifecycle callbacks, and it defines a few additional callbacks.
+LitElement components support all standard web component lifecycle callbacks, and also have several convenient non-standard ones
 
 The most commonly used lifecycle callbacks are:
 
@@ -470,7 +470,7 @@ import TodoModel from "../../generated/com/example/application/data/entity/TodoM
 export class TodoView extends LitElement { // <3>
 }
 ----
-<1> Import the UI components, helpers, and generated TypeScript models you will need for building the view.
+<1> Import the UI components, helpers, and generated TypeScript models required for building the view.
 <2> Register the new component with the browser. This makes it available as `<todo-view>`. The routing in `index.ts` is already set up to show it when you navigate to the application.
 <3> Define the component class that extends from `LitElement`.
 
@@ -590,7 +590,7 @@ async createTodo() {
 }
 ----
 <1> Use binder to submit the form to `TodoEndpoint`.
-The binder will validate the input before posting it and the server will re-validate it.
+The binder validates the input before posting it and the server re-validates it.
 <2> If the `Todo` was saved successfully, update the `todos` array and clear the form.
 
 Finally, add a method for updating the `todo` state right below `createTodo()`:
@@ -709,10 +709,13 @@ image::images/quickstart-running-2.png[Running project]
 
 == Next Steps and Helpful Links
 
+pass:[<!-- vale Google.Exclamation = NO -->]
 Congratulations on finishing the tutorial!
+pass:[<!-- vale Google.Exclamation = YES -->]
+
 In the following are some helpful links to continue your learning:
 
-- https://github.com/vaadin-learning-center/fusion-basics-tutorial[GitHub repo for the completed project source code].
+- https://github.com/vaadin-learning-center/fusion-basics-tutorial[GitHub repository for the completed project source code].
 
 - <<routing/routing-defining,Learn to add more views to your app>>.
 
@@ -722,7 +725,7 @@ In the following are some helpful links to continue your learning:
 
 - https://lit-element.polymer-project.org/guide[Read the LitElement guide].
 
-If you get stuck or need help, please reach out to us:
+If you get stuck or need help, please reach out to the Vaadin community:
 
 - https://vaadin.com/forum[Vaadin Forum]
-- https://vaad.in/chat[Vaadin Community Chat]
+- http://discord.gg/vaadin[Vaadin Community Discord]

--- a/articles/fusion/quick-start-tutorial.asciidoc
+++ b/articles/fusion/quick-start-tutorial.asciidoc
@@ -185,7 +185,7 @@ image::images/quickstart-running-1.png[Running project]
 ==  Create a Typed Server Endpoint
 
 One of the key features of Vaadin Fusion is type-safe server access through _endpoints_.
-When you define an `@Endpoint`, Vaadin creates the needed REST-like endpoints, secures them, and generates TypeScript interfaces for all the used data types and methods.
+When you define an `@Endpoint`, Vaadin creates the needed REST-like endpoints, secures them, and generates TypeScript interfaces for all the used data types and public methods.
 Having full-stack type safety helps you stay productive through autocomplete and helps guard against accidental UI breakage when the data model changes on the server.
 
 Create a new `TodoEndpoint.java` file in `src/main/java/com/example/application/data/endpoint`:
@@ -221,6 +221,7 @@ public class TodoEndpoint {
 }
 ----
 <1> Annotating a class with `@Endpoint` exposes it as a service for client-side views.
+All *public* methods of an endpoint are callable from TypeScript.
 <2> By default, endpoint access requires an authenticated user. `@AnonymousAllowed` enables access for anyone. See <<configuring-security,Configuring Security>> for more information on endpoint security.
 <3> Use Spring to autowire the `TodoRepository` for database access.
 

--- a/articles/fusion/quick-start-tutorial.asciidoc
+++ b/articles/fusion/quick-start-tutorial.asciidoc
@@ -728,4 +728,4 @@ In the following are some helpful links to continue your learning:
 If you get stuck or need help, please reach out to the Vaadin community:
 
 - https://vaadin.com/forum[Vaadin Forum]
-- http://discord.gg/vaadin[Vaadin Community Discord]
+- https://discord.gg/vaadin[Vaadin Community Discord]

--- a/articles/fusion/quick-start-tutorial.asciidoc
+++ b/articles/fusion/quick-start-tutorial.asciidoc
@@ -101,7 +101,7 @@ The starter you download already includes the needed dependencies in `pom.xml`.
 
 Define a JPA _entity_ class for the data model, by creating a new `Todo.java` file in `src/main/java/com/example/application/data/entity` with the following content:
 
-.Todo.java
+.`Todo.java`
 [source,java,subs="callouts+"]
 ----
 package com.example.application.data.entity;
@@ -151,7 +151,7 @@ You only need to provide an interface with type information, Spring Data takes c
 
 Create a new file, `TodoRepository.java`, in `src/main/java/com/example/application/data/service` with the following contents:
 
-.TodoRepository.java
+.`TodoRepository.java`
 [source,java,subs="callouts+"]
 ----
 package com.example.application.data.service;
@@ -190,7 +190,7 @@ Having full-stack type safety helps you stay productive through autocomplete and
 
 Create a new `TodoEndpoint.java` file in `src/main/java/com/example/application/data/endpoint`:
 
-.TodoEndpoint.java
+.`TodoEndpoint.java`
 [source,java,subs="callouts+"]
 ----
 package com.example.application.data.endpoint;
@@ -612,7 +612,7 @@ The `map` operator creates a new array where the changed `todo` is swapped out.
 
 The completed view code is as follows:
 
-.todo-view.ts
+.`todo-view.ts`
 [source,typescript,subs="callouts+"]
 ----
 import {


### PR DESCRIPTION
This is based on direct user feedback. Ppl do not immediately realise that non-public endpoint methods are not exposed to TypeScript.

Related: https://github.com/vaadin/flow/issues/7681