### PR TITLE
fix: remove dspublisher generated files

### DIFF
--- a/dspublisher/docker-compose.build.yml
+++ b/dspublisher/docker-compose.build.yml
@@ -15,7 +15,7 @@ services:
       - DOCS_TITLE=${DOCS_TITLE}
       - DOCS_VERSIONS_URL=${DOCS_VERSIONS_URL}
       - DOCS_SITE_URL=${DOCS_SITE_URL}
-    command: "sh -c 'npm run dspublisher:build && cp -r /docs-app/public /out/'"
+    command: "sh -c 'npm run dspublisher:build && rm -rf /out/public && cp -r /docs-app/public /out/'"
     volumes:
       - ~/.m2:/root/.m2
       - ..:/docs
@@ -25,7 +25,7 @@ services:
   docs:
     image: vaadin/dspublisher:latest
     working_dir: /docs
-    command: "sh -c 'mvn clean package -DskipTests -Pproduction && cp -r /docs/target/*.jar /out/'"
+    command: "sh -c 'mvn clean package -DskipTests -Pproduction && rm -rf /out/*.jar && cp -r /docs/target/*.jar /out/'"
     volumes:
       - ~/.m2:/root/.m2
       - ./out:/out

--- a/dspublisher/docker-compose.rmtarget.yml
+++ b/dspublisher/docker-compose.rmtarget.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  rmtarget:
+    image: vaadin/dspublisher:latest
+    command: "rm -rf /docs/target"
+    volumes:
+      - ..:/docs

--- a/package.json
+++ b/package.json
@@ -178,8 +178,9 @@
   },
   "scripts": {
     "lint": "eslint --ignore-path .gitignore ./frontend --ext ts --ext js --ext json",
-    "dspublisher:license-check": "mvn -P dspublisher-license-check && mvn clean",
-    "dspublisher:clean": "rm -rf target && docker-compose -f dspublisher/docker-compose.develop.yml down -v && docker-compose -f dspublisher/docker-compose.build.yml down -v",
+    "dspublisher:license-check": "npm run dspublisher:rmtarget && mvn -P dspublisher-license-check && mvn clean",
+    "dspublisher:rmtarget": "docker-compose -f dspublisher/docker-compose.rmtarget.yml up",
+    "dspublisher:clean": "npm run dspublisher:rmtarget && docker-compose -f dspublisher/docker-compose.develop.yml down -v && docker-compose -f dspublisher/docker-compose.build.yml down -v",
     "dspublisher:start": "npm run dspublisher:license-check && (cd dspublisher && docker-compose -f docker-compose.develop.yml up)",
     "dspublisher:build": "npm run dspublisher:license-check && (cd dspublisher && docker-compose -f docker-compose.build.yml up)"
   },


### PR DESCRIPTION
Fixes https://github.com/vaadin/docs-app/issues/250

This PR adds a docker-compose file whose sole purpose is to remove the `docs/target` dir before running the license check. This is needed on Linux hosts, where the generated target files get owned by the root user and so can't be changed by the current user.

Also, any existing build artifacts under `dspublisher/out` get cleaned up on build.