### PR TITLE
chore: disable CRUD sorting and filtering in separate section

### DIFF
--- a/articles/ds/components/crud/index.asciidoc
+++ b/articles/ds/components/crud/index.asciidoc
@@ -261,10 +261,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudHiddenToolbar.j
 --
 
 == Sorting & Filtering
+By default, CRUD allows sorting and filtering of any column. For more information about sorting and filtering, please see the basic <<../grid#,Grid documentation>>.
 
+=== Disabling Sorting and Filtering
 Sorting and filtering can be disabled.
-For more information about sorting and filtering, please see the basic <<../grid#,Grid documentation>>.
-
 [.example]
 --
 


### PR DESCRIPTION
## Description

The PR is the follow-up on the internal discussion where it was agreed that it would be more clear if the “Disabling sorting and filtering” example in the "Sorting & Filtering" section on the CRUD page was moved to a separate sub-section.

Otherwise, it is quite confusing that the first example in the "Sorting & Filtering" section doesn’t actually allow sorting and filtering items and, instead, demonstrates how it would look like if sorting and filtering were disabled.

### Before

![image](https://user-images.githubusercontent.com/5039436/139663494-ac6cc619-3458-4e23-a02b-6781c07a85c8.png)

### After

![image](https://user-images.githubusercontent.com/5039436/139662777-5131fef1-c24f-4e8a-a627-c5b22c8ff43b.png)

## Type of change

- [x] Documentation
