### PR TITLE
fix: update frontend errors for updating to 22alpha5

### DIFF
--- a/articles/fusion/advanced/client-middleware.asciidoc
+++ b/articles/fusion/advanced/client-middleware.asciidoc
@@ -26,7 +26,7 @@ Here is an example logging middleware with the structure explained.
 .my-log-middleware.ts
 [source,typescript]
 ----
-import { Middleware, MiddlewareContext, MiddlewareNext } from '@vaadin/flow-frontend';
+import { Middleware, MiddlewareContext, MiddlewareNext } from '@vaadin/fusion-frontend';
 
 // A middleware is an async function, that receives the `context` and `next`
 export const MyLogMiddleware: Middleware = async function(
@@ -74,7 +74,7 @@ To use a middleware, when the Vaadin TypeScript client is instantiated, include 
 .connect-client.ts
 [source,typescript]
 ----
-import { ConnectClient } from '@vaadin/flow-frontend';
+import { ConnectClient } from '@vaadin/fusion-frontend';
 import { MyLogMiddleware } from './my-log-middleware';
 
 const client = new ConectClient({
@@ -108,7 +108,7 @@ To make a low-level modification on the request in a middleware, replace the `co
 .my-api-dispatcher-middleware.ts
 [source,typescript]
 ----
-import { Middleware, MiddlewareContext, MiddlewareNext } from '@vaadin/flow-frontend';
+import { Middleware, MiddlewareContext, MiddlewareNext } from '@vaadin/fusion-frontend';
 
 // An example middleware that uses a different server for selected requests
 export const MyApiDispatcherMiddleware: Middleware = async function(
@@ -134,7 +134,7 @@ A middleware can also replace the response by returning a custom `Response` inst
 .my-stub-middleware.ts
 [source,typescript]
 ----
-import { Middleware, MiddlewareContext, MiddlewareNext } from '@vaadin/flow-frontend';
+import { Middleware, MiddlewareContext, MiddlewareNext } from '@vaadin/fusion-frontend';
 
 // An example middleware that returns an empty response instead of calling the backend endpoint
 export const MyStubMiddleware: Middleware = async function(

--- a/articles/fusion/advanced/connection-indicator.asciidoc
+++ b/articles/fusion/advanced/connection-indicator.asciidoc
@@ -111,7 +111,7 @@ For example:
 [source,typescript]
 ----
 // ...
-import { connectionIndicator } from '@vaadin/flow-frontend';
+import { connectionIndicator } from '@vaadin/fusion-frontend';
 
 // Use custom theming
 connectionIndicator.applyDefaultTheme = false;

--- a/articles/fusion/advanced/typescript-client.asciidoc
+++ b/articles/fusion/advanced/typescript-client.asciidoc
@@ -7,8 +7,7 @@ layout: page
 == TypeScript Client Library
 
 Vaadin consists of two parts: a backend and a client.
-The client part is represented by the `@vaadin/flow-frontend/Connect` library that is able to support the features the backend part provides.
-The library is part of `@vaadin/flow-frontend`.
+The client part is represented by the `@vaadin/fusion-frontend` library that is able to support the features the backend part provides.
 
 One of the main public entities of the library is the `ConnectClient` object, that provides a seamless way to communicate with Vaadin endpoints on the backend.
 
@@ -29,7 +28,7 @@ Consider Vaadin backend that is started on `/customEndpoint` endpoint and has a 
 and a method `customMethod` requiring a `number` parameter to be specified.
 
 To access this method from the client part, depending on how many generated files are present, you can use one of the approaches below.
-The required `@vaadin/flow-frontend/Connect` TypeScript library is automatically installed by the Vaadin Maven plugin.
+The required `@vaadin/fusion-frontend` TypeScript library is automatically installed by the Vaadin Maven plugin.
 
 === Using the Generated Client Module
 
@@ -69,7 +68,7 @@ Client library usage requires an extra step where we specify the endpoint of the
 [source,typescript]
 [[client-library]]
 ----
-import { ConnectClient } from '@vaadin/flow-frontend';
+import { ConnectClient } from '@vaadin/fusion-frontend';
 const client = new ConnectClient({endpoint: '/customEndpoint'});
 
 (async() => {

--- a/articles/fusion/tutorials/in-depth-course/installing-and-offline-pwa.adoc
+++ b/articles/fusion/tutorials/in-depth-course/installing-and-offline-pwa.adoc
@@ -69,7 +69,7 @@ Start by importing connection state helpers from Vaadin.
 import {
  ConnectionState,
  ConnectionStateStore,
-} from "@vaadin/flow-frontend/ConnectionState";
+} from "@vaadin/fusion-frontend";
 ----
 
 Next, add an `offline` observable and helpers for tracking changes in the connection state:

--- a/articles/fusion/tutorials/in-depth-course/login-and-authentication.adoc
+++ b/articles/fusion/tutorials/in-depth-course/login-and-authentication.adoc
@@ -129,7 +129,7 @@ Import the needed login methods at the top of the file.
 import {
  login as serverLogin,
  logout as serverLogout,
-} from "@vaadin/flow-frontend";
+} from "@vaadin/fusion-frontend";
 import { crmStore } from "./app-store";
 ----
 
@@ -342,9 +342,7 @@ Create a middleware that listens for the HTTP 401 response code, signifying that
 .`connect-client.ts`
 [source,typescript]
 ----
-import { MiddlewareContext } from "@vaadin/flow-frontend";
-import { MiddlewareNext } from "@vaadin/flow-frontend";
-import { ConnectClient } from "@vaadin/flow-frontend";
+import { MiddlewareContext, MiddlewareNext, ConnectClient } from "@vaadin/fusion-frontend";
 import { uiStore } from "./stores/app-store";
 
 const client = new ConnectClient({

--- a/frontend/demo/component/custom-field/custom-field-basic.ts
+++ b/frontend/demo/component/custom-field/custom-field-basic.ts
@@ -4,7 +4,7 @@ import { customElement } from 'lit/decorators.js';
 import '@vaadin/vaadin-custom-field/vaadin-custom-field';
 import '@vaadin/vaadin-date-picker/vaadin-date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
-import { Binder, field } from 'Frontend/../target/flow-frontend/form';
+import { Binder, field } from '@vaadin/form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
 import { differenceInDays, parseISO, isAfter } from 'date-fns';
 

--- a/frontend/demo/component/select/select-complex-value-label.ts
+++ b/frontend/demo/component/select/select-complex-value-label.ts
@@ -4,7 +4,7 @@ import { html, LitElement, render } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { guard } from 'lit/directives/guard.js';
 import '@vaadin/vaadin-select/vaadin-select';
-import { SelectElement } from '@vaadin/vaadin-select';
+import { Select } from '@vaadin/vaadin-select';
 import '@vaadin/vaadin-list-box/vaadin-list-box';
 import '@vaadin/vaadin-item/vaadin-item';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   private people: Person[] = [];
 
   @query('vaadin-select')
-  private select?: SelectElement;
+  private select?: Select;
 
   async firstUpdated() {
     this.people = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -4,7 +4,7 @@ import { html, LitElement, render } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { guard } from 'lit/directives/guard.js';
 import '@vaadin/vaadin-select/vaadin-select';
-import { SelectElement } from '@vaadin/vaadin-select';
+import { Select } from '@vaadin/vaadin-select';
 import '@vaadin/vaadin-list-box/vaadin-list-box';
 import '@vaadin/vaadin-item/vaadin-item';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   private people: Person[] = [];
 
   @query('vaadin-select')
-  private select?: SelectElement;
+  private select?: Select;
 
   async firstUpdated() {
     this.people = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -3,7 +3,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/vaadin-select/vaadin-select';
-import { SelectElement } from '@vaadin/vaadin-select/vaadin-select';
+import { Select } from '@vaadin/vaadin-select/vaadin-select';
 import '@vaadin/vaadin-list-box/vaadin-list-box';
 import '@vaadin/vaadin-item/vaadin-item';
 import { getPeople } from 'Frontend/demo/domain/DataService';
@@ -23,7 +23,7 @@ export class Example extends LitElement {
   private people: Person[] = [];
 
   @query('vaadin-select')
-  private select?: SelectElement;
+  private select?: Select;
 
   async firstUpdated() {
     const { people } = await getPeople({ count: 4 });

--- a/frontend/demo/fusion/authentication/auth.ts
+++ b/frontend/demo/fusion/authentication/auth.ts
@@ -1,6 +1,6 @@
 // tag::impl[]
 // Uses the Vaadin provided login an logout helper methods
-import { login as loginImpl, LoginResult, logout as logoutImpl } from '@vaadin/flow-frontend';
+import { login as loginImpl, LoginResult, logout as logoutImpl } from '@vaadin/fusion-frontend';
 // end::impl[]
 // tag::userinfo[]
 import { UserInfoEndpoint } from 'Frontend/generated/endpoints';

--- a/frontend/demo/fusion/authentication/handle-session-expiration/connect-client.ts
+++ b/frontend/demo/fusion/authentication/handle-session-expiration/connect-client.ts
@@ -1,4 +1,4 @@
-import { ConnectClient, InvalidSessionMiddleware } from '@vaadin/flow-frontend';
+import { ConnectClient, InvalidSessionMiddleware } from '@vaadin/fusion-frontend';
 import { setSessionExpired } from '../auth';
 const client = new ConnectClient({
   prefix: 'connect',

--- a/frontend/demo/fusion/authentication/handle-session-expiration/login-overlay.ts
+++ b/frontend/demo/fusion/authentication/handle-session-expiration/login-overlay.ts
@@ -1,7 +1,7 @@
 import { LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Router } from '@vaadin/router';
-import { LoginResult } from '@vaadin/flow-frontend';
+import { LoginResult } from '@vaadin/fusion-frontend';
 
 @customElement('login-view')
 export class LoginView extends LitElement {

--- a/frontend/demo/fusion/authentication/login-view.ts
+++ b/frontend/demo/fusion/authentication/login-view.ts
@@ -1,6 +1,6 @@
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { LoginResult } from '@vaadin/flow-frontend';
+import { LoginResult } from '@vaadin/fusion-frontend';
 import { login } from './auth';
 import { AfterEnterObserver, RouterLocation } from '@vaadin/router';
 import '@vaadin/vaadin-login/vaadin-login-overlay';

--- a/frontend/demo/fusion/errorhandling/catch-error.ts
+++ b/frontend/demo/fusion/errorhandling/catch-error.ts
@@ -1,4 +1,4 @@
-import { EndpointError } from '@vaadin/flow-frontend';
+import { EndpointError } from '@vaadin/fusion-frontend';
 
 import { DataEndpoint } from 'Frontend/generated/endpoints';
 

--- a/frontend/demo/fusion/errorhandling/catch-error.ts
+++ b/frontend/demo/fusion/errorhandling/catch-error.ts
@@ -5,7 +5,7 @@ import { DataEndpoint } from 'Frontend/generated/endpoints';
 export async function callEndpoint() {
   try {
     await DataEndpoint.getViewData();
-  } catch (error) {
+  } catch (error: any) {
     console.warn(error.message); // "Not implemented"
     if (error instanceof EndpointError) {
       console.warn(error.type); // "com.vaadin.fusion.exception.EndpointException"

--- a/frontend/demo/fusion/errorhandling/catch-invalid-args.ts
+++ b/frontend/demo/fusion/errorhandling/catch-invalid-args.ts
@@ -1,4 +1,4 @@
-import { EndpointValidationError } from '@vaadin/flow-frontend';
+import { EndpointValidationError } from '@vaadin/fusion-frontend';
 
 import { DateEndpoint } from 'Frontend/generated/endpoints';
 

--- a/frontend/demo/fusion/errorhandling/catch-invalid-args.ts
+++ b/frontend/demo/fusion/errorhandling/catch-invalid-args.ts
@@ -8,7 +8,7 @@ export async function callEndpoint() {
     const tomorrow = await DateEndpoint.getTomorrow('2021-02-29');
     console.log(tomorrow);
     // handle result...
-  } catch (error) {
+  } catch (error: any) {
     if (error instanceof EndpointValidationError) {
       error.validationErrorData.forEach(({ parameterName, message }) => {
         console.warn(parameterName); // "date"

--- a/frontend/demo/pwa/offline/ts-view-with-endpoint.ts
+++ b/frontend/demo/pwa/offline/ts-view-with-endpoint.ts
@@ -1,4 +1,4 @@
-import { EndpointError } from '@vaadin/flow-frontend';
+import { EndpointError } from '@vaadin/fusion-frontend';
 
 // import the remote endpoint
 import { DataEndpoint } from 'Frontend/generated/endpoints';

--- a/package.json
+++ b/package.json
@@ -84,11 +84,12 @@
     "@webcomponents/shadycss": "1.9.6",
     "construct-style-sheets-polyfill": "2.4.16",
     "date-fns": "2.23.0",
-    "lit": "2.0.0-rc.3",
+    "lit": "2.0.0",
     "lumo-css-framework": "^4.0.8",
     "mobx": "^6.1.5",
     "promise-file-reader": "^1.0.3",
-    "vanilla-colorful": "^0.5.3"
+    "vanilla-colorful": "^0.5.3",
+    "@vaadin/common-frontend": "0.0.16"
   },
   "devDependencies": {
     "@types/validator": "13.1.0",
@@ -121,16 +122,18 @@
     "loader-utils": "2.0.0",
     "prettier": "^2.2.1",
     "ts-loader": "8.0.12",
-    "typescript": "4.3.3",
+    "typescript": "4.4.3",
     "validator": "13.1.17",
     "webpack": "4.46.0",
-    "webpack-cli": "3.3.12",
-    "webpack-dev-server": "3.11.0",
+    "webpack-cli": "4.8.0",
+    "webpack-dev-server": "4.1.1",
     "webpack-manifest-plugin": "3.0.0",
     "webpack-merge": "4.2.2",
     "workbox-core": "6.2.0",
     "workbox-precaching": "6.2.0",
-    "workbox-webpack-plugin": "6.2.0"
+    "workbox-webpack-plugin": "6.2.0",
+    "@vaadin/build-status-plugin": "./target/plugins/build-status-plugin",
+    "esbuild-loader": "2.15.1"
   },
   "husky": {
     "hooks": {
@@ -237,8 +240,9 @@
       "@webcomponents/shadycss": "1.9.6",
       "construct-style-sheets-polyfill": "2.4.16",
       "date-fns": "2.23.0",
-      "lit": "2.0.0-rc.3",
-      "mobx": "^6.1.5"
+      "lit": "2.0.0",
+      "mobx": "^6.1.5",
+      "@vaadin/common-frontend": "0.0.16"
     },
     "devDependencies": {
       "@types/validator": "13.1.0",
@@ -254,16 +258,17 @@
       "lit-css-loader": "0.1.0",
       "loader-utils": "2.0.0",
       "ts-loader": "8.0.12",
-      "typescript": "4.3.3",
+      "typescript": "4.4.3",
       "validator": "13.1.17",
       "webpack": "4.46.0",
-      "webpack-cli": "3.3.12",
-      "webpack-dev-server": "3.11.0",
+      "webpack-cli": "4.8.0",
+      "webpack-dev-server": "4.1.1",
       "webpack-manifest-plugin": "3.0.0",
       "webpack-merge": "4.2.2",
       "workbox-core": "6.2.0",
       "workbox-precaching": "6.2.0",
-      "workbox-webpack-plugin": "6.2.0"
+      "workbox-webpack-plugin": "6.2.0",
+      "esbuild-loader": "2.15.1"
     },
     "hash": "f657a7a452f144cdfdc04f9a299d31eb51c52d0bad71bb01118209a7cdb48a1d"
   }

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- tag::vaadin-version[] -->
-        <vaadin.version>22.0.0.alpha3</vaadin.version>
+        <vaadin.version>22.0.0.alpha5</vaadin.version>
         <!-- end::vaadin-version[] -->
 
         <drivers.dir>${project.basedir}/drivers</drivers.dir>


### PR DESCRIPTION
- update the fusion imports from `@vaadin/flow-frontend` to `@vaadin/fusion-frontend`.
- update select component imports
- add `any` type to param in catch statement