### PR TITLE
feat: deprecate mispelled icons on icons preview page

### DIFF
--- a/frontend/demo/foundation/icons-preview.ts
+++ b/frontend/demo/foundation/icons-preview.ts
@@ -1,6 +1,14 @@
 import { IconsetElement } from '@vaadin/vaadin-icon/vaadin-iconset';
 import '@vaadin/vaadin-icon/vaadin-icon';
 
+const DEPRECATED_ICONS: Record<string, string> = {
+  buss: 'bus',
+  palete: 'palette',
+  funcion: 'function',
+  megafone: 'megaphone',
+  'trendind-down': 'trending-down',
+};
+
 export class IconsPreview extends HTMLElement {
   connectedCallback() {
     const iconsetName = this.getAttribute('name')!;
@@ -29,6 +37,10 @@ export class IconsPreview extends HTMLElement {
           text-align: center;
           padding-bottom: var(--docs-space-l);
           line-height: 1;
+        }
+
+        .docs-icon-preview.deprecated {
+          text-decoration: line-through;
         }
 
         .docs-icon-preview.hidden {
@@ -66,8 +78,18 @@ export class IconsPreview extends HTMLElement {
     `;
 
     iconNames.forEach((name: string) => {
+      let title = '';
+      const isDeprecated = name in DEPRECATED_ICONS;
+
+      if (isDeprecated) {
+        title = `Since Vaadin 21, '${name}' is deprecated. Please use '${DEPRECATED_ICONS[name]}' instead.`;
+      }
+
       html += `
-        <div class="docs-icon-preview icon-${name}">
+        <div
+          class="docs-icon-preview icon-${name} ${isDeprecated ? 'deprecated' : ''}"
+          title="${title}"
+        >
           <vaadin-icon icon="${iconsetName}:${name}"></vaadin-icon>
           <span class="docs-icon-preview-name">${name}</div>
         </div>`;


### PR DESCRIPTION
## Description

- Crosses out the deprecated misspelled icons on [the icons preview page](https://vaadin.com/docs/latest/ds/foundation/icons/vaadin)
- Adds the `title` attribute to show a tooltip, e.g: `Since Vaadin 21, 'buss' is deprecated. Please use 'bus' instead.`

![image](https://user-images.githubusercontent.com/5039436/123784348-04383b00-d8e0-11eb-97be-2990447487b8.png)

Fixes https://github.com/vaadin/web-components/issues/2108

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
