### PR TITLE
Fix @import instructions

### DIFF
--- a/articles/ds/customization/custom-theme.asciidoc
+++ b/articles/ds/customization/custom-theme.asciidoc
@@ -72,7 +72,7 @@ The master style sheet typically contains:
 .`styles.css`
 [source, CSS]
 ----
-@import other-styles.css        <1>
+@import 'other-styles.css';     <1>
 
 html, :host {                   <2>
   --lumo-border-radius: 0.5em; 


### PR DESCRIPTION
The example for using imports is 
```css
@import other-styles.css
```
However import doesn't work if you don't:
1. quote the file
2. add a ; at the end.

The format that works is 
```css
@import 'other-styles.css';     
```