### PR TITLE
refactor: improve the dsp deployment example

### DIFF
--- a/dspublisher/deployment-example-docker/docker-compose.yml
+++ b/dspublisher/deployment-example-docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
     links:
       - docs
 

--- a/dspublisher/deployment-example-docker/docs-app.Dockerfile
+++ b/dspublisher/deployment-example-docker/docs-app.Dockerfile
@@ -1,7 +1,3 @@
-FROM node:14-alpine
+FROM nginx:1.19.9-alpine
 
-RUN npm i -g light-server@2.9.1
-
-COPY out/public /pub
-
-CMD light-server -s /pub -p 80 -x http://docs:8080 --proxypath "/vaadin" --proxypath "/connect"
+COPY out/public /usr/share/nginx/html

--- a/dspublisher/deployment-example-docker/nginx.conf
+++ b/dspublisher/deployment-example-docker/nginx.conf
@@ -1,0 +1,21 @@
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+      listen 80;
+      root /usr/share/nginx/html;
+      error_page 404 /404/index.html;
+
+      location /connect/ {
+          proxy_pass http://docs:8080/connect/;
+      }
+
+      location /vaadin/ {
+          proxy_pass http://docs:8080/vaadin/;
+      }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/vaadin/docs-app/issues/246

This PR improves the deployment example generated for custom documentation projects:
- changed from light-server to more customizable nginx
- 404 page works as expected
- removed trailing slashes work out of the box