### PR TITLE
Fix the link between v14 docs and latest

### DIFF
--- a/articles/flow/styling/lumo/icons.asciidoc
+++ b/articles/flow/styling/lumo/icons.asciidoc
@@ -10,7 +10,7 @@ Lumo comes with a set of icons that are designed to fit in with the default Lumo
 
 == Available Icons
 
-You can browse the icon set in the link:../../../latest/ds/foundation/icons[latest documentation, role=skip-xref-check].
+You can browse the icon set in the link:../../../../../latest/ds/foundation/icons[latest documentation, role=skip-xref-check].
 
 == Icons Size
 


### PR DESCRIPTION
Fix the relative link between v14 and latest.
Currently it's https://vaadin.com/docs/v14/flow/latest/ds/foundation/icons