### PR TITLE
docs: make loading CSS instructions more clear

### DIFF
--- a/articles/ds/components/charts/java-api/css-styling.asciidoc
+++ b/articles/ds/components/charts/java-api/css-styling.asciidoc
@@ -33,8 +33,13 @@ A comprehensive list of the supported style classes can be found https://www.hig
 1. Create a CSS file (by convention this should be at `frontend/styles/`).
 2. Specify the desired CSS rules in the theme file.
 3. If multiple charts are present, each one can be specifically targeted by the host selector e.g `:host(.first-chart-class)`.
-4. Add the annotations to import the default theme module (`@JsModule("@vaadin/vaadin-charts/theme/vaadin-chart-default-theme")` and the style file (`@CssImport(value = "./styles/my-charts-styles.css", themeFor = "vaadin-chart", include = "vaadin-chart-default-theme")`).
-
+4. Add the annotations to import the default theme module and the style file:
++
+[source,java]
+----
+@JsModule("@vaadin/vaadin-charts/theme/vaadin-chart-default-theme")
+@CssImport(value = "./styles/my-charts-styles.css", themeFor = "vaadin-chart", include = "vaadin-chart-default-theme")
+----
 +
 NOTE: If there are multiple theme modules *only one* of them should declare the `include` in step 4 above.
 


### PR DESCRIPTION
The instructions to add the annotations needed for using the styled mode on a Chart is inlined on the text, which can be a little confusing.
Add the instructions on a code block bellow the text.