### PR TITLE
feat: support Flow-only documentation

### DIFF
--- a/docbuilder/build/docker-compose.yml
+++ b/docbuilder/build/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: vaadin/docbuilder:latest
     working_dir: /docs-app
     environment:
+      - DOCS_IMPORT_EXAMPLE_RESOURCES=${DOCS_IMPORT_EXAMPLE_RESOURCES}
       - DOCS_ARTICLES_PATH=${DOCS_ARTICLES_PATH}
       - DOCS_PATH_PREFIX=${DOCS_PATH_PREFIX}
       - DOCS_EXAMPLES_INCLUDE_URL_PREFIX=${DOCS_PATH_PREFIX}/vaadin/web-component/

--- a/docbuilder/develop/docker-compose.yml
+++ b/docbuilder/develop/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   docs-app:
     image: vaadin/docbuilder:latest
     environment:
+      - DOCS_IMPORT_EXAMPLE_RESOURCES=${DOCS_IMPORT_EXAMPLE_RESOURCES}
       - DOCS_ARTICLES_PATH=${DOCS_ARTICLES_PATH}
       - DOCS_PROXY_VAADIN_HOSTNAME=docs
       - DOCS_TITLE=${DOCS_TITLE}

--- a/frontend/demo/all-example-resources.ts
+++ b/frontend/demo/all-example-resources.ts
@@ -1,0 +1,2 @@
+import './init-flow-namespace';
+import '../../target/frontend/generated-flow-imports';

--- a/frontend/demo/all-example-resources.ts
+++ b/frontend/demo/all-example-resources.ts
@@ -1,2 +1,0 @@
-import './init-flow-namespace';
-import '../../target/frontend/generated-flow-imports';

--- a/frontend/demo/example-resources.ts
+++ b/frontend/demo/example-resources.ts
@@ -1,7 +1,7 @@
 import './init-flow-namespace';
 import 'all-flow-imports-or-empty';
+import { applyTheme } from 'generated/theme';
 // See webpack.config 'externals.generated/theme'
 // This file ends up in the docs-app bundle
-import { applyTheme } from 'generated/theme';
 // @ts-ignore
 window.__applyTheme = { applyTheme };

--- a/frontend/demo/example-resources.ts
+++ b/frontend/demo/example-resources.ts
@@ -1,3 +1,5 @@
+import './init-flow-namespace';
+import 'all-flow-imports-or-empty';
 // See webpack.config 'externals.generated/theme'
 // This file ends up in the docs-app bundle
 import { applyTheme } from 'generated/theme';

--- a/frontend/demo/example-resources.ts
+++ b/frontend/demo/example-resources.ts
@@ -1,7 +1,8 @@
 import './init-flow-namespace';
-import 'all-flow-imports-or-empty';
 import { applyTheme } from 'generated/theme';
 // See webpack.config 'externals.generated/theme'
 // This file ends up in the docs-app bundle
 // @ts-ignore
 window.__applyTheme = { applyTheme };
+// @ts-ignore
+import('all-flow-imports-or-empty').catch(() => {});

--- a/frontend/demo/init-flow-namespace.ts
+++ b/frontend/demo/init-flow-namespace.ts
@@ -1,0 +1,5 @@
+// The connectors require window.Vaadin.Flow namespace to exists
+// @ts-ignore
+window.Vaadin = window.Vaadin || {};
+// @ts-ignore
+window.Vaadin.Flow = window.Vaadin.Flow || {};

--- a/frontend/demo/init.ts
+++ b/frontend/demo/init.ts
@@ -1,5 +1,4 @@
 import './init-flow-namespace';
-import 'all-example-resources-or-empty';
 import '@vaadin/flow-frontend/dndConnector-es6.js';
 import '@vaadin/flow-frontend/flow-component-renderer.js';
 // @ts-ignore

--- a/frontend/demo/init.ts
+++ b/frontend/demo/init.ts
@@ -1,3 +1,5 @@
+import './init-flow-namespace';
+import 'all-example-resources-or-empty';
 import '@vaadin/flow-frontend/dndConnector-es6.js';
 import '@vaadin/flow-frontend/flow-component-renderer.js';
 // @ts-ignore
@@ -22,12 +24,6 @@ applyTheme(div.shadowRoot);
 
 // @ts-ignore
 client.prefix = __VAADIN_CONNECT_PREFIX__;
-
-// The connectors require window.Vaadin.Flow namespace to exists
-// @ts-ignore
-window.Vaadin = window.Vaadin || {};
-// @ts-ignore
-window.Vaadin.Flow = window.Vaadin.Flow || {};
 
 // @ts-ignore Workaround a Vaadin issue
 AppointmentModel.createEmptyValue = () => Appointment;

--- a/webpack.docbuilder.js
+++ b/webpack.docbuilder.js
@@ -53,7 +53,7 @@ const applyThemePath = path.resolve(
 );
 
 module.exports = function (config) {
-  const allFlowImportsPath = path.resolve(__dirname, 'target/frontend/generated-flow-imports');
+  const allFlowImportsPath = path.resolve(__dirname, 'target/frontend/generated-flow-imports.js');
   config.resolve.alias['all-flow-imports-or-empty'] =
     process.env.DOCS_IMPORT_EXAMPLE_RESOURCES === 'true'
       ? allFlowImportsPath

--- a/webpack.docbuilder.js
+++ b/webpack.docbuilder.js
@@ -52,7 +52,14 @@ const applyThemePath = path.resolve(
   'theme.js'
 );
 
-module.exports = function(config) {
+module.exports = function (config) {
+  const allFlowImportsPath = path.resolve(__dirname, 'target/frontend/generated-flow-imports');
+  config.resolve.alias['all-flow-imports-or-empty'] =
+    process.env.DOCS_IMPORT_EXAMPLE_RESOURCES === 'true'
+      ? allFlowImportsPath
+      : // false not supported in Webpack 4, let's use a resource that would get included anyway
+        applyThemePath;
+
   config.resolve.alias['themes/theme-generated.js'] = applyThemePath;
   config.resolve.alias['generated/theme'] = applyThemePath;
   config.resolve.alias.themes = themesPath;
@@ -70,7 +77,7 @@ module.exports = function(config) {
     use: ['raw-loader', 'extract-loader', 'css-loader']
   });
 
-  // The docbuilder bundle should never contain the embedded Vaadin examples
+  // The docs-app bundle should never contain the embedded Vaadin examples
   config.module.rules.push({
     test: embeddedWcRegex,
     use: ['null-loader']

--- a/webpack.docbuilder.js
+++ b/webpack.docbuilder.js
@@ -76,11 +76,6 @@ module.exports = function(config) {
     use: ['null-loader']
   });
 
-  // Resolve all-example-resources-or-empty if it hasn't been resolved (by docs-app)
-  if (!config.resolve.alias['all-example-resources-or-empty']) {
-    config.resolve.alias['all-example-resources-or-empty'] = path.resolve(__dirname, 'frontend/demo/init.ts');
-  }
-
   // Avoid having the docs-app dev server recompile whenever the Java-sources or generated files change
   config.devServer = {
     watchOptions: {

--- a/webpack.docbuilder.js
+++ b/webpack.docbuilder.js
@@ -40,6 +40,8 @@ const themeOptions = {
 // this matches css files in the theme
 const themeCssRegex = /(\\|\/).*frontend(\\|\/)themes\1[\s\S]*?\.css/;
 
+const embeddedWcRegex = /(\\|\/).*target(\\|\/)frontend(\\|\/)[\s\S]*-wc.js/;
+
 const projectThemePath = path.resolve(__dirname, 'frontend/themes');
 const reusableThemesPath = path.resolve(__dirname, 'target/flow-frontend/themes');
 const hasReusableThemes = fs.existsSync(reusableThemesPath);
@@ -66,6 +68,12 @@ module.exports = function(config) {
   config.module.rules.push({
     test: themeCssRegex,
     use: ['raw-loader', 'extract-loader', 'css-loader']
+  });
+
+  // The docbuilder bundle should never contain the embedded Vaadin examples
+  config.module.rules.push({
+    test: embeddedWcRegex,
+    use: ['null-loader']
   });
 
   // Avoid having the docs-app dev server recompile whenever the Java-sources or generated files change

--- a/webpack.docbuilder.js
+++ b/webpack.docbuilder.js
@@ -76,6 +76,11 @@ module.exports = function(config) {
     use: ['null-loader']
   });
 
+  // Resolve all-example-resources-or-empty if it hasn't been resolved (by docs-app)
+  if (!config.resolve.alias['all-example-resources-or-empty']) {
+    config.resolve.alias['all-example-resources-or-empty'] = path.resolve(__dirname, 'frontend/demo/init.ts');
+  }
+
   // Avoid having the docs-app dev server recompile whenever the Java-sources or generated files change
   config.devServer = {
     watchOptions: {


### PR DESCRIPTION
Fixes https://github.com/vaadin/docs-app/issues/215

With the enviroment variable `DOCS_IMPORT_EXAMPLE_RESOURCES` set "true", this will make the app import all the generated Flow resources once the first rendered/live code example is encountered.

## Testing the feature:

### with docbuilder
- (Rebuild the docbuilder image in case it's outdated)
- Add the following `.env` files with content `DOCS_IMPORT_EXAMPLE_RESOURCES="true"`:
  - `docs/docbuilder/develop/.env`
  - `docs/docbuilder/build/.env`

### without docbuilder
- under `docs-app`, run  `DOCS_IMPORT_EXAMPLE_RESOURCES="true" npm start`
