### PR TITLE
fix: broken style modules in foundation docs

### DIFF
--- a/frontend/demo/foundation/lumo-tokens.ts
+++ b/frontend/demo/foundation/lumo-tokens.ts
@@ -1,3 +1,4 @@
+import '@vaadin/polymer-legacy-adapter/style-modules'; // hidden-source-line
 // Import all Lumo CSS custom properties into the global style scope
 // tag::color[]
 import '@vaadin/vaadin-lumo-styles/color';


### PR DESCRIPTION
## Description

Adds the Polymer legacy adapter for style modules to the foundation docs, in order to fix issues with including the modules' CSS contents.

Internal discussion: https://vaadin.slack.com/archives/C3TGRP4HY/p1635429159105800
