### PR TITLE
Remove repetitive re-fetching of principal in docs

### DIFF
--- a/articles/flow/tutorials/in-depth-course/login-and-authentication.adoc
+++ b/articles/flow/tutorials/in-depth-course/login-and-authentication.adoc
@@ -186,7 +186,7 @@ public class SecurityService {
         SecurityContext context = SecurityContextHolder.getContext();
         Object principal = context.getAuthentication().getPrincipal();
         if (principal instanceof UserDetails) {
-            return (UserDetails) context.getAuthentication().getPrincipal();
+            return (UserDetails) principal;
         }
         // Anonymous or no authentication.
         return null;


### PR DESCRIPTION
## Description
Documentation code snippet had `context.getAuthentication().getPrincipal()` called repeatedly even though it was already in a variable.

Improves documentation code snippet, nothing else.