### PR TITLE
docs: fix typos in LitElement basics

### DIFF
--- a/articles/fusion/application/lit-element.asciidoc
+++ b/articles/fusion/application/lit-element.asciidoc
@@ -143,7 +143,7 @@ This callback is invoked each time the element is connected to the DOM.
 +
 In most cases, the `connectedCallback` is used for setting up component-level event listeners, etc.
 +
-.Use <<first-updated,`first-updated`>> callback to execute the code after the first render
+.Use <<first-updated,`firstUpdated`>> callback to execute the code after the first render
 [NOTE]
 Since `render` is asynchronous it does not over when the `connectedCallback` finishes.
 +
@@ -181,7 +181,7 @@ It receives an object that contains all changed properties.
 *Specificity*: LitElement
 +
 This callback is invoked after each render; for the first render, it is invoked right after the `firstUpdated` callback.
-Just like `firstUpdate`, it receives an object that contains all properties changed after the previous render.
+Just like `firstUpdated`, it receives an object that contains all properties changed after the previous render.
 
 [source,typescript]
 ----


### PR DESCRIPTION
Corrected two small typos related to `firstUpdated` lifecycle callback.