### PR TITLE
fix: remove 'incomplete' icon for button and form-layout

### DIFF
--- a/articles/ds/components/button/index.asciidoc
+++ b/articles/ds/components/button/index.asciidoc
@@ -5,7 +5,6 @@ tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-button-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-button-flow}]
   - https://github.com/vaadin/vaadin-button/releases/tag/v{moduleNpmVersion:vaadin-button}[Web Component {moduleNpmVersion:vaadin-button}]
-section-nav: incomplete
 ---
 
 = Button

--- a/articles/ds/components/form-layout/index.asciidoc
+++ b/articles/ds/components/form-layout/index.asciidoc
@@ -5,7 +5,6 @@ tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}]
   - https://github.com/vaadin/vaadin-form-layout/releases/tag/v{moduleNpmVersion:vaadin-form-layout}[Web Component {moduleNpmVersion:vaadin-form-layout}]
-section-nav: incomplete
 ---
 
 = Form Layout


### PR DESCRIPTION
The 'incomplete' icon appears next to a component in the navigation menu for those components that have neither Java nor TS examples in the new docs site. This is no longer the case for button and form-layout, so let's remove the icon for them.