### PR TITLE
Fix link to /start and remove ref to spring.io

### DIFF
--- a/articles/flow/integrations/spring/spring-boot.asciidoc
+++ b/articles/flow/integrations/spring/spring-boot.asciidoc
@@ -20,7 +20,7 @@ https://spring.io/projects/spring-boot[Spring Boot] speeds up the development pr
 [NOTE]
 See <<spring-mvc#,Using Vaadin with Spring MVC>> to learn how to use Vaadin in more traditional https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html[Spring MVC] web application, without Spring Boot.
 
-The easiest way to create an application with Spring Boot and Vaadin is to start with a template application created by https://vaadin.com/start or https://start.spring.io/, but you can also add required dependencies manually to your project.
+The easiest way to create an application with Spring Boot and Vaadin is to start with a template application created by https://start.vaadin.com/, but you can also add required dependencies manually to your project.
 
 == Adding Dependencies
 


### PR DESCRIPTION
Replace the link to /start with the now-prefered https://start.vaadin.com/. Also, remove the link to spring.io as there's no point in sending users away from our website. 
