### PR TITLE
fix: use guard() when assigning a renderer

### DIFF
--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -7,6 +7,7 @@ import '@vaadin/vaadin-icons/vaadin-iconset';
 import type { GridColumnElement, GridItemModel } from '@vaadin/vaadin-grid';
 import { applyTheme } from 'Frontend/generated/theme';
 import { html, LitElement, render } from 'lit';
+import { guard } from 'lit/directives/guard';
 import { customElement, state } from 'lit/decorators.js';
 
 @customElement('badge-icons-only-table')
@@ -27,41 +28,45 @@ export class Example extends LitElement {
 
   render() {
     // tag::snippet[]
-    const renderBoolean = (
-      root: HTMLElement,
-      column?: GridColumnElement,
-      model?: GridItemModel<UserPermissions>
-    ): void => {
-      if (!column || !model) {
-        return;
-      }
+    const renderBoolean = guard(
+      [],
+      () =>
+        (
+          root: HTMLElement,
+          column?: GridColumnElement,
+          model?: GridItemModel<UserPermissions>
+        ): void => {
+          if (!column || !model) {
+            return;
+          }
 
-      let icon: string;
-      let title: string;
-      let theme: string;
+          let icon: string;
+          let title: string;
+          let theme: string;
 
-      if (model.item[column.id as keyof UserPermissions]) {
-        icon = 'vaadin:check-circle';
-        title = 'Confirmed';
-        theme = 'success';
-      } else {
-        icon = 'vaadin:close-circle';
-        title = 'Cancelled';
-        theme = 'error';
-      }
+          if (model.item[column.id as keyof UserPermissions]) {
+            icon = 'vaadin:check-circle';
+            title = 'Confirmed';
+            theme = 'success';
+          } else {
+            icon = 'vaadin:close-circle';
+            title = 'Cancelled';
+            theme = 'error';
+          }
 
-      render(
-        html`
-          <vaadin-icon
-            icon="${icon}"
-            theme="badge ${theme} pill"
-            title="${title}"
-            aria-label="${title}"
-          ></vaadin-icon>
-        `,
-        root
-      );
-    };
+          render(
+            html`
+              <vaadin-icon
+                icon="${icon}"
+                theme="badge ${theme} pill"
+                title="${title}"
+                aria-label="${title}"
+              ></vaadin-icon>
+            `,
+            root
+          );
+        }
+    );
 
     return html`
       <vaadin-grid .items="${this.items}">


### PR DESCRIPTION
## Description

> When binding a renderer to a component, it should be always assigned through Lit's `guard()` to prevent re-assigning on every render.

Seems that I've missed covering some of the badge examples within #595. 

This PR is a follow-up to #595.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
