### PR TITLE
fix: add WiP note to the board page

### DIFF
--- a/articles/ds/components/board/index.asciidoc
+++ b/articles/ds/components/board/index.asciidoc
@@ -21,8 +21,8 @@ It reorders the components inside it on different screen sizes while maximising 
 .Work In Progress
 [NOTE]
 ====
-The usage examples for this component are currently in progress.
-In the meantime, you can view the previous examples for the web component, and the Java/Flow component.
+The Java examples for this component are currently in progress.
+In the meantime, you can view the previous examples.
 
 [.buttons]
 - https://vaadin.com/components/vaadin-board/java-examples[Java Component Examples]

--- a/articles/ds/components/board/index.asciidoc
+++ b/articles/ds/components/board/index.asciidoc
@@ -18,6 +18,16 @@ Board is a powerful and easy to use layout element for building responsive views
 It reorders the components inside it on different screen sizes while maximising the use of available space.
 // end::description[]
 
+.Work In Progress
+[NOTE]
+====
+The usage examples for this component are currently in progress.
+In the meantime, you can view the previous examples for the web component, and the Java/Flow component.
+
+[.buttons]
+- https://vaadin.com/components/vaadin-board/java-examples[Java Component Examples]
+====
+
 [.example]
 --
 


### PR DESCRIPTION
The WiP note should be present on the pages that have either TS or Java examples missing. Board is missing Java examples, and therefore should have the WiP note.