### PR TITLE
fix: Use pinned supported pnpm version by default

### DIFF
--- a/articles/flow/guide/start/gradle.asciidoc
+++ b/articles/flow/guide/start/gradle.asciidoc
@@ -511,6 +511,10 @@ Use byte code scanner strategy to discover frontend components.
 Instructs to use pnpm for installing npm frontend resources.
 Default is true
 
+`useGlobalPnpm: Boolean = false`::
+Instructs to use globally installed pnpm tool or the default supported pnpm version.
+Default is false
+
 `requireHomeNodeExec: Boolean = false`::
 Whether vaadin home node executable usage is forced.
 If it's set to `true` then vaadin home 'node' is checked and installed if absent.

--- a/articles/flow/guide/start/gradle.asciidoc
+++ b/articles/flow/guide/start/gradle.asciidoc
@@ -509,11 +509,11 @@ Use byte code scanner strategy to discover frontend components.
 
 `pnpmEnable: Boolean = true`::
 Instructs to use pnpm for installing npm frontend resources.
-Default is true
+Defaults to true.
 
 `useGlobalPnpm: Boolean = false`::
 Instructs to use globally installed pnpm tool or the default supported pnpm version.
-Default is false
+Defaults to false.
 
 `requireHomeNodeExec: Boolean = false`::
 Whether vaadin home node executable usage is forced.

--- a/articles/shared/guide/configuration/_maven.asciidoc
+++ b/articles/shared/guide/configuration/_maven.asciidoc
@@ -88,7 +88,7 @@ Defaults to `true`.
 
 `useGlobalPnpm`::
 Instructs to use globally installed pnpm tool or the default supported pnpm version.
-Defaults to `false`
+Defaults to `false`.
 
 `productionMode`::
 Define if application is running in productionMode.

--- a/articles/shared/guide/install/_index.asciidoc
+++ b/articles/shared/guide/install/_index.asciidoc
@@ -139,9 +139,15 @@ pnpm reduces the download time across multiple projects by caching the downloade
 It is the recommended and default package manager for Vaadin projects.
 
 You do not need to install pnpm separately.
-Vaadin uses npx, the node package runner to locate (and if necessary download) a compatible pnpm version.
-If you have installed pnpm globally (via `npm install -g pnpm`), the installed version is used by default unless it is determined to be too old.
 
+[role="since:com.vaadin:vaadin@V22"]
+==== Local And Global Installation
+Vaadin uses npx, the node package runner to download and use the default compatible pnpm version via version specifier - `pnpm@5.18.10`.
+
+If you have installed pnpm globally (via `npm install -g pnpm`) and set up the configuration parameter `vaadin.pnpm.global=true`, the installed version is used unless it is determined to be too old.
+Note that Vaadin requires pnpm 5 or newer.
+
+==== Install a Custom Package
 To install a custom frontend package into your project with pnpm, install Node.js globally and run pnpm using npx.
 For example, to add the `mobx` package as a dependency in `package.json` as well as install it into `node_modules`, run the following command in the project directory:
 
@@ -155,8 +161,7 @@ If you have installed pnpm globally, you can alternatively call it directly:
 pnpm add mobx
 ```
 
-Vaadin requires pnpm 5 or newer.
-If you have already installed an older version of pnpm globally the above command runs the old version; either upgrade pnpm or pass a version specifier to npx, for example `pnpm@5.15.2` instead of `pnpm`.
+If you have already installed an older version of pnpm globally the above command runs the old version; either upgrade pnpm or pass a version specifier to npx, for example `pnpm@5.18.10` instead of `pnpm`.
 See the https://pnpm.js.org/[pnpm website] for more information about available commands and flags.
 
 [NOTE]

--- a/articles/shared/guide/install/_index.asciidoc
+++ b/articles/shared/guide/install/_index.asciidoc
@@ -141,13 +141,16 @@ It is the recommended and default package manager for Vaadin projects.
 You do not need to install pnpm separately.
 
 [role="since:com.vaadin:vaadin@V22"]
-==== Local And Global Installation
-Vaadin uses npx, the node package runner to download and use the default compatible pnpm version via version specifier - `pnpm@5.18.10`.
+==== Local and Global Installation
 
-If you have installed pnpm globally (via `npm install -g pnpm`) and set up the configuration parameter `vaadin.pnpm.global=true`, the installed version is used unless it is determined to be too old.
+Vaadin uses npx, the node package runner to download and use a compatible version of pnpm.
+It specifies the version using a version specifier, such as `pnpm@5.18.10`.
+
+If you have installed pnpm globally (with `npm install -g pnpm`) and set up the configuration parameter `vaadin.pnpm.global=true`, the installed version is used unless it is determined to be too old.
 Note that Vaadin requires pnpm 5 or newer.
 
 ==== Install a Custom Package
+
 To install a custom frontend package into your project with pnpm, install Node.js globally and run pnpm using npx.
 For example, to add the `mobx` package as a dependency in `package.json` as well as install it into `node_modules`, run the following command in the project directory:
 
@@ -161,7 +164,8 @@ If you have installed pnpm globally, you can alternatively call it directly:
 pnpm add mobx
 ```
 
-If you have already installed an older version of pnpm globally the above command runs the old version; either upgrade pnpm or pass a version specifier to npx, for example `pnpm@5.18.10` instead of `pnpm`.
+If you have already installed an older version of pnpm globally, the above command runs the old version.
+In such case, either upgrade the globally installed pnpm or pass a version specifier to npx, for example, `pnpm@5.18.10`, instead of `pnpm`.
 See the https://pnpm.js.org/[pnpm website] for more information about available commands and flags.
 
 [NOTE]

--- a/articles/shared/guide/production/_index.asciidoc
+++ b/articles/shared/guide/production/_index.asciidoc
@@ -180,4 +180,4 @@ and will be used as entry point of the application.
     Whether to use the _pnpm_ or _npm_ tool to handle frontend resources. By default _npm_ is used.
 
 *useGlobalPnpm* (default: `false`)::
-    Whether to use globally installed _pnpm_ tool or the default supported _pnpm_ version.
+    Whether to use a globally installed _pnpm_ tool instead of the default supported version of _pnpm_.

--- a/articles/shared/guide/production/_index.asciidoc
+++ b/articles/shared/guide/production/_index.asciidoc
@@ -178,3 +178,6 @@ and will be used as entry point of the application.
 
 *pnpmEnable* (default: `false`)::
     Whether to use the _pnpm_ or _npm_ tool to handle frontend resources. By default _npm_ is used.
+
+*useGlobalPnpm* (default: `false`)::
+    Whether to use globally installed _pnpm_ tool or the default supported _pnpm_ version.


### PR DESCRIPTION
## Description

Introduce `pnpm.global` config parameter to enable using globally installed pnpm.
Default is false, and the pinned supported version of pnpm tool is used.

Related-to https://github.com/vaadin/flow/issues/11730

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
