### PR TITLE
fix: use .js extension for Lit decorator/directive imports (v21)

### DIFF
--- a/articles/ds/foundation/icons/index.asciidoc
+++ b/articles/ds/foundation/icons/index.asciidoc
@@ -35,7 +35,7 @@ In client-side views (Fusion/TypeScript):
 [source,typescript]
 ----
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators';
+import { customElement } from 'lit/decorators.js';
 import '@vaadin/vaadin-icon/vaadin-icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 

--- a/frontend/demo/component/badge/badge-highlight.ts
+++ b/frontend/demo/component/badge/badge-highlight.ts
@@ -4,7 +4,7 @@ import Report from 'Frontend/generated/com/vaadin/demo/domain/Report'; // hidden
 import '@vaadin/flow-frontend/gridConnector.js'; // hidden-source-line (Grid's connector)
 import '@vaadin/vaadin-template-renderer/src/vaadin-template-renderer.js'; // hidden-source-line (Legacy template renderer)
 import { html, LitElement, render } from 'lit';
-import { guard } from 'lit/directives/guard';
+import { guard } from 'lit/directives/guard.js';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/vaadin-grid/vaadin-grid';
 import { GridColumnElement, GridItemModel } from '@vaadin/vaadin-grid';

--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -4,7 +4,7 @@ import UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermi
 import '@vaadin/flow-frontend/gridConnector.js'; // hidden-source-line (Grid's connector)
 import '@vaadin/vaadin-template-renderer/src/vaadin-template-renderer.js'; // hidden-source-line (Legacy template renderer)
 import { html, LitElement, render } from 'lit';
-import { guard } from 'lit/directives/guard';
+import { guard } from 'lit/directives/guard.js';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/vaadin-grid/vaadin-grid';
 import { GridColumnElement, GridItemModel } from '@vaadin/vaadin-grid';

--- a/frontend/demo/component/badge/badge-icons.ts
+++ b/frontend/demo/component/badge/badge-icons.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/vaadin-icon/vaadin-icon';
 import '@vaadin/vaadin-icons/vaadin-iconset';

--- a/frontend/demo/component/board/example-indicator.ts
+++ b/frontend/demo/component/board/example-indicator.ts
@@ -1,6 +1,6 @@
 import { applyTheme } from 'Frontend/generated/theme';
 import { css, html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators';
+import { customElement, property } from 'lit/decorators.js';
 import '@vaadin/vaadin-ordered-layout/vaadin-vertical-layout';
 import '@vaadin/vaadin-icon/vaadin-icon';
 import '@vaadin/vaadin-icons/vaadin-iconset';

--- a/frontend/demo/component/notification/notification-basic.ts
+++ b/frontend/demo/component/notification/notification-basic.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
-import { guard } from 'lit/directives/guard';
+import { customElement, state } from 'lit/decorators.js';
+import { guard } from 'lit/directives/guard.js';
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
 import {

--- a/frontend/demo/component/notification/notification-contrast.ts
+++ b/frontend/demo/component/notification/notification-contrast.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
-import { guard } from 'lit/directives/guard';
+import { customElement, state } from 'lit/decorators.js';
+import { guard } from 'lit/directives/guard.js';
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
 import {

--- a/frontend/demo/component/notification/notification-error.ts
+++ b/frontend/demo/component/notification/notification-error.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/vaadin-icon/vaadin-icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import '@vaadin/vaadin-button/vaadin-button';

--- a/frontend/demo/component/notification/notification-keyboard-a11y.ts
+++ b/frontend/demo/component/notification/notification-keyboard-a11y.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
 import {

--- a/frontend/demo/component/notification/notification-position.ts
+++ b/frontend/demo/component/notification/notification-position.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement } from 'lit/decorators';
+import { customElement } from 'lit/decorators.js';
 import '@vaadin/vaadin-icon/vaadin-icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import '@vaadin/vaadin-button/vaadin-button';

--- a/frontend/demo/component/notification/notification-primary.ts
+++ b/frontend/demo/component/notification/notification-primary.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
-import { guard } from 'lit/directives/guard';
+import { customElement, state } from 'lit/decorators.js';
+import { guard } from 'lit/directives/guard.js';
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
 import {

--- a/frontend/demo/component/notification/notification-retry.ts
+++ b/frontend/demo/component/notification/notification-retry.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/vaadin-icon/vaadin-icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import '@vaadin/vaadin-button/vaadin-button';

--- a/frontend/demo/component/notification/notification-success.ts
+++ b/frontend/demo/component/notification/notification-success.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
-import { guard } from 'lit/directives/guard';
+import { customElement, state } from 'lit/decorators.js';
+import { guard } from 'lit/directives/guard.js';
 import '@vaadin/vaadin-button/vaadin-button';
 import '@vaadin/vaadin-notification/vaadin-notification';
 import {

--- a/frontend/demo/component/notification/notification-undo.ts
+++ b/frontend/demo/component/notification/notification-undo.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/vaadin-icon/vaadin-icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import '@vaadin/vaadin-button/vaadin-button';


### PR DESCRIPTION
Cherry-pick https://github.com/vaadin/docs/pull/901 to v21