### PR TITLE
fix: Correct sample for asset url in css

### DIFF
--- a/articles/ds/customization/custom-theme-configuration.asciidoc
+++ b/articles/ds/customization/custom-theme-configuration.asciidoc
@@ -108,7 +108,7 @@ The SVG images mapped by the example above are now available on the path `fontaw
 [source,css]
 ----
 .icon-snowflake {
-  background-image: url('fontawesome/icons/snowflake.svg');
+  background-image: url('./fontawesome/icons/snowflake.svg');
 }
 ----
 
@@ -120,7 +120,7 @@ The assets block supports multiple packages and multiple mappings per package.
 {
   "assets": {
     "@fortawesome/fontawesome-free": {
-      "svgs/regular/**": "fortawesome/icons",
+      "svgs/regular/**": "fontawesome/icons",
       "webfonts/**": "webfonts"
     },
     "@fortawesome/free-solid-svg-icons": {


### PR DESCRIPTION
Update the sample for using a node asset
in css to be correct.

part of vaadin/flow#10426