### PR TITLE
chore: remove polymer legacy adapter in foundation docs

### DIFF
--- a/frontend/demo/foundation/include-module.ts
+++ b/frontend/demo/foundation/include-module.ts
@@ -1,7 +1,7 @@
-import { cssFromModule } from '@polymer/polymer/lib/utils/style-gather';
+import { CSSResult } from 'lit';
 
-export function includeModule(moduleName: string, parseCss: (css: string) => string) {
-  const css = cssFromModule(moduleName);
+export function includeModule(cssModule: CSSResult, parseCss: (css: string) => string) {
+  const css = cssModule.cssText;
   const style = document.createElement('style');
   style.innerHTML = parseCss(css);
   document.head.appendChild(style);

--- a/frontend/demo/foundation/lumo-tokens.ts
+++ b/frontend/demo/foundation/lumo-tokens.ts
@@ -1,8 +1,8 @@
-import '@vaadin/polymer-legacy-adapter/style-modules'; // hidden-source-line
 // Import all Lumo CSS custom properties into the global style scope
 // tag::color[]
 import '@vaadin/vaadin-lumo-styles/color';
 // end::color[]
+import { color } from '@vaadin/vaadin-lumo-styles/color'; // hidden-source-line
 // tag::typography[]
 import '@vaadin/vaadin-lumo-styles/typography';
 // end::typography[]
@@ -21,6 +21,6 @@ import 'lumo-css-framework/all-classes.css';
 import { includeModule } from './include-module'; // hidden-source-line
 import { applyTheme } from 'Frontend/generated/theme'; // hidden-source-line
 // prettier-ignore
-includeModule('lumo-color', (css) => `[theme~="dark"] ${css.split("[theme~='dark']")[1].split('}')[0]} }`); // hidden-source-line
+includeModule(color, (css) => `[theme~="dark"] ${css.split("[theme~='dark']")[1].split('}')[0]} }`); // hidden-source-line
 applyTheme(document); // hidden-source-line
 window.dispatchEvent(new CustomEvent('custom-properties-changed')); // hidden-source-line

--- a/frontend/demo/foundation/material-tokens.ts
+++ b/frontend/demo/foundation/material-tokens.ts
@@ -2,10 +2,11 @@
 // tag::color[]
 import '@vaadin/vaadin-material-styles/color';
 // end::color[]
+import { colorDark } from '@vaadin/vaadin-material-styles/color'; // hidden-source-line
 // tag::typography[]
 import '@vaadin/vaadin-material-styles/typography';
 // end::typography[]
 import { includeModule } from './include-module'; // hidden-source-line
 // prettier-ignore
-includeModule('material-color-dark', (css) => css.replace(':host', 'html[theme~="dark"]').replace('background-color: var(--material-background-color);', '').replace('color: var(--material-body-text-color);', '')); // hidden-source-line
+includeModule(colorDark, (css) => css.replace(':host', 'html[theme~="dark"]').replace('background-color: var(--material-background-color);', '').replace('color: var(--material-body-text-color);', '')); // hidden-source-line
 window.dispatchEvent(new CustomEvent('custom-properties-changed')); // hidden-source-line


### PR DESCRIPTION
## Description

Removes the Polymer legacy adapter from the Foundation docs, which was used to access the dark theme CSS, and uses CSSResults instead which are now exported by the Lumo style modules in V22.
