### PR TITLE
Automatically add content labels and block merge if exist

### DIFF
--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "AsciiDoc": ["*.asciidoc"],
+    "Java": ["*.java"],
+    "TypeScript": ["*.ts"]
+  }
+}

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,14 @@
+name: Auto Label
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  auto-label:
+    name: Auto Label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: banyan/auto-label@1.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,7 +1,7 @@
 name: Auto Label
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   auto-label:

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 0
+          labels: "AsciiDoc, Java, TypeScript"

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,4 +1,4 @@
-name: Verify that content labels are resolved
+name: Content labels are resolved
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,4 +1,4 @@
-name: Pull Request Labels
+name: Verify that content labels are resolved
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,7 +1,7 @@
 name: Content labels are resolved
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [labeled, unlabeled]
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/articles/guide/contributing-docs/submitting.asciidoc
+++ b/articles/guide/contributing-docs/submitting.asciidoc
@@ -94,8 +94,8 @@ Click [guibutton]#Compare & pull request#.
 == Labeling
 
 A pull request is automatically labeled with *AsciiDoc*, *Java*, and *TypeScript* according to the files included in the pull request.
-Please check that the labels are set correctly.
-Once each content type has been reviewd, the labels should be changed to *AsciiDoc OK*, *Java OK*, and *TypeScript OK*, respectively.
+Please check that the action has set the labels correctly.
+Once each content type has been reviewed, the labels should be changed to *AsciiDoc OK*, *Java OK*, and *TypeScript OK*, respectively.
 This enables having multiple reviewers with different tasks.
 
 == Requirements for Merging

--- a/articles/guide/contributing-docs/submitting.asciidoc
+++ b/articles/guide/contributing-docs/submitting.asciidoc
@@ -91,13 +91,21 @@ Click [guibutton]#Compare & pull request#.
 . Make fixes requested in the review.
 . Merge the PR by yourself or have the team lead or main author do it.
 
+== Labeling
+
+A pull request is automatically labeled with *AsciiDoc*, *Java*, and *TypeScript* according to the files included in the pull request.
+Please check that the labels are set correctly.
+Once each content type has been reviewd, the labels should be changed to *AsciiDoc OK*, *Java OK*, and *TypeScript OK*, respectively.
+This enables having multiple reviewers with different tasks.
+
 == Requirements for Merging
 
 Merging a pull request has the following requirements:
 
-* The PR must have been accepted in review
-* Deployment preview build must finish successfully
-* You must have signed the Contributor License Agreement
+* Labels *AsciiDoc*, *Java*, and *TypeScript* must have been resolved to *AsciiDoc OK*, *Java OK*, and *TypeScript OK*, respectively.
+* The PR must have been accepted in review (admin can merge at any time if the above labels are OK).
+* Deployment preview build must finish successfully.
+* You must have signed the Contributor License Agreement.
 
 The following requirements are optional and not enforced:
 

--- a/frontend/demo/flow/application/ui/ui-menu-basic.ts
+++ b/frontend/demo/flow/application/ui/ui-menu-basic.ts
@@ -14,6 +14,7 @@ export class UiMenu extends LitElement {
           <vaadin-tab>Venus</vaadin-tab>
           <vaadin-tab>Earth</vaadin-tab>
           <vaadin-tab>Mars</vaadin-tab>
+          <vaadin-tab>Jupiter</vaadin-tab>
         </vaadin-tabs>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->

--- a/src/main/java/com/vaadin/demo/flow/application/mainview/HelloWorldView.java
+++ b/src/main/java/com/vaadin/demo/flow/application/mainview/HelloWorldView.java
@@ -35,6 +35,8 @@ public class HelloWorldView extends HorizontalLayout {
         sayHello = new Button("Say hello");
         add(name, sayHello);
         setVerticalComponentAlignment(Alignment.END, name, sayHello);
+
+        // Handle clicks
         sayHello.addClickListener(e -> {
             Notification.show("Hello " + name.getValue());
         });


### PR DESCRIPTION
## Description

Automatically adds **AsciiDoc**, **Java**, and **TypeScript** labels to a PR depending on the file types changed.
Blocks merging if they still exist.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
