### PR TITLE
fix: Bump the required version of Spring Boot for v21 (#577)

### DIFF
--- a/articles/guide/upgrading.asciidoc
+++ b/articles/guide/upgrading.asciidoc
@@ -32,7 +32,7 @@ Click the "Expand code" button to view a complete reference `pom.xml` file.
 
 . Update Spring Version (Spring-based projects only).
 +
-Vaadin is compatible with Spring 5.2.0 or newer, and Spring Boot 2.2.0 or newer.
+Vaadin is compatible with Spring 5.3.0 or newer, and Spring Boot 2.4.0 or newer.
 If your application uses an older version of Spring, update it to a compatible version:
 +
 [source,xml]


### PR DESCRIPTION
Cherry-picking #577 for v20.

Co-authored-by: Pekka Hyvönen <pekka@vaadin.com>