### PR TITLE
fix: Update how MPR annotations are given

### DIFF
--- a/articles/tools/mpr/configuration/custom-ui.asciidoc
+++ b/articles/tools/mpr/configuration/custom-ui.asciidoc
@@ -27,17 +27,16 @@ public class MyCustomUI extends MprUI {
 You need to call `super.init(request)` if you need to override the init method
 
 Then you need to tell the application that this class should be used with the
-annotation `@LegacyUI()`.
+annotation `@LegacyUI()` by defining it in a class implementing `AppShellConfigurator`.
 
 [source,java]
 ----
-@Route("")
 @LegacyUI(MyCustomUI.class)
-public class MainLayout extends Div {
+public class Configuration implements AppShellConfigurator {
 }
 ----
 
-Now when navigating to the "" (root) route you will get a MyCustomUI instead of the
+Now using the application you will get a MyCustomUI instead of the
 default MprUI.
 
 <<../overview#,<- Go back to the overview>>

--- a/articles/tools/mpr/configuration/legacy-theme.asciidoc
+++ b/articles/tools/mpr/configuration/legacy-theme.asciidoc
@@ -7,12 +7,8 @@ layout: page
 = Legacy theme in MPR
 
 By default the theme used with MPR is 'valo' and this can be changed with
-adding the `MprTheme` annotation with the wanted theme name to your root navigation
-level, RouterLayout or to the top level @Route.
-
-The closest instance found will be used for first initialization for
-a `UI` instance, but the recommendation would be to put it always on the
-top most `RouterLayout` in the view chain.
+adding the `MprTheme` annotation with the wanted theme name to your `AppShellConfigurator`
+configuration class.
 
 [NOTE]
 Runtime changing of the theme is not supported
@@ -21,6 +17,9 @@ Runtime changing of the theme is not supported
 [source,java]
 ----
 @MprTheme("reindeer")
+public class Configuration implements AppShellConfigurator {
+}
+
 public class MainLayout extends Div implements RouterLayout {
 }
 

--- a/articles/tools/mpr/configuration/legacy-widgetset.asciidoc
+++ b/articles/tools/mpr/configuration/legacy-widgetset.asciidoc
@@ -17,17 +17,16 @@ When using MPR you can not use CDN for the widgetset. This means that the config
 `<vaadin.widgetset.mode>cdn</vaadin.widgetset.mode>` should be removed.
 
 To use a custom widgetset for the legacy framework embedded with MPR,
-just add `MprWidgetset` annotation to your root navigation level,
-RouterLayout or to the top level @Route.
-
-The closest instance found
-will be used for first initialization for a `UI` instance, but the recommendation
-would be to put it always on the top most `RouterLayout` in the view chain.
+just add `MprWidgetset` annotation to your `AppShellConfigurator`
+configuration class.
 
 .Sample widgetset definition
 [source,java]
 ----
 @MprWidgetset("com.vaadin.mpr.DemoWidgetset")
+public class Configuration implements AppShellConfigurator {
+}
+
 public class MainLayout extends Div implements RouterLayout {
 }
 


### PR DESCRIPTION
Since all other annotations should be on the
AppShellConfiguration implementation class
in v19+ also MPR should only look for the
annotations on the configuration class.

part of vaadin/multiplatform-runtime#83