### PR TITLE
docs: update a button example to use disableOnClick

### DIFF
--- a/src/main/java/com/vaadin/demo/component/button/ButtonDisableLongAction.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonDisableLongAction.java
@@ -13,10 +13,8 @@ public class ButtonDisableLongAction extends Div {
         // tag::snippet[]
         Button button = new Button("Perform Action");
         FakeProgressBar progressBar = new FakeProgressBar();
-        button.addClickListener(event -> {
-            button.setEnabled(false);
-            progressBar.simulateProgress();
-        });
+        button.setDisableOnClick(true);
+        button.addClickListener(event -> progressBar.simulateProgress());
 
         progressBar.addProgressEndListener(event -> {
             button.setEnabled(true);


### PR DESCRIPTION
This PR changes the ButtonDisableLongAction example to utilize the `button.setDisableOnClick(true);` feature (this is the Java example of that particular feature).