### PR TITLE
Remove deprication in V19 -tag from V14 instructions

### DIFF
--- a/articles/ce/tutorial.asciidoc
+++ b/articles/ce/tutorial.asciidoc
@@ -28,7 +28,6 @@ Visit the <<going-to-production#, Setting up for production>> section of our doc
 Download a new Vaadin project from https://start.vaadin.com/?preset=lts.
 
 [[ce.tutorial.install]]
-[role="deprecated:com.vaadin:vaadin@V19"]
 === Installing Collaboration Engine
 
 Collaboration Engine is a dependency that you add to your Vaadin project.


### PR DESCRIPTION
Remove deprection tag from V14 instructions. It notes that something has changed in V19, which should not be relevant in any way for a developer reading instructions for V14 specifically. The `latest` branch already has better instructions for this.