### PR TITLE
mention the scroll to index issue in TreeGrid

### DIFF
--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -68,15 +68,15 @@ You can scroll to a specific item by calling the [methodname]`scrollToIndex(inde
 However, the effective index of an item changes depending on which nodes are expanded or collapsed and other factors.
 What portion of the grid is visible also affects how an item's effective index is calculated.
 
-Scrolling right after expanding or collapsing nodes in a single action (for example, a button click) will result in a scroll action before children of expanded nodes are rendered and children of collapsed nodes removed.
-Since the effective index of some items changes after the expand or collapse, the grid might have ended up scrolling to a different item than intended.
+.Index of Items Can Vary
+CAUTION: Items in a TreeGrid are not guaranteed to hold a specific index exclusively.
 
 The `scrollToIndex(index)` method was designed to work in a pre-order traversal method.
 Yet, TreeGrid doesn't know about all children (or the children of those children) a node has.
-In addition, nodes are loaded lazily for performance reasons, increasing the lack of knowledge of the complete structure of the tree.
+In addition, nodes are loaded in a lazy fashion for performance reasons, increasing the lack of knowledge of the complete structure of the tree.
 
-.Index of Items Can Vary
-CAUTION: Items in a TreeGrid are not guaranteed to hold a specific index exclusively.
+Scrolling right after expanding or collapsing nodes in a single action (for example, a button click) results in a scroll action before children of expanded nodes are rendered and children of collapsed nodes removed.
+Since the effective index of some items changes after the expand or collapse, the grid might have ended up scrolling to a different item than intended.
 
 == Rich Content
 

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -91,14 +91,13 @@ Tree Grid is not meant to be used as a navigation menu.
 
 === Avoid Using Scroll to Index
 
-The effective index of an item changes depending on which nodes are expanded or collapsed and other factors.
+In contrast to Grid, the `scrollToIndex(index)` method in TreeGrid was designed to work in a pre-order traversal method.
+The effective index of an item depends on the complete hierarchy of the tree.
+Nodes are loaded in a lazy fashion for performance reasons.
+Without the knowledge of the complete hierarchy, TreeGrid can't reliably calculate an exact scroll index.
 
 .Index of Items Can Vary
 CAUTION: Items in a TreeGrid are not guaranteed to hold a specific index exclusively.
-
-In contrast to Grid, the `scrollToIndex(index)` method in TreeGrid was designed to work in a pre-order traversal method.
-Yet, TreeGrid doesn't know about all children (or the children of those children) a node has.
-In addition, nodes are loaded in a lazy fashion for performance reasons, increasing the lack of knowledge of the complete structure of the tree.
 The behaviour of *this method in TreeGrid* is not deterministic and *should be avoided*.
 
 == Related Components

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -71,9 +71,10 @@ What portion of the grid is visible also affects how an item's effective index i
 .Index of Items Can Vary
 CAUTION: Items in a TreeGrid are not guaranteed to hold a specific index exclusively.
 
-The `scrollToIndex(index)` method was designed to work in a pre-order traversal method.
+In contrast to Grid, the `scrollToIndex(index)` method in TreeGrid was designed to work in a pre-order traversal method.
 Yet, TreeGrid doesn't know about all children (or the children of those children) a node has.
 In addition, nodes are loaded in a lazy fashion for performance reasons, increasing the lack of knowledge of the complete structure of the tree.
+The behaviour of *this method in TreeGrid* is not deterministic and *should be avoided*.
 
 Scrolling right after expanding or collapsing nodes in a single action (for example, a button click) results in a scroll action before children of expanded nodes are rendered and children of collapsed nodes removed.
 Since the effective index of some items changes after the expand or collapse, the grid might have ended up scrolling to a different item than intended.

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -89,16 +89,9 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags
 
 Tree Grid is not meant to be used as a navigation menu.
 
-=== Avoid Using Scroll to Index
-
-In contrast to Grid, the [methodname]#scrollToIndex(index)# method in TreeGrid works in a pre-order traversal method.
-The effective index of an item depends on the complete hierarchy of the tree.
-TreeGrid uses lazy loading for performance reasons and does not know about the complete hierarchy.
-Without the knowledge of the complete hierarchy, TreeGrid can't reliably calculate an exact scroll position.
-
-.Index of Items Can Vary
-CAUTION: Items in a TreeGrid are not guaranteed to hold a specific index exclusively.
-The behaviour of *this method in TreeGrid* is not deterministic and *should be avoided*.
+.scrollToIndex not reliable
+CAUTION: The behavior of the scrollToIndex method in Tree Grid is not deterministic due to lazy loading hierarchical data.
+Usage of this method is not recommended.
 
 == Related Components
 

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -91,10 +91,10 @@ Tree Grid is not meant to be used as a navigation menu.
 
 === Avoid Using Scroll to Index
 
-In contrast to Grid, the `scrollToIndex(index)` method in TreeGrid was designed to work in a pre-order traversal method.
+In contrast to Grid, the [methodname]#scrollToIndex(index)# method in TreeGrid works in a pre-order traversal method.
 The effective index of an item depends on the complete hierarchy of the tree.
-Nodes are loaded in a lazy fashion for performance reasons.
-Without the knowledge of the complete hierarchy, TreeGrid can't reliably calculate an exact scroll index.
+TreeGrid uses lazy loading for performance reasons and does not know about the complete hierarchy.
+Without the knowledge of the complete hierarchy, TreeGrid can't reliably calculate an exact scroll position.
 
 .Index of Items Can Vary
 CAUTION: Items in a TreeGrid are not guaranteed to hold a specific index exclusively.

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -65,18 +65,18 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags
 == Scroll to Index
 
 You can scroll to a specific item by calling the [methodname]`scrollToIndex(index)` method and passing the item's index.
-The index of an item depends on the item's position in the grid.
-Since hierarchical data is lazy loaded, the grid doesn't know how many children each node has unless they're expanded.
-Children items will take the indexes between their surrounding nodes *only if their parent node is expanded*.
+However, the effective index of an item changes depending on which nodes are expanded or collapsed and other factors.
+What portion of the grid is visible also affects how an item's effective index is calculated.
 
-.The Index of a Node Can Change
-CAUTION: The effective index of a node will change when nodes before it are expanded or collapsed.
+Scrolling right after expanding or collapsing nodes in a single action (for example, a button click) will result in a scroll action before children of expanded nodes are rendered and children of collapsed nodes removed.
+Since the effective index of some items changes after the expand or collapse, the grid might have ended up scrolling to a different item than intended.
 
-=== Scrolling Right After Expanding
+The `scrollToIndex(index)` method was designed to work in a pre-order traversal method.
+Yet, TreeGrid doesn't know about all children (or the children of those children) a node has.
+In addition, nodes are loaded lazily for performance reasons, increasing the lack of knowledge of the complete structure of the tree.
 
-When calling [methodname]`scrollToIndex(index)` right after expanding some nodes (during a single action, like a button click), the scrolling might execute _before_ the children nodes are rendered.
-This means that it might perform the scrolling to a different target than the one you intended, as the indexes will change when the children nodes are rendered.
-To work around this timing issue, you can expand the items in one action and perform the scrolling in a separate action (one button for each).
+.Index of Items Can Vary
+CAUTION: Items in a TreeGrid are not guaranteed to hold a specific index exclusively.
 
 == Rich Content
 

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -62,23 +62,6 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags
 ----
 --
 
-== Scroll to Index
-
-You can scroll to a specific item by calling the [methodname]`scrollToIndex(index)` method and passing the item's index.
-However, the effective index of an item changes depending on which nodes are expanded or collapsed and other factors.
-What portion of the grid is visible also affects how an item's effective index is calculated.
-
-.Index of Items Can Vary
-CAUTION: Items in a TreeGrid are not guaranteed to hold a specific index exclusively.
-
-In contrast to Grid, the `scrollToIndex(index)` method in TreeGrid was designed to work in a pre-order traversal method.
-Yet, TreeGrid doesn't know about all children (or the children of those children) a node has.
-In addition, nodes are loaded in a lazy fashion for performance reasons, increasing the lack of knowledge of the complete structure of the tree.
-The behaviour of *this method in TreeGrid* is not deterministic and *should be avoided*.
-
-Scrolling right after expanding or collapsing nodes in a single action (for example, a button click) results in a scroll action before children of expanded nodes are rendered and children of collapsed nodes removed.
-Since the effective index of some items changes after the expand or collapse, the grid might have ended up scrolling to a different item than intended.
-
 == Rich Content
 
 Like Grid, Tree Grid supports rich content.
@@ -105,6 +88,18 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags
 == Best Practises
 
 Tree Grid is not meant to be used as a navigation menu.
+
+=== Avoid Using Scroll to Index
+
+The effective index of an item changes depending on which nodes are expanded or collapsed and other factors.
+
+.Index of Items Can Vary
+CAUTION: Items in a TreeGrid are not guaranteed to hold a specific index exclusively.
+
+In contrast to Grid, the `scrollToIndex(index)` method in TreeGrid was designed to work in a pre-order traversal method.
+Yet, TreeGrid doesn't know about all children (or the children of those children) a node has.
+In addition, nodes are loaded in a lazy fashion for performance reasons, increasing the lack of knowledge of the complete structure of the tree.
+The behaviour of *this method in TreeGrid* is not deterministic and *should be avoided*.
 
 == Related Components
 

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -62,6 +62,22 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags
 ----
 --
 
+== Scroll to Index
+
+You can scroll to a specific item by calling the [methodname]`scrollToIndex(index)` method and passing the item's index.
+The index of an item depends on the item's position in the grid.
+Since hierarchical data is lazy loaded, the grid doesn't know how many children each node has unless they're expanded.
+Children items will take the indexes between their surrounding nodes *only if their parent node is expanded*.
+
+.The Index of a Node Can Change
+CAUTION: The effective index of a node will change when nodes before it are expanded or collapsed.
+
+=== Scrolling Right After Expanding
+
+When calling [methodname]`scrollToIndex(index)` right after expanding some nodes (during a single action, like a button click), the scrolling might execute _before_ the children nodes are rendered.
+This means that it might perform the scrolling to a different target than the one you intended, as the indexes will change when the children nodes are rendered.
+To work around this timing issue, you can expand the items in one action and perform the scrolling in a separate action (one button for each).
+
 == Rich Content
 
 Like Grid, Tree Grid supports rich content.


### PR DESCRIPTION
## Description

Add a mention to an issue with the `scrollToIndex(index)` method in TreeGrid.

Related issue: https://github.com/vaadin/flow-components/issues/1016