### PR TITLE
docs: make focus outline always visible in grid cell focus example

### DIFF
--- a/articles/ds/components/grid/index.asciidoc
+++ b/articles/ds/components/grid/index.asciidoc
@@ -662,7 +662,7 @@ The following keyboard shortcuts are available:
 The cell focus event can be used to get notified when the user changes focus between cells.
 
 By default, the focus outline is only visible when using keyboard navigation.
-For demonstration purposes the example below uses custom styles to also show the focus outline when clicking on cells.
+For demonstration purposes, the example below uses custom styles to also show the focus outline when clicking on cells.
 
 [.example]
 --

--- a/articles/ds/components/grid/index.asciidoc
+++ b/articles/ds/components/grid/index.asciidoc
@@ -661,8 +661,8 @@ The following keyboard shortcuts are available:
 
 The cell focus event can be used to get notified when the user changes focus between cells.
 
-The focus outline is only visible when using keyboard navigation.
-In the example below, try clicking on a cell and then use one of the arrow keys.
+By default, the focus outline is only visible when using keyboard navigation.
+For demonstration purposes the example below uses custom styles to also show the focus outline when clicking on cells.
 
 [.example]
 --
@@ -675,6 +675,11 @@ include::{root}/frontend/demo/component/grid/grid-cell-focus.ts[render,tags=snip
 [source,java]
 ----
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridCellFocus.java[render,tags=snippet,indent=0,group=Java]
+----
+
+[source,css]
+----
+include::{root}/frontend/themes/docs/components/vaadin-grid-cell-focus.css[render,tags=snippet,indent=0,group=CSS]
 ----
 
 --

--- a/articles/ds/components/grid/index.asciidoc
+++ b/articles/ds/components/grid/index.asciidoc
@@ -679,7 +679,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridCellFocus.java[
 
 [source,css]
 ----
-include::{root}/frontend/themes/docs/components/vaadin-grid-cell-focus.css[render,tags=snippet,indent=0,group=CSS]
+include::{root}/frontend/themes/docs/components/vaadin-grid-cell-focus.css[]
 ----
 
 --

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -43,6 +43,7 @@ export class Example extends LitElement {
   render() {
     return html`
       <vaadin-grid
+        theme="force-focus-outline"
         .items="${this.items}"
         @cell-focus="${(e: CustomEvent) => {
           const eventContext = this.grid.getEventContext(e) as GridEventContext<Person>;

--- a/frontend/themes/docs/components/vaadin-grid-cell-focus.css
+++ b/frontend/themes/docs/components/vaadin-grid-cell-focus.css
@@ -1,4 +1,5 @@
-/* tag::snippet[] */
+/* frontend/theme/[my-theme]/components/vaadin-grid.css */
+
 :host([theme~='force-focus-outline']) [part~='cell']:focus::before {
     content: '';
     position: absolute;
@@ -9,4 +10,3 @@
     pointer-events: none;
     box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
 }
-/* end::snippet[] */

--- a/frontend/themes/docs/components/vaadin-grid-cell-focus.css
+++ b/frontend/themes/docs/components/vaadin-grid-cell-focus.css
@@ -1,0 +1,12 @@
+/* tag::snippet[] */
+:host([theme~='force-focus-outline']) [part~='cell']:focus::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    pointer-events: none;
+    box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
+}
+/* end::snippet[] */

--- a/frontend/themes/docs/components/vaadin-grid.css
+++ b/frontend/themes/docs/components/vaadin-grid.css
@@ -1,1 +1,2 @@
 @import 'vaadin-grid-styling.css';
+@import 'vaadin-grid-cell-focus.css';

--- a/src/main/java/com/vaadin/demo/component/grid/GridCellFocus.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridCellFocus.java
@@ -16,6 +16,7 @@ public class GridCellFocus extends Div {
 
     public GridCellFocus() {
         Grid<Person> grid = new Grid<>(Person.class, false);
+        grid.setThemeName("force-focus-outline");
         grid.addColumn(Person::getFirstName)
                 .setKey("firstName")
                 .setHeader("First name");


### PR DESCRIPTION
## Description

Modifies the grid cell focus example to always show the focus outline for demonstration purposes, and adds a hint to the asciidoc about differences to the default behaviour.

Based on feedback from DX testing of the grid cell focus event.