### PR TITLE
Fix minimum Maven and Gradle versions required in latest

### DIFF
--- a/articles/guide/compatibility.asciidoc
+++ b/articles/guide/compatibility.asciidoc
@@ -19,7 +19,7 @@ With these combinations, Vaadin can provide everything you need for fully featur
 |Java Frameworks |Spring, JavaEE/CDI, etc.
 |IDEs |Eclipse IDE, NetBeans IDE, IntelliJ IDEA, VS Code, Atom, etc.
 |Servlet Containers |Apache Tomcat, Apache TomEE, WildFly, GlassFish, JBoss, Jetty, etc.
-|Server-Side Build Management |Maven (3 or newer), Ivy, Gradle (5.6)
+|Server-Side Build Management |Maven (3.5 or newer) or Gradle (6 or newer)
 |Client-Side Build Management |Node (10 or newer) / npm (5.6 or newer)
 |Browsers |Chrome, Firefox, Edge, Safari
 |===


### PR DESCRIPTION
Fix minimum Maven and Gradle versions required in latest docs to match the versions mentioned in the tech strategy: https://docs.google.com/document/d/174rhIJimwG1fZ7oLzEXqLIUG7A9CWkzXlcUMvT5WgAc/edit#

And remove Ivy as its usage is not recommended.

