### PR TITLE
fix: use .js extension for Lit decorator/directive imports

### DIFF
--- a/articles/ds/foundation/icons/index.asciidoc
+++ b/articles/ds/foundation/icons/index.asciidoc
@@ -35,7 +35,7 @@ In client-side views (Fusion/TypeScript):
 [source,typescript]
 ----
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators';
+import { customElement } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 

--- a/frontend/demo/component/badge/badge-highlight.ts
+++ b/frontend/demo/component/badge/badge-highlight.ts
@@ -4,7 +4,7 @@ import Report from 'Frontend/generated/com/vaadin/demo/domain/Report'; // hidden
 import '@vaadin/flow-frontend/gridConnector.js'; // hidden-source-line (Grid's connector)
 import '@vaadin/polymer-legacy-adapter/template-renderer.js'; // hidden-source-line (Legacy template renderer)
 import { html, LitElement, render } from 'lit';
-import { guard } from 'lit/directives/guard';
+import { guard } from 'lit/directives/guard.js';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import { GridColumn, GridItemModel } from '@vaadin/grid';

--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -4,7 +4,7 @@ import UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermi
 import '@vaadin/flow-frontend/gridConnector.js'; // hidden-source-line (Grid's connector)
 import '@vaadin/polymer-legacy-adapter/template-renderer.js'; // hidden-source-line (Legacy template renderer)
 import { html, LitElement, render } from 'lit';
-import { guard } from 'lit/directives/guard';
+import { guard } from 'lit/directives/guard.js';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import { GridColumn, GridItemModel } from '@vaadin/grid';

--- a/frontend/demo/component/badge/badge-icons.ts
+++ b/frontend/demo/component/badge/badge-icons.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/icon';
 import '@vaadin/icons';

--- a/frontend/demo/component/board/example-indicator.ts
+++ b/frontend/demo/component/board/example-indicator.ts
@@ -1,6 +1,6 @@
 import { applyTheme } from 'Frontend/generated/theme';
 import { css, html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators';
+import { customElement, property } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/vertical-layout';

--- a/frontend/demo/component/notification/notification-basic.ts
+++ b/frontend/demo/component/notification/notification-basic.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import { Notification, NotificationOpenedChangedEvent } from '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/notification/notification-contrast.ts
+++ b/frontend/demo/component/notification/notification-contrast.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import { Notification, NotificationOpenedChangedEvent } from '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/notification/notification-error.ts
+++ b/frontend/demo/component/notification/notification-error.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';

--- a/frontend/demo/component/notification/notification-keyboard-a11y.ts
+++ b/frontend/demo/component/notification/notification-keyboard-a11y.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/notification';

--- a/frontend/demo/component/notification/notification-position.ts
+++ b/frontend/demo/component/notification/notification-position.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators';
+import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import { Notification, NotificationPosition } from '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/notification/notification-primary.ts
+++ b/frontend/demo/component/notification/notification-primary.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import { Notification, NotificationOpenedChangedEvent } from '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/notification/notification-retry.ts
+++ b/frontend/demo/component/notification/notification-retry.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';

--- a/frontend/demo/component/notification/notification-static-helper.ts
+++ b/frontend/demo/component/notification/notification-static-helper.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators';
+import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import { Notification } from '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/notification/notification-success.ts
+++ b/frontend/demo/component/notification/notification-success.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import { Notification, NotificationOpenedChangedEvent } from '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/notification/notification-undo.ts
+++ b/frontend/demo/component/notification/notification-undo.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';


### PR DESCRIPTION
Based on https://github.com/lit/lit/issues/1986, the `.js` is required by Lit.
