### PR TITLE
feat: add first batch of flow Button examples

### DIFF
--- a/articles/ds/components/button/index.asciidoc
+++ b/articles/ds/components/button/index.asciidoc
@@ -32,10 +32,10 @@ The Java examples for this component are currently in progress. In the meantime,
 include::{root}/frontend/demo/component/button/button-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
-// [source,java]
-// ----
-// include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java[render,tags=snippet,indent=0,group=Java]
-// ----
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java[render,tags=snippet,indent=0,group=Java]
+----
 
 --
 
@@ -48,6 +48,11 @@ The following variants can be used to distinguish between actions of different i
 [source,html]
 ----
 include::{root}/frontend/demo/component/button/button-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+----
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonStyles.java[render,tags=snippet,indent=0,group=Java]
 ----
 --
 
@@ -82,6 +87,10 @@ A style for distinguishing actions related to dangers, warnings, or errors.
 include::{root}/frontend/demo/component/button/button-error.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonError.java[render,tags=snippet,indent=0,group=Java]
+----
 --
 
 Use this style for:
@@ -102,6 +111,10 @@ The following size variants are available for Button instances whose size needs 
 include::{root}/frontend/demo/component/button/button-sizes.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java[render,tags=snippet,indent=0,group=Java]
+----
 --
 
 [cols="1,3",grid=rows]
@@ -136,6 +149,10 @@ It should not be confused with a link:[Link], however.
 include::{root}/frontend/demo/component/button/button-tertiary-inline.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonTertiaryInline.java[render,tags=snippet,indent=0,group=Java]
+----
 --
 
 
@@ -149,6 +166,10 @@ The *Success* and *Contrast* variants should provide additional color options fo
 include::{root}/frontend/demo/component/button/button-success.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonSuccess.java[render,tags=snippet,indent=0,group=Java]
+----
 --
 
 
@@ -160,6 +181,10 @@ include::{root}/frontend/demo/component/button/button-success.ts[render,tags=sni
 include::{root}/frontend/demo/component/button/button-contrast.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonContrast.java[render,tags=snippet,indent=0,group=Java]
+----
 --
 
 
@@ -181,6 +206,10 @@ Buttons can have icons instead of text, or on either side in addition to text:
 include::{root}/frontend/demo/component/button/button-icons.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonIcons.java[render,tags=snippet,indent=0,group=Java]
+----
 --
 
 Usage recommendations:
@@ -205,6 +234,10 @@ Images can be used similarly to icons. See icon usage recommendations.
 include::{root}/frontend/demo/component/button/button-images.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonImages.java[render,tags=snippet,indent=0,group=Java]
+----
 --
 
 == Disabled
@@ -220,6 +253,10 @@ A disabled button is rendered as "dimmed", and is excluded from the focus order 
 include::{root}/frontend/demo/component/button/button-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonDisabled.java[render,tags=snippet,indent=0,group=Java]
+----
 --
 
 === Hidden vs Disabled

--- a/frontend/demo/component/button/button-basic.ts
+++ b/frontend/demo/component/button/button-basic.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing" style="align-items: baseline">
         <vaadin-button @click="${() => this.counter++}">Button</vaadin-button>
-        <div>Clicked ${this.counter} times</div>
+        <p>Clicked ${this.counter} times</p>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->
     `;

--- a/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java
@@ -16,7 +16,7 @@ public class ButtonBasic extends Div {
         // tag::snippet[]
         Button button = new Button("Button");
         Paragraph info = new Paragraph(infoText());
-        button.addClickListener(_e -> {
+        button.addClickListener(clickEvent -> {
             counter += 1;
             info.setText(infoText());
         });

--- a/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java
@@ -1,24 +1,35 @@
 package com.vaadin.demo.component.button;
 
-import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
 @Route("button-basic")
 public class ButtonBasic extends Div {
+    private int counter = 0;
 
-  public ButtonBasic() {
-    // tag::snippet[]
-    Button button = new Button("Button");
-    Text clickedText = new Text("");
-    button.addClickListener(e -> clickedText.setText("The button was clicked"));
+    public ButtonBasic() {
+        // tag::snippet[]
+        Button button = new Button("Button");
+        Paragraph info = new Paragraph(infoText());
+        button.addClickListener(_e -> {
+            counter += 1;
+            info.setText(infoText());
+        });
+        // end::snippet[]
+        HorizontalLayout horizontalLayout = new HorizontalLayout(button, info);
+        horizontalLayout.setAlignItems(FlexComponent.Alignment.BASELINE);
+        add(horizontalLayout);
+    }
 
-    add(button, clickedText);
-    // end::snippet[]
-  }
+    private String infoText() {
+        return String.format("Clicked %d times", counter);
+    }
 
-  public static class Exporter extends DemoExporter<ButtonBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ButtonBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/button/ButtonContrast.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonContrast.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
+import static com.vaadin.flow.component.button.ButtonVariant.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -11,13 +12,13 @@ public class ButtonContrast extends Div {
     public ButtonContrast() {
         // tag::snippet[]
         Button primaryButton = new Button("Primary");
-        primaryButton.addThemeNames("primary contrast");
+        primaryButton.addThemeVariants(LUMO_PRIMARY, LUMO_CONTRAST);
 
         Button secondaryButton = new Button("Secondary");
-        secondaryButton.addThemeNames("secondary contrast");
+        secondaryButton.addThemeVariants(LUMO_CONTRAST);
 
         Button tertiaryButton = new Button("Tertiary (avoid)");
-        tertiaryButton.addThemeNames("tertiary contrast");
+        tertiaryButton.addThemeVariants(LUMO_TERTIARY, LUMO_CONTRAST);
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
         add(horizontalLayout);

--- a/src/main/java/com/vaadin/demo/component/button/ButtonContrast.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonContrast.java
@@ -1,0 +1,29 @@
+package com.vaadin.demo.component.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("button-contrast")
+public class ButtonContrast extends Div {
+    public ButtonContrast() {
+        // tag::snippet[]
+        Button primaryButton = new Button("Primary");
+        primaryButton.addThemeNames("primary contrast");
+
+        Button secondaryButton = new Button("Secondary");
+        secondaryButton.addThemeNames("secondary contrast");
+
+        Button tertiaryButton = new Button("Tertiary (avoid)");
+        tertiaryButton.addThemeNames("tertiary contrast");
+        // end::snippet[]
+        HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
+        horizontalLayout.getThemeList().add("spacing");
+        add(horizontalLayout);
+    }
+
+    public static class Exporter extends DemoExporter<ButtonContrast> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/button/ButtonContrast.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonContrast.java
@@ -20,7 +20,6 @@ public class ButtonContrast extends Div {
         tertiaryButton.addThemeNames("tertiary contrast");
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
-        horizontalLayout.getThemeList().add("spacing");
         add(horizontalLayout);
     }
 

--- a/src/main/java/com/vaadin/demo/component/button/ButtonDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonDisabled.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
+import static com.vaadin.flow.component.button.ButtonVariant.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -12,15 +13,14 @@ public class ButtonDisabled extends Div {
         // tag::snippet[]
         Button primaryButton = new Button("Primary");
         primaryButton.setEnabled(false);
-        primaryButton.addThemeNames("primary");
+        primaryButton.addThemeVariants(LUMO_PRIMARY);
 
         Button secondaryButton = new Button("Secondary");
         secondaryButton.setEnabled(false);
-        secondaryButton.addThemeNames("secondary");
 
         Button tertiaryButton = new Button("Tertiary");
         tertiaryButton.setEnabled(false);
-        tertiaryButton.addThemeNames("tertiary");
+        tertiaryButton.addThemeVariants(LUMO_TERTIARY);
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
         add(horizontalLayout);

--- a/src/main/java/com/vaadin/demo/component/button/ButtonDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonDisabled.java
@@ -1,0 +1,32 @@
+package com.vaadin.demo.component.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("button-disabled")
+public class ButtonDisabled extends Div {
+    public ButtonDisabled() {
+        // tag::snippet[]
+        Button primaryButton = new Button("Primary");
+        primaryButton.getElement().setAttribute("disabled", "true");
+        primaryButton.addThemeNames("primary");
+
+        Button secondaryButton = new Button("Secondary");
+        secondaryButton.getElement().setAttribute("disabled", "true");
+        secondaryButton.addThemeNames("secondary");
+
+        Button tertiaryButton = new Button("Tertiary");
+        tertiaryButton.getElement().setAttribute("disabled", "true");
+        tertiaryButton.addThemeNames("tertiary");
+        // end::snippet[]
+        HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
+        horizontalLayout.getThemeList().add("spacing");
+        add(horizontalLayout);
+    }
+
+    public static class Exporter extends DemoExporter<ButtonDisabled> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/button/ButtonDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonDisabled.java
@@ -11,19 +11,18 @@ public class ButtonDisabled extends Div {
     public ButtonDisabled() {
         // tag::snippet[]
         Button primaryButton = new Button("Primary");
-        primaryButton.getElement().setAttribute("disabled", "true");
+        primaryButton.setEnabled(false);
         primaryButton.addThemeNames("primary");
 
         Button secondaryButton = new Button("Secondary");
-        secondaryButton.getElement().setAttribute("disabled", "true");
+        secondaryButton.setEnabled(false);
         secondaryButton.addThemeNames("secondary");
 
         Button tertiaryButton = new Button("Tertiary");
-        tertiaryButton.getElement().setAttribute("disabled", "true");
+        tertiaryButton.setEnabled(false);
         tertiaryButton.addThemeNames("tertiary");
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
-        horizontalLayout.getThemeList().add("spacing");
         add(horizontalLayout);
     }
 

--- a/src/main/java/com/vaadin/demo/component/button/ButtonError.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonError.java
@@ -1,0 +1,29 @@
+package com.vaadin.demo.component.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("button-error")
+public class ButtonError extends Div {
+    public ButtonError() {
+        // tag::snippet[]
+        Button primaryButton = new Button("Primary");
+        primaryButton.addThemeNames("primary error");
+
+        Button secondaryButton = new Button("Secondary");
+        secondaryButton.addThemeNames("secondary error");
+
+        Button tertiaryButton = new Button("Tertiary");
+        tertiaryButton.addThemeNames("tertiary error");
+        // end::snippet[]
+        HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
+        horizontalLayout.getThemeList().add("spacing");
+        add(horizontalLayout);
+    }
+
+    public static class Exporter extends DemoExporter<ButtonError> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/button/ButtonError.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonError.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
+import static com.vaadin.flow.component.button.ButtonVariant.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -11,13 +12,13 @@ public class ButtonError extends Div {
     public ButtonError() {
         // tag::snippet[]
         Button primaryButton = new Button("Primary");
-        primaryButton.addThemeNames("primary error");
+        primaryButton.addThemeVariants(LUMO_PRIMARY, LUMO_ERROR);
 
         Button secondaryButton = new Button("Secondary");
-        secondaryButton.addThemeNames("secondary error");
+        secondaryButton.addThemeVariants(LUMO_ERROR);
 
         Button tertiaryButton = new Button("Tertiary");
-        tertiaryButton.addThemeNames("tertiary error");
+        tertiaryButton.addThemeVariants(LUMO_TERTIARY, LUMO_ERROR);
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
         add(horizontalLayout);

--- a/src/main/java/com/vaadin/demo/component/button/ButtonError.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonError.java
@@ -20,7 +20,6 @@ public class ButtonError extends Div {
         tertiaryButton.addThemeNames("tertiary error");
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
-        horizontalLayout.getThemeList().add("spacing");
         add(horizontalLayout);
     }
 

--- a/src/main/java/com/vaadin/demo/component/button/ButtonIcons.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonIcons.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
+import static com.vaadin.flow.component.button.ButtonVariant.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
@@ -13,11 +14,11 @@ public class ButtonIcons extends Div {
     public ButtonIcons() {
         // tag::snippet[]
         Button plusButton = new Button(new Icon(VaadinIcon.PLUS));
-        plusButton.addThemeNames("icon");
+        plusButton.addThemeVariants(LUMO_ICON);
         plusButton.getElement().setAttribute("aria-label", "Add item");
 
         Button closeButton = new Button(new Icon(VaadinIcon.CLOSE_SMALL));
-        closeButton.addThemeNames("icon");
+        closeButton.addThemeVariants(LUMO_ICON);
         closeButton.getElement().setAttribute("aria-label", "Close");
 
         Button arrowLeftButton = new Button("Left", new Icon(VaadinIcon.ARROW_LEFT));

--- a/src/main/java/com/vaadin/demo/component/button/ButtonIcons.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonIcons.java
@@ -26,7 +26,6 @@ public class ButtonIcons extends Div {
         arrowRightButton.setIconAfterText(true);
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(plusButton, closeButton, arrowLeftButton, arrowRightButton);
-        horizontalLayout.getThemeList().add("spacing");
         add(horizontalLayout);
     }
 

--- a/src/main/java/com/vaadin/demo/component/button/ButtonIcons.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonIcons.java
@@ -1,0 +1,35 @@
+package com.vaadin.demo.component.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("button-icons")
+public class ButtonIcons extends Div {
+    public ButtonIcons() {
+        // tag::snippet[]
+        Button plusButton = new Button(new Icon(VaadinIcon.PLUS));
+        plusButton.addThemeNames("icon");
+        plusButton.getElement().setAttribute("aria-label", "Add item");
+
+        Button closeButton = new Button(new Icon(VaadinIcon.CLOSE_SMALL));
+        closeButton.addThemeNames("icon");
+        closeButton.getElement().setAttribute("aria-label", "Close");
+
+        Button arrowLeftButton = new Button("Left", new Icon(VaadinIcon.ARROW_LEFT));
+
+        Button arrowRightButton = new Button("Right", new Icon(VaadinIcon.ARROW_RIGHT));
+        arrowRightButton.setIconAfterText(true);
+        // end::snippet[]
+        HorizontalLayout horizontalLayout = new HorizontalLayout(plusButton, closeButton, arrowLeftButton, arrowRightButton);
+        horizontalLayout.getThemeList().add("spacing");
+        add(horizontalLayout);
+    }
+
+    public static class Exporter extends DemoExporter<ButtonIcons> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/button/ButtonImages.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonImages.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
+import static com.vaadin.flow.component.button.ButtonVariant.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.server.StreamResource;
@@ -18,7 +19,7 @@ public class ButtonImages extends Div {
         img.setWidth("100px");
 
         Button imgButton = new Button(img);
-        imgButton.addThemeNames("icon");
+        imgButton.addThemeVariants(LUMO_ICON);
         // end::snippet[]
         add(imgButton);
     }

--- a/src/main/java/com/vaadin/demo/component/button/ButtonImages.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonImages.java
@@ -1,0 +1,28 @@
+package com.vaadin.demo.component.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("button-images")
+public class ButtonImages extends Div {
+    public ButtonImages() {
+        StreamResource src = new StreamResource(
+                "vaadin-logo-dark.png",
+                () -> getClass().getResourceAsStream("/images/vaadin-logo-dark.png"));
+        // tag::snippet[]
+        Image img = new Image(src, "Vaadin logo");
+        img.setWidth("100px");
+
+        Button imgButton = new Button(img);
+        imgButton.addThemeNames("icon");
+        // end::snippet[]
+        add(imgButton);
+    }
+
+    public static class Exporter extends DemoExporter<ButtonImages> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
+import static com.vaadin.flow.component.button.ButtonVariant.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -11,13 +12,12 @@ public class ButtonSizes extends Div {
     public ButtonSizes() {
         // tag::snippet[]
         Button largeButton = new Button("Large");
-        largeButton.addThemeNames("large");
+        largeButton.addThemeVariants(LUMO_LARGE);
 
         Button normalButton = new Button("Normal");
-        normalButton.addThemeNames("normal");
 
         Button smallButton = new Button("Small");
-        smallButton.addThemeNames("small");
+        smallButton.addThemeVariants(LUMO_SMALL);
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(largeButton, normalButton, smallButton);
         add(horizontalLayout);

--- a/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java
@@ -1,0 +1,29 @@
+package com.vaadin.demo.component.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("button-sizes")
+public class ButtonSizes extends Div {
+    public ButtonSizes() {
+        // tag::snippet[]
+        Button largeButton = new Button("Large");
+        largeButton.addThemeNames("large");
+
+        Button normalButton = new Button("Normal");
+        normalButton.addThemeNames("normal");
+
+        Button smallButton = new Button("Small");
+        smallButton.addThemeNames("small");
+        // end::snippet[]
+        HorizontalLayout horizontalLayout = new HorizontalLayout(largeButton, normalButton, smallButton);
+        horizontalLayout.getThemeList().add("spacing");
+        add(horizontalLayout);
+    }
+
+    public static class Exporter extends DemoExporter<ButtonSizes> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java
@@ -20,7 +20,6 @@ public class ButtonSizes extends Div {
         smallButton.addThemeNames("small");
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(largeButton, normalButton, smallButton);
-        horizontalLayout.getThemeList().add("spacing");
         add(horizontalLayout);
     }
 

--- a/src/main/java/com/vaadin/demo/component/button/ButtonStyles.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonStyles.java
@@ -20,7 +20,6 @@ public class ButtonStyles extends Div {
         tertiaryButton.addThemeNames("tertiary");
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
-        horizontalLayout.getThemeList().add("spacing");
         add(horizontalLayout);
     }
 

--- a/src/main/java/com/vaadin/demo/component/button/ButtonStyles.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonStyles.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
+import static com.vaadin.flow.component.button.ButtonVariant.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -11,13 +12,12 @@ public class ButtonStyles extends Div {
     public ButtonStyles() {
         // tag::snippet[]
         Button primaryButton = new Button("Primary");
-        primaryButton.addThemeNames("primary");
+        primaryButton.addThemeVariants(LUMO_PRIMARY);
 
         Button secondaryButton = new Button("Secondary");
-        secondaryButton.addThemeNames("secondary");
 
         Button tertiaryButton = new Button("Tertiary");
-        tertiaryButton.addThemeNames("tertiary");
+        tertiaryButton.addThemeVariants(LUMO_TERTIARY);
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
         add(horizontalLayout);

--- a/src/main/java/com/vaadin/demo/component/button/ButtonStyles.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonStyles.java
@@ -1,0 +1,29 @@
+package com.vaadin.demo.component.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("button-styles")
+public class ButtonStyles extends Div {
+    public ButtonStyles() {
+        // tag::snippet[]
+        Button primaryButton = new Button("Primary");
+        primaryButton.addThemeNames("primary");
+
+        Button secondaryButton = new Button("Secondary");
+        secondaryButton.addThemeNames("secondary");
+
+        Button tertiaryButton = new Button("Tertiary");
+        tertiaryButton.addThemeNames("tertiary");
+        // end::snippet[]
+        HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
+        horizontalLayout.getThemeList().add("spacing");
+        add(horizontalLayout);
+    }
+
+    public static class Exporter extends DemoExporter<ButtonStyles> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/button/ButtonSuccess.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonSuccess.java
@@ -20,7 +20,6 @@ public class ButtonSuccess extends Div {
         tertiaryButton.addThemeNames("tertiary success");
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
-        horizontalLayout.getThemeList().add("spacing");
         add(horizontalLayout);
     }
 

--- a/src/main/java/com/vaadin/demo/component/button/ButtonSuccess.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonSuccess.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
+import static com.vaadin.flow.component.button.ButtonVariant.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -11,13 +12,13 @@ public class ButtonSuccess extends Div {
     public ButtonSuccess() {
         // tag::snippet[]
         Button primaryButton = new Button("Primary");
-        primaryButton.addThemeNames("primary success");
+        primaryButton.addThemeVariants(LUMO_PRIMARY, LUMO_SUCCESS);
 
         Button secondaryButton = new Button("Secondary");
-        secondaryButton.addThemeNames("secondary success");
+        secondaryButton.addThemeVariants(LUMO_SUCCESS);
 
         Button tertiaryButton = new Button("Tertiary");
-        tertiaryButton.addThemeNames("tertiary success");
+        tertiaryButton.addThemeVariants(LUMO_TERTIARY, LUMO_SUCCESS);
         // end::snippet[]
         HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
         add(horizontalLayout);

--- a/src/main/java/com/vaadin/demo/component/button/ButtonSuccess.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonSuccess.java
@@ -1,0 +1,30 @@
+package com.vaadin.demo.component.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("button-success")
+public class ButtonSuccess extends Div {
+    public ButtonSuccess() {
+        // tag::snippet[]
+        Button primaryButton = new Button("Primary");
+        primaryButton.addThemeNames("primary success");
+
+        Button secondaryButton = new Button("Secondary");
+        secondaryButton.addThemeNames("secondary success");
+
+        Button tertiaryButton = new Button("Tertiary");
+        tertiaryButton.addThemeNames("tertiary success");
+        // end::snippet[]
+        HorizontalLayout horizontalLayout = new HorizontalLayout(primaryButton, secondaryButton, tertiaryButton);
+        horizontalLayout.getThemeList().add("spacing");
+        add(horizontalLayout);
+    }
+
+    public static class Exporter extends DemoExporter<ButtonSuccess> { // hidden-source-line
+    } // hidden-source-line
+}
+

--- a/src/main/java/com/vaadin/demo/component/button/ButtonTertiaryInline.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonTertiaryInline.java
@@ -1,0 +1,20 @@
+package com.vaadin.demo.component.button;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("button-tertiary-inline")
+public class ButtonTertiaryInline extends Div {
+    public ButtonTertiaryInline() {
+        // tag::snippet[]
+        Button tertiaryInlineButton = new Button("Tertiary inline");
+        tertiaryInlineButton.addThemeNames("tertiary-inline");
+        // end::snippet[]
+        add(tertiaryInlineButton);
+    }
+
+    public static class Exporter extends DemoExporter<ButtonTertiaryInline> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/button/ButtonTertiaryInline.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonTertiaryInline.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
+import static com.vaadin.flow.component.button.ButtonVariant.*;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
@@ -10,7 +11,7 @@ public class ButtonTertiaryInline extends Div {
     public ButtonTertiaryInline() {
         // tag::snippet[]
         Button tertiaryInlineButton = new Button("Tertiary inline");
-        tertiaryInlineButton.addThemeNames("tertiary-inline");
+        tertiaryInlineButton.addThemeVariants(LUMO_TERTIARY_INLINE);
         // end::snippet[]
         add(tertiaryInlineButton);
     }


### PR DESCRIPTION
Adds the following examples for Flow Button

- basics
- styles
- error
- size
- tertiary-inline
- success
- contrast
- icons
- images
- disabled