### PR TITLE
CE: Pin avatar image size to it's absolute image size

### DIFF
--- a/articles/ce/overview.asciidoc
+++ b/articles/ce/overview.asciidoc
@@ -30,7 +30,7 @@ Avatars::
 End users see who else is looking at the same data as they are.
 The avatars are automatically updated when users join or leave.
 +
-image:images/collaboration-avatar-group-example.png[Avatar group with three avatars visible, and three more truncated together]
+image:images/collaboration-avatar-group-example.png[Avatar group with three avatars visible, and three more truncated together,153,62]
 
 Real-time discussion::
 End users can send messages with each other within the application, either in real time or asynchronously.


### PR DESCRIPTION
The image is blown up to 100% width right now and it is too big and pixelated. Try to keep original size.

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
