### PR TITLE
fix: use guard() when assigning a renderer

### DIFF
--- a/frontend/demo/component/badge/badge-highlight.ts
+++ b/frontend/demo/component/badge/badge-highlight.ts
@@ -6,6 +6,7 @@ import '@vaadin/vaadin-lumo-styles/icons';
 import type { GridColumnElement, GridItemModel } from '@vaadin/vaadin-grid';
 import { applyTheme } from 'Frontend/generated/theme';
 import { html, LitElement, render } from 'lit';
+import { guard } from 'lit/directives/guard';
 import { customElement, state } from 'lit/decorators.js';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -37,69 +38,67 @@ export class Example extends LitElement {
         <vaadin-grid-column path="report" header="Report"></vaadin-grid-column>
         <vaadin-grid-column
           header="Due Date"
-          .renderer="${(
-            root: HTMLElement,
-            column?: GridColumnElement,
-            model?: GridItemModel<Report>
-          ) => {
-            if (!column || !model) {
-              return;
-            }
+          .renderer="${guard(
+            [],
+            () => (root: HTMLElement, column?: GridColumnElement, model?: GridItemModel<Report>) => {
+              if (!column || !model) {
+                return;
+              }
 
-            render(html`${dateFormatter.format(new Date(model.item.due))}`, root);
-          }}"
+              render(html`${dateFormatter.format(new Date(model.item.due))}`, root);
+            }
+          )}"
         ></vaadin-grid-column>
         <vaadin-grid-column path="assignee" header="Assignee"></vaadin-grid-column>
         <vaadin-grid-column
           header="Status"
-          .renderer="${(
-            root: HTMLElement,
-            column?: GridColumnElement,
-            model?: GridItemModel<Report>
-          ) => {
-            if (!column || !model) {
-              return;
+          .renderer="${guard(
+            [],
+            () => (root: HTMLElement, column?: GridColumnElement, model?: GridItemModel<Report>) => {
+              if (!column || !model) {
+                return;
+              }
+
+              const { status } = model.item;
+
+              let icon: string;
+              let title: string;
+              let theme: string;
+
+              switch (status) {
+                case ReportStatus.COMPLETED:
+                  icon = 'lumo:checkmark';
+                  title = 'Completed';
+                  theme = 'success';
+                  break;
+                case ReportStatus.IN_PROGRESS:
+                  icon = 'lumo:cog';
+                  title = 'In Progress';
+                  theme = '';
+                  break;
+                case ReportStatus.CANCELLED:
+                  icon = 'lumo:cross';
+                  title = 'Cancelled';
+                  theme = 'error';
+                  break;
+                default:
+                  icon = 'lumo:clock';
+                  title = 'On Hold';
+                  theme = 'contrast';
+                  break;
+              }
+
+              render(
+                html`
+                  <span theme="badge ${theme} primary">
+                    <iron-icon icon="${icon}"></iron-icon>
+                    <span>${title}</span>
+                  </span>
+                `,
+                root
+              );
             }
-
-            const { status } = model.item;
-
-            let icon: string;
-            let title: string;
-            let theme: string;
-
-            switch (status) {
-              case ReportStatus.COMPLETED:
-                icon = 'lumo:checkmark';
-                title = 'Completed';
-                theme = 'success';
-                break;
-              case ReportStatus.IN_PROGRESS:
-                icon = 'lumo:cog';
-                title = 'In Progress';
-                theme = '';
-                break;
-              case ReportStatus.CANCELLED:
-                icon = 'lumo:cross';
-                title = 'Cancelled';
-                theme = 'error';
-                break;
-              default:
-                icon = 'lumo:clock';
-                title = 'On Hold';
-                theme = 'contrast';
-                break;
-            }
-
-            render(
-              html`
-                <span theme="badge ${theme} primary">
-                  <iron-icon icon="${icon}"></iron-icon>
-                  <span>${title}</span>
-                </span>
-              `,
-              root
-            );
-          }}"
+          )}"
         ></vaadin-grid-column>
       </vaadin-grid>
     `;


### PR DESCRIPTION
## Description

When binding a renderer to a component, it should be always assigned via Lit's `guard()` to prevent re-assigning on every render.

**Note:** Currently there is [a bug](https://github.com/vaadin/web-components/issues/2161) in Web Components that appears when re-assigning a Lit-based renderer without `guard()`.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
