### PR TITLE
Fix 'english' not beginning with a capital letter

### DIFF
--- a/articles/guide/contributing/overview.asciidoc
+++ b/articles/guide/contributing/overview.asciidoc
@@ -69,7 +69,7 @@ Straight up crashes and lockups are pretty convincing, but not all bugs are that
 Even if the problem was spotted during code review, describe the impact you think it can have on users. 
 +
 Once the problem is established, describe what you are actually doing about it in technical detail. 
-It's important to describe the change in plain english for the reviewer to verify that the code is behaving as you intend it to.
+It's important to describe the change in plain English for the reviewer to verify that the code is behaving as you intend it to.
 Describe your changes in imperative mood, for example "make xyzzy do frotz". 
 If the patch fixes a logged bug entry, refer to that bug entry by number or URL. 
 However, try to make your explanation understandable without external resources.  


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Languages always begin with a capital letter in English.
