### PR TITLE
Make MessageService a class to fix Spring DI

### DIFF
--- a/src/main/java/com/vaadin/demo/domain/MessageService.java
+++ b/src/main/java/com/vaadin/demo/domain/MessageService.java
@@ -6,8 +6,11 @@ import java.util.stream.Stream;
 import com.vaadin.flow.spring.annotation.SpringComponent;
 
 @SpringComponent
-public interface MessageService {
-    Stream<Message> findAllByTopicSince(String topic, Instant since);
+public class MessageService {
+    public Stream<Message> findAllByTopicSince(String topic, Instant since) {
+        return null;
+    }
 
-    void save(Message message);
+    public void save(Message message) {
+    }
 }


### PR DESCRIPTION
It breaks currently Flow component demos, because when switching to Java examples, Spring tries to inject the dependencies of MyMessagePerister, although that's part of the CE docs and not related to component demos.