### PR TITLE
fix: use date-fns for parsing/formatting, reuse editor instance

### DIFF
--- a/frontend/demo/component/gridpro/grid-pro-editors.ts
+++ b/frontend/demo/component/gridpro/grid-pro-editors.ts
@@ -10,6 +10,7 @@ import { getPeople } from 'Frontend/demo/domain/DataService';
 import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 import { GridColumnElement, GridItemModel } from '@vaadin/vaadin-grid';
+import { format, parseISO } from 'date-fns';
 
 @customElement('grid-pro-editors')
 export class Example extends LitElement {
@@ -43,24 +44,29 @@ export class Example extends LitElement {
         <vaadin-grid-pro-edit-column
           path="birthday"
           .renderer="${(root: HTMLElement, _column?: GridColumnElement, model?: GridItemModel) => {
-            if (model?.item) {
-              const person = model.item as Person;
-              const birthday = new Date(`${person.birthday} 00:00.0000`).toLocaleDateString();
-              root.textContent = birthday;
+            if (!model) {
+              return;
             }
+            const person = model.item as Person;
+            root.textContent = format(parseISO(person.birthday), 'MM/dd/yyyy');
           }}"
           .editModeRenderer="${(
             root: HTMLElement,
             _column?: GridColumnElement,
             model?: GridItemModel
           ) => {
-            root.innerHTML = '';
-            const datePicker = document.createElement('vaadin-date-picker');
-            if (model?.item) {
-              const person = model.item as Person;
-              datePicker.value = person.birthday;
+            if (!model) {
+              return;
             }
-            root.appendChild(datePicker);
+            const person = model.item as Person;
+
+            let datePicker = root.querySelector('vaadin-date-picker');
+            if (!datePicker) {
+              root.innerHTML = '';
+              datePicker = document.createElement('vaadin-date-picker');
+              root.appendChild(datePicker);
+            }
+            datePicker.value = person.birthday;
           }}"
         ></vaadin-grid-pro-edit-column>
       </vaadin-grid-pro>


### PR DESCRIPTION
## Description

Fixes the custom renderers in Grid Pro - Recommended Built-in Editors example:
- Use date-fns for parsing/formatting
  - Aligned the date format of the representation in the column with the default format of vaadin-date-picker
- Reuse an editor component instance in the edit renderer, if one exists

Fixes #441 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.