### PR TITLE
fix: remove quotation marks from the generated .env file

### DIFF
--- a/scripts/dspublisher-init.js
+++ b/scripts/dspublisher-init.js
@@ -33,11 +33,11 @@ module.exports = async function(config) {
 
   // Create the env file for dspublisher
   const envVariables = [
-    `DOCS_ARTICLES_PATH="articles/ds"`,
-    `DOCS_THEME_PATH="${relativeThemePath}"`,
-    `DOCS_TITLE="${config.dsName}"`,
-    'DOCS_IMPORT_EXAMPLE_RESOURCES="true"',
-    'DOCS_IMPORT_HEADER_IN_DEV="true"'
+    `DOCS_ARTICLES_PATH=articles/ds`,
+    `DOCS_THEME_PATH=${relativeThemePath}`,
+    `DOCS_TITLE=${config.dsName}`,
+    'DOCS_IMPORT_EXAMPLE_RESOURCES=true',
+    'DOCS_IMPORT_HEADER_IN_DEV=true',
   ];
   fs.writeFileSync(path.resolve(ROOT, 'dspublisher/.env'), envVariables.join('\n'));
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/docs-app/issues/249