### PR TITLE
docs: add section for Notification.show helper

### DIFF
--- a/articles/ds/components/notification/index.asciidoc
+++ b/articles/ds/components/notification/index.asciidoc
@@ -433,6 +433,24 @@ include::{root}/src/main/java/com/vaadin/demo/component/notification/Notificatio
 ----
 --
 
+== Static Helper
+
+For simple, one-off notifications, it is more convenient to use the static `show` helper.
+The helper manages the notification's lifecycle, and adds and removes it from the DOM automatically.
+
+[.example]
+--
+[source,typescript]
+----
+include::{root}/frontend/demo/component/notification/notification-static-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+----
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java[render,tags=snippet,indent=0,group=Java]
+----
+--
+
 == Best Practices
 
 

--- a/articles/ds/components/notification/index.asciidoc
+++ b/articles/ds/components/notification/index.asciidoc
@@ -435,7 +435,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/notification/Notificatio
 
 == Static Helper
 
-For simple, one-off notifications, it is more convenient to use the static `show` helper.
+For simple, one-off notifications, it is convenient to use the static `show()` helper method.
 The helper manages the notification's lifecycle, and adds and removes it from the DOM automatically.
 
 [.example]

--- a/articles/ds/components/notification/index.asciidoc
+++ b/articles/ds/components/notification/index.asciidoc
@@ -48,9 +48,7 @@ include::{root}/frontend/demo/component/notification/notification-basic-preview.
 
 [.example]
 --
-include::../_shared.asciidoc[tag=guard-directive-note]
-
-[source,html]
+[source,typescript]
 ----
 include::{root}/frontend/demo/component/notification/notification-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
@@ -79,9 +77,7 @@ include::{root}/frontend/demo/component/notification/notification-success-previe
 
 [.example]
 --
-include::../_shared.asciidoc[tag=guard-directive-note]
-
-[source,html]
+[source,typescript]
 ----
 include::{root}/frontend/demo/component/notification/notification-success.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
@@ -145,9 +141,7 @@ include::{root}/frontend/demo/component/notification/notification-primary-previe
 
 [.example]
 --
-include::../_shared.asciidoc[tag=guard-directive-note]
-
-[source,html]
+[source,typescript]
 ----
 include::{root}/frontend/demo/component/notification/notification-primary.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
@@ -173,9 +167,7 @@ include::{root}/frontend/demo/component/notification/notification-contrast-previ
 
 [.example]
 --
-include::../_shared.asciidoc[tag=guard-directive-note]
-
-[source,html]
+[source,typescript]
 ----
 include::{root}/frontend/demo/component/notification/notification-contrast.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----

--- a/frontend/demo/component/notification/notification-basic.ts
+++ b/frontend/demo/component/notification/notification-basic.ts
@@ -1,14 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement, render } from 'lit';
+import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators';
-import { guard } from 'lit/directives/guard';
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
-import {
-  NotificationRenderer,
-  NotificationOpenedChangedEvent,
-} from '@vaadin/vaadin-notification/vaadin-notification';
+import { NotificationElement } from '@vaadin/vaadin-notification/vaadin-notification';
 import { applyTheme } from 'Frontend/generated/theme';
+import { NotificationOpenedChangedEvent } from '@vaadin/vaadin-notification/src/interfaces';
 
 @customElement('notification-basic')
 export class Example extends LitElement {
@@ -22,30 +19,27 @@ export class Example extends LitElement {
     return root;
   }
 
+  handleClick() {
+    // tag::snippet[]
+    const notification = NotificationElement.show('Financial report generated', {
+      position: 'middle',
+    });
+    // end::snippet[]
+    this.notificationOpened = true;
+    const handleOpenChanged = (e: NotificationOpenedChangedEvent) => {
+      if (!e.detail.value) {
+        this.notificationOpened = false;
+        notification.removeEventListener('opened-changed', handleOpenChanged);
+      }
+    };
+    notification.addEventListener('opened-changed', handleOpenChanged);
+  }
+
   render() {
     return html`
-      <vaadin-button
-        @click="${() => (this.notificationOpened = true)}"
-        .disabled="${this.notificationOpened}"
-      >
+      <vaadin-button @click="${this.handleClick}" .disabled="${this.notificationOpened}">
         Try it
       </vaadin-button>
-
-      <!-- tag::snippet[] -->
-      <vaadin-notification
-        position="middle"
-        .opened="${this.notificationOpened}"
-        @opened-changed="${(e: NotificationOpenedChangedEvent) => {
-          this.notificationOpened = e.detail.value;
-        }}"
-        .renderer="${guard(
-          [],
-          (): NotificationRenderer => (root) => {
-            render(html`Financial report generated`, root);
-          }
-        )}"
-      ></vaadin-notification>
-      <!-- end::snippet[] -->
     `;
   }
 }

--- a/frontend/demo/component/notification/notification-contrast.ts
+++ b/frontend/demo/component/notification/notification-contrast.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement, render } from 'lit';
+import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators';
-import { guard } from 'lit/directives/guard';
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
 import {
-  NotificationRenderer,
+  NotificationElement,
   NotificationOpenedChangedEvent,
 } from '@vaadin/vaadin-notification/vaadin-notification';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -22,31 +21,28 @@ export class Example extends LitElement {
     return root;
   }
 
+  handleClick() {
+    // tag::snippet[]
+    const notification = NotificationElement.show('5 tasks deleted', {
+      position: 'middle',
+    });
+    notification.setAttribute('theme', 'contrast');
+    // end::snippet[]
+    this.notificationOpened = true;
+    const handleOpenChanged = (e: NotificationOpenedChangedEvent) => {
+      if (!e.detail.value) {
+        this.notificationOpened = false;
+        notification.removeEventListener('opened-changed', handleOpenChanged);
+      }
+    };
+    notification.addEventListener('opened-changed', handleOpenChanged);
+  }
+
   render() {
     return html`
-      <vaadin-button
-        @click="${() => (this.notificationOpened = true)}"
-        .disabled="${this.notificationOpened}"
-      >
+      <vaadin-button @click="${this.handleClick}" .disabled="${this.notificationOpened}">
         Try it
       </vaadin-button>
-
-      <!-- tag::snippet[] -->
-      <vaadin-notification
-        theme="contrast"
-        position="middle"
-        .opened="${this.notificationOpened}"
-        @opened-changed="${(e: NotificationOpenedChangedEvent) => {
-          this.notificationOpened = e.detail.value;
-        }}"
-        .renderer="${guard(
-          [],
-          (): NotificationRenderer => (root) => {
-            render(html`5 tasks deleted`, root);
-          }
-        )}"
-      ></vaadin-notification>
-      <!-- end::snippet[] -->
     `;
   }
 }

--- a/frontend/demo/component/notification/notification-position.ts
+++ b/frontend/demo/component/notification/notification-position.ts
@@ -1,5 +1,5 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement, render } from 'lit';
+import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators';
 import '@vaadin/vaadin-icon/vaadin-icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
@@ -44,20 +44,8 @@ export class Example extends LitElement {
     // Use the button label as the location
     const position = (event.target as HTMLElement).textContent as NotificationPosition;
 
-    const notification = new NotificationElement();
-    notification.position = position;
-    notification.renderer = (root) => {
-      render(html`${position}`, root);
-    };
-
-    document.body.appendChild(notification);
-    notification.open();
-
-    // Remember to clean up the element from the DOM
-    // if you are not reusing the same notification
-    notification.addEventListener('opened-changed', () => {
-      document.body.removeChild(notification);
-    });
+    NotificationElement.show(position, { position });
   }
+
   // end::snippet[]
 }

--- a/frontend/demo/component/notification/notification-primary.ts
+++ b/frontend/demo/component/notification/notification-primary.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement, render } from 'lit';
+import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators';
-import { guard } from 'lit/directives/guard';
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
 import {
-  NotificationRenderer,
+  NotificationElement,
   NotificationOpenedChangedEvent,
 } from '@vaadin/vaadin-notification/vaadin-notification';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -22,31 +21,28 @@ export class Example extends LitElement {
     return root;
   }
 
+  handleClick() {
+    // tag::snippet[]
+    const notification = NotificationElement.show('New project plan available', {
+      position: 'middle',
+    });
+    notification.setAttribute('theme', 'primary');
+    // end::snippet[]
+    this.notificationOpened = true;
+    const handleOpenChanged = (e: NotificationOpenedChangedEvent) => {
+      if (!e.detail.value) {
+        this.notificationOpened = false;
+        notification.removeEventListener('opened-changed', handleOpenChanged);
+      }
+    };
+    notification.addEventListener('opened-changed', handleOpenChanged);
+  }
+
   render() {
     return html`
-      <vaadin-button
-        @click="${() => (this.notificationOpened = true)}"
-        .disabled="${this.notificationOpened}"
-      >
+      <vaadin-button @click="${this.handleClick}" .disabled="${this.notificationOpened}">
         Try it
       </vaadin-button>
-
-      <!-- tag::snippet[] -->
-      <vaadin-notification
-        theme="primary"
-        position="middle"
-        .opened="${this.notificationOpened}"
-        @opened-changed="${(e: NotificationOpenedChangedEvent) => {
-          this.notificationOpened = e.detail.value;
-        }}"
-        .renderer="${guard(
-          [],
-          (): NotificationRenderer => (root) => {
-            render(html`New project plan available`, root);
-          }
-        )}"
-      ></vaadin-notification>
-      <!-- end::snippet[] -->
     `;
   }
 }

--- a/frontend/demo/component/notification/notification-static-helper.ts
+++ b/frontend/demo/component/notification/notification-static-helper.ts
@@ -1,0 +1,56 @@
+import 'Frontend/demo/init'; // hidden-source-line
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators';
+import '@vaadin/vaadin-button/vaadin-button';
+import '@vaadin/vaadin-notification/vaadin-notification';
+import { NotificationElement } from '@vaadin/vaadin-notification/vaadin-notification';
+import { applyTheme } from 'Frontend/generated/theme';
+
+@customElement('notification-static-helper')
+export class Example extends LitElement {
+  protected createRenderRoot() {
+    const root = super.createRenderRoot();
+    // Apply custom theme (only supported if your app uses one)
+    applyTheme(root);
+    return root;
+  }
+
+  handleTextNotification() {
+    // tag::snippet[]
+    // Show a simple text-based notification
+    NotificationElement.show('Financial report generated', {
+      position: 'middle',
+    });
+    // end::snippet[]
+  }
+
+  handleLitTemplateNotification() {
+    // tag::snippet[]
+    // Show a notification with markup using a Lit template
+    NotificationElement.show(
+      html`
+        <b>@John:</b>
+        &nbsp;
+        <span>
+          How about lunch at
+          <span style="color: var(--lumo-primary-text-color)">12:30pm</span>?
+        </span>
+      `,
+      {
+        position: 'middle',
+      }
+    );
+    // end::snippet[]
+  }
+
+  render() {
+    return html`
+      <vaadin-button @click="${this.handleTextNotification}">
+        Show text notification
+      </vaadin-button>
+      <vaadin-button @click="${this.handleLitTemplateNotification}">
+        Show notification with markup
+      </vaadin-button>
+    `;
+  }
+}

--- a/frontend/demo/component/notification/notification-success.ts
+++ b/frontend/demo/component/notification/notification-success.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement, render } from 'lit';
+import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators';
-import { guard } from 'lit/directives/guard';
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
 import {
-  NotificationRenderer,
+  NotificationElement,
   NotificationOpenedChangedEvent,
 } from '@vaadin/vaadin-notification/vaadin-notification';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -22,31 +21,28 @@ export class Example extends LitElement {
     return root;
   }
 
+  handleClick() {
+    // tag::snippet[]
+    const notification = NotificationElement.show('Application submitted!', {
+      position: 'middle',
+    });
+    notification.setAttribute('theme', 'success');
+    // end::snippet[]
+    this.notificationOpened = true;
+    const handleOpenChanged = (e: NotificationOpenedChangedEvent) => {
+      if (!e.detail.value) {
+        this.notificationOpened = false;
+        notification.removeEventListener('opened-changed', handleOpenChanged);
+      }
+    };
+    notification.addEventListener('opened-changed', handleOpenChanged);
+  }
+
   render() {
     return html`
-      <vaadin-button
-        @click="${() => (this.notificationOpened = true)}"
-        .disabled="${this.notificationOpened}"
-      >
+      <vaadin-button @click="${this.handleClick}" .disabled="${this.notificationOpened}">
         Try it
       </vaadin-button>
-
-      <!-- tag::snippet[] -->
-      <vaadin-notification
-        theme="success"
-        position="middle"
-        .opened="${this.notificationOpened}"
-        @opened-changed="${(e: NotificationOpenedChangedEvent) => {
-          this.notificationOpened = e.detail.value;
-        }}"
-        .renderer="${guard(
-          [],
-          (): NotificationRenderer => (root) => {
-            render(html`Application submitted!`, root);
-          }
-        )}"
-      ></vaadin-notification>
-      <!-- end::snippet[] -->
     `;
   }
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java
@@ -1,0 +1,27 @@
+package com.vaadin.demo.component.notification;
+
+import com.vaadin.demo.DemoExporter;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.router.Route;
+
+@Route("notification-static-helper")
+public class NotificationStaticHelper extends Div {
+
+  public NotificationStaticHelper() {
+    Button button = new Button("Show text notification");
+    button.addClickListener(clickEvent -> {
+      // tag::snippet[]
+      // Show a simple text-based notification
+      Notification notification = Notification.show("Financial report generated");
+      notification.setPosition(Notification.Position.MIDDLE);
+      // end::snippet[]
+    });
+
+    add(button);
+  }
+
+  public static class Exporter extends DemoExporter<NotificationStaticHelper> { // hidden-source-line
+  } // hidden-source-line
+}


### PR DESCRIPTION
## Description

Adds new section for the Notification.show helper method, now that it is available in both Java + TS. Also updated the basic TS examples to use the helper.

I decided to introduce a new section for this. Although the helper is used in several other examples I though it would be easier to discover this way. Also was easier to explicitely hint at the support for Lit templates in the TS example.

Related to: https://github.com/vaadin/components-team-tasks/issues/593