### PR TITLE
Update Web Component GitHub and API links to the monorepo

### DIFF
--- a/articles/ds/components/accordion/api.asciidoc
+++ b/articles/ds/components/accordion/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-accordion/{moduleNpmVersion:vaadin-accordion}/#/elements/vaadin-accordion[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-accordion}/#/elements/vaadin-accordion[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/accordion/Accordion.html[Java Component API]
 ====

--- a/articles/ds/components/accordion/index.asciidoc
+++ b/articles/ds/components/accordion/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-accordion-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-accordion-flow}]
-  - https://github.com/vaadin/vaadin-accordion/releases/tag/v{moduleNpmVersion:vaadin-accordion}[Web Component {moduleNpmVersion:vaadin-accordion}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-accordion}[Web Component {moduleNpmVersion:vaadin-accordion}]
 ---
 
 = Accordion

--- a/articles/ds/components/accordion/index.asciidoc
+++ b/articles/ds/components/accordion/index.asciidoc
@@ -3,7 +3,7 @@ title: Accordion
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-accordion-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-accordion-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-accordion-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-accordion-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-accordion}[Web Component {moduleNpmVersion:vaadin-accordion}]
 ---
 

--- a/articles/ds/components/app-layout/api.asciidoc
+++ b/articles/ds/components/app-layout/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-app-layout/{moduleNpmVersion:vaadin-app-layout}/#/elements/vaadin-app-layout[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-app-layout}/#/elements/vaadin-app-layout[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/applayout/AppLayout.html[Java Component API]
 ====

--- a/articles/ds/components/app-layout/index.asciidoc
+++ b/articles/ds/components/app-layout/index.asciidoc
@@ -3,7 +3,7 @@ title: App Layout
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-app-layout}[Web Component {moduleNpmVersion:vaadin-app-layout}]
 ---
 

--- a/articles/ds/components/app-layout/index.asciidoc
+++ b/articles/ds/components/app-layout/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-app-layout-flow}]
-  - https://github.com/vaadin/vaadin-app-layout/releases/tag/v{moduleNpmVersion:vaadin-app-layout}[Web Component {moduleNpmVersion:vaadin-app-layout}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-app-layout}[Web Component {moduleNpmVersion:vaadin-app-layout}]
 ---
 
 = App Layout

--- a/articles/ds/components/avatar/api.asciidoc
+++ b/articles/ds/components/avatar/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-avatar/{moduleNpmVersion:vaadin-avatar}/#/elements/vaadin-avatar[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-avatar}/#/elements/vaadin-avatar[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/avatar/Avatar.html[Java Component API]
 ====

--- a/articles/ds/components/avatar/index.asciidoc
+++ b/articles/ds/components/avatar/index.asciidoc
@@ -3,7 +3,7 @@ title: Avatar
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-avatar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-avatar-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-avatar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-avatar-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-avatar}[Web Component {moduleNpmVersion:vaadin-avatar}]
 ---
 

--- a/articles/ds/components/avatar/index.asciidoc
+++ b/articles/ds/components/avatar/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-avatar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-avatar-flow}]
-  - https://github.com/vaadin/vaadin-avatar/releases/tag/v{moduleNpmVersion:vaadin-avatar}[Web Component {moduleNpmVersion:vaadin-avatar}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-avatar}[Web Component {moduleNpmVersion:vaadin-avatar}]
 ---
 
 = Avatar

--- a/articles/ds/components/board/api.asciidoc
+++ b/articles/ds/components/board/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-board/{moduleNpmVersion:vaadin-board}/#/elements/vaadin-board[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-board}/#/elements/vaadin-board[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/board/Board.html[Java Component API]
 ====

--- a/articles/ds/components/board/index.asciidoc
+++ b/articles/ds/components/board/index.asciidoc
@@ -3,7 +3,7 @@ title: Board
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-board-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-board-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-board-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-board-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-board}[Web Component {moduleNpmVersion:vaadin-board}]
 section-nav: commercial
 ---

--- a/articles/ds/components/board/index.asciidoc
+++ b/articles/ds/components/board/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-board-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-board-flow}]
-  - https://github.com/vaadin/vaadin-board/releases/tag/v{moduleNpmVersion:vaadin-board}[Web Component {moduleNpmVersion:vaadin-board}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-board}[Web Component {moduleNpmVersion:vaadin-board}]
 section-nav: commercial
 ---
 

--- a/articles/ds/components/button/api.asciidoc
+++ b/articles/ds/components/button/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-button/{moduleNpmVersion:vaadin-button}/#/elements/vaadin-button[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-button}/#/elements/vaadin-button[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/button/Button.html[Java Component API]
 ====

--- a/articles/ds/components/button/index.asciidoc
+++ b/articles/ds/components/button/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-button-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-button-flow}]
-  - https://github.com/vaadin/vaadin-button/releases/tag/v{moduleNpmVersion:vaadin-button}[Web Component {moduleNpmVersion:vaadin-button}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-button}[Web Component {moduleNpmVersion:vaadin-button}]
 ---
 
 = Button

--- a/articles/ds/components/button/index.asciidoc
+++ b/articles/ds/components/button/index.asciidoc
@@ -3,7 +3,7 @@ title: Button
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-button-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-button-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-button-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-button-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-button}[Web Component {moduleNpmVersion:vaadin-button}]
 ---
 

--- a/articles/ds/components/checkbox/api.asciidoc
+++ b/articles/ds/components/checkbox/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-checkbox/{moduleNpmVersion:vaadin-checkbox}/#/elements/vaadin-checkbox[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-checkbox}/#/elements/vaadin-checkbox[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/checkbox/Checkbox.html[Java Component API]
 ====

--- a/articles/ds/components/checkbox/index.asciidoc
+++ b/articles/ds/components/checkbox/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}]
-  - https://github.com/vaadin/vaadin-checkbox/releases/tag/v{moduleNpmVersion:vaadin-checkbox}[Web Component {moduleNpmVersion:vaadin-checkbox}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-checkbox}[Web Component {moduleNpmVersion:vaadin-checkbox}]
 ---
 
 = Checkbox

--- a/articles/ds/components/checkbox/index.asciidoc
+++ b/articles/ds/components/checkbox/index.asciidoc
@@ -3,7 +3,7 @@ title: Checkbox
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-checkbox-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-checkbox}[Web Component {moduleNpmVersion:vaadin-checkbox}]
 ---
 

--- a/articles/ds/components/combo-box/api.asciidoc
+++ b/articles/ds/components/combo-box/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-combo-box/{moduleNpmVersion:vaadin-combo-box}/#/elements/vaadin-combo-box[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-combo-box}/#/elements/vaadin-combo-box[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/combobox/ComboBox.html[Java Component API]
 ====

--- a/articles/ds/components/combo-box/index.asciidoc
+++ b/articles/ds/components/combo-box/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}]
-  - https://github.com/vaadin/vaadin-combo-box/releases/tag/v{moduleNpmVersion:vaadin-combo-box}[Web Component {moduleNpmVersion:vaadin-combo-box}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-combo-box}[Web Component {moduleNpmVersion:vaadin-combo-box}]
 ---
 
 = Combo Box

--- a/articles/ds/components/combo-box/index.asciidoc
+++ b/articles/ds/components/combo-box/index.asciidoc
@@ -3,7 +3,7 @@ title: Combo Box
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-combo-box-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-combo-box}[Web Component {moduleNpmVersion:vaadin-combo-box}]
 ---
 

--- a/articles/ds/components/confirm-dialog/api.asciidoc
+++ b/articles/ds/components/confirm-dialog/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-confirm-dialog/{moduleNpmVersion:vaadin-confirm-dialog}/#/elements/vaadin-confirm-dialog[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-confirm-dialog}/#/elements/vaadin-confirm-dialog[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/confirmdialog/ConfirmDialog.html[Java Component API]
 ====

--- a/articles/ds/components/confirm-dialog/index.asciidoc
+++ b/articles/ds/components/confirm-dialog/index.asciidoc
@@ -3,7 +3,7 @@ title: Confirm Dialog
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-confirm-dialog}[Web Component {moduleNpmVersion:vaadin-confirm-dialog}]
 section-nav: commercial
 ---

--- a/articles/ds/components/confirm-dialog/index.asciidoc
+++ b/articles/ds/components/confirm-dialog/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-confirm-dialog-flow}]
-  - https://github.com/vaadin/vaadin-confirm-dialog/releases/tag/v{moduleNpmVersion:vaadin-confirm-dialog}[Web Component {moduleNpmVersion:vaadin-confirm-dialog}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-confirm-dialog}[Web Component {moduleNpmVersion:vaadin-confirm-dialog}]
 section-nav: commercial
 ---
 

--- a/articles/ds/components/context-menu/api.asciidoc
+++ b/articles/ds/components/context-menu/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-context-menu/{moduleNpmVersion:vaadin-context-menu}/#/elements/vaadin-context-menu[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-context-menu}/#/elements/vaadin-context-menu[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/contextmenu/ContextMenu.html[Java Component API]
 ====

--- a/articles/ds/components/context-menu/index.asciidoc
+++ b/articles/ds/components/context-menu/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}]
-  - https://github.com/vaadin/vaadin-context-menu/releases/tag/v{moduleNpmVersion:vaadin-context-menu}[Web Component {moduleNpmVersion:vaadin-context-menu}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-context-menu}[Web Component {moduleNpmVersion:vaadin-context-menu}]
 ---
 
 = Context Menu

--- a/articles/ds/components/context-menu/index.asciidoc
+++ b/articles/ds/components/context-menu/index.asciidoc
@@ -3,7 +3,7 @@ title: Context Menu
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-context-menu-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-context-menu}[Web Component {moduleNpmVersion:vaadin-context-menu}]
 ---
 

--- a/articles/ds/components/cookie-consent/api.asciidoc
+++ b/articles/ds/components/cookie-consent/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-cookie-consent/{moduleNpmVersion:vaadin-cookie-consent}/#/elements/vaadin-cookie-consent[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-cookie-consent}/#/elements/vaadin-cookie-consent[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/cookieconsent/CookieConsent.html[Java Component API]
 ====

--- a/articles/ds/components/cookie-consent/index.asciidoc
+++ b/articles/ds/components/cookie-consent/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}]
-  - https://github.com/vaadin/vaadin-cookie-consent/releases/tag/v{moduleNpmVersion:vaadin-cookie-consent}[Web Component {moduleNpmVersion:vaadin-cookie-consent}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-cookie-consent}[Web Component {moduleNpmVersion:vaadin-cookie-consent}]
 section-nav: commercial
 ---
 

--- a/articles/ds/components/cookie-consent/index.asciidoc
+++ b/articles/ds/components/cookie-consent/index.asciidoc
@@ -3,7 +3,7 @@ title: Cookie Consent
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-cookie-consent-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-cookie-consent}[Web Component {moduleNpmVersion:vaadin-cookie-consent}]
 section-nav: commercial
 ---

--- a/articles/ds/components/crud/api.asciidoc
+++ b/articles/ds/components/crud/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-crud/{moduleNpmVersion:vaadin-crud}/#/elements/vaadin-crud[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-crud}/#/elements/vaadin-crud[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/crud/Crud.html[Java Component API]
 ====

--- a/articles/ds/components/crud/index.asciidoc
+++ b/articles/ds/components/crud/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-crud-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-crud-flow}]
-  - https://github.com/vaadin/vaadin-crud/releases/tag/v{moduleNpmVersion:vaadin-crud}[Web Component {moduleNpmVersion:vaadin-crud}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-crud}[Web Component {moduleNpmVersion:vaadin-crud}]
 section-nav: commercial
 ---
 

--- a/articles/ds/components/crud/index.asciidoc
+++ b/articles/ds/components/crud/index.asciidoc
@@ -3,7 +3,7 @@ title: CRUD
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-crud-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-crud-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-crud-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-crud-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-crud}[Web Component {moduleNpmVersion:vaadin-crud}]
 section-nav: commercial
 ---

--- a/articles/ds/components/custom-field/api.asciidoc
+++ b/articles/ds/components/custom-field/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-custom-field/{moduleNpmVersion:vaadin-custom-field}/#/elements/vaadin-custom-field[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-custom-field}/#/elements/vaadin-custom-field[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/customfield/CustomField.html[Java Component API]
 ====

--- a/articles/ds/components/custom-field/index.asciidoc
+++ b/articles/ds/components/custom-field/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}]
-  - https://github.com/vaadin/vaadin-custom-field/releases/tag/v{moduleNpmVersion:vaadin-custom-field}[Web Component {moduleNpmVersion:vaadin-custom-field}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-custom-field}[Web Component {moduleNpmVersion:vaadin-custom-field}]
 ---
 
 = Custom Field

--- a/articles/ds/components/custom-field/index.asciidoc
+++ b/articles/ds/components/custom-field/index.asciidoc
@@ -3,7 +3,7 @@ title: Custom Field
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-custom-field-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-custom-field}[Web Component {moduleNpmVersion:vaadin-custom-field}]
 ---
 

--- a/articles/ds/components/date-picker/api.asciidoc
+++ b/articles/ds/components/date-picker/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-date-picker/{moduleNpmVersion:vaadin-date-picker}/#/elements/vaadin-date-picker[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-date-picker}/#/elements/vaadin-date-picker[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/datepicker/DatePicker.html[Java Component API]
 ====

--- a/articles/ds/components/date-picker/index.asciidoc
+++ b/articles/ds/components/date-picker/index.asciidoc
@@ -3,7 +3,7 @@ title: Date Picker
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-date-picker}[Web Component {moduleNpmVersion:vaadin-date-picker}]
 ---
 

--- a/articles/ds/components/date-picker/index.asciidoc
+++ b/articles/ds/components/date-picker/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-date-picker-flow}]
-  - https://github.com/vaadin/vaadin-date-picker/releases/tag/v{moduleNpmVersion:vaadin-date-picker}[Web Component {moduleNpmVersion:vaadin-date-picker}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-date-picker}[Web Component {moduleNpmVersion:vaadin-date-picker}]
 ---
 
 = Date Picker

--- a/articles/ds/components/date-time-picker/api.asciidoc
+++ b/articles/ds/components/date-time-picker/api.asciidoc
@@ -9,6 +9,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-date-time-picker/{moduleNpmVersion:vaadin-date-time-picker}/#/elements/vaadin-date-time-picker[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-date-time-picker}/#/elements/vaadin-date-time-picker[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/datetimepicker/DateTimePicker.html[Java Component API]
 ====

--- a/articles/ds/components/date-time-picker/index.asciidoc
+++ b/articles/ds/components/date-time-picker/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}]
-  - https://github.com/vaadin/vaadin-date-time-picker/releases/tag/v{moduleNpmVersion:vaadin-date-time-picker}[Web Component {moduleNpmVersion:vaadin-date-time-picker}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-date-time-picker}[Web Component {moduleNpmVersion:vaadin-date-time-picker}]
 ---
 
 = Date Time Picker

--- a/articles/ds/components/date-time-picker/index.asciidoc
+++ b/articles/ds/components/date-time-picker/index.asciidoc
@@ -3,7 +3,7 @@ title: Date Time Picker
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-date-time-picker-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-date-time-picker}[Web Component {moduleNpmVersion:vaadin-date-time-picker}]
 ---
 

--- a/articles/ds/components/details/api.asciidoc
+++ b/articles/ds/components/details/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-details/{moduleNpmVersion:vaadin-details}/#/elements/vaadin-details[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-details}/#/elements/vaadin-details[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/details/Details.html[Java Component API]
 ====

--- a/articles/ds/components/details/index.asciidoc
+++ b/articles/ds/components/details/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-details-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-details-flow}]
-  - https://github.com/vaadin/vaadin-details/releases/tag/v{moduleNpmVersion:vaadin-details}[Web Component {moduleNpmVersion:vaadin-details}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-details}[Web Component {moduleNpmVersion:vaadin-details}]
 ---
 
 = Details

--- a/articles/ds/components/details/index.asciidoc
+++ b/articles/ds/components/details/index.asciidoc
@@ -3,7 +3,7 @@ title: Details
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-details-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-details-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-details-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-details-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-details}[Web Component {moduleNpmVersion:vaadin-details}]
 ---
 

--- a/articles/ds/components/dialog/api.asciidoc
+++ b/articles/ds/components/dialog/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-dialog/{moduleNpmVersion:vaadin-dialog}/#/elements/vaadin-dialog[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-dialog}/#/elements/vaadin-dialog[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/dialog/Dialog.html[Java Component API]
 ====

--- a/articles/ds/components/dialog/index.asciidoc
+++ b/articles/ds/components/dialog/index.asciidoc
@@ -3,7 +3,7 @@ title: Dialog
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-dialog-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-dialog-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-dialog-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-dialog-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-dialog}[Web Component {moduleNpmVersion:vaadin-dialog}]
 ---
 

--- a/articles/ds/components/dialog/index.asciidoc
+++ b/articles/ds/components/dialog/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-dialog-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-dialog-flow}]
-  - https://github.com/vaadin/vaadin-dialog/releases/tag/v{moduleNpmVersion:vaadin-dialog}[Web Component {moduleNpmVersion:vaadin-dialog}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-dialog}[Web Component {moduleNpmVersion:vaadin-dialog}]
 ---
 
 = Dialog

--- a/articles/ds/components/email-field/api.asciidoc
+++ b/articles/ds/components/email-field/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-text-field/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-email-field[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-email-field[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/EmailField.html[Java Component API]
 ====

--- a/articles/ds/components/email-field/index.asciidoc
+++ b/articles/ds/components/email-field/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
-  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Email Field
 

--- a/articles/ds/components/email-field/index.asciidoc
+++ b/articles/ds/components/email-field/index.asciidoc
@@ -3,7 +3,7 @@ title: Email Field
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Email Field

--- a/articles/ds/components/form-layout/api.asciidoc
+++ b/articles/ds/components/form-layout/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-form-layout/{moduleNpmVersion:vaadin-form-layout}/#/elements/vaadin-form-layout[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-form-layout}/#/elements/vaadin-form-layout[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/formlayout/FormLayout.html[Java Component API]
 ====

--- a/articles/ds/components/form-layout/index.asciidoc
+++ b/articles/ds/components/form-layout/index.asciidoc
@@ -3,7 +3,7 @@ title: Form Layout
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-form-layout}[Web Component {moduleNpmVersion:vaadin-form-layout}]
 ---
 

--- a/articles/ds/components/form-layout/index.asciidoc
+++ b/articles/ds/components/form-layout/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-form-layout-flow}]
-  - https://github.com/vaadin/vaadin-form-layout/releases/tag/v{moduleNpmVersion:vaadin-form-layout}[Web Component {moduleNpmVersion:vaadin-form-layout}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-form-layout}[Web Component {moduleNpmVersion:vaadin-form-layout}]
 ---
 
 = Form Layout

--- a/articles/ds/components/grid-pro/api.asciidoc
+++ b/articles/ds/components/grid-pro/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-grid-pro/{moduleNpmVersion:vaadin-grid-pro}/#/elements/vaadin-grid-pro[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-grid-pro}/#/elements/vaadin-grid-pro[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/gridpro/GridPro.html[Java Component API]
 ====

--- a/articles/ds/components/grid-pro/index.asciidoc
+++ b/articles/ds/components/grid-pro/index.asciidoc
@@ -3,7 +3,7 @@ title: Grid Pro
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-grid-pro}[Web Component {moduleNpmVersion:vaadin-grid-pro}]
 section-nav: commercial
 ---

--- a/articles/ds/components/grid-pro/index.asciidoc
+++ b/articles/ds/components/grid-pro/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-pro-flow}]
-  - https://github.com/vaadin/vaadin-grid-pro/releases/tag/v{moduleNpmVersion:vaadin-grid-pro}[Web Component {moduleNpmVersion:vaadin-grid-pro}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-grid-pro}[Web Component {moduleNpmVersion:vaadin-grid-pro}]
 section-nav: commercial
 ---
 

--- a/articles/ds/components/grid/api.asciidoc
+++ b/articles/ds/components/grid/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-grid/{moduleNpmVersion:vaadin-grid}/#/elements/vaadin-grid[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-grid}/#/elements/vaadin-grid[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/grid/Grid.html[Java Component API]
 ====

--- a/articles/ds/components/grid/index.asciidoc
+++ b/articles/ds/components/grid/index.asciidoc
@@ -3,7 +3,7 @@ title: Grid
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-grid}[Web Component {moduleNpmVersion:vaadin-grid}]
 ---
 

--- a/articles/ds/components/grid/index.asciidoc
+++ b/articles/ds/components/grid/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-flow}]
-  - https://github.com/vaadin/vaadin-grid/releases/tag/v{moduleNpmVersion:vaadin-grid}[Web Component {moduleNpmVersion:vaadin-grid}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-grid}[Web Component {moduleNpmVersion:vaadin-grid}]
 ---
 
 = Grid

--- a/articles/ds/components/list-box/api.asciidoc
+++ b/articles/ds/components/list-box/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-list-box/{moduleNpmVersion:vaadin-list-box}/#/elements/vaadin-list-box[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-list-box}/#/elements/vaadin-list-box[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/listbox/ListBox.html[Java Component API]
 ====

--- a/articles/ds/components/list-box/index.asciidoc
+++ b/articles/ds/components/list-box/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-list-box-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-list-box-flow}]
-  - https://github.com/vaadin/vaadin-list-box/releases/tag/v{moduleNpmVersion:vaadin-list-box}[Web Component {moduleNpmVersion:vaadin-list-box}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-list-box}[Web Component {moduleNpmVersion:vaadin-list-box}]
 ---
 
 = List Box

--- a/articles/ds/components/list-box/index.asciidoc
+++ b/articles/ds/components/list-box/index.asciidoc
@@ -3,7 +3,7 @@ title: List Box
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-list-box-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-list-box-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-list-box-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-list-box-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-list-box}[Web Component {moduleNpmVersion:vaadin-list-box}]
 ---
 

--- a/articles/ds/components/login/api.asciidoc
+++ b/articles/ds/components/login/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-login/{moduleNpmVersion:vaadin-login}/#/elements/vaadin-login-overlay[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-login}/#/elements/vaadin-login-overlay[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/login/LoginOverlay.html[Java Component API]
 ====

--- a/articles/ds/components/login/index.asciidoc
+++ b/articles/ds/components/login/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-login-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-login-flow}]
-  - https://github.com/vaadin/vaadin-login/releases/tag/v{moduleNpmVersion:vaadin-login}[Web Component {moduleNpmVersion:vaadin-login}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-login}[Web Component {moduleNpmVersion:vaadin-login}]
 ---
 
 = Login

--- a/articles/ds/components/login/index.asciidoc
+++ b/articles/ds/components/login/index.asciidoc
@@ -3,7 +3,7 @@ title: Login
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-login-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-login-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-login-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-login-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-login}[Web Component {moduleNpmVersion:vaadin-login}]
 ---
 

--- a/articles/ds/components/menu-bar/api.asciidoc
+++ b/articles/ds/components/menu-bar/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-menu-bar/{moduleNpmVersion:vaadin-menu-bar}/#/elements/vaadin-menu-bar[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-menu-bar}/#/elements/vaadin-menu-bar[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/menubar/MenuBar.html[Java Component API]
 ====

--- a/articles/ds/components/menu-bar/index.asciidoc
+++ b/articles/ds/components/menu-bar/index.asciidoc
@@ -3,7 +3,7 @@ title: Menu Bar
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-menu-bar}[Web Component {moduleNpmVersion:vaadin-menu-bar}]
 ---
 

--- a/articles/ds/components/menu-bar/index.asciidoc
+++ b/articles/ds/components/menu-bar/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-menu-bar-flow}]
-  - https://github.com/vaadin/vaadin-menu-bar/releases/tag/v{moduleNpmVersion:vaadin-menu-bar}[Web Component {moduleNpmVersion:vaadin-menu-bar}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-menu-bar}[Web Component {moduleNpmVersion:vaadin-menu-bar}]
 ---
 
 = Menu Bar

--- a/articles/ds/components/messages/api.asciidoc
+++ b/articles/ds/components/messages/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-messages/{moduleNpmVersion:vaadin-messages}/#/elements/vaadin-message[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-messages}/#/elements/vaadin-message[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/messages/MessageList.html[Java Component API]
 ====

--- a/articles/ds/components/messages/index.asciidoc
+++ b/articles/ds/components/messages/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-messages-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-messages-flow}]
-  - https://github.com/vaadin/vaadin-messages/releases/tag/v{moduleNpmVersion:vaadin-messages}[Web Component {moduleNpmVersion:vaadin-messages}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-messages}[Web Component {moduleNpmVersion:vaadin-messages}]
 ---
 
 = Messages

--- a/articles/ds/components/messages/index.asciidoc
+++ b/articles/ds/components/messages/index.asciidoc
@@ -3,7 +3,7 @@ title: Messages
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-messages-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-messages-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-messages-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-messages-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-messages}[Web Component {moduleNpmVersion:vaadin-messages}]
 ---
 

--- a/articles/ds/components/notification/api.asciidoc
+++ b/articles/ds/components/notification/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-notification/{moduleNpmVersion:vaadin-notification}/#/elements/vaadin-notification[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-notification}/#/elements/vaadin-notification[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/notification/Notification.html[Java Component API]
 ====

--- a/articles/ds/components/notification/index.asciidoc
+++ b/articles/ds/components/notification/index.asciidoc
@@ -3,7 +3,7 @@ title: Notification
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-notification-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-notification-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-notification-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-notification-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-notification}[Web Component {moduleNpmVersion:vaadin-notification}]
 ---
 

--- a/articles/ds/components/notification/index.asciidoc
+++ b/articles/ds/components/notification/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-notification-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-notification-flow}]
-  - https://github.com/vaadin/vaadin-notification/releases/tag/v{moduleNpmVersion:vaadin-notification}[Web Component {moduleNpmVersion:vaadin-notification}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-notification}[Web Component {moduleNpmVersion:vaadin-notification}]
 ---
 
 = Notification

--- a/articles/ds/components/number-field/api.asciidoc
+++ b/articles/ds/components/number-field/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-text-field/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-number-field[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-number-field[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/NumberField.html[Java Component API]
 ====

--- a/articles/ds/components/number-field/index.asciidoc
+++ b/articles/ds/components/number-field/index.asciidoc
@@ -3,7 +3,7 @@ title: Number Field
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 

--- a/articles/ds/components/number-field/index.asciidoc
+++ b/articles/ds/components/number-field/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
-  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 
 = Number Field

--- a/articles/ds/components/password-field/api.asciidoc
+++ b/articles/ds/components/password-field/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-text-field/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-password-field[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-password-field[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/PasswordField.html[Java Component API]
 ====

--- a/articles/ds/components/password-field/index.asciidoc
+++ b/articles/ds/components/password-field/index.asciidoc
@@ -3,7 +3,7 @@ title: Password Field
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Password Field

--- a/articles/ds/components/password-field/index.asciidoc
+++ b/articles/ds/components/password-field/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
-  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Password Field
 

--- a/articles/ds/components/progress-bar/api.asciidoc
+++ b/articles/ds/components/progress-bar/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-progress-bar/{moduleNpmVersion:vaadin-progress-bar}/#/elements/vaadin-progress-bar[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-progress-bar}/#/elements/vaadin-progress-bar[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/progressbar/ProgressBar.html[Java Component API]
 ====

--- a/articles/ds/components/progress-bar/index.asciidoc
+++ b/articles/ds/components/progress-bar/index.asciidoc
@@ -3,7 +3,7 @@ title: Progress Bar
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-progress-bar}[Web Component {moduleNpmVersion:vaadin-progress-bar}]
 ---
 

--- a/articles/ds/components/progress-bar/index.asciidoc
+++ b/articles/ds/components/progress-bar/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-progress-bar-flow}]
-  - https://github.com/vaadin/vaadin-progress-bar/releases/tag/v{moduleNpmVersion:vaadin-progress-bar}[Web Component {moduleNpmVersion:vaadin-progress-bar}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-progress-bar}[Web Component {moduleNpmVersion:vaadin-progress-bar}]
 ---
 
 = Progress Bar

--- a/articles/ds/components/radio-button/api.asciidoc
+++ b/articles/ds/components/radio-button/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-radio-button/{moduleNpmVersion:vaadin-radio-button}/#/elements/vaadin-radio-button[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-radio-button}/#/elements/vaadin-radio-button[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/radiobutton/RadioButtonGroup.html[Java Component API]
 ====

--- a/articles/ds/components/radio-button/index.asciidoc
+++ b/articles/ds/components/radio-button/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}]
-  - https://github.com/vaadin/vaadin-radio-button/releases/tag/v{moduleNpmVersion:vaadin-radio-button}[Web Component {moduleNpmVersion:vaadin-radio-button}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-radio-button}[Web Component {moduleNpmVersion:vaadin-radio-button}]
 ---
 
 = Radio Button

--- a/articles/ds/components/radio-button/index.asciidoc
+++ b/articles/ds/components/radio-button/index.asciidoc
@@ -3,7 +3,7 @@ title: Radio Button
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-radio-button-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-radio-button}[Web Component {moduleNpmVersion:vaadin-radio-button}]
 ---
 

--- a/articles/ds/components/rich-text-editor/api.asciidoc
+++ b/articles/ds/components/rich-text-editor/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-rich-text-editor/{moduleNpmVersion:vaadin-rich-text-editor}/#/elements/vaadin-rich-text-editor[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-rich-text-editor}/#/elements/vaadin-rich-text-editor[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/richtexteditor/RichTextEditor.html[Java Component API]
 ====

--- a/articles/ds/components/rich-text-editor/index.asciidoc
+++ b/articles/ds/components/rich-text-editor/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}]
-  - https://github.com/vaadin/vaadin-rich-text-editor/releases/tag/v{moduleNpmVersion:vaadin-rich-text-editor}[Web Component {moduleNpmVersion:vaadin-rich-text-editor}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-rich-text-editor}[Web Component {moduleNpmVersion:vaadin-rich-text-editor}]
 section-nav: commercial
 ---
 

--- a/articles/ds/components/rich-text-editor/index.asciidoc
+++ b/articles/ds/components/rich-text-editor/index.asciidoc
@@ -3,7 +3,7 @@ title: Rich Text Editor
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-rich-text-editor-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-rich-text-editor}[Web Component {moduleNpmVersion:vaadin-rich-text-editor}]
 section-nav: commercial
 ---

--- a/articles/ds/components/scroller/api.asciidoc
+++ b/articles/ds/components/scroller/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-ordered-layout/{moduleNpmVersion:vaadin-ordered-layout}/#/elements/vaadin-scroller[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-ordered-layout}/#/elements/vaadin-scroller[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/orderedlayout/Scroller.html[Java Component API]
 ====

--- a/articles/ds/components/scroller/index.asciidoc
+++ b/articles/ds/components/scroller/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}]
-  - https://github.com/vaadin/vaadin-ordered-layout/releases/tag/v{moduleNpmVersion:vaadin-ordered-layout}[Web Component {moduleNpmVersion:vaadin-ordered-layout}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-ordered-layout}[Web Component {moduleNpmVersion:vaadin-ordered-layout}]
 ---
 = Scroller
 

--- a/articles/ds/components/scroller/index.asciidoc
+++ b/articles/ds/components/scroller/index.asciidoc
@@ -3,7 +3,7 @@ title: Scroller
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-ordered-layout-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-ordered-layout}[Web Component {moduleNpmVersion:vaadin-ordered-layout}]
 ---
 = Scroller

--- a/articles/ds/components/select/api.asciidoc
+++ b/articles/ds/components/select/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-select/{moduleNpmVersion:vaadin-select}/#/elements/vaadin-select[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-select}/#/elements/vaadin-select[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/select/Select.html[Java Component API]
 ====

--- a/articles/ds/components/select/index.asciidoc
+++ b/articles/ds/components/select/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-select-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-select-flow}]
-  - https://github.com/vaadin/vaadin-select/releases/tag/v{moduleNpmVersion:vaadin-select}[Web Component {moduleNpmVersion:vaadin-select}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-select}[Web Component {moduleNpmVersion:vaadin-select}]
 ---
 
 = Select

--- a/articles/ds/components/select/index.asciidoc
+++ b/articles/ds/components/select/index.asciidoc
@@ -3,7 +3,7 @@ title: Select
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-select-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-select-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-select-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-select-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-select}[Web Component {moduleNpmVersion:vaadin-select}]
 ---
 

--- a/articles/ds/components/split-layout/api.asciidoc
+++ b/articles/ds/components/split-layout/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-split-layout/{moduleNpmVersion:vaadin-split-layout}/#/elements/vaadin-split-layout[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-split-layout}/#/elements/vaadin-split-layout[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/splitlayout/SplitLayout.html[Java Component API]
 ====

--- a/articles/ds/components/split-layout/index.asciidoc
+++ b/articles/ds/components/split-layout/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}]
-  - https://github.com/vaadin/vaadin-split-layout/releases/tag/v{moduleNpmVersion:vaadin-split-layout}[Web Component {moduleNpmVersion:vaadin-split-layout}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-split-layout}[Web Component {moduleNpmVersion:vaadin-split-layout}]
 ---
 
 = Split Layout

--- a/articles/ds/components/split-layout/index.asciidoc
+++ b/articles/ds/components/split-layout/index.asciidoc
@@ -3,7 +3,7 @@ title: Split Layout
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-split-layout-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-split-layout}[Web Component {moduleNpmVersion:vaadin-split-layout}]
 ---
 

--- a/articles/ds/components/tabs/api.asciidoc
+++ b/articles/ds/components/tabs/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-tabs/{moduleNpmVersion:vaadin-tabs}/#/elements/vaadin-tabs[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-tabs}/#/elements/vaadin-tabs[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/tabs/Tabs.html[Java Component API]
 ====

--- a/articles/ds/components/tabs/index.asciidoc
+++ b/articles/ds/components/tabs/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-tabs-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-tabs-flow}]
-  - https://github.com/vaadin/vaadin-tabs/releases/tag/v{moduleNpmVersion:vaadin-tabs}[Web Component {moduleNpmVersion:vaadin-tabs}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-tabs}[Web Component {moduleNpmVersion:vaadin-tabs}]
 ---
 
 = Tabs

--- a/articles/ds/components/tabs/index.asciidoc
+++ b/articles/ds/components/tabs/index.asciidoc
@@ -3,7 +3,7 @@ title: Tabs
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-tabs-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-tabs-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-tabs-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-tabs-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-tabs}[Web Component {moduleNpmVersion:vaadin-tabs}]
 ---
 

--- a/articles/ds/components/text-area/api.asciidoc
+++ b/articles/ds/components/text-area/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-text-field/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-text-area[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-text-area[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/TextArea.html[Java Component API]
 ====

--- a/articles/ds/components/text-area/index.asciidoc
+++ b/articles/ds/components/text-area/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
-  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Text Area
 

--- a/articles/ds/components/text-area/index.asciidoc
+++ b/articles/ds/components/text-area/index.asciidoc
@@ -3,7 +3,7 @@ title: Text Area
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Text Area

--- a/articles/ds/components/text-field/api.asciidoc
+++ b/articles/ds/components/text-field/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-text-field/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-text-field[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-text-field[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/TextField.html[Java Component API]
 ====

--- a/articles/ds/components/text-field/index.asciidoc
+++ b/articles/ds/components/text-field/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
-  - https://github.com/vaadin/vaadin-text-field/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Text Field
 

--- a/articles/ds/components/text-field/index.asciidoc
+++ b/articles/ds/components/text-field/index.asciidoc
@@ -3,7 +3,7 @@ title: Text Field
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-text-field-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-text-field-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-text-field}[Web Component {moduleNpmVersion:vaadin-text-field}]
 ---
 = Text Field

--- a/articles/ds/components/time-picker/api.asciidoc
+++ b/articles/ds/components/time-picker/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-time-picker/{moduleNpmVersion:vaadin-time-picker}/#/elements/vaadin-time-picker[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-time-picker}/#/elements/vaadin-time-picker[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/timepicker/TimePicker.html[Java Component API]
 ====

--- a/articles/ds/components/time-picker/index.asciidoc
+++ b/articles/ds/components/time-picker/index.asciidoc
@@ -3,7 +3,7 @@ title: Time Picker
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-time-picker}[Web Component {moduleNpmVersion:vaadin-time-picker}]
 ---
 

--- a/articles/ds/components/time-picker/index.asciidoc
+++ b/articles/ds/components/time-picker/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-time-picker-flow}]
-  - https://github.com/vaadin/vaadin-time-picker/releases/tag/v{moduleNpmVersion:vaadin-time-picker}[Web Component {moduleNpmVersion:vaadin-time-picker}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-time-picker}[Web Component {moduleNpmVersion:vaadin-time-picker}]
 ---
 
 = Time Picker

--- a/articles/ds/components/tree-grid/api.asciidoc
+++ b/articles/ds/components/tree-grid/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-grid/{moduleNpmVersion:vaadin-grid}/#/elements/vaadin-grid-tree-column[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-grid}/#/elements/vaadin-grid-tree-column[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/grid/TreeGrid.html[Java Component API]
 ====

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-flow}]
-  - https://github.com/vaadin/vaadin-grid/releases/tag/v{moduleNpmVersion:vaadin-grid}[Web Component {moduleNpmVersion:vaadin-grid}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-grid}[Web Component {moduleNpmVersion:vaadin-grid}]
 ---
 
 = Tree Grid

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -3,7 +3,7 @@ title: Tree Grid
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-grid-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-grid-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-grid}[Web Component {moduleNpmVersion:vaadin-grid}]
 ---
 

--- a/articles/ds/components/upload/api.asciidoc
+++ b/articles/ds/components/upload/api.asciidoc
@@ -10,6 +10,6 @@ title: API
 The component API documentation will eventually be embedded here. Until then, you can view them in the external locations.
 
 [.buttons]
-- https://cdn.vaadin.com/vaadin-upload/{moduleNpmVersion:vaadin-upload}/#/elements/vaadin-upload[Web Component API]
+- https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-upload}/#/elements/vaadin-upload[Web Component API]
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/upload/Upload.html[Java Component API]
 ====

--- a/articles/ds/components/upload/index.asciidoc
+++ b/articles/ds/components/upload/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Usage
 page-links:
   - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-upload-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-upload-flow}]
-  - https://github.com/vaadin/vaadin-upload/releases/tag/v{moduleNpmVersion:vaadin-upload}[Web Component {moduleNpmVersion:vaadin-upload}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-upload}[Web Component {moduleNpmVersion:vaadin-upload}]
 ---
 
 = Upload

--- a/articles/ds/components/upload/index.asciidoc
+++ b/articles/ds/components/upload/index.asciidoc
@@ -3,7 +3,7 @@ title: Upload
 layout: tabbed-page
 tab-title: Usage
 page-links:
-  - https://github.com/vaadin/vaadin-flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-upload-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-upload-flow}]
+  - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-upload-flow}[Flow {moduleMavenVersion:com.vaadin:vaadin-upload-flow}]
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-upload}[Web Component {moduleNpmVersion:vaadin-upload}]
 ---
 

--- a/articles/ds/components/upload/index.asciidoc
+++ b/articles/ds/components/upload/index.asciidoc
@@ -216,7 +216,7 @@ include::{root}/frontend/demo/component/upload/upload-start-button.ts[render]
 == Internationalization (i18n)
 
 All of Upload's labels and messages are configurable.
-For a complete list please refer to the https://cdn.vaadin.com/vaadin-upload/{moduleNpmVersion:vaadin-upload}/#/elements/vaadin-upload#property-i18n[API documentation].
+For a complete list please refer to the https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-upload}/#/elements/vaadin-upload#property-i18n[API documentation].
 
 [.example]
 --

--- a/articles/ds/foundation/color/index.asciidoc
+++ b/articles/ds/foundation/color/index.asciidoc
@@ -4,7 +4,7 @@ tab-title: Lumo
 layout: tabbed-page
 order: 20
 page-links:
-  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/color.html[Source]
+  - https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/color.js[Source]
   - https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=714%3A3821[Figma Library]
 ---
 

--- a/articles/ds/foundation/elevation.asciidoc
+++ b/articles/ds/foundation/elevation.asciidoc
@@ -2,7 +2,7 @@
 title: Elevation
 order: 50
 page-links:
-  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/style.html[Source]
+  - https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/style.js[Source]
   - https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=20%3A1[Figma Library]
 ---
 

--- a/articles/ds/foundation/icons/index.asciidoc
+++ b/articles/ds/foundation/icons/index.asciidoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 tab-title: Lumo Icons
 order: 70
 page-links:
-  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/iconset.html[Source]
+  - https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/iconset.js[Source]
   - https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=1343%3A3247[Figma Library]
 ---
 

--- a/articles/ds/foundation/interaction.asciidoc
+++ b/articles/ds/foundation/interaction.asciidoc
@@ -2,7 +2,7 @@
 title: Interaction
 order: 60
 page-links:
-  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/style.html[Source]
+  - https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/style.js[Source]
 ---
 
 = Interaction

--- a/articles/ds/foundation/shape.asciidoc
+++ b/articles/ds/foundation/shape.asciidoc
@@ -2,7 +2,7 @@
 title: Shape
 order: 40
 page-links:
-  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/style.html[Source]
+  - https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/style.js[Source]
 ---
 
 = Shape

--- a/articles/ds/foundation/size-space.asciidoc
+++ b/articles/ds/foundation/size-space.asciidoc
@@ -2,8 +2,8 @@
 title: Size and Space
 order: 30
 page-links:
-  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/sizing.html[Source (size)]
-  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/spacing.html[Source (space)]
+  - https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/sizing.js[Source (size)]
+  - https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/spacing.js[Source (space)]
 ---
 
 = Size and Space
@@ -75,7 +75,7 @@ Lumo has a compact sizing preset available. It reduces the font size and the siz
 Apply compact sizing by importing the style sheet, which sets new values for the
 <<typography#,Typography>> and the <<size>> and <<space>> CSS properties.
 ifdef::web[]
-You can https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/presets/compact.html[view the values] from the source code.
+You can https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/presets/compact.js[view the values] from the source code.
 endif::web[]
 
 .`Java`

--- a/articles/ds/foundation/typography/index.asciidoc
+++ b/articles/ds/foundation/typography/index.asciidoc
@@ -4,7 +4,7 @@ tab-title: Lumo
 layout: tabbed-page
 order: 10
 page-links:
-  - https://github.com/vaadin/vaadin-lumo-styles/blob/v{moduleNpmVersion:vaadin-lumo-styles}/typography.html[Source]
+  - https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/typography.js[Source]
   - https://www.figma.com/file/IxQ49ZwaHwk7w7dhbtjFp0Uy/Vaadin-Design-System?node-id=20%3A2[Figma Library]
 ---
 


### PR DESCRIPTION
## Description

Starting from Vaadin 20 Vaadin web components are moved from individual repos into the `web-components` monorepo. All links to the API reference and the GitHub release should be updated accordingly.

Fixes #408

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
