### PR TITLE
feat: add new docs version entry to versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,9 +1,16 @@
 [
   {
-    "title": "Vaadin 19 and later",
-    "shortTitle": "V19+",
-    "description": "New features since the current LTS version",
+    "title": "Vaadin 21 (pre-release)",
+    "shortTitle": "V21",
+    "description": "Upcoming major version",
     "url": "/docs/latest",
+    "canonicalUrl": "/docs"
+  },
+  {
+    "title": "Vaadin 19-20",
+    "shortTitle": "V19-V20",
+    "description": "New features since the current LTS version",
+    "url": "/docs/v20",
     "canonicalUrl": "/docs"
   },
   {


### PR DESCRIPTION
## Description

Adds a new docs version entry to `versions.json` so that there will be a new `v20` branch that corresponds to docs for V19-20 and the `latest` branch will be for V21 (alpha) for now.

Internal Slack thread for context: https://vaadin.slack.com/archives/CQUQWJ4KU/p1621601391035000

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it. _(no issue)_
- [ ] I have added tests to ensure my change is effective and works as intended. _(not relevant)_
- [ ] New and existing tests are passing locally with my change. _(not relevant)_
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
