### PR TITLE
CE: Tip about entry scope for topic data

### DIFF
--- a/articles/ce/advanced/topic-api.asciidoc
+++ b/articles/ce/advanced/topic-api.asciidoc
@@ -50,7 +50,7 @@ Since the example does not (yet) register any own listeners that need cleanup, i
 
 === Define a category in the Topic
 
-The topic stores collaborative data in named maps.
+The topic stores collaborative data in named maps and lists.
 
 In the activation callback, get a map by its name:
 
@@ -80,6 +80,10 @@ Topic maps
   |_ isFriday: true/false
 ----
 
+.Adding scope to Topic data
+[TIP]
+By default values will be stored in the Topic until explicitly removed.
+You can use methods accepting a scope parameter and use `EntryScope.CONNECTION` to have the entry removed when the connection is deactivated.
 
 === Subscribe to Topic Changes
 


### PR DESCRIPTION
This adds a TIP about using `EntryScope` when adding values to a topic.