### PR TITLE
docs: add menubar section for internationalization

### DIFF
--- a/articles/ds/components/menu-bar/index.asciidoc
+++ b/articles/ds/components/menu-bar/index.asciidoc
@@ -301,6 +301,24 @@ include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarComboButt
 
 --
 
+== Internationalization (i18n)
+
+The menu bar component provides an API for localization.
+Currently, only the accessible label for the overflow menu button can be customized.
+
+[.example]
+--
+[source,typescript]
+----
+include::{root}/frontend/demo/component/menubar/menu-bar-internationalization.ts[tags=snippet,indent=0,group=TypeScript]
+----
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarInternationalization.java[tags=snippet,indent=0,group=Java]
+----
+--
+
 == Best Practices
 
 * Menu Bar should not be used for navigation. Use <<../tabs#,tabs>> for switching between content, or anchor elements for regular navigation.

--- a/articles/ds/components/menu-bar/index.asciidoc
+++ b/articles/ds/components/menu-bar/index.asciidoc
@@ -303,7 +303,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarComboButt
 
 == Internationalization (i18n)
 
-The menu bar component provides an API for localization.
+Menu Bar provides an API for localization.
 Currently, only the accessible label for the overflow menu button can be customized.
 
 [.example]

--- a/frontend/demo/component/menubar/menu-bar-internationalization.ts
+++ b/frontend/demo/component/menubar/menu-bar-internationalization.ts
@@ -1,0 +1,52 @@
+import 'Frontend/demo/init'; // hidden-source-line
+
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import '@vaadin/vaadin-menu-bar/vaadin-menu-bar';
+import '@vaadin/vaadin-split-layout/vaadin-split-layout';
+import { applyTheme } from 'Frontend/generated/theme';
+import { MenuBarI18n } from '@vaadin/vaadin-menu-bar';
+
+@customElement('menu-bar-internationalization')
+export class Example extends LitElement {
+  protected createRenderRoot() {
+    const root = super.createRenderRoot();
+    // Apply custom theme (only supported if your app uses one)
+    applyTheme(root);
+    return root;
+  }
+
+  @state()
+  private items = [
+    { text: 'View' },
+    { text: 'Edit' },
+    {
+      text: 'Share',
+      children: [
+        {
+          text: 'On social media',
+          children: [{ text: 'Facebook' }, { text: 'Twitter' }, { text: 'Instagram' }],
+        },
+        { text: 'By email' },
+        { text: 'Get link' },
+      ],
+    },
+    {
+      text: 'Move',
+      children: [{ text: 'To folder' }, { text: 'To trash' }],
+    },
+    { text: 'Duplicate' },
+  ];
+
+  render() {
+    // tag::snippet[]
+    const customI18n: MenuBarI18n = {
+      // Provide accessible label for the overflow menu button
+      // to screen readers
+      moreOptions: 'More actions',
+    };
+
+    return html` <vaadin-menu-bar .i18n="${customI18n}" .items="${this.items}"></vaadin-menu-bar> `;
+    // end::snippet[]
+  }
+}

--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarInternationalization.java
@@ -1,0 +1,49 @@
+package com.vaadin.demo.component.menubar;
+
+import com.vaadin.demo.DemoExporter;
+import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.contextmenu.SubMenu;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.router.Route;
+
+@Route("menu-bar-internationalization")
+public class MenuBarInternationalization extends Div {
+
+  public MenuBarInternationalization() {
+    // tag::snippet[]
+    MenuBar menuBar = new MenuBar();
+    MenuBar.MenuBarI18n customI18n = new MenuBar.MenuBarI18n()
+            // Provide accessible label for the overflow menu button
+            // to screen readers
+            .setMoreOptions("More actions");
+
+    menuBar.setI18n(customI18n);
+    // end::snippet[]
+
+    menuBar.addItem("View");
+    menuBar.addItem("Edit");
+
+    MenuItem share = menuBar.addItem("Share");
+    SubMenu shareSubMenu = share.getSubMenu();
+    MenuItem onSocialMedia = shareSubMenu.addItem("On social media");
+    SubMenu socialMediaSubMenu = onSocialMedia.getSubMenu();
+    socialMediaSubMenu.addItem("Facebook");
+    socialMediaSubMenu.addItem("Twitter");
+    socialMediaSubMenu.addItem("Instagram");
+    shareSubMenu.addItem("By email");
+    shareSubMenu.addItem("Get Link");
+
+    MenuItem move = menuBar.addItem("Move");
+    SubMenu moveSubMenu = move.getSubMenu();
+    moveSubMenu.addItem("To folder");
+    moveSubMenu.addItem("To trash");
+
+    menuBar.addItem("Duplicate");
+
+    add(menuBar);
+  }
+
+  public static class Exporter extends DemoExporter<MenuBarInternationalization> { // hidden-source-line
+  } // hidden-source-line
+}


### PR DESCRIPTION
## Description

Adds a new internationalization section for the menu bar component. Currently only a single aria-label can be localized so I noted that fact in the docs. I also decided to not render the examples, as most users will not be able to make out the difference (if an overflow button is visible, then it has a different aria-label).

Related to https://github.com/vaadin/components-team-tasks/issues/594