### PR TITLE
Make v7 tutorial version more explicit

### DIFF
--- a/articles/designer/designer-overview.asciidoc
+++ b/articles/designer/designer-overview.asciidoc
@@ -1,11 +1,11 @@
 ---
-title: Overview
+title: Vaadin 7 Designer Overview
 order: 1
 layout: page
 ---
 
 [[designer.overview]]
-= Designer
+= Vaadin 7 Designer
 
 Vaadin Designer is a visual WYSIWYG tool for creating Vaadin UIs and views by
 using drag&amp;drop and direct manipulation. With features such as live external

--- a/articles/framework/tutorial.adoc
+++ b/articles/framework/tutorial.adoc
@@ -1,5 +1,6 @@
 ---
-title: Vaadin Tutorial
+title: Vaadin 7 Tutorial
+page-title: "Vaadin 7 Tutorial"
 order: 1
 layout: page
 subnav_auto_list_numbers: true
@@ -37,9 +38,9 @@ subnav:
 :sectnums:
 
 [[framework.tutorial]]
-= Vaadin Tutorial
+= Vaadin 7 Tutorial
 
-This tutorial gives you an overview of how you can use https://vaadin.com/framework[Vaadin Framework] to build single-page web UIs for your Java application.
+This tutorial gives you an overview of how you can use https://vaadin.com/framework[Vaadin 7 Framework] to build single-page web UIs for your Java application.
 All you need to start with it is JDK 8 and an https://en.wikipedia.org/wiki/Integrated_development_environment[IDE], such as Eclipse.
 While this tutorial is written for Eclipse users, you can use your IDE of choice.
 No extensive knowledge of Java is needed, only basic programming skills are required.

--- a/articles/testbench/chapter-testbench.asciidoc
+++ b/articles/testbench/chapter-testbench.asciidoc
@@ -1,5 +1,5 @@
 [[testbench]]
-== Vaadin TestBench
+== Vaadin 7 TestBench
 
 This chapter describes the installation and use of the Vaadin TestBench.
 

--- a/articles/testbench/testbench-overview.asciidoc
+++ b/articles/testbench/testbench-overview.asciidoc
@@ -1,11 +1,11 @@
 ---
-title: Overview
+title: Vaadin 7 TestBench Overview
 order: 1
 layout: page
 ---
 
 [[testbench.overview]]
-= TestBench
+= Vaadin 7 TestBench TestBench
 
 Testing is one of the cornerstones of modern software development. Extending
 throughout the development process, testing is the thread that binds the product

--- a/articles/testbench/testbench-quickstart.asciidoc
+++ b/articles/testbench/testbench-quickstart.asciidoc
@@ -1,11 +1,11 @@
 ---
-title: Quickstart
+title: Vaadin 7 TestBench Quickstart
 order: 2
 layout: page
 ---
 
 [[testbench.quickstart]]
-= Quickstart
+= Vaadin 7 TestBench Quickstart
 
 This section walks you through the steps needed to add a Testbench test to your Vaadin application.
 We use Maven to set up the project and handle the dependencies.

--- a/articles/testbench/testbench-tutorial.asciidoc
+++ b/articles/testbench/testbench-tutorial.asciidoc
@@ -1,11 +1,11 @@
 ---
-title: Vaadin TestBench Tutorial
+title: Vaadin 7 TestBench Tutorial
 order: 3
 layout: page
 ---
 
 [[testbench.tutorial]]
-= TestBench Tutorial
+= Vaadin 7 TestBench Tutorial
 
 [[testbench.tutorial.introduction]]
 == Introduction


### PR DESCRIPTION
Google search of Vaadin-related queries often provides outdated (and hence misleading) v7, v8, and v10 results for Vaadin tutorial. 

This PR clarifies the used Vaadin version for v7 docs. This will hopefully affect Google search results so that the tutorials of LTS and latest are promoted. But even if that doesn't happen, clarifying the tutorial version should reduce the likelihood of misleading users. 