### PR TITLE
Set project download as primary CTA of Flow QuickStart

### DIFF
--- a/articles/flow/tutorials/quick-start-tutorial.adoc
+++ b/articles/flow/tutorials/quick-start-tutorial.adoc
@@ -23,7 +23,7 @@ image::images/app-overview.png[Todo application with a header, checkboxes for to
 
 ++++
 <p>
-<a href="https://vaadin.com/vaadincom/start-service/lts/project-base?appName=My Todo&groupId=org.vaadin.example&techStack=spring" class="button secondary water quickstart-download-project"
+<a href="https://vaadin.com/vaadincom/start-service/lts/project-base?appName=My Todo&groupId=org.vaadin.example&techStack=spring" class="button primary water quickstart-download-project"
  onClick="function test(){ _hsq && _hsq.push(['trackEvent', { id: '000007517662', value: null }]); } test(); return true;">Download</a>
 
 <span>&nbsp;</span>


### PR DESCRIPTION
The quickstart tutorial can be completed either by downloading a project or running things in an online IDE. The former should, however, be encouraged as most developers continue to do their development locally, and many of them are not used to online IDEs. 

Downloading a project should thus be styled as the primary CTA. 