### PR TITLE
fix: fix broken TreeGrid examples

### DIFF
--- a/frontend/demo/component/tree-grid/tree-grid-basic.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-basic.ts
@@ -1,5 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/flow-frontend/gridConnector.js'; // hidden-source-line (Grid's connector)
+import '@vaadin/vaadin-template-renderer/src/vaadin-template-renderer.js'; // hidden-source-line (Legacy template renderer)
 
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -28,7 +29,7 @@ export class Example extends LitElement {
     callback: GridDataProviderCallback<Person>
   ) {
     // The requested page and the full length of the corresponding
-    // hierarhcy level is requested from the data service
+    // hierarchy level is requested from the data service
     const { people, hierarchyLevelSize } = await getPeople({
       count: params.pageSize,
       startIndex: params.page * params.pageSize,

--- a/frontend/demo/component/tree-grid/tree-grid-column.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-column.ts
@@ -1,5 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/flow-frontend/gridConnector.js'; // hidden-source-line (Grid's connector)
+import '@vaadin/vaadin-template-renderer/src/vaadin-template-renderer.js'; // hidden-source-line (Legacy template renderer)
 
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -1,5 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/flow-frontend/gridConnector.js'; // hidden-source-line (Grid's connector)
+import '@vaadin/vaadin-template-renderer/src/vaadin-template-renderer.js'; // hidden-source-line (Legacy template renderer)
 
 import { html, LitElement, render } from 'lit';
 import { customElement, state } from 'lit/decorators.js';

--- a/src/main/java/com/vaadin/demo/component/treegrid/TreeGridBasic.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/TreeGridBasic.java
@@ -26,7 +26,7 @@ public class TreeGridBasic extends Div {
     }
 
     public List<Person> getStaff(Person manager) {
-        return DataService.getPeople(manager.getManagerId());
+        return DataService.getPeople(manager.getId());
     }
     public static class Exporter extends DemoExporter<TreeGridBasic> {} // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/treegrid/TreeGridColumn.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/TreeGridColumn.java
@@ -45,7 +45,7 @@ public class TreeGridColumn extends Div {
     }
 
     public List<Person> getStaff(Person manager) {
-        return DataService.getPeople(manager.getManagerId());
+        return DataService.getPeople(manager.getId());
     }
     public static class Exporter extends DemoExporter<TreeGridColumn> {} // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java
@@ -94,7 +94,7 @@ public class TreeGridRichContent extends Div {
     }
 
     public List<Person> getStaff(Person manager) {
-        return DataService.getPeople(manager.getManagerId());
+        return DataService.getPeople(manager.getId());
     }
     public static class Exporter extends DemoExporter<TreeGridRichContent> {} // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/domain/DataService.java
+++ b/src/main/java/com/vaadin/demo/domain/DataService.java
@@ -57,8 +57,9 @@ public class DataService {
    * Get employees for a given manager.
    */
   public static List<Person> getPeople(Integer managerId) {
-    List<Person> people = getPeople();
-    people.removeIf(person -> person.getManagerId() != managerId);
+    List<Person> people = new ArrayList<>(getPeople());
+    people.removeIf(person -> person.getManagerId() == null
+            || !person.getManagerId().equals(managerId));
     return people;
   }
 
@@ -66,7 +67,7 @@ public class DataService {
    * Get all managers.
    */
   public static List<Person> getManagers() {
-    List<Person> people = getPeople();
+    List<Person> people = new ArrayList<>(getPeople());
     people.removeIf(person -> !person.isManager());
     return people;
   }


### PR DESCRIPTION
## Description

Currently all Flow TreeGrid examples are broken. This change fixes that by:
- fixing the `DataService.getManagers` and `DataService.getPeople` methods to use a mutable collection before using `removeIf`
- adding missing Flow JS imports
- passing the person ID into `getStaff`, instead of `getManagerId()`, which is always null for managers
