### PR TITLE
Added "GreetService" to the files to be added to the ui folder

### DIFF
--- a/articles/flow/tutorials/in-depth-course/components-and-layouts.adoc
+++ b/articles/flow/tutorials/in-depth-course/components-and-layouts.adoc
@@ -90,7 +90,7 @@ To define packages:
 +
 image::images/basics/create-package.png[create new package]
 
-. Drag `MainView` into the `ui` package. 
+. Drag `MainView` and `GreetService` into the `ui` package. 
 If IntelliJ asks you if you want to refactor the code, say yes.
 
 +


### PR DESCRIPTION
The description previously read differently to what the screenshot said.

The file "GreetService" needs to be added to the `com.vaadin.tutorial.crm.ui` folder as well, not just `MainView`

This commit simply adds the words "and `GreetService`" to the text.

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Simply adding two words to the tutorial.

## Type of change

- [x] Bugfix (tutorial)
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
