### PR TITLE
CE: Fix topic-api examples

### DIFF
--- a/articles/ce/topic-api.asciidoc
+++ b/articles/ce/topic-api.asciidoc
@@ -29,7 +29,14 @@ First, create the view with a checkbox but not yet any collaborative functionali
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=topic-view;add-components;!*,indent=0]
+// NOTE: In a real application, use the user id of the logged in user
+// instead
+String userId = System.identityHashCode(UI.getCurrent()) + "";
+UserInfo localUser = new UserInfo(userId, "User " + userId);
+CollaborationEngine.getInstance().openTopicConnection(this, "tutorial",
+        localUser, topic -> {
+          return null;
+        });
 ----
 
 === Define Topic Connection
@@ -43,7 +50,12 @@ The user who is related to the topic connection must be defined.
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=user-info;open-topic;!*,indent=0]
+CollaborationEngine.getInstance().openTopicConnection(this, "tutorial",
+        localUser, topic -> {
+            CollaborationMap fieldValues = topic
+                    .getNamedMap("fieldValues");
+            return null;
+        });
 ----
 
 The activation callback should return a registration that is run when the connection is deactivated.

--- a/articles/ce/topic-api.asciidoc
+++ b/articles/ce/topic-api.asciidoc
@@ -29,14 +29,7 @@ First, create the view with a checkbox but not yet any collaborative functionali
 
 [source,java]
 ----
-// NOTE: In a real application, use the user id of the logged in user
-// instead
-String userId = System.identityHashCode(UI.getCurrent()) + "";
-UserInfo localUser = new UserInfo(userId, "User " + userId);
-CollaborationEngine.getInstance().openTopicConnection(this, "tutorial",
-        localUser, topic -> {
-          return null;
-        });
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=topic-view;add-components;!*,indent=0]
 ----
 
 === Define Topic Connection
@@ -50,11 +43,13 @@ The user who is related to the topic connection must be defined.
 
 [source,java]
 ----
+// NOTE: In a real application, use the user id of the logged in user
+// instead
+String userId = System.identityHashCode(UI.getCurrent()) + "";
+UserInfo localUser = new UserInfo(userId, "User " + userId);
 CollaborationEngine.getInstance().openTopicConnection(this, "tutorial",
         localUser, topic -> {
-            CollaborationMap fieldValues = topic
-                    .getNamedMap("fieldValues");
-            return null;
+          return null;
         });
 ----
 
@@ -67,7 +62,12 @@ In the activation callback, get a map by its name:
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=open-topic;get-map;!*,indent=0]
+CollaborationEngine.getInstance().openTopicConnection(this, "tutorial",
+        localUser, topic -> {
+            CollaborationMap fieldValues = topic
+                    .getNamedMap("fieldValues");
+            return null;
+        });
 ----
 
 === Pass Values to the Topic

--- a/articles/ce/topic-api.asciidoc
+++ b/articles/ce/topic-api.asciidoc
@@ -44,8 +44,7 @@ The user who is related to the topic connection must be defined.
 [source,java]
 ----
 include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=user-info;open-topic-method-call;!*,indent=0]
-            Registration registration = null;
-include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=return-registration;!*,indent=12]
+            return null;
 include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=open-topic-method-call-end;!*,indent=8]
 ----
 
@@ -59,8 +58,7 @@ In the activation callback, get a map by its name:
 [source,java]
 ----
 include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=user-info;open-topic-method-call;get-map;!*,indent=0]
-            Registration registration = null;
-include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=return-registration;!*,indent=12]
+            return null;
 include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=open-topic-method-call-end;!*,indent=8]
 ----
 
@@ -72,7 +70,7 @@ Add a value change listener that updates the related topic map.
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=open-topic;get-map;registration;!*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=open-topic-method-call;get-map;registration;open-topic-method-call-end;!*,indent=0]
 ----
 
 The topic's structure now looks like:

--- a/articles/ce/topic-api.asciidoc
+++ b/articles/ce/topic-api.asciidoc
@@ -44,8 +44,9 @@ The user who is related to the topic connection must be defined.
 [source,java]
 ----
 include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=user-info;open-topic-method-call;!*,indent=0]
-    Registration registration = null;
-include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=return-registration;open-topic-method-call-end;!*,indent=0]
+            Registration registration = null;
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=return-registration;!*,indent=12]
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=open-topic-method-call-end;!*,indent=8]
 ----
 
 The activation callback should return a registration that is run when the connection is deactivated.
@@ -59,7 +60,8 @@ In the activation callback, get a map by its name:
 ----
 include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=user-info;open-topic-method-call;get-map;!*,indent=0]
             Registration registration = null;
-include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=return-registration;open-topic-method-call-end;!*,indent=8]
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=return-registration;!*,indent=12]
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=open-topic-method-call-end;!*,indent=8]
 ----
 
 === Pass Values to the Topic

--- a/articles/ce/topic-api.asciidoc
+++ b/articles/ce/topic-api.asciidoc
@@ -43,14 +43,9 @@ The user who is related to the topic connection must be defined.
 
 [source,java]
 ----
-// NOTE: In a real application, use the user id of the logged in user
-// instead
-String userId = System.identityHashCode(UI.getCurrent()) + "";
-UserInfo localUser = new UserInfo(userId, "User " + userId);
-CollaborationEngine.getInstance().openTopicConnection(this, "tutorial",
-        localUser, topic -> {
-          return null;
-        });
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=user-info;open-topic-method-call;!*,indent=0]
+    Registration registration = null;
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=return-registration;open-topic-method-call-end;!*,indent=0]
 ----
 
 The activation callback should return a registration that is run when the connection is deactivated.
@@ -62,12 +57,9 @@ In the activation callback, get a map by its name:
 
 [source,java]
 ----
-CollaborationEngine.getInstance().openTopicConnection(this, "tutorial",
-        localUser, topic -> {
-            CollaborationMap fieldValues = topic
-                    .getNamedMap("fieldValues");
-            return null;
-        });
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=user-info;open-topic-method-call;get-map;!*,indent=0]
+            Registration registration = null;
+include::{root}/src/main/java/com/vaadin/demo/ce/TopicView.java[tags=return-registration;open-topic-method-call-end;!*,indent=8]
 ----
 
 === Pass Values to the Topic

--- a/src/main/java/com/vaadin/demo/ce/TopicView.java
+++ b/src/main/java/com/vaadin/demo/ce/TopicView.java
@@ -35,13 +35,12 @@ public class TopicView extends VerticalLayout {
                     CollaborationMap fieldValues = topic
                             .getNamedMap("fieldValues");
                     // end::get-map[]
-                    // tag::registration-declaration[]
+                    // tag::registration[]
                     Registration registration = checkbox
                             .addValueChangeListener(valueChangeEvent -> {
                                 fieldValues.put("isFriday",
                                         valueChangeEvent.getValue());
                             });
-                    // end::registration-declaration[]
                     // tag::subscribe[]
                     fieldValues.subscribe(event -> {
                         if ("isFriday".equals(event.getKey())) {
@@ -50,9 +49,8 @@ public class TopicView extends VerticalLayout {
                         }
                     });
                     // end::subscribe[]
-                    // tag::return-registration[]
                     return registration;
-                    // end::return-registration[]
+                    // end::registration[]
                 // tag::open-topic-method-call-end[]
                 });
                 // end::open-topic-method-call-end[]

--- a/src/main/java/com/vaadin/demo/ce/TopicView.java
+++ b/src/main/java/com/vaadin/demo/ce/TopicView.java
@@ -27,18 +27,21 @@ public class TopicView extends VerticalLayout {
         UserInfo localUser = new UserInfo(userId, "User " + userId);
         // end::user-info[]
         // tag::open-topic[]
+        // tag::open-topic-method-call[]
         CollaborationEngine.getInstance().openTopicConnection(this, "tutorial",
                 localUser, topic -> {
+        // end::open-topic-method-call[]
                     // tag::get-map[]
                     CollaborationMap fieldValues = topic
                             .getNamedMap("fieldValues");
                     // end::get-map[]
-                    // tag::registration[]
+                    // tag::registration-declaration[]
                     Registration registration = checkbox
                             .addValueChangeListener(valueChangeEvent -> {
                                 fieldValues.put("isFriday",
                                         valueChangeEvent.getValue());
                             });
+                    // end::registration-declaration[]
                     // tag::subscribe[]
                     fieldValues.subscribe(event -> {
                         if ("isFriday".equals(event.getKey())) {
@@ -47,9 +50,12 @@ public class TopicView extends VerticalLayout {
                         }
                     });
                     // end::subscribe[]
+                    // tag::return-registration[]
                     return registration;
-                    // end::registration[]
+                    // end::return-registration[]
+                // tag::open-topic-method-call-end[]
                 });
+                // end::open-topic-method-call-end[]
         // end::open-topic[]
     }
 }


### PR DESCRIPTION
The partial examples don't compile if you simply omit parts of the code.
I inlined the partial examples so I could add a "return null" to in the
lambda expression.