### PR TITLE
CP clarify document.css usages in theming embedded components

### DIFF
--- a/articles/flow/styling/custom-theme.asciidoc
+++ b/articles/flow/styling/custom-theme.asciidoc
@@ -161,6 +161,10 @@ These assets can be used in the theme’s style sheets through URIs relative to 
 To ensure that certain styles are always applied to the document root rather than the shadow root of an embedded Flow application or component, they can be placed in a special style sheet in the theme folder root called [filename]#document.css#.
 This is mainly needed for `@font-face` declarations that are not supported inside web component shadow DOM, and only when the theme is going to be used with <<{articles}/flow/integrations/embedding/tutorial-webcomponent-intro#, embedded Flow applications or components>> inside another application or used with Design System Publisher.
 
+Another example is when the theme should be applied to an <<{articles}/flow/integrations/embedding/overview#,embedded Flow application or component>> which is shown in an overlay inside another application.
+Since the overlay cannot access the styles from web component shadow DOM, the styles must also be added to the [filename]#document.css#.
+To avoid copy-pasting such styles in two places, move them into a separate style sheet and use `@import` to include them in both [filename]#styles.css# and [filename]#document.css#.
+
 == Style Loading Order
 
 When using a custom theme, CSS is loaded in a Vaadin application in the following order:
@@ -179,4 +183,3 @@ Custom themes are always loaded on top of the Lumo theme.
 * At the moment all @import statements need to be in style sheets in the theme root folder.
 
 See https://github.com/vaadin/flow/issues/9794[Vaadin Flow issue 9794].
-

--- a/articles/flow/styling/custom-theme.asciidoc
+++ b/articles/flow/styling/custom-theme.asciidoc
@@ -161,7 +161,7 @@ These assets can be used in the theme’s style sheets through URIs relative to 
 To ensure that certain styles are always applied to the document root rather than the shadow root of an embedded Flow application or component, they can be placed in a special style sheet in the theme folder root called [filename]#document.css#.
 This is mainly needed for `@font-face` declarations that are not supported inside web component shadow DOM, and only when the theme is going to be used with <<{articles}/flow/integrations/embedding/tutorial-webcomponent-intro#, embedded Flow applications or components>> inside another application or used with Design System Publisher.
 
-Another example is when the theme should be applied to an <<{articles}/flow/integrations/embedding/overview#,embedded Flow application or component>> which is shown in an overlay inside another application.
+Another example is when the theme should be applied to an <<{articles}/flow/integrations/embedding/tutorial-webcomponent-intro#, embedded Flow application or component>> which is shown in an overlay inside another application.
 Since the overlay cannot access the styles from web component shadow DOM, the styles must also be added to the [filename]#document.css#.
 To avoid copy-pasting such styles in two places, move them into a separate style sheet and use `@import` to include them in both [filename]#styles.css# and [filename]#document.css#.
 


### PR DESCRIPTION
* fix: clarify more on document.css usages in theming embedded components (#398)