### PR TITLE
Remove superfluous "since V14.7" from CE pages

### DIFF
--- a/articles/ce/developing-with-ce.asciidoc
+++ b/articles/ce/developing-with-ce.asciidoc
@@ -7,7 +7,6 @@ layout: page
 [[ce.developing]]
 = Licensing and Pricing Model
 
-[role="since:com.vaadin:vaadin@V14.7 standalone"]
 --
 --
 

--- a/articles/ce/going-to-production.asciidoc
+++ b/articles/ce/going-to-production.asciidoc
@@ -7,7 +7,6 @@ layout: page
 [[ce.production]]
 = Setting Up for Production
 
-[role="since:com.vaadin:vaadin@V14.7 standalone"]
 --
 --
 

--- a/articles/ce/overview.asciidoc
+++ b/articles/ce/overview.asciidoc
@@ -7,7 +7,6 @@ order: 1
 [[ce.overview]]
 = Collaboration Engine
 
-[role="since:com.vaadin:vaadin@V14.7 standalone"]
 --
 --
 

--- a/articles/ce/topic-api.asciidoc
+++ b/articles/ce/topic-api.asciidoc
@@ -7,7 +7,6 @@ layout: page
 [[ce.topic-tutorial]]
 = Getting Started with the Topic API
 
-[role="since:com.vaadin:vaadin@V14.7 standalone"]
 --
 --
 


### PR DESCRIPTION
Related Slack discussion: https://vaadin.slack.com/archives/C01580Y9FLJ/p1632812666025900