### PR TITLE
Fix the code example Broadcaster

### DIFF
--- a/articles/framework/advanced/advanced-push.asciidoc
+++ b/articles/framework/advanced/advanced-push.asciidoc
@@ -304,23 +304,23 @@ public class Broadcaster implements Serializable {
     public interface BroadcastListener {
         void receiveBroadcast(String message);
     }
-    
-    private static LinkedList<BroadcastListener> listeners =
-        new LinkedList<BroadcastListener>();
-    
+
+    private static WeakHashMap<BroadcastListener, Object> listeners =
+        new WeakHashMap<BroadcastListener, Object>();
+
     public static synchronized void register(
             BroadcastListener listener) {
-        listeners.add(listener);
+        listeners.put(listener, null);
     }
-    
+
     public static synchronized void unregister(
             BroadcastListener listener) {
         listeners.remove(listener);
     }
-    
+
     public static synchronized void broadcast(
             final String message) {
-        for (final BroadcastListener listener: listeners)
+        for (final BroadcastListener listener: listeners.keySet())
             executorService.execute(new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
The old version leaks memory as listeners are effectively UI's.

See also: https://vaadin.com/forum/thread/18546873/messagebroadcaster-memory-leak