### PR TITLE
chore: reduce # of false positives and false negatives of Vale linter

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -5,34 +5,8 @@ Vocab = Docs
 # Ignored CSS class names
 IgnoredClasses = filename, classname, methodname, interfacename, propertyname, guibutton, guilabel, custom-property
 
-# Some rules are still applied on asciidoc files unless they are replicated here
-[*]
-
-# Ignored (blocks)
-# Front matter
-# # Block annotations (roles, etc)
-BlockIgnores = (---[\S\s]*---), \
-(\[\S+\])
-
 # Rules for asciidoc files
 [*.{asciidoc,adoc}]
-
-# Ignored (blocks)
-# Front matter
-# # Include directives
-BlockIgnores = (---[\S\s]*---), \
-(include::\S+\[.*])
-
-# Ignored (inline text)
-# Attribute substitution names
-# Cross reference paths
-# Include directives
-# Image directives
-TokenIgnores = \
-({\S+}), \
-(<<\S+\,), (<<[^\,]+>>), \
-(include::\S+\[.*]), \
-(image:{1\,2}\S+\[.*])
 
 BasedOnStyles = Vaadin, Google, Microsoft, write-good, Vale
 


### PR DESCRIPTION
Before
```
$ vale ./articles/**/*.asciidoc
2002 errors, 5518 warnings and 0 suggestions in 481 files.
```

After
```
$ vale ./articles/**/*.asciidoc
2213 errors, 6109 warnings and 0 suggestions in 481 files.
```

The `BlockIgnores` and `TokenIgnores` regular expressions in the Vale config were causing incorrect / unnecesary modifications to input AsciiDoc files, and that lead to both valid text triggering errors (false positive) and invalid text not triggering errors (false negative).

### Rationale
There is no need to try to exclude special asciidoc syntax (like `image:` and `include:` macros and `link:` and `<<>>` links) for Vale.

Before linting the text, Vale passes the asciidoc files through an asciidoc processor and works on the HTML output. This means that all special asciidoc syntax that does not get rendered in HTML is ignored by Vale (by design).

Also, when working with asciidoc files Vale automatically processes the front matter, so there is no need to explicitly mention it in `BlockIgnores`.

### Examples
**Valid text that (incorrectly) triggered errors**
1. The `(\[\S+\])` block ignore incorrectly modifies links (and breaks them)
   This happens only if the link is prepended with the `link:` macro and the link text contains no spaces:
   ```asciidoc
   link:https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin[lit-plugin^]
   ```
   is (unintentionally) transformed into
   ```asciidoc
   link:https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin
   ----
   [lit-plugin^]
   ----
   ```
   and that triggers an error (because `link:https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin` is not recognized as a URL and is printed literally into the HTML output)
   ```
   5:3    error    Did you really mean 'https'?    Vale.Spelling
   ```
2. The `({\S+})` token ignore incorrectly modifies links with attributes (and breaks them)
   This happens with an attribute is used in a link:
   ```asciidoc
   using the <<{articles}/ds/foundation/size-space#space,spacing properties>> to be consistent
   ```
   is (unintentionally) transformed into
   ```asciidoc
   using the `<<`{articles}`/ds/foundation/size-space#space,`spacing properties>> to be consistent
   ```
   and that triggers an error
   ```
   1:24   error    Did you really mean 'ds'?       Vale.Spelling
   ```

**Invalid text that (incorrectly) passed without triggering errors**
1. The `(---[\S\s]*---)` and `(\[\S+\])` pair of block ignores applied two times excludes entire sections of text from linting
   Example:
   ```asciidoc
   ---
   title: Overview
   layout: page
   order: 1
   ---
   
   [[ce.overview]]
   = Collaboration Engine
   
   Collaboration Engine is a solution for building real-time collaboration features into web apps with a few lines of code.
   This means that end users can collaboratively edit and communicate in real time, directly within secure Vaadin web applications.

   .Subscription required for production use
   [IMPORTANT]
   Collaboration Engine is a commercial product that requires a subscription for production use.
   ```
   is (unintentionally) transformed into
   ```asciidoc
   ----
   ----
   ----
   title: Overview
   layout: page
   order: 1
   ----
   ----
   
   
   
   
   ----
   [[ce.overview]]
   ----
   
   = Collaboration Engine
   
   Collaboration Engine is a solution for building real-time collaboration features into web apps with a few lines of code.
   This means that end users can collaboratively edit and communicate in real time, directly within secure Vaadin web applications.
   
   .Subscription required for production use
   
   ----
   [IMPORTANT]
   ----
   ----
   
   Collaboration Engine is a commercial product that requires a subscription for production use.
   ```
   After the fix the previously excluded text sections are linted, and that may expose earlier undetected issues, like
   ```
   70:100  warning  Consider removing               Microsoft.Adverbs  
                  'separately'.
   ```