### PR TITLE
Update page link format

### DIFF
--- a/articles/ds/components/accordion/index.asciidoc
+++ b/articles/ds/components/accordion/index.asciidoc
@@ -2,9 +2,9 @@
 title: Accordion
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-accordion-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-accordion-flow}], \
-https://github.com/vaadin/vaadin-accordion/releases/tag/v{moduleNpmVersion:vaadin-accordion}\[Web Component {moduleNpmVersion:vaadin-accordion}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-accordion-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-accordion-flow}]
+  - https://github.com/vaadin/vaadin-accordion/releases/tag/v{moduleNpmVersion:vaadin-accordion}[Web Component {moduleNpmVersion:vaadin-accordion}]
 ---
 
 = Accordion

--- a/articles/ds/components/app-layout/index.asciidoc
+++ b/articles/ds/components/app-layout/index.asciidoc
@@ -2,9 +2,9 @@
 title: App Layout
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}], \
-https://github.com/vaadin/vaadin-app-layout/releases/tag/v{moduleNpmVersion:vaadin-app-layout}\[Web Component {moduleNpmVersion:vaadin-app-layout}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}]
+  - https://github.com/vaadin/vaadin-app-layout/releases/tag/v{moduleNpmVersion:vaadin-app-layout}[Web Component {moduleNpmVersion:vaadin-app-layout}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/avatar/index.asciidoc
+++ b/articles/ds/components/avatar/index.asciidoc
@@ -2,9 +2,9 @@
 title: Avatar
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-avatar-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-avatar-flow}], \
-https://github.com/vaadin/vaadin-avatar/releases/tag/v{moduleNpmVersion:vaadin-avatar}\[Web Component {moduleNpmVersion:vaadin-avatar}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-avatar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-avatar-flow}]
+  - https://github.com/vaadin/vaadin-avatar/releases/tag/v{moduleNpmVersion:vaadin-avatar}[Web Component {moduleNpmVersion:vaadin-avatar}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/badge/index.asciidoc
+++ b/articles/ds/components/badge/index.asciidoc
@@ -1,8 +1,8 @@
 ---
 title: Badge
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/badge.html[Source]
+page-links:
+  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/badge.html[Source]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/board/index.asciidoc
+++ b/articles/ds/components/board/index.asciidoc
@@ -2,9 +2,9 @@
 title: Board
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-board-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-board-flow}], \
-https://github.com/vaadin/vaadin-board/releases/tag/v{moduleNpmVersion:vaadin-board}\[Web Component {moduleNpmVersion:vaadin-board}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-board-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-board-flow}]
+  - https://github.com/vaadin/vaadin-board/releases/tag/v{moduleNpmVersion:vaadin-board}[Web Component {moduleNpmVersion:vaadin-board}]
 section-nav: incomplete, commercial
 ---
 

--- a/articles/ds/components/button/index.asciidoc
+++ b/articles/ds/components/button/index.asciidoc
@@ -2,9 +2,9 @@
 title: Button
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-button-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-button-flow}], \
-https://github.com/vaadin/vaadin-button/releases/tag/v{moduleNpmVersion:vaadin-button}\[Web Component {moduleNpmVersion:vaadin-button}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-button-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-button-flow}]
+  - https://github.com/vaadin/vaadin-button/releases/tag/v{moduleNpmVersion:vaadin-button}[Web Component {moduleNpmVersion:vaadin-button}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/checkbox/index.asciidoc
+++ b/articles/ds/components/checkbox/index.asciidoc
@@ -2,9 +2,9 @@
 title: Checkbox
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}], \
-https://github.com/vaadin/vaadin-checkbox/releases/tag/v{moduleNpmVersion:vaadin-checkbox}\[Web Component {moduleNpmVersion:vaadin-checkbox}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}]
+  - https://github.com/vaadin/vaadin-checkbox/releases/tag/v{moduleNpmVersion:vaadin-checkbox}[Web Component {moduleNpmVersion:vaadin-checkbox}]
 ---
 
 = Checkbox

--- a/articles/ds/components/combo-box/index.asciidoc
+++ b/articles/ds/components/combo-box/index.asciidoc
@@ -2,9 +2,9 @@
 title: Combo Box
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}], \
-https://github.com/vaadin/vaadin-combo-box/releases/tag/v{moduleNpmVersion:vaadin-combo-box}\[Web Component {moduleNpmVersion:vaadin-combo-box}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}]
+  - https://github.com/vaadin/vaadin-combo-box/releases/tag/v{moduleNpmVersion:vaadin-combo-box}[Web Component {moduleNpmVersion:vaadin-combo-box}]
 ---
 
 = Combo Box

--- a/articles/ds/components/confirm-dialog/index.asciidoc
+++ b/articles/ds/components/confirm-dialog/index.asciidoc
@@ -2,9 +2,9 @@
 title: Confirm Dialog
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}], \
-https://github.com/vaadin/vaadin-confirm-dialog/releases/tag/v{moduleNpmVersion:vaadin-confirm-dialog}\[Web Component {moduleNpmVersion:vaadin-confirm-dialog}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}]
+  - https://github.com/vaadin/vaadin-confirm-dialog/releases/tag/v{moduleNpmVersion:vaadin-confirm-dialog}[Web Component {moduleNpmVersion:vaadin-confirm-dialog}]
 section-nav: incomplete, commercial
 ---
 

--- a/articles/ds/components/context-menu/index.asciidoc
+++ b/articles/ds/components/context-menu/index.asciidoc
@@ -2,9 +2,9 @@
 title: Context Menu
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}], \
-https://github.com/vaadin/vaadin-context-menu/releases/tag/v{moduleNpmVersion:vaadin-context-menu}\[Web Component {moduleNpmVersion:vaadin-context-menu}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}]
+  - https://github.com/vaadin/vaadin-context-menu/releases/tag/v{moduleNpmVersion:vaadin-context-menu}[Web Component {moduleNpmVersion:vaadin-context-menu}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/cookie-consent/index.asciidoc
+++ b/articles/ds/components/cookie-consent/index.asciidoc
@@ -2,9 +2,9 @@
 title: Cookie Consent
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}], \
-https://github.com/vaadin/vaadin-cookie-consent/releases/tag/v{moduleNpmVersion:vaadin-cookie-consent}\[Web Component {moduleNpmVersion:vaadin-cookie-consent}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}]
+  - https://github.com/vaadin/vaadin-cookie-consent/releases/tag/v{moduleNpmVersion:vaadin-cookie-consent}[Web Component {moduleNpmVersion:vaadin-cookie-consent}]
 section-nav: incomplete, commercial
 ---
 

--- a/articles/ds/components/crud/index.asciidoc
+++ b/articles/ds/components/crud/index.asciidoc
@@ -2,9 +2,9 @@
 title: CRUD
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-crud-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-crud-flow}], \
-https://github.com/vaadin/vaadin-crud/releases/tag/v{moduleNpmVersion:vaadin-crud}\[Web Component {moduleNpmVersion:vaadin-crud}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-crud-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-crud-flow}]
+  - https://github.com/vaadin/vaadin-crud/releases/tag/v{moduleNpmVersion:vaadin-crud}[Web Component {moduleNpmVersion:vaadin-crud}]
 section-nav: incomplete, commercial
 ---
 

--- a/articles/ds/components/custom-field/index.asciidoc
+++ b/articles/ds/components/custom-field/index.asciidoc
@@ -2,9 +2,9 @@
 title: Custom Field
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}], \
-https://github.com/vaadin/vaadin-custom-field/releases/tag/v{moduleNpmVersion:vaadin-custom-field}\[Web Component {moduleNpmVersion:vaadin-custom-field}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}]
+  - https://github.com/vaadin/vaadin-custom-field/releases/tag/v{moduleNpmVersion:vaadin-custom-field}[Web Component {moduleNpmVersion:vaadin-custom-field}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/date-picker/index.asciidoc
+++ b/articles/ds/components/date-picker/index.asciidoc
@@ -2,9 +2,9 @@
 title: Date Picker
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}], \
-https://github.com/vaadin/vaadin-date-picker/releases/tag/v{moduleNpmVersion:vaadin-date-picker}\[Web Component {moduleNpmVersion:vaadin-date-picker}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}]
+  - https://github.com/vaadin/vaadin-date-picker/releases/tag/v{moduleNpmVersion:vaadin-date-picker}[Web Component {moduleNpmVersion:vaadin-date-picker}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/date-time-picker/index.asciidoc
+++ b/articles/ds/components/date-time-picker/index.asciidoc
@@ -2,9 +2,9 @@
 title: Date Time Picker
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}], \
-https://github.com/vaadin/vaadin-date-time-picker/releases/tag/v{moduleNpmVersion:vaadin-date-time-picker}\[Web Component {moduleNpmVersion:vaadin-date-time-picker}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}]
+  - https://github.com/vaadin/vaadin-date-time-picker/releases/tag/v{moduleNpmVersion:vaadin-date-time-picker}[Web Component {moduleNpmVersion:vaadin-date-time-picker}]
 ---
 
 = Date Time Picker

--- a/articles/ds/components/details/index.asciidoc
+++ b/articles/ds/components/details/index.asciidoc
@@ -2,9 +2,9 @@
 title: Details
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-details-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-details-flow}], \
-https://github.com/vaadin/vaadin-details/releases/tag/v{moduleNpmVersion:vaadin-details}\[Web Component {moduleNpmVersion:vaadin-details}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-details-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-details-flow}]
+  - https://github.com/vaadin/vaadin-details/releases/tag/v{moduleNpmVersion:vaadin-details}[Web Component {moduleNpmVersion:vaadin-details}]
 ---
 
 = Details

--- a/articles/ds/components/dialog/index.asciidoc
+++ b/articles/ds/components/dialog/index.asciidoc
@@ -2,9 +2,9 @@
 title: Dialog
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-dialog-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-dialog-flow}], \
-https://github.com/vaadin/vaadin-dialog/releases/tag/v{moduleNpmVersion:vaadin-dialog}\[Web Component {moduleNpmVersion:vaadin-dialog}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-dialog-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-dialog-flow}]
+  - https://github.com/vaadin/vaadin-dialog/releases/tag/v{moduleNpmVersion:vaadin-dialog}[Web Component {moduleNpmVersion:vaadin-dialog}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/email-field/index.asciidoc
+++ b/articles/ds/components/email-field/index.asciidoc
@@ -2,9 +2,9 @@
 title: Email Field
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}], \
-https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}\[Web Component {moduleNpmVersion:vaadin-text-field}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Email Field
 

--- a/articles/ds/components/form-layout/index.asciidoc
+++ b/articles/ds/components/form-layout/index.asciidoc
@@ -2,9 +2,9 @@
 title: Form Layout
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}], \
-https://github.com/vaadin/vaadin-form-layout/releases/tag/v{moduleNpmVersion:vaadin-form-layout}\[Web Component {moduleNpmVersion:vaadin-form-layout}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}]
+  - https://github.com/vaadin/vaadin-form-layout/releases/tag/v{moduleNpmVersion:vaadin-form-layout}[Web Component {moduleNpmVersion:vaadin-form-layout}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/grid-pro/index.asciidoc
+++ b/articles/ds/components/grid-pro/index.asciidoc
@@ -2,9 +2,9 @@
 title: Grid Pro
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}], \
-https://github.com/vaadin/vaadin-grid-pro/releases/tag/v{moduleNpmVersion:vaadin-grid-pro}\[Web Component {moduleNpmVersion:vaadin-grid-pro}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}]
+  - https://github.com/vaadin/vaadin-grid-pro/releases/tag/v{moduleNpmVersion:vaadin-grid-pro}[Web Component {moduleNpmVersion:vaadin-grid-pro}]
 section-nav: incomplete, commercial
 ---
 

--- a/articles/ds/components/grid/index.asciidoc
+++ b/articles/ds/components/grid/index.asciidoc
@@ -2,9 +2,9 @@
 title: Grid
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-flow}], \
-https://github.com/vaadin/vaadin-grid/releases/tag/v{moduleNpmVersion:vaadin-grid}\[Web Component {moduleNpmVersion:vaadin-grid}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-flow}]
+  - https://github.com/vaadin/vaadin-grid/releases/tag/v{moduleNpmVersion:vaadin-grid}[Web Component {moduleNpmVersion:vaadin-grid}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/item/index.asciidoc
+++ b/articles/ds/components/item/index.asciidoc
@@ -2,8 +2,8 @@
 title: Item
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-item/releases/tag/v{moduleNpmVersion:vaadin-item}\[Web Component {moduleNpmVersion:vaadin-item}]
+page-links:
+  - https://github.com/vaadin/vaadin-item/releases/tag/v{moduleNpmVersion:vaadin-item}[Web Component {moduleNpmVersion:vaadin-item}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/list-box/index.asciidoc
+++ b/articles/ds/components/list-box/index.asciidoc
@@ -2,9 +2,9 @@
 title: List Box
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-list-box-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-list-box-flow}], \
-https://github.com/vaadin/vaadin-list-box/releases/tag/v{moduleNpmVersion:vaadin-list-box}\[Web Component {moduleNpmVersion:vaadin-list-box}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-list-box-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-list-box-flow}]
+  - https://github.com/vaadin/vaadin-list-box/releases/tag/v{moduleNpmVersion:vaadin-list-box}[Web Component {moduleNpmVersion:vaadin-list-box}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/login/index.asciidoc
+++ b/articles/ds/components/login/index.asciidoc
@@ -2,9 +2,9 @@
 title: Login
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-login-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-login-flow}], \
-https://github.com/vaadin/vaadin-login/releases/tag/v{moduleNpmVersion:vaadin-login}\[Web Component {moduleNpmVersion:vaadin-login}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-login-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-login-flow}]
+  - https://github.com/vaadin/vaadin-login/releases/tag/v{moduleNpmVersion:vaadin-login}[Web Component {moduleNpmVersion:vaadin-login}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/menu-bar/index.asciidoc
+++ b/articles/ds/components/menu-bar/index.asciidoc
@@ -2,9 +2,9 @@
 title: Menu Bar
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}], \
-https://github.com/vaadin/vaadin-menu-bar/releases/tag/v{moduleNpmVersion:vaadin-menu-bar}\[Web Component {moduleNpmVersion:vaadin-menu-bar}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}]
+  - https://github.com/vaadin/vaadin-menu-bar/releases/tag/v{moduleNpmVersion:vaadin-menu-bar}[Web Component {moduleNpmVersion:vaadin-menu-bar}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/notification/index.asciidoc
+++ b/articles/ds/components/notification/index.asciidoc
@@ -2,9 +2,9 @@
 title: Notification
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-notification-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-notification-flow}], \
-https://github.com/vaadin/vaadin-notification/releases/tag/v{moduleNpmVersion:vaadin-notification}\[Web Component {moduleNpmVersion:vaadin-notification}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-notification-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-notification-flow}]
+  - https://github.com/vaadin/vaadin-notification/releases/tag/v{moduleNpmVersion:vaadin-notification}[Web Component {moduleNpmVersion:vaadin-notification}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/number-field/index.asciidoc
+++ b/articles/ds/components/number-field/index.asciidoc
@@ -2,9 +2,9 @@
 title: Number Field
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}], \
-https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}\[Web Component {moduleNpmVersion:vaadin-text-field}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 
 = Number Field

--- a/articles/ds/components/password-field/index.asciidoc
+++ b/articles/ds/components/password-field/index.asciidoc
@@ -2,9 +2,9 @@
 title: Password Field
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}], \
-https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}\[Web Component {moduleNpmVersion:vaadin-text-field}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Password Field
 

--- a/articles/ds/components/progress-bar/index.asciidoc
+++ b/articles/ds/components/progress-bar/index.asciidoc
@@ -2,9 +2,9 @@
 title: Progress Bar
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}], \
-https://github.com/vaadin/vaadin-progress-bar/releases/tag/v{moduleNpmVersion:vaadin-progress-bar}\[Web Component {moduleNpmVersion:vaadin-progress-bar}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}]
+  - https://github.com/vaadin/vaadin-progress-bar/releases/tag/v{moduleNpmVersion:vaadin-progress-bar}[Web Component {moduleNpmVersion:vaadin-progress-bar}]
 ---
 
 = Progress Bar

--- a/articles/ds/components/radio-button/index.asciidoc
+++ b/articles/ds/components/radio-button/index.asciidoc
@@ -2,9 +2,9 @@
 title: Radio Button
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}], \
-https://github.com/vaadin/vaadin-radio-button/releases/tag/v{moduleNpmVersion:vaadin-radio-button}\[Web Component {moduleNpmVersion:vaadin-radio-button}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}]
+  - https://github.com/vaadin/vaadin-radio-button/releases/tag/v{moduleNpmVersion:vaadin-radio-button}[Web Component {moduleNpmVersion:vaadin-radio-button}]
 ---
 
 = Radio Button

--- a/articles/ds/components/rich-text-editor/index.asciidoc
+++ b/articles/ds/components/rich-text-editor/index.asciidoc
@@ -2,9 +2,9 @@
 title: Rich Text Editor
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}], \
-https://github.com/vaadin/vaadin-rich-text-editor/releases/tag/v{moduleNpmVersion:vaadin-rich-text-editor}\[Web Component {moduleNpmVersion:vaadin-rich-text-editor}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}]
+  - https://github.com/vaadin/vaadin-rich-text-editor/releases/tag/v{moduleNpmVersion:vaadin-rich-text-editor}[Web Component {moduleNpmVersion:vaadin-rich-text-editor}]
 section-nav: incomplete, commercial
 ---
 

--- a/articles/ds/components/scroller/index.asciidoc
+++ b/articles/ds/components/scroller/index.asciidoc
@@ -2,9 +2,9 @@
 title: Scroller
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}], \
-https://github.com/vaadin/vaadin-ordered-layout/releases/tag/v{moduleNpmVersion:vaadin-ordered-layout}\[Web Component {moduleNpmVersion:vaadin-ordered-layout}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}]
+  - https://github.com/vaadin/vaadin-ordered-layout/releases/tag/v{moduleNpmVersion:vaadin-ordered-layout}[Web Component {moduleNpmVersion:vaadin-ordered-layout}]
 ---
 = Scroller
 

--- a/articles/ds/components/select/index.asciidoc
+++ b/articles/ds/components/select/index.asciidoc
@@ -2,9 +2,9 @@
 title: Select
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-select-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-select-flow}], \
-https://github.com/vaadin/vaadin-select/releases/tag/v{moduleNpmVersion:vaadin-select}\[Web Component {moduleNpmVersion:vaadin-select}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-select-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-select-flow}]
+  - https://github.com/vaadin/vaadin-select/releases/tag/v{moduleNpmVersion:vaadin-select}[Web Component {moduleNpmVersion:vaadin-select}]
 ---
 
 = Select

--- a/articles/ds/components/split-layout/index.asciidoc
+++ b/articles/ds/components/split-layout/index.asciidoc
@@ -2,9 +2,9 @@
 title: Split Layout
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}], \
-https://github.com/vaadin/vaadin-split-layout/releases/tag/v{moduleNpmVersion:vaadin-split-layout}\[Web Component {moduleNpmVersion:vaadin-split-layout}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}]
+  - https://github.com/vaadin/vaadin-split-layout/releases/tag/v{moduleNpmVersion:vaadin-split-layout}[Web Component {moduleNpmVersion:vaadin-split-layout}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/tabs/index.asciidoc
+++ b/articles/ds/components/tabs/index.asciidoc
@@ -2,9 +2,9 @@
 title: Tabs
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-tabs-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-tabs-flow}], \
-https://github.com/vaadin/vaadin-tabs/releases/tag/v{moduleNpmVersion:vaadin-tabs}\[Web Component {moduleNpmVersion:vaadin-tabs}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-tabs-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-tabs-flow}]
+  - https://github.com/vaadin/vaadin-tabs/releases/tag/v{moduleNpmVersion:vaadin-tabs}[Web Component {moduleNpmVersion:vaadin-tabs}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/components/text-area/index.asciidoc
+++ b/articles/ds/components/text-area/index.asciidoc
@@ -2,9 +2,9 @@
 title: Text Area
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}], \
-https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}\[Web Component {moduleNpmVersion:vaadin-text-field}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Text Area
 

--- a/articles/ds/components/text-field/index.asciidoc
+++ b/articles/ds/components/text-field/index.asciidoc
@@ -2,9 +2,9 @@
 title: Text Field
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}], \
-https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}\[Web Component {moduleNpmVersion:vaadin-text-field}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Text Field
 

--- a/articles/ds/components/time-picker/index.asciidoc
+++ b/articles/ds/components/time-picker/index.asciidoc
@@ -2,9 +2,9 @@
 title: Time Picker
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}], \
-https://github.com/vaadin/vaadin-time-picker/releases/tag/v{moduleNpmVersion:vaadin-time-picker}\[Web Component {moduleNpmVersion:vaadin-time-picker}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}]
+  - https://github.com/vaadin/vaadin-time-picker/releases/tag/v{moduleNpmVersion:vaadin-time-picker}[Web Component {moduleNpmVersion:vaadin-time-picker}]
 ---
 
 = Time Picker

--- a/articles/ds/components/upload/index.asciidoc
+++ b/articles/ds/components/upload/index.asciidoc
@@ -2,9 +2,9 @@
 title: Upload
 layout: tabbed-page
 tab-title: Usage
-page-links: \
-https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-upload-flow}\[Flow {moduleMavenVersion:com.vaadin:vaadin-upload-flow}], \
-https://github.com/vaadin/vaadin-upload/releases/tag/v{moduleNpmVersion:vaadin-upload}\[Web Component {moduleNpmVersion:vaadin-upload}]
+page-links:
+  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-upload-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-upload-flow}]
+  - https://github.com/vaadin/vaadin-upload/releases/tag/v{moduleNpmVersion:vaadin-upload}[Web Component {moduleNpmVersion:vaadin-upload}]
 section-nav: incomplete
 ---
 

--- a/articles/ds/foundation/color/index.asciidoc
+++ b/articles/ds/foundation/color/index.asciidoc
@@ -3,9 +3,9 @@ title: Color
 tab-title: Lumo
 layout: tabbed-page
 order: 20
-page-links: \
-https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/color.html[Source], \
-https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=714%3A3821[Figma Library]
+page-links:
+  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/color.html[Source]
+  - https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=714%3A3821[Figma Library]
 ---
 
 = Lumo Color

--- a/articles/ds/foundation/color/material.asciidoc
+++ b/articles/ds/foundation/color/material.asciidoc
@@ -1,7 +1,7 @@
 ---
 title: Material
-page-links: \
-https://github.com/vaadin/vaadin-material-styles/blob/v{moduleNpmVersion:vaadin-material-styles}/color.html[Source]
+page-links:
+  - https://github.com/vaadin/vaadin-material-styles/blob/v{moduleNpmVersion:vaadin-material-styles}/color.html[Source]
 ---
 
 = Material Color

--- a/articles/ds/foundation/elevation.asciidoc
+++ b/articles/ds/foundation/elevation.asciidoc
@@ -1,9 +1,9 @@
 ---
 title: Elevation
 order: 50
-page-links: \
-https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/style.html[Source], \
-https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=20%3A1[Figma Library]
+page-links:
+  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/style.html[Source]
+  - https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=20%3A1[Figma Library]
 ---
 
 = Elevation

--- a/articles/ds/foundation/icons/index.asciidoc
+++ b/articles/ds/foundation/icons/index.asciidoc
@@ -3,9 +3,9 @@ title: Icons
 layout: tabbed-page
 tab-title: Lumo Icons
 order: 70
-page-links: \
-https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/iconset.html[Source], \
-https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=1343%3A3247[Figma Library]
+page-links:
+  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/iconset.html[Source]
+  - https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=1343%3A3247[Figma Library]
 ---
 
 = Lumo Icons

--- a/articles/ds/foundation/interaction.asciidoc
+++ b/articles/ds/foundation/interaction.asciidoc
@@ -1,8 +1,8 @@
 ---
 title: Interaction
 order: 60
-page-links: \
-https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/style.html[Source]
+page-links:
+  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/style.html[Source]
 ---
 
 = Interaction

--- a/articles/ds/foundation/shape.asciidoc
+++ b/articles/ds/foundation/shape.asciidoc
@@ -1,8 +1,8 @@
 ---
 title: Shape
 order: 40
-page-links: \
-https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/style.html[Source]
+page-links:
+  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/style.html[Source]
 ---
 
 = Shape

--- a/articles/ds/foundation/size-space.asciidoc
+++ b/articles/ds/foundation/size-space.asciidoc
@@ -1,9 +1,9 @@
 ---
 title: Size and Space
 order: 30
-page-links: \
-https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/sizing.html[Source (size)], \
-https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/spacing.html[Source (space)]
+page-links:
+  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/sizing.html[Source (size)]
+  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/spacing.html[Source (space)]
 ---
 
 = Size and Space

--- a/articles/ds/foundation/typography/index.asciidoc
+++ b/articles/ds/foundation/typography/index.asciidoc
@@ -3,9 +3,9 @@ title: Typography
 tab-title: Lumo
 layout: tabbed-page
 order: 10
-page-links: \
-https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/typography.html[Source], \
-https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=20%3A2[Figma Library]
+page-links:
+  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/typography.html[Source]
+  - https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=20%3A2[Figma Library]
 ---
 
 = Lumo Typography

--- a/articles/index.asciidoc
+++ b/articles/index.asciidoc
@@ -2,7 +2,8 @@
 root: true
 title: Docs
 layout: index
-page-links: https://github.com/vaadin/platform/releases/tag/{moduleMavenVersion:com.vaadin:vaadin}[{moduleMavenVersion:com.vaadin:vaadin}]
+page-links:
+  - https://github.com/vaadin/platform/releases/tag/{moduleMavenVersion:com.vaadin:vaadin}[{moduleMavenVersion:com.vaadin:vaadin}]
 ---
 
 = Develop Web Apps on Java Backends


### PR DESCRIPTION
Front matter is parsed as YAML after https://github.com/vaadin/docs-app/pull/228 is merged.

Update all existing page-links to use YAML array format. The current formatting causes the build to fail.