### PR TITLE
Collaboration Engine article titles

### DIFF
--- a/articles/ce/collaboration-avatar-group.asciidoc
+++ b/articles/ce/collaboration-avatar-group.asciidoc
@@ -1,5 +1,5 @@
 ---
-title: CollaborationAvatarGroup
+title: Avatar Group
 order: 6
 layout: page
 ---

--- a/articles/ce/collaboration-binder.asciidoc
+++ b/articles/ce/collaboration-binder.asciidoc
@@ -8,12 +8,7 @@ layout: page
 = Collaborative Form Editing
 
 The recommended way of binding data from Java beans to forms in Vaadin applications is to use `Binder`
-ifdef::articles[]
 (read <<{articles}/flow/binding-data/components-binder#,Binding Data to Forms>> to learn more).
-endif::articles[]
-ifndef::articles[]
-(read <<../flow/binding-data/components-binder#,Binding Data to Forms>> to learn more).
-endif::articles[]
 Collaboration Engine provides a `Binder` extension called `CollaborationBinder`,
 which adds the following real-time features on top of the binder's data binding and validation APIs:
 

--- a/articles/ce/collaboration-binder.asciidoc
+++ b/articles/ce/collaboration-binder.asciidoc
@@ -1,5 +1,5 @@
 ---
-title: CollaborationBinder
+title: Binder
 order: 7
 layout: page
 ---

--- a/articles/ce/collaboration-message-list.asciidoc
+++ b/articles/ce/collaboration-message-list.asciidoc
@@ -1,5 +1,5 @@
 ---
-title: CollaborationMessageList
+title: Message List
 order: 8
 layout: page
 ---

--- a/articles/ce/developing-with-ce.asciidoc
+++ b/articles/ce/developing-with-ce.asciidoc
@@ -1,5 +1,5 @@
 ---
-title: Licensing and Pricing Model
+title: Licensing pass:[&] Pricing
 order: 3
 layout: page
 ---
@@ -38,13 +38,13 @@ To download this license, visit the <<going-to-production#, "When you take your 
 [[ce.developing.paid-commercial-license]]
 == Commercial License
 
-This license requires an active commercial Vaadin subscription (Pro, Prime, or Enterprise). 
+This license requires an active commercial Vaadin subscription (Pro, Prime, or Enterprise).
 Each commercial Vaadin subscription is entitled to a bundled quota of end users, which depends on the number of developer seats in the subscription.
 
 * Pro subscribers get 10 bundled end users per developer seat.
 * Prime subscribers get 25 bundled end users per developer seat.
 * Enterprise subscribers can negotiate a custom quota.
 
-The end user quota can be expanded at a fixed rate of 1 USD (or 1 EUR) per user. 
+The end user quota can be expanded at a fixed rate of 1 USD (or 1 EUR) per user.
 
 If you already have a commercial Vaadin subscription, please https://vaadin.com/collaboration#contact-us[contact our team to request a license]. Otherwise, please visit the https://vaadin.com/pricing[pricing page] to purchase a commercial Vaadin subscription.

--- a/articles/ce/going-to-production.asciidoc
+++ b/articles/ce/going-to-production.asciidoc
@@ -7,12 +7,7 @@ layout: page
 [[ce.production]]
 = Production Configuration
 
-ifdef::articles[]
 Enabling production mode for a Vaadin application is described in <<{articles}/guide/production#, Deploying to Production>>.
-endif::articles[]
-ifndef::articles[]
-Enabling production mode for a Vaadin application is described in <<../flow/production/production-mode-basic#, Deploying to Production>>.
-endif::articles[]
 If your application uses Collaboration Engine, it requires some extra steps when you take your application to production.
 These steps are described here.
 
@@ -106,12 +101,7 @@ com.company.myapp.MyVaadinInitListener
 
 For another way, you can pass the data directory as a parameter on server startup.
 This way assumes that you have already a production-ready build available and want to run the package on the server.
-ifdef::articles[]
 Read <<{articles}/guide/production#, Deploying to Production>> to learn more about building your application for production.
-endif::articles[]
-ifndef::articles[]
-Read <<../flow/production/production-mode-basic#, Deploying to Production>> to learn more about building your application for production.
-endif::articles[]
 
 ==== Spring Boot Applications
 
@@ -136,12 +126,7 @@ For example, you can pass the context parameter to Jetty as follows:
 mvn jetty:run -Dvaadin.ce.dataDir=/Users/steve/vaadin/collaboration-engine/
 ```
 
-ifdef::articles[]
 See <<{articles}/guide/configuration#,Configuration Properties>> for more information.
-endif::articles[]
-ifndef::articles[]
-See <<../flow/advanced/flow-runtime-configuration#,Changing the Application Behavior with Runtime Configuration>> for more information.
-endif::articles[]
 
 The directory should be both readable and writable by the user running the Vaadin application.
 

--- a/articles/ce/going-to-production.asciidoc
+++ b/articles/ce/going-to-production.asciidoc
@@ -1,11 +1,11 @@
 ---
-title: Setting Up for Production
+title: Production Configuration
 order: 4
 layout: page
 ---
 
 [[ce.production]]
-= Setting Up for Production
+= Production Configuration
 
 ifdef::articles[]
 Enabling production mode for a Vaadin application is described in <<{articles}/guide/production#, Deploying to Production>>.

--- a/articles/ce/tutorial.asciidoc
+++ b/articles/ce/tutorial.asciidoc
@@ -144,12 +144,7 @@ In that case, the same `CollaborationAvatarGroup` component could be reused for 
 
 To enable collaboration with the text field and date picker components, we'll use a class called `CollaborationBinder`.
 It extends the functionality of the `Binder` class, which binds values between Java beans and Vaadin field components.
-ifdef::articles[]
 Read <<{articles}/flow/binding-data/components-binder#,Binding Data to Forms>> to learn more about the binder.
-endif::articles[]
-ifndef::articles[]
-Read <<../flow/binding-data/components-binder#,Binding Data to Forms>> to learn more about the binder.
-endif::articles[]
 
 To initialize a collaboration binder, we need to provide the type that will be edited, as well as the local user's information.
 After initializing, we use the regular binder methods to bind the person object's name property to our text field component, and the date of birth property to our date picker component.


### PR DESCRIPTION
## Description

The current article titles are a bit long, and some of them are formatted like Java class names, which is discouraged in general.

This change makes the titles short enough to fit on one line, and avoids the class name formatting. That said, those particular articles have very different page headings vs the nav titles. I’m open for suggestions if we can bring them closer together.

(remove unnecessary `ifdef` macros at the same time, those are no longer needed)

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] ~~The issue is created in the corresponding repository and I have referenced it.~~
- [ ] ~~I have added tests to ensure my change is effective and works as intended.~~
- [ ] ~~New and existing tests are passing locally with my change.~~
- [x] I have performed self-review and corrected misspellings.
