### PR TITLE
Update import of Lumo CSS framework classes in Fusion tutorial

### DIFF
--- a/articles/fusion/tutorials/in-depth-course/creating-views.adoc
+++ b/articles/fusion/tutorials/in-depth-course/creating-views.adoc
@@ -149,11 +149,11 @@ Then, import the styles in the main theme CSS file, `frontend/themes/fusioncrmtu
 .`styles.css`
 [source,css]
 ----
-@import 'lumo-css-framework/classes.css';
+@import 'lumo-css-framework/all-classes.css';
 ----
 
 The styles are now automatically available in all views and layouts.
-You can browse all the classes in `node_modules/lumo-css-framework/classes.css`
+You can browse all the classes in `node_modules/lumo-css-framework/all-classes.css`
 
 == Adding CSS Classes to The View Component
 


### PR DESCRIPTION
## Description

`classes.css` was only available in `lumo-css-framework` v1 and v2 so the instructions don't work if that isn't updated. Since v3.0.10 there is `all-classes.css`. Currently if you follow the tutorial you will get `lumo-css-framework` v4.

This should also be cherry-picked to the `v20` branch.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
