### PR TITLE
fix: use timestamp to check if session is still alive

### DIFF
--- a/frontend/demo/example-resources.ts
+++ b/frontend/demo/example-resources.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import { withPrefix } from 'gatsby';
 import './init-flow-namespace';
 import { applyTheme } from 'Frontend/generated/theme';
 // See webpack.config 'externals.Frontend/generated/theme'
@@ -9,38 +7,5 @@ window.__applyTheme = { applyTheme };
 // @ts-ignore
 import('all-flow-imports-or-empty').catch(() => {});
 
-// Stores the last time UI polls the server
-let timestamp: number;
-let interval: ReturnType<typeof setInterval>;
-const sessionTimeout = 20 * 60 * 1000;
-
-const compareTimestamps = () => {
-  // Event could be emitted with a delay up to 2 seconds after the poll
-  // Check if the timestamp is not updated after two intervals
-  if (Date.now() - timestamp > 2 * sessionTimeout) {
-    // Make sure we are not reloading the page before the server becomes available
-    fetch(withPrefix('/vaadin/index.html')).then((serverData) => {
-      if (serverData.ok) {
-        // If the server is up and running and the session is expired, reload the page
-        location.reload();
-      }
-    });
-  }
-};
-
-const updateTimestamps = () => {
-  // Check if session is expired
-  compareTimestamps();
-  timestamp = Date.now();
-  // Avoid setting multiple intervals
-  if (interval) {
-    clearInterval(interval);
-  }
-
-  // Make sure interval starts at the time of UI polling the server
-  interval = setInterval(compareTimestamps, sessionTimeout);
-};
-
-// Examples are not available when session expires
-// Event is emitted when UI polls the server. It keeps session alive
-window.addEventListener('update-timestamp', updateTimestamps);
+// Verify if session is still active and reload the page otherwise
+import './session-verification';

--- a/frontend/demo/example-resources.ts
+++ b/frontend/demo/example-resources.ts
@@ -9,14 +9,19 @@ window.__applyTheme = { applyTheme };
 // @ts-ignore
 import('all-flow-imports-or-empty').catch(() => {});
 
-let timestamp = Date.now();
+// Stores the last time UI polls the server
+let timestamp: number;
 let interval: ReturnType<typeof setInterval>;
-const sessionTimeout = 30 * 60 * 1000;
+const sessionTimeout = 20 * 60 * 1000;
 
 const compareTimestamps = () => {
-  if (Date.now() - timestamp > sessionTimeout) {
+  // Event could be emitted with a delay up to 2 seconds after the poll
+  // Check if the timestamp is not updated after two intervals
+  if (Date.now() - timestamp > 2 * sessionTimeout) {
+    // Make sure we are not reloading the page before the server becomes available
     fetch(withPrefix('/vaadin/index.html')).then((serverData) => {
       if (serverData.ok) {
+        // If the server is up and running and the session is expired, reload the page
         location.reload();
       }
     });
@@ -25,18 +30,15 @@ const compareTimestamps = () => {
 
 const updateTimestamps = () => {
   timestamp = Date.now();
+  // Avoid setting multiple intervals
   if (interval) {
     clearInterval(interval);
   }
 
+  // Make sure interval starts at the time of UI polling the server
   interval = setInterval(compareTimestamps, sessionTimeout);
 };
 
-const initialListener = () => {
-  window.removeEventListener('update-timestamp', initialListener);
-  interval = setInterval(compareTimestamps, sessionTimeout);
-  window.addEventListener('update-timestamp', updateTimestamps);
-};
-
-// Examples are not available when session is expired. Logic prevents that by reloading the page.
-window.addEventListener('update-timestamp', initialListener);
+// Examples are not available when session expires
+// Event is emitted when UI polls the server. It keeps session alive
+window.addEventListener('update-timestamp', updateTimestamps);

--- a/frontend/demo/example-resources.ts
+++ b/frontend/demo/example-resources.ts
@@ -29,6 +29,8 @@ const compareTimestamps = () => {
 };
 
 const updateTimestamps = () => {
+  // Check if session is expired
+  compareTimestamps();
   timestamp = Date.now();
   // Avoid setting multiple intervals
   if (interval) {

--- a/frontend/demo/session-verification.ts
+++ b/frontend/demo/session-verification.ts
@@ -4,7 +4,7 @@ import { withPrefix } from 'gatsby';
 // Stores the last time UI polls the server
 let timestamp: number;
 let interval: ReturnType<typeof setInterval>;
-const sessionTimeout = 20 * 60 * 1000;
+let sessionTimeout: number;
 
 const compareTimestamps = () => {
   // Event could be emitted with a delay up to 2 seconds after the poll
@@ -20,7 +20,7 @@ const compareTimestamps = () => {
   }
 };
 
-const updateTimestamps = () => {
+const updateTimestamps = ((e: CustomEvent) => {
   // Check if session is expired
   compareTimestamps();
   timestamp = Date.now();
@@ -29,9 +29,10 @@ const updateTimestamps = () => {
     clearInterval(interval);
   }
 
+  sessionTimeout = e.detail;
   // Make sure interval starts at the time of UI polling the server
-  interval = setInterval(compareTimestamps, sessionTimeout);
-};
+  interval = setInterval(compareTimestamps, e.detail);
+}) as EventListener;
 
 // Examples are not available when session expires
 // Event is emitted when UI polls the server. It keeps session alive

--- a/frontend/demo/session-verification.ts
+++ b/frontend/demo/session-verification.ts
@@ -11,7 +11,7 @@ const compareTimestamps = () => {
   // Check if the timestamp is not updated after two intervals
   if (Date.now() - timestamp > 2 * sessionTimeout) {
     // Make sure we are not reloading the page before the server becomes available
-    fetch(withPrefix('/vaadin/index.html')).then((serverData) => {
+    fetch(withPrefix('/vaadin/index')).then((serverData) => {
       if (serverData.ok) {
         // If the server is up and running and the session is expired, reload the page
         location.reload();

--- a/frontend/demo/session-verification.ts
+++ b/frontend/demo/session-verification.ts
@@ -1,0 +1,38 @@
+// @ts-ignore
+import { withPrefix } from 'gatsby';
+
+// Stores the last time UI polls the server
+let timestamp: number;
+let interval: ReturnType<typeof setInterval>;
+const sessionTimeout = 20 * 60 * 1000;
+
+const compareTimestamps = () => {
+  // Event could be emitted with a delay up to 2 seconds after the poll
+  // Check if the timestamp is not updated after two intervals
+  if (Date.now() - timestamp > 2 * sessionTimeout) {
+    // Make sure we are not reloading the page before the server becomes available
+    fetch(withPrefix('/vaadin/index.html')).then((serverData) => {
+      if (serverData.ok) {
+        // If the server is up and running and the session is expired, reload the page
+        location.reload();
+      }
+    });
+  }
+};
+
+const updateTimestamps = () => {
+  // Check if session is expired
+  compareTimestamps();
+  timestamp = Date.now();
+  // Avoid setting multiple intervals
+  if (interval) {
+    clearInterval(interval);
+  }
+
+  // Make sure interval starts at the time of UI polling the server
+  interval = setInterval(compareTimestamps, sessionTimeout);
+};
+
+// Examples are not available when session expires
+// Event is emitted when UI polls the server. It keeps session alive
+window.addEventListener('update-timestamp', updateTimestamps);

--- a/src/main/java/com/vaadin/demo/DemoExporter.java
+++ b/src/main/java/com/vaadin/demo/DemoExporter.java
@@ -7,8 +7,12 @@ import com.vaadin.flow.component.webcomponent.WebComponent;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.theme.Theme;
 
+import java.time.Duration;
+
 @Theme("docs")
 public abstract class DemoExporter<T extends Component> extends WebComponentExporter<T> {
+
+  private boolean initializedPoll;
 
   public DemoExporter() {
     super("");
@@ -26,8 +30,11 @@ public abstract class DemoExporter<T extends Component> extends WebComponentExpo
 
   @Override
   protected void configureInstance(final WebComponent<T> webComponent, final T demo) {
-    UI.getCurrent().setPollInterval(30 * 60 * 1000);
-    UI.getCurrent().addPollListener(e -> emitUpdateTimestamp());
+    if (!initializedPoll) {
+      UI.getCurrent().setPollInterval((int) Duration.ofMinutes(20).toMillis());
+      UI.getCurrent().addPollListener(e -> emitUpdateTimestamp());
+      initializedPoll = true;
+    }
     emitUpdateTimestamp();
   }
 

--- a/src/main/java/com/vaadin/demo/DemoExporter.java
+++ b/src/main/java/com/vaadin/demo/DemoExporter.java
@@ -5,6 +5,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.webcomponent.WebComponent;
 import com.vaadin.flow.internal.ReflectTools;
+import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.theme.Theme;
 
 import java.time.Duration;
@@ -28,15 +29,16 @@ public abstract class DemoExporter<T extends Component> extends WebComponentExpo
 
   @Override
   protected void configureInstance(final WebComponent<T> webComponent, final T demo) {
+    int interval = (int) Duration.ofSeconds(VaadinSession.getCurrent().getSession().getMaxInactiveInterval() - 10 * 60).toMillis();
     if (UI.getCurrent().getPollInterval() == -1) {
-      UI.getCurrent().setPollInterval((int) Duration.ofMinutes(20).toMillis());
-      UI.getCurrent().addPollListener(e -> emitUpdateTimestamp());
+      UI.getCurrent().setPollInterval(interval);
+      UI.getCurrent().addPollListener(e -> emitUpdateTimestamp(interval));
     }
-    emitUpdateTimestamp();
+    emitUpdateTimestamp(interval);
   }
 
-  private void emitUpdateTimestamp() {
-    UI.getCurrent().getPage().executeJs("window.dispatchEvent(new Event('update-timestamp'))");
+  private void emitUpdateTimestamp(int interval) {
+    UI.getCurrent().getPage().executeJs("window.dispatchEvent(new CustomEvent('update-timestamp', {detail: $0}))", interval);
   }
 }
 

--- a/src/main/java/com/vaadin/demo/DemoExporter.java
+++ b/src/main/java/com/vaadin/demo/DemoExporter.java
@@ -12,7 +12,7 @@ import java.time.Duration;
 @Theme("docs")
 public abstract class DemoExporter<T extends Component> extends WebComponentExporter<T> {
 
-  private boolean initializedPoll;
+  private static boolean initializedPoll;
 
   public DemoExporter() {
     super("");

--- a/src/main/java/com/vaadin/demo/DemoExporter.java
+++ b/src/main/java/com/vaadin/demo/DemoExporter.java
@@ -12,8 +12,6 @@ import java.time.Duration;
 @Theme("docs")
 public abstract class DemoExporter<T extends Component> extends WebComponentExporter<T> {
 
-  private static boolean initializedPoll;
-
   public DemoExporter() {
     super("");
 
@@ -30,10 +28,9 @@ public abstract class DemoExporter<T extends Component> extends WebComponentExpo
 
   @Override
   protected void configureInstance(final WebComponent<T> webComponent, final T demo) {
-    if (!initializedPoll) {
+    if (UI.getCurrent().getPollInterval() == -1) {
       UI.getCurrent().setPollInterval((int) Duration.ofMinutes(20).toMillis());
       UI.getCurrent().addPollListener(e -> emitUpdateTimestamp());
-      initializedPoll = true;
     }
     emitUpdateTimestamp();
   }

--- a/src/main/java/com/vaadin/demo/DemoExporter.java
+++ b/src/main/java/com/vaadin/demo/DemoExporter.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.webcomponent.WebComponent;
 import com.vaadin.flow.internal.ReflectTools;
@@ -25,5 +26,13 @@ public abstract class DemoExporter<T extends Component> extends WebComponentExpo
 
   @Override
   protected void configureInstance(final WebComponent<T> webComponent, final T demo) {
+    UI.getCurrent().setPollInterval(30 * 60 * 1000);
+    UI.getCurrent().addPollListener(e -> emitUpdateTimestamp());
+    emitUpdateTimestamp();
+  }
+
+  private void emitUpdateTimestamp() {
+    UI.getCurrent().getPage().executeJs("window.dispatchEvent(new Event('update-timestamp'))");
   }
 }
+


### PR DESCRIPTION
`setPollInterval` will keep the session alive while user is online.
If the user or server is not going online for more than 40 minutes, the tab will be reloaded once the server is available.
Logic won't be executed if the included example is not on the page.