### PR TITLE
fix: add missing @PermitAll to the crm auth turorial code example

### DIFF
--- a/articles/fusion/tutorials/in-depth-course/login-and-authentication.adoc
+++ b/articles/fusion/tutorials/in-depth-course/login-and-authentication.adoc
@@ -102,6 +102,7 @@ Remove this annotation from the endpoint to require authentication.
 [source,java]
 ----
 @Endpoint
+@PermitAll
 public class CrmEndpoint {
 }
 ----


### PR DESCRIPTION
The default permission for endpoint used to be `@PermitAll`, it changed to `@DenyAll` by default, so updating the tutorial accordingly.