### PR TITLE
Update the quick start tutorial so all code samples can be copy-pastes without syntax errors.

### DIFF
--- a/articles/fusion/application/state-management.asciidoc
+++ b/articles/fusion/application/state-management.asciidoc
@@ -73,7 +73,7 @@ This is a link:https://mobx.js.org/observable-state.html#limitations[MobX limita
 == Using a Store
 
 .`my-view.ts`
-[source,typescript,subs="callouts+"]
+[source,typescript]
 ----
 import { customElement, html } from 'lit-element';
 import '@vaadin/vaadin-text-field/vaadin-text-field';

--- a/articles/fusion/tutorials/quick-start-tutorial.asciidoc
+++ b/articles/fusion/tutorials/quick-start-tutorial.asciidoc
@@ -257,7 +257,7 @@ import '@vaadin/vaadin-text-field';
 import '@vaadin/vaadin-button';
 import '@vaadin/vaadin-checkbox';
 import { Binder, field } from '@vaadin/form';
-import { TodoEndpoint } from 'Frontend/generated/TodoEndpoint';
+import * as TodoEndpoint from 'Frontend/generated/TodoEndpoint';
 import Todo from 'Frontend/generated/com/example/application/data/entity/Todo';
 import TodoModel from 'Frontend/generated/com/example/application/data/entity/TodoModel';
 
@@ -319,13 +319,12 @@ return html`
    <div class="form">
     <vaadin-text-field
       ...=${field(this.binder.model.task)}
-    ></vaadin-text-field> <1>
+    ></vaadin-text-field> <!-- 1 -->
     <vaadin-button
       theme="primary"
-      @click=${this.createTodo} <2>
-      ?disabled=${this.binder.invalid} <3>
-      >Add</vaadin-button
-    >
+      @click=${this.createTodo /* <2> */}
+      ?disabled=${this.binder.invalid /* <3> */}
+      >Add</vaadin-button>
    </div>
 `;
 ----
@@ -341,10 +340,10 @@ Right underneath the previous `<div>`, add the following code:
 ----
 return html`
    <div class="todos">
-    ${this.todos.map((todo) => html` <1>
+    ${this.todos.map((todo) => html` <!-- 1 -->
         <div class="todo">
           <vaadin-checkbox
-            ?checked=${todo.done} <2>
+            ?checked=${todo.done} <!-- 2 -->
             @checked-changed=${(e: CustomEvent) => // <3>
               this.updateTodoState(todo, e.detail.value)}
           ></vaadin-checkbox>
@@ -398,8 +397,8 @@ Finally, add a method for updating the `todo` state right below `createTodo()`:
 ----
 updateTodoState(todo: Todo, done: boolean) {
  const updatedTodo = { ...todo, done }; // <1>
- this.todos = this.todos.map((t) => (t.id === todo.id ? updatedTodo : t)); //<2>
- TodoEndpoint.save(updatedTodo); //<3>
+ this.todos = this.todos.map((t) => (t.id === todo.id ? updatedTodo : t)); // <2>
+ TodoEndpoint.save(updatedTodo); // <3>
 }
 ----
 <1> Create a new `Todo` with the updated `done` state.
@@ -426,7 +425,7 @@ import '@vaadin/vaadin-text-field';
 import '@vaadin/vaadin-button';
 import '@vaadin/vaadin-checkbox';
 import { Binder, field } from '@vaadin/form';
-import { TodoEndpoint } from 'Frontend/generated/TodoEndpoint';
+import * as TodoEndpoint from 'Frontend/generated/TodoEndpoint';
 import Todo from 'Frontend/generated/com/example/application/data/entity/Todo';
 import TodoModel from 'Frontend/generated/com/example/application/data/entity/TodoModel';
 

--- a/articles/fusion/tutorials/quick-start-tutorial.asciidoc
+++ b/articles/fusion/tutorials/quick-start-tutorial.asciidoc
@@ -99,7 +99,7 @@ The starter you download already includes the needed dependencies in `pom.xml`.
 Define a JPA _entity_ class for the data model, by creating a new `Todo.java` file in `src/main/java/com/example/application/data/entity` with the following content:
 
 .`Todo.java`
-[source,java,subs="callouts+"]
+[source,java]
 ----
 package com.example.application.data.entity;
 
@@ -149,7 +149,7 @@ You only need to provide an interface with type information, Spring Data takes c
 Create a new file, `TodoRepository.java`, in `src/main/java/com/example/application/data/service` with the following contents:
 
 .`TodoRepository.java`
-[source,java,subs="callouts+"]
+[source,java]
 ----
 package com.example.application.data.service;
 
@@ -188,7 +188,7 @@ Having full-stack type safety helps you stay productive through autocomplete and
 Create a new `TodoEndpoint.java` file in `src/main/java/com/example/application/data/endpoint`:
 
 .`TodoEndpoint.java`
-[source,java,subs="callouts+"]
+[source,java]
 ----
 package com.example.application.data.endpoint;
 
@@ -242,7 +242,7 @@ Now that you know the basics of reactive UI programming and LitElement, you are 
 
 Open `frontend/views/todo/todo-view.ts` and replace its contents with the following:
 
-[source,typescript,subs="callouts+"]
+[source,typescript]
 ----
 import {
  // <1>
@@ -273,7 +273,7 @@ export class TodoView extends LitElement { // <3>
 
 Inside the `TodoView` class, define the view state as follows:
 
-[source,typescript,subs="callouts+"]
+[source,typescript]
 ----
  @internalProperty()
  private todos: Todo[] = []; // <1>
@@ -292,11 +292,11 @@ Read more about forms in <<../forms/overview#,Creating Client-Side Forms>>.
  static styles = css`
    :host {
      display: block;
-     padding: var(--lumo-space-m) var(--lumo-space-l); /*<1>*/
+     padding: var(--lumo-space-m) var(--lumo-space-l); /* <1> */
    }
  `;
 ----
-<1>The `padding` property is defined using the <<{articles}/ds/foundation/size-space#space,spacing properties>> to be consistent with the rest of the app.
+<1> The `padding` property is defined using the <<{articles}/ds/foundation/size-space#space,spacing properties>> to be consistent with the rest of the app.
 
 === Defining the HTML Template
 
@@ -313,13 +313,13 @@ render() {
 
 Add the following code within the `html` template:
 
-[source, typescript, subs="callouts+"]
+[source, typescript]
 ----
 return html`
    <div class="form">
     <vaadin-text-field
       ...=${field(this.binder.model.task)}
-    ></vaadin-text-field> <!-- 1 -->
+    ></vaadin-text-field> <!--1-->
     <vaadin-button
       theme="primary"
       @click=${this.createTodo /* <2> */}
@@ -336,14 +336,14 @@ You can read more about forms in <<../forms/overview#,Creating Client-Side Forms
 
 Right underneath the previous `<div>`, add the following code:
 
-[source, typescript, subs="callouts+"]
+[source, typescript]
 ----
 return html`
    <div class="todos">
-    ${this.todos.map((todo) => html` <!-- 1 -->
+    ${this.todos.map((todo) => html` <!--1-->
         <div class="todo">
           <vaadin-checkbox
-            ?checked=${todo.done} <!-- 2 -->
+            ?checked=${todo.done /* <2> */}
             @checked-changed=${(e: CustomEvent) => // <3>
               this.updateTodoState(todo, e.detail.value)}
           ></vaadin-checkbox>
@@ -362,7 +362,7 @@ The template for a single `Todo` contains a checkbox and the task text.
 
 Below the `render()` method in the `TodoView` class, add a `connectedCallback()` https://lit-element.polymer-project.org/guide/lifecycle[lifecycle callback] to initialize the view when it is attached to the DOM.
 
-[source, typescript, subs="callouts+"]
+[source, typescript]
 ----
 async connectedCallback() { // <1>
  super.connectedCallback(); // <2>
@@ -377,7 +377,7 @@ The `await` keyword waits for the server response without blocking the UI.
 
 Below the connectedCallback(), add another method to handle the creation of new `Todo`s.
 
-[source, typescript, subs="callouts+"]
+[source, typescript]
 ----
 async createTodo() {
  const createdTodo = await this.binder.submitTo(TodoEndpoint.save); // <1>
@@ -393,7 +393,7 @@ The binder validates the input before posting it and the server re-validates it.
 
 Finally, add a method for updating the `todo` state right below `createTodo()`:
 
-[source, typescript, subs="callouts+"]
+[source, typescript]
 ----
 updateTodoState(todo: Todo, done: boolean) {
  const updatedTodo = { ...todo, done }; // <1>
@@ -411,7 +411,7 @@ The `map` operator creates a new array where the changed `todo` is swapped out.
 The completed view code is as follows:
 
 .`todo-view.ts`
-[source,typescript,subs="callouts+"]
+[source,typescript]
 ----
 import {
  LitElement,
@@ -506,8 +506,8 @@ image::../images/quickstart-running-2.png[Running project]
 
 == Optional: Deploy the Application to Heroku
 
-The following steps are optional. 
-You can follow them to deploy your application to https://www.heroku.com/[Heroku], a cloud deployment platform that offers a free tier that does not require a credit card. 
+The following steps are optional.
+You can follow them to deploy your application to https://www.heroku.com/[Heroku], a cloud deployment platform that offers a free tier that does not require a credit card.
 
 include::_heroku-steps.adoc[leveloffset=+1]
 


### PR DESCRIPTION
The problems were detected when running tests with Studio.