### PR TITLE
chore: use themable-mixin to detect version

### DIFF
--- a/articles/ds/overview.asciidoc
+++ b/articles/ds/overview.asciidoc
@@ -3,7 +3,7 @@ title: Overview
 order: 10
 layout: index
 page-links:
-  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-element-mixin}[Web Components {moduleNpmVersion:vaadin-element-mixin}]
+  - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-themable-mixin}[Web Components {moduleNpmVersion:vaadin-element-mixin}]
   - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-lumo-theme}[Flow Components {moduleMavenVersion:com.vaadin:vaadin-lumo-theme}]
 ---
 


### PR DESCRIPTION
## Description

The `vaadin-element-mixin` package has been removed so let's use `vaadin-themable-mixin` instead.
