### PR TITLE
fix: do not give false hope on bundle splitting

### DIFF
--- a/articles/guide/production/index.asciidoc
+++ b/articles/guide/production/index.asciidoc
@@ -91,7 +91,7 @@ This makes the application load faster.
 
 == Splitting the Webpack Bundle Into Multiple Chunks
 
-This is an upcoming feature for a Vaadin Platform 14.x minor release, probably during 2020. For information on customizing bundling when using compatibility mode, see the https://vaadin.com/docs/v13/flow/production/tutorial-production-mode-customising.html[Vaadin 13 documentation on this topic]. You can follow & comment on https://github.com/vaadin/flow/issues/5537 if this is important for you.
+This is not currently possible. In case it would be important for you to be able to split the bundle, please let us know in the issue: https://github.com/vaadin/flow/issues/5537.
 
 == Plugin Goals and Goal Parameters
 


### PR DESCRIPTION
As it is not on the roadmap at the moment.