### PR TITLE
Svg generator DX fixes

### DIFF
--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -41,6 +41,8 @@ Configuration configuration = new Configuration();
 // ...
 try (SVGGenerator generator = new SVGGenerator()) {
     String svg = generator.generate(configuration);
+} catch (IOException | InterruptedException ex) {
+    // handle exceptions accordingly
 }
 ----
 
@@ -57,6 +59,9 @@ Some attributes about the resulting SVG can be customized. Customizable options 
 
 Any customizations are handled with the [classname]#ExportOptions# class.
 
+.CSS styling not supported
+NOTE: CSS styling is not supported when exporting a chart as SVG.
+
 [source,java]
 ----
 Configuration configuration = new Configuration();
@@ -66,11 +71,10 @@ options.setWidth(800);
 options.setHeight(600);
 try (SVGGenerator generator = new SVGGenerator()) {
     String svg = generator.generate(configuration, options);
+} catch (IOException | InterruptedException ex) {
+    // handle exceptions accordingly
 }
 ----
-
-.CSS styling not supported
-NOTE: CSS styling is not supported when exporting a chart as SVG.
 
 === Executing JavaScript Functions
 
@@ -90,6 +94,8 @@ ExportOptions options = new ExportOptions();
 options.setExecuteFunctions(true);
 try (SVGGenerator generator = new SVGGenerator()) {
     String svg = generator.generate(configuration, options);
+} catch (IOException | InterruptedException ex) {
+    // handle exceptions accordingly
 }
 ----
 
@@ -109,6 +115,8 @@ Configuration configuration = new Configuration();
 try (SVGGenerator generator = new SVGGenerator()) {
     String svg = generator.generate(configuration);
     div.getElement().setProperty("innerHTML", svg);
+} catch (IOException | InterruptedException ex) {
+    // handle exceptions accordingly
 }
 add(div);
 ----

--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -24,7 +24,7 @@ Add the `vaadin-charts-flow-svg-generator` dependency to your project's `pom.xml
 
 .NodeJS required
 NOTE: NodeJS must be installed for the generator to work.
-You can see installation instructions <<../../../../guide/install#node-js,here>>.
+Please see the installation instructions in <<{articles}/guide/install#node-js,Installing Node.js>>.
 
 == Using the Generator
 
@@ -48,8 +48,9 @@ try (SVGGenerator generator = new SVGGenerator()) {
 
 == Customizing SVG Generation
 
-Some attributes about the resulting SVG can be customized. 
-Customizable options include:
+You can customize some attributes of the resulting SVG.
+
+The customizable options include the following:
 
 * Width
 * Height
@@ -79,7 +80,7 @@ try (SVGGenerator generator = new SVGGenerator()) {
 
 === Executing JavaScript Functions
 
-It is possible to execute functions from [classname]#Configuration# objects, for example, formatter functions.
+Your can execute functions from [classname]#Configuration# objects, for example, formatter functions.
 Executing functions must be explicitly enabled by setting the `executeFunctions` flag to `true`.
 
 .Only Run Trusted Code
@@ -102,11 +103,11 @@ try (SVGGenerator generator = new SVGGenerator()) {
 
 == Preview SVG (For Debugging)
 
-You can add the SVG to a component to see the resulting image.
+You can add the generated SVG to a component to see the resulting image.
 
 .For debugging purposes only
 CAUTION: Use the <<./basic-use#,Chart>> component to render charts.
-This approach is only intended to help you debug your app.
+This approach is only intended to help you debug your application.
 
 [source,java]
 ----

--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -48,7 +48,8 @@ try (SVGGenerator generator = new SVGGenerator()) {
 
 == Customizing SVG Generation
 
-Some attributes about the resulting SVG can be customized. Customizable options include:
+Some attributes about the resulting SVG can be customized. 
+Customizable options include:
 
 * Width
 * Height
@@ -82,7 +83,7 @@ It is possible to execute functions from [classname]#Configuration# objects, for
 Executing functions must be explicitly enabled by setting the `executeFunctions` flag to `true`.
 
 .Only Run Trusted Code
-CAUTION: Enabling this option will allow JavaScript code to run on your server.
+CAUTION: Enabling this option allows JavaScript code to run on your server.
 Make sure to only allow safe and trusted code.
 
 [source,java]
@@ -99,7 +100,7 @@ try (SVGGenerator generator = new SVGGenerator()) {
 }
 ----
 
-== Preview SVG (for debugging)
+== Preview SVG (For Debugging)
 
 You can add the SVG to a component to see the resulting image.
 

--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -92,3 +92,23 @@ try (SVGGenerator generator = new SVGGenerator()) {
     String svg = generator.generate(configuration, options);
 }
 ----
+
+== Preview SVG (for debugging)
+
+You can add the SVG to a component to see the resulting image.
+
+.For debugging purposes only
+CAUTION: Use the <<../../../basic-use,Chart>> component to render charts.
+This approach is only intended to help you debug your app.
+
+[source,java]
+----
+Div div = new Div();
+Configuration configuration = new Configuration();
+// ...
+try (SVGGenerator generator = new SVGGenerator()) {
+    String svg = generator.generate(configuration);
+    div.getElement().setProperty("innerHTML", svg);
+}
+add(div);
+----

--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -80,7 +80,7 @@ try (SVGGenerator generator = new SVGGenerator()) {
 
 === Executing JavaScript Functions
 
-Your can execute functions from [classname]#Configuration# objects, for example, formatter functions.
+You can execute functions from [classname]#Configuration# objects, for example, formatter functions.
 Executing functions must be explicitly enabled by setting the `executeFunctions` flag to `true`.
 
 .Only Run Trusted Code

--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -22,8 +22,9 @@ Add the `vaadin-charts-flow-svg-generator` dependency to your project's `pom.xml
 </dependency>
 ----
 
-.Node.js is required
-NOTE: Node.js must be installed for the generator to work.
+.NodeJS required
+NOTE: NodeJS must be installed for the generator to work.
+You can see installation instructions <<../../../../guide/install#node-js,here>>.
 
 == Using the Generator
 

--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -45,7 +45,15 @@ try (SVGGenerator generator = new SVGGenerator()) {
 
 == Customizing SVG Generation
 
-Some attributes about the resulting SVG can be customized, like width, height, theme, or language.
+Some attributes about the resulting SVG can be customized. Customizable options include:
+
+* Width
+* Height
+* Theme
+* Language
+* Showing timeline
+* Executing JavaScript code (formatter functions)
+
 Any customizations are handled with the [classname]#ExportOptions# class.
 
 [source,java]

--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -31,7 +31,8 @@ You can see installation instructions <<../../../../guide/install#node-js,here>>
 Create an instance of [classname]#SVGGenerator# and call the [methodname]#generate()# method, passing the chart's [classname]#Configuration# as an argument.
 The method returns a string with the SVG data of the chart.
 
-Remember to close the generator when you're done using it.
+.Close the generator
+WARNING: Remember to *close the generator when you're done using it*.
 It is recommended to use a try-with-resources block, so the generator is automatically closed.
 
 [source,java]

--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -22,8 +22,8 @@ Add the `vaadin-charts-flow-svg-generator` dependency to your project's `pom.xml
 </dependency>
 ----
 
-.NodeJS required
-NOTE: NodeJS must be installed for the generator to work.
+.Node.js required
+NOTE: Node.js must be installed for the generator to work.
 Please see the installation instructions in <<{articles}/guide/install#node-js,Installing Node.js>>.
 
 == Using the Generator

--- a/articles/ds/components/charts/java-api/svg-generator.asciidoc
+++ b/articles/ds/components/charts/java-api/svg-generator.asciidoc
@@ -105,7 +105,7 @@ try (SVGGenerator generator = new SVGGenerator()) {
 You can add the SVG to a component to see the resulting image.
 
 .For debugging purposes only
-CAUTION: Use the <<../../../basic-use,Chart>> component to render charts.
+CAUTION: Use the <<./basic-use#,Chart>> component to render charts.
 This approach is only intended to help you debug your app.
 
 [source,java]


### PR DESCRIPTION
Changes to the documentation page of the SVG generator feature that came up as a result of DX tests.

* add link to installation instructions for NodeJS
* add list of customizable options
* add a warning block and bold formatting to highlight closing the generator.
* add section to preview SVG image
* add catch clauses to code samples