### PR TITLE
style: fix some lit-plugin warnings

### DIFF
--- a/frontend/demo/component/grid/grid-column-borders.ts
+++ b/frontend/demo/component/grid/grid-column-borders.ts
@@ -51,7 +51,7 @@ export class Example extends LitElement {
           img="${model.item.pictureUrl}"
           name="${model.item.firstName} ${model.item.lastName}"
           alt="User avatar"
-        />
+        ></vaadin-avatar>
       `,
       root
     );

--- a/frontend/demo/component/grid/grid-context-menu.ts
+++ b/frontend/demo/component/grid/grid-context-menu.ts
@@ -36,7 +36,7 @@ export class Example extends LitElement {
   // tag::snippet[]
   private contextMenuRenderer =
     () => (root: HTMLElement, elem: ContextMenuElement, context: ContextMenuRendererContext) => {
-      const { sourceEvent } = context.detail! as { sourceEvent: Event };
+      const { sourceEvent } = context.detail as { sourceEvent: Event };
       const grid = elem.firstElementChild as GridElement<Person>;
 
       const eventContext = grid.getEventContext(sourceEvent);

--- a/frontend/demo/component/grid/grid-no-border.ts
+++ b/frontend/demo/component/grid/grid-no-border.ts
@@ -51,7 +51,7 @@ export class Example extends LitElement {
           img="${model.item.pictureUrl}"
           name="${model.item.firstName} ${model.item.lastName}"
           alt="User avatar"
-        />
+        ></vaadin-avatar>
       `,
       root
     );

--- a/frontend/demo/component/grid/grid-no-row-border.ts
+++ b/frontend/demo/component/grid/grid-no-row-border.ts
@@ -51,7 +51,7 @@ export class Example extends LitElement {
           img="${model.item.pictureUrl}"
           name="${model.item.firstName} ${model.item.lastName}"
           alt="User avatar"
-        />
+        ></vaadin-avatar>
       `,
       root
     );

--- a/frontend/demo/component/grid/grid-row-reordering.ts
+++ b/frontend/demo/component/grid/grid-row-reordering.ts
@@ -84,7 +84,7 @@ export class Example extends LitElement {
           img="${model.item.pictureUrl}"
           name="${model.item.firstName} ${model.item.lastName}"
           alt="User avatar"
-        />
+        ></vaadin-avatar>
       `,
       root
     );

--- a/frontend/demo/component/grid/grid-row-stripes.ts
+++ b/frontend/demo/component/grid/grid-row-stripes.ts
@@ -51,7 +51,7 @@ export class Example extends LitElement {
           img="${model.item.pictureUrl}"
           name="${model.item.firstName} ${model.item.lastName}"
           alt="User avatar"
-        />
+        ></vaadin-avatar>
       `,
       root
     );

--- a/frontend/demo/component/grid/grid-wrap-cell-content.ts
+++ b/frontend/demo/component/grid/grid-wrap-cell-content.ts
@@ -53,7 +53,7 @@ export class Example extends LitElement {
           img="${model.item.pictureUrl}"
           name="${model.item.firstName} ${model.item.lastName}"
           alt="User avatar"
-        />
+        ></vaadin-avatar>
       `,
       root
     );


### PR DESCRIPTION
## Description

1. Updated the renderers to not use self-closing tags which is not correct for Custom Elements
2. Updated the grid context menu example to remove non-null assertion (type cast is enough).