### PR TITLE
docs: removing Template API

### DIFF
--- a/articles/fusion/advanced/components-definitions.asciidoc
+++ b/articles/fusion/advanced/components-definitions.asciidoc
@@ -15,7 +15,7 @@ Depending on the IDE you use, TypeScript definitions can also enable better code
 
 If you are using Visual Studio Code, we recommend to install
 https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin[lit-plugin] which provides
-syntax highlighting and type checking support for LitElement templates. 
+syntax highlighting and type checking support for LitElement templates.
 You can also use
 https://www.npmjs.com/package/lit-analyzer[lit-analyzer] CLI tool by the same author for type checking.
 
@@ -55,9 +55,6 @@ operator.
 This tells the TypeScript compiler that the `dialog` property is initialized indirectly and does not need a default value.
 
 === Renderer Functions [[renderer-functions]]
-
-Some Vaadin components like Grid and Dialog allow to pass the `<template>` element and then use it to stamp the content.
-This API is not compatible with lit-html. Use `renderer` functions in LitElement-based views instead.
 
 Renderer function is a class method that accepts one or several arguments.
 To access them without TypeScript warnings, you need to get them typed by importing and using the corresponding type declarations:

--- a/articles/fusion/application/basics.asciidoc
+++ b/articles/fusion/application/basics.asciidoc
@@ -138,8 +138,10 @@ To navigate between views, you need to define routes (see <<../routing/overview#
 .frontend/my-view.ts
 [source,typescript]
 ----
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, render } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
+import { guard } from 'lit/directives/guard.js';
+
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
 
@@ -161,11 +163,16 @@ export class MyView extends LitElement {
       <vaadin-button theme="primary" @click="${this.clickHandler}">
         Click me
       </vaadin-button>
-      <vaadin-notification id="notification" duration="2000">
-        <template>
-          Hello, World!
-        </template>
-      </vaadin-notification>
+      <vaadin-notification
+        id="notification"
+        duration="2000"
+        .renderer="${guard([], () => (root: HTMLElement) => {
+          render(
+            html`Hello, World!`,
+            root
+          );
+        })}"
+      ></vaadin-notification>
     `;
   }
 

--- a/articles/fusion/forms/appendix-vaadin-components.asciidoc
+++ b/articles/fusion/forms/appendix-vaadin-components.asciidoc
@@ -197,14 +197,21 @@ import '@vaadin/vaadin-select';
 ...
 render() {
   return html`
-  <vaadin-select ...="${field(this.binder.model.mySelectField)}" label="select">
-    <template>
-      <vaadin-list-box>
-        <vaadin-item><span>item-1</span></vaadin-item>
-        <vaadin-item><span>item-2</span></vaadin-item>
-      </vaadin-list-box>
-    </template>
-  </vaadin-select>
+    <vaadin-select
+      ...="${field(this.binder.model.mySelectField)}"
+      label="select"
+      .renderer="${guard([], () => (root: HTMLElement) => {
+        render(
+          html`
+            <vaadin-list-box>
+              <vaadin-item><span>item-1</span></vaadin-item>
+              <vaadin-item><span>item-2</span></vaadin-item>
+            </vaadin-list-box>
+          `,
+          root
+        );
+      })}"
+    ></vaadin-select>
   `;
 }
 ----

--- a/articles/guide/upgrading.asciidoc
+++ b/articles/guide/upgrading.asciidoc
@@ -48,11 +48,11 @@ The following instructions apply when upgrading from a version before Vaadin 21.
 
 === The Vaadin Web Components No Longer Support <template>
 
-The Vaadin Web Components no longer support `<template>` to render a content.
+The Vaadin Web Components no longer support `<template>` to render content.
 
 Please, use renderer functions instead.
 
-Alternatively, you can use the `@vaadin/vaadin-template-renderer` package which is created to maintain the backward compatibility.
+Alternatively, you can use the `@vaadin/vaadin-template-renderer` package which is created to maintain backward compatibility.
 
 ==== Installation
 
@@ -70,9 +70,9 @@ import '@vaadin/vaadin-template-renderer';
 
 ==== Deprecation Warning
 
-By default, `vaadin-template-renderer` shows a deprecation warning once a component when using `<template>`.
+By default, `vaadin-template-renderer` shows a deprecation warning once a component using `<template>`.
 
-To suppress the warning, add the `suppress-template-warning` attribute to the component, e.g:
+To suppress the warning, add the `suppress-template-warning` attribute to the component:
 
 [source,html]
 ----

--- a/articles/guide/upgrading.asciidoc
+++ b/articles/guide/upgrading.asciidoc
@@ -46,9 +46,9 @@ include::{root}/pom.xml[tag=spring-version, indent=0]
 
 The following instructions apply when upgrading from a version before Vaadin 21.
 
-=== The Web Components No Longer Support <template>
+=== The Vaadin Web Components No Longer Support <template>
 
-As a part of migration to LitElement, the Web Components no longer support `<template>` to render a content.
+The Vaadin Web Components no longer support `<template>` to render a content.
 
 Please, use renderer functions instead.
 
@@ -66,6 +66,17 @@ Import `vaadin-template-renderer` before any other components:
 [source,typescript]
 ----
 import '@vaadin/vaadin-template-renderer';
+----
+
+Now, you can use templates as before:
+
+[source,html]
+----
+<vaadin-combo-box>
+    <template>
+        Content
+    </template>
+</vaadin-combo-box>
 ----
 
 ==== Deprecation Warning

--- a/articles/guide/upgrading.asciidoc
+++ b/articles/guide/upgrading.asciidoc
@@ -46,6 +46,43 @@ include::{root}/pom.xml[tag=spring-version, indent=0]
 
 The following instructions apply when upgrading from a version before Vaadin 21.
 
+=== The Web Components No Longer Support <template>
+
+As a part of migration to LitElement, the Web Components no longer support `<template>` to render a content.
+
+Please, use renderer functions instead.
+
+Alternatively, you can use the `@vaadin/vaadin-template-renderer` package which is created to maintain the backward compatibility.
+
+==== Installation
+
+Install `vaadin-template-renderer`:
+```
+npm i @vaadin/vaadin-template-renderer --save
+```
+
+Import `vaadin-template-renderer` before any other components:
+
+[source,typescript]
+----
+import '@vaadin/vaadin-template-renderer';
+----
+
+==== Deprecation Warning
+
+By default, `vaadin-template-renderer` shows a deprecation warning once a component when using `<template>`.
+
+To suppress the warning, add the `suppress-template-warning` attribute to the component, e.g:
+
+[source,html]
+----
+<vaadin-combo-box suppress-template-warning>
+    <template>
+        Content
+    </template>
+</vaadin-combo-box>
+----
+
 === Lit Templates Use Lit 2
 
 Previously, Lit templates were based on LitElement 2.x and lit-html 1.x.
@@ -106,7 +143,6 @@ The most noticeable change is that the `@internalProperty` decorator has been re
 == Changes in Vaadin 20
 
 The following instructions apply when upgrading from a version before Vaadin 20.
-
 
 === Endpoints Access is Denied by Default
 

--- a/articles/guide/upgrading.asciidoc
+++ b/articles/guide/upgrading.asciidoc
@@ -70,7 +70,7 @@ import '@vaadin/vaadin-template-renderer';
 
 ==== Deprecation Warning
 
-By default, `vaadin-template-renderer` shows a deprecation warning once a component using `<template>`.
+By default, `vaadin-template-renderer` shows a deprecation warning when `<template>` is used with a component.
 
 To suppress the warning, add the `suppress-template-warning` attribute to the component:
 

--- a/articles/guide/upgrading.asciidoc
+++ b/articles/guide/upgrading.asciidoc
@@ -68,17 +68,6 @@ Import `vaadin-template-renderer` before any other components:
 import '@vaadin/vaadin-template-renderer';
 ----
 
-Now, you can use templates as before:
-
-[source,html]
-----
-<vaadin-combo-box>
-    <template>
-        Content
-    </template>
-</vaadin-combo-box>
-----
-
 ==== Deprecation Warning
 
 By default, `vaadin-template-renderer` shows a deprecation warning once a component when using `<template>`.

--- a/articles/guide/upgrading.asciidoc
+++ b/articles/guide/upgrading.asciidoc
@@ -49,14 +49,12 @@ The following instructions apply when upgrading from a version before Vaadin 21.
 === The Vaadin Web Components No Longer Support <template>
 
 The Vaadin Web Components no longer support `<template>` to render content.
-
 Please, use renderer functions instead.
-
 Alternatively, you can use the `@vaadin/vaadin-template-renderer` package which is created to maintain backward compatibility.
 
 ==== Installation
 
-Install `vaadin-template-renderer`:
+Install `vaadin-template-renderer` as follows:
 ```
 npm i @vaadin/vaadin-template-renderer --save
 ```

--- a/articles/guide/upgrading.asciidoc
+++ b/articles/guide/upgrading.asciidoc
@@ -66,7 +66,6 @@ Import `vaadin-template-renderer` before any other components:
 [source,typescript]
 ----
 import '@vaadin/vaadin-template-renderer';
-import '@vaadin/vaadin-combo-box';
 ----
 
 ==== Deprecation Warning

--- a/articles/guide/upgrading.asciidoc
+++ b/articles/guide/upgrading.asciidoc
@@ -66,6 +66,7 @@ Import `vaadin-template-renderer` before any other components:
 [source,typescript]
 ----
 import '@vaadin/vaadin-template-renderer';
+import '@vaadin/vaadin-combo-box';
 ----
 
 ==== Deprecation Warning


### PR DESCRIPTION
- Adds a section to the Upgrading Guide explaining that the Template API (`<template>`) is no longer supported and renderer functions or the template renderer package should be used instead.
- Removes any mentions of Template API support
- Converts templates to renderer functions in the Fusion examples

Closes https://github.com/vaadin/web-components/issues/2100
Closes https://github.com/vaadin/web-components/issues/2113
