### PR TITLE
Add mention of select component's empty selection item and Java examples

### DIFF
--- a/articles/ds/components/select/index.asciidoc
+++ b/articles/ds/components/select/index.asciidoc
@@ -101,6 +101,8 @@ include::{root}/src/main/java/com/vaadin/demo/component/select/SelectPlaceholder
 == Empty Selection Item (Flow Only)
 
 An empty item can be set as the first option.
+Use it in cases where you want to allow users to clear their selection.
+The value of the empty item is represented as `null`.
 
 [.example]
 --

--- a/articles/ds/components/select/index.asciidoc
+++ b/articles/ds/components/select/index.asciidoc
@@ -113,10 +113,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/select/SelectEmptySelect
 
 === Customizing Empty Selection Caption
 
-The label for the empty item can be customized.
+The label for the empty item is customizable.
 
-.Placeholder not shown
-NOTE: The placeholder will be replaced by the caption set for the empty selection item.
+The caption set replaces the placeholder for the empty selection item.
 
 [.example]
 --

--- a/articles/ds/components/select/index.asciidoc
+++ b/articles/ds/components/select/index.asciidoc
@@ -98,6 +98,35 @@ include::{root}/src/main/java/com/vaadin/demo/component/select/SelectPlaceholder
 ----
 --
 
+== Empty Selection Item (Flow Only)
+
+An empty item can be set as the first option.
+
+[.example]
+--
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectEmptySelection.java[render,tags=snippet,indent=0,group=Java]
+----
+--
+
+=== Customizing Empty Selection Caption
+
+The label for the empty item can be customized.
+
+.Placeholder not shown
+NOTE: The placeholder will be replaced by the caption set for the empty selection item.
+
+[.example]
+--
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectEmptySelectionCaption.java[render,tags=snippet,indent=0,group=Java]
+----
+--
+
 == Custom Item Presentation
 
 Items can be rendered with rich content instead of plain text.

--- a/src/main/java/com/vaadin/demo/component/select/SelectEmptySelection.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectEmptySelection.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.select;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.router.Route;

--- a/src/main/java/com/vaadin/demo/component/select/SelectEmptySelection.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectEmptySelection.java
@@ -1,0 +1,25 @@
+package com.vaadin.demo.component.select;
+
+import com.vaadin.demo.DemoExporter;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.router.Route;
+
+@Route("select-empty-selection")
+public class SelectEmptySelection extends Div {
+
+  public SelectEmptySelection() {
+    Select<String> select = new Select<>();
+    // tag::snippet[]
+    select.setEmptySelectionAllowed(true);
+    // end::snippet[]
+    select.setLabel("Size");
+    select.setItems("XS", "S", "M", "L", "XL");
+    select.setPlaceholder("Select size");
+
+    add(select);
+  }
+
+  public static class Exporter extends DemoExporter<SelectEmptySelection> { // hidden-source-line
+  } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/select/SelectEmptySelectionCaption.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectEmptySelectionCaption.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.select;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.router.Route;
@@ -10,9 +10,9 @@ public class SelectEmptySelectionCaption extends Div {
 
   public SelectEmptySelectionCaption() {
     Select<String> select = new Select<>();
-    select.setEmptySelectionAllowed(true);
     // tag::snippet[]
-    select.setEmptySelectionCaption("Random size");
+    select.setEmptySelectionAllowed(true);
+    select.setEmptySelectionCaption("Unknown size");
     // end::snippet[]
     select.setLabel("Size");
     select.setItems("XS", "S", "M", "L", "XL");

--- a/src/main/java/com/vaadin/demo/component/select/SelectEmptySelectionCaption.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectEmptySelectionCaption.java
@@ -1,0 +1,25 @@
+package com.vaadin.demo.component.select;
+
+import com.vaadin.demo.DemoExporter;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.router.Route;
+
+@Route("select-empty-selection-caption")
+public class SelectEmptySelectionCaption extends Div {
+
+  public SelectEmptySelectionCaption() {
+    Select<String> select = new Select<>();
+    select.setEmptySelectionAllowed(true);
+    // tag::snippet[]
+    select.setEmptySelectionCaption("Random size");
+    // end::snippet[]
+    select.setLabel("Size");
+    select.setItems("XS", "S", "M", "L", "XL");
+
+    add(select);
+  }
+
+  public static class Exporter extends DemoExporter<SelectEmptySelectionCaption> { // hidden-source-line
+  } // hidden-source-line
+}


### PR DESCRIPTION
## Description

There is an option in the Select component (Flow) to allow an empty item and also to set a caption for this empty item. No documentation exists for this feature. This PR adds a mention and example for both allowing the empty item and setting a caption.

Related: https://github.com/vaadin/flow-components/issues/1085

## Type of change

- [x] Documentation
