### PR TITLE
docs: restore cross-references in component docs

### DIFF
--- a/articles/ds/components/accordion/index.asciidoc
+++ b/articles/ds/components/accordion/index.asciidoc
@@ -30,8 +30,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionBasic
 
 Accordion consists of stacked panels, each composed of two parts: a summary and a content area.
 Only one panel can be expanded at a time.
-// TODO: restore after porting remaining components
-// (The <<../details#,Details>> component can be used to allow multiple simultaneously expanded sections.)
+(The <<../details#,Details>> component can be used to allow multiple simultaneously expanded sections.)
 
 === Summary
 

--- a/articles/ds/components/accordion/index.asciidoc
+++ b/articles/ds/components/accordion/index.asciidoc
@@ -159,15 +159,14 @@ include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionDisab
 == Best Practices
 * Accordions are suitable when users need to focus on smaller pieces of content at a time.
 However, when the whole content is relevant to the user to make a decision, Accordions should be avoided.
-* Contents that are logically linked should be grouped together in one panel.
+* Contents that are logically linked
+should be grouped together in one panel.
 * Accordions are better suited for long labels compared to Tabs.
 However, Accordions can feel “jumpy” as panels are toggled (if there are a lot of panels or the panel content is long).
 * Details can be used instead of Accordion when there is a need to see content from multiple panels simultaneously.
 * Accordions can be used to break a complex form into smaller step-by-step sections.
 
 
-// TODO: restore after porting remaining components
-////
 == Related Components
 
 [cols="1,2"]
@@ -178,4 +177,3 @@ However, Accordions can feel “jumpy” as panels are toggled (if there are a l
 
 |<<../tabs#,Tabs>>|Component for organizing and grouping content into navigable sections.
 |===
-////

--- a/articles/ds/components/avatar/index.asciidoc
+++ b/articles/ds/components/avatar/index.asciidoc
@@ -266,7 +266,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarSizes.java[
 
 Size variants should only be used in special cases.
 
-// TODO: restore after porting remaining docs
+// TODO: restore after porting foundation docs
 // See <<../../foundation/size-space#,Size and Space>> for details on how to change the default Avatar size.
 
 == Use Cases

--- a/articles/ds/components/button/index.asciidoc
+++ b/articles/ds/components/button/index.asciidoc
@@ -121,7 +121,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java[
 |Compact option for cramped parts of the UI, if a Tertiary variant is not deemed appropriate.
 |===
 
-// TODO: restore after porting remaining docs
+// TODO: restore after porting foundation docs
 // .Default button size can be customized
 // [TIP]
 // Size variants should only be used in special cases. See <<../../foundation/size-space#size-and-space,Size and Space>> for details on how to change the default button size.
@@ -181,7 +181,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonContrast.ja
 
 The *Tertiary + Contrast* combination should be avoided due to its similarity to non-interactive text elements.
 
-// TODO: restore after porting remaining docs
+// TODO: restore after porting foundation docs
 // .Default button colors can be customized
 // [TIP]
 // Note that the standard Button colors can be adjusted using <<../../foundation/color#,theme features>>, show these variants should not be used to replace standard buttons just to achieve a different color.
@@ -260,9 +260,7 @@ Hiding an unavailable action entirely is often preferable to a disabled button, 
 
 === Showing an Error on Click
 
-As an alternative to hiding or disabling buttons, unavailable actions can instead be configured to show an error message when the button is clicked (using a Notification, or an adjacent inline text element).
-// TODO: restore after porting remaining docs, replace line above
-// As an alternative to hiding or disabling buttons, unavailable actions can instead be configured to show an error message when the button is clicked (using a <<../notification/index#,Notification>> or an adjacent inline text element).
+As an alternative to hiding or disabling buttons, unavailable actions can instead be configured to show an error message when the button is clicked (using a <<../notification/index#,Notification>> or an adjacent inline text element).
 This approach is the most accessible option, but may cause frustration in users who expect unavailable actions to be somehow distinguished from available actions.
 
 === Prevent Multiple Clicks
@@ -288,9 +286,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonDisableLong
 
 == Focus
 
-Similarly to input fields, the focus ring is only rendered when the button is focused by keyboard or programmatically.
-// TODO: restore after porting remaining docs, replace line above
-// Similarly to <<../input-fields#,input fields>>, the focus ring is only rendered when the button is focused by keyboard or programmatically.
+Similarly to <<../input-fields#,input fields>>, the focus ring is only rendered when the button is focused by keyboard or programmatically.
 
 [.example.render-only]
 --
@@ -332,14 +328,10 @@ A focused button can be triggered with kbd:[Enter] or kbd:[Space].
 
 * The label should describe the action, preferably using active verbs, such as _"View details"_ rather than just _"Details"_.
 * In cases where there is a risk for ambiguity, also specify the object of the verb, such as _"Save changes"_ instead of _"Save"_.
-* Button groups representing options, such as the buttons of a Confirm Dialog, should state what each option represents, such as _"Save changes"_ instead of _"Yes"_, as the latter forces the user to read the question being asked, and increases the risk of selecting the wrong option.
-// TODO: restore after porting remaining docs, replace line above
-// * Button groups representing options, such as the buttons of a <<../confirm-dialog#,Confirm Dialog>>, should state what each option represents, such as _"Save changes"_ instead of _"Yes"_, as the latter forces the user to read the question being asked, and increases the risk of selecting the wrong option.
+* Button groups representing options, such as the buttons of a <<../confirm-dialog#,Confirm Dialog>>, should state what each option represents, such as _"Save changes"_ instead of _"Yes"_, as the latter forces the user to read the question being asked, and increases the risk of selecting the wrong option.
 * Keep labels short, ideally less than three words or 25 characters.
 * Use ellipsis (…) when an action is *not immediate* but requires more steps to complete.
-This is useful, for example, for destructive actions like _"Delete..."_ when a Confirm Dialog is used to confirm the action before it's executed.
-// TODO: restore after porting remaining docs, replace line above
-// This is useful, for example, for destructive actions like _"Delete..."_ when a <<../confirm-dialog#,Confirm Dialog>> is used to confirm the action before it's executed.
+This is useful, for example, for destructive actions like _"Delete..."_ when a <<../confirm-dialog#,Confirm Dialog>> is used to confirm the action before it's executed.
 
 === ARIA Labels
 
@@ -405,9 +397,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonDialog.java
 
 === Global vs Selection-Specific Actions
 
-In lists of selectable items (such as in a Grid) that provide actions applicable to the selected item, buttons for selection-specific actions should be placed separately from "global" non-selection-specific actions, preferably below the list of selectable items.
-// TODO: restore after porting remaining docs, replace line above
-// In lists of selectable items (such as in a <<../grid#,Grid>>) that provide actions applicable to the selected item, buttons for selection-specific actions should be placed separately from "global" non-selection-specific actions, preferably below the list of selectable items.
+In lists of selectable items (such as in a <<../grid#,Grid>>) that provide actions applicable to the selected item, buttons for selection-specific actions should be placed separately from "global" non-selection-specific actions, preferably below the list of selectable items.
 In the example below, the global _"Add user"_ action is separated from the selection-specific actions below the Grid.
 
 [.example]
@@ -424,8 +414,6 @@ include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonGrid.java[r
 ----
 --
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 [cols="1,2"]
@@ -439,4 +427,3 @@ include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonGrid.java[r
 |Overlay menus with items that trigger actions.
 Can also be used for single "*menu buttons*" and "*button groups*" without overlay menus.
 |===
-////

--- a/articles/ds/components/checkbox/index.asciidoc
+++ b/articles/ds/components/checkbox/index.asciidoc
@@ -43,9 +43,8 @@ include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBa
 Use Checkbox Group to group related items.
 Individual checkboxes should be used for options that are not related to each other in any way.
 
-// TODO: restore after porting remaining docs
-// :component-name: Checkbox Group
-// include::../_shared.asciidoc[tag=field-features]
+:component-name: Checkbox Group
+include::../_shared.asciidoc[tag=field-features]
 
 == States
 
@@ -156,8 +155,6 @@ include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxAdjacen
 ----
 --
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 [cols="1,2"]
@@ -174,4 +171,3 @@ Supports single and multi-select.
 
 |<<../radio-button#,Radio Button Group>>|Corresponding component for mutually exclusive options, or “single-select”.
 |===
-////

--- a/articles/ds/components/combo-box/index.asciidoc
+++ b/articles/ds/components/combo-box/index.asciidoc
@@ -34,12 +34,9 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[tags=*,indent=
 The overlay opens when the user clicks the field using a pointing device.
 Using the Up/Down arrow keys or typing a character (found in at least one of the options) when the field is focused also opens the popup.
 
-// TODO: restore after porting remaining docs
-////
 :component-name: Combo Box
 :text-field-features: true
 include::../_shared.asciidoc[tag=field-features]
-////
 
 == Custom Value Entry
 
@@ -79,8 +76,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomE
 
 == Custom Item Presentation
 
-// TODO: restore after porting remaining docs
-// See <<../select#custom-item-presentation, Select, Custom Item Presentation.>>
+See <<../select#custom-item-presentation, Select, Custom Item Presentation.>>
 
 Items can be customised to display more information than a single line of text.
 
@@ -218,8 +214,6 @@ It reduces the initial load time, consumes less bandwidth and resources.
 Combo Box is an input field component, not a generic menu component.
 Use the Menu Bar component to create overlays for actions.
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 [cols="1,2"]
@@ -239,4 +233,3 @@ Supports single and multi-select.
 |<<../menu-bar#,Menu Bar>>
 |Overlay menus for items that trigger actions.
 |===
-////

--- a/articles/ds/components/confirm-dialog/index.asciidoc
+++ b/articles/ds/components/confirm-dialog/index.asciidoc
@@ -140,8 +140,6 @@ include::{root}/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDia
 
 Confirm Dialog can be closed by clicking one of its buttons (all buttons close the dialog by default), or by pressing kbd:[Esc] (which triggers the action associated with the Cancel button if one exists). Closing on kbd:[Esc] can be disabled by setting the noCloseOnEsc property to false.
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 |===
@@ -150,4 +148,3 @@ Confirm Dialog can be closed by clicking one of its buttons (all buttons close t
 |<<../dialog#,Dialog>>|Component for presenting information and UI elements in an overlay.
 
 |===
-////

--- a/articles/ds/components/context-menu/index.asciidoc
+++ b/articles/ds/components/context-menu/index.asciidoc
@@ -192,9 +192,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuB
 === Context Menu vs Menu Bar
 
 You should use Context Menu when there is no dedicated button for opening an overlay menu, such as right-clicking a grid row.
-When there is a dedicated element/component, such as an overflow menu, use Menu Bar.
-// TODO: restore after porting remaining docs, replace line above
-// When there is a dedicated element/component, such as an <<../menu-bar#,overflow menu>>, use Menu Bar.
+When there is a dedicated element/component, such as an <<../menu-bar#,overflow menu>>, use Menu Bar.
 
 === Icons
 
@@ -207,8 +205,6 @@ Use icons consistently throughout a list of options.
 Suffix a menu item with “...” when the associated action won't be executed, but instead reveal some UI, like a dialog, for completing the action.
 
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 |===
@@ -218,4 +214,3 @@ Suffix a menu item with “...” when the associated action won't be executed, 
 |Component for displaying a horizontal menu with multi-level sub-menus.
 
 |===
-////

--- a/articles/ds/components/crud/index.asciidoc
+++ b/articles/ds/components/crud/index.asciidoc
@@ -97,9 +97,7 @@ However, they block the user from viewing and interacting with the Grid beneath.
 
 The `aside` position displays the editor as an overlay next to the grid.
 Use this position when there's sufficient horizontal space to accommodate both the grid and the editor, and it's beneficial for the user to be able to view and interact with the grid while the editor is open.
-Aside positioning is also a good fit for single-column forms.
-// TODO: restore after porting remaining docs, replace line above
-// Aside positioning is also a good fit for <<../form-layout#,single-column forms>>.
+Aside positioning is also a good fit for <<../form-layout#,single-column forms>>.
 
 [.example]
 --
@@ -190,9 +188,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.
 
 CRUD's default Grid is replaceable.
 This is useful when you wish to customise the Grid, for example, to place the edit Button in the first column.
-See Grid documentation for details on configuring grids.
-// TODO: restore after porting remaining docs, replace line above
-// See <<../grid#,Grid documentation>> for details on configuring grids.
+See <<../grid#,Grid documentation>> for details on configuring grids.
 
 [.example]
 --
@@ -248,9 +244,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.
 == Sorting & Filtering
 
 Sorting and filtering can be disabled.
-For more information about sorting and filtering, please see the basic Grid documentation.
-// TODO: restore after porting remaining docs, replace line above
-// For more information about sorting and filtering, please see the basic <<../grid#,Grid documentation>>.
+For more information about sorting and filtering, please see the basic <<../grid#,Grid documentation>>.
 
 [.example]
 --
@@ -300,8 +294,6 @@ include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.
 ----
 --
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 |===
@@ -316,4 +308,3 @@ include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.
 |<<../tree-grid#,Tree Grid>>
 |Component for showing hierarchical data.
 |===
-////

--- a/articles/ds/components/custom-field/index.asciidoc
+++ b/articles/ds/components/custom-field/index.asciidoc
@@ -12,9 +12,7 @@ page-links:
 // tag::description[]
 Custom Field is a component for wrapping multiple components as a single field.
 // end::description[]
-It has the same features as Input Fields, such as its own label, helper, validation, and data binding.
-// TODO: restore after porting remaining docs, replace line above
-// It has the same features as <<{components-path-prefix}input-fields#,Input Fields>>, such as its own label, helper, validation, and data binding.
+It has the same features as <<{components-path-prefix}input-fields#,Input Fields>>, such as its own label, helper, validation, and data binding.
 Use it to create custom input components.
 
 [.example]
@@ -50,18 +48,6 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Appointment.java[tags=snipp
 
 Custom Field is optimised for wrapping the following components:
 
-* Text Field
-* Number Field
-* Password Field
-* Text Area
-* Select
-* Combo Box
-* Date Picker
-* Time Picker
-
-// TODO: restore after porting remaining docs, replace block above
-
-////
 * <<../text-field#,Text Field>>
 * <<../number-field#,Number Filed>>
 * <<../password-field#,Password Field>>
@@ -70,11 +56,8 @@ Custom Field is optimised for wrapping the following components:
 * <<../combo-box#,Combo Box>>
 * <<../date-picker#,Date Picker>>
 * <<../time-picker#,Time Picker>>
-////
 
-It can also be used to provide a label, helper, and the other field features, for components that don't have them built-in, such as List Box.
-// TODO: restore after porting remaining docs, replace block above
-// It can also be used to provide a label, helper, and the other field features, for components that don't have them built-in, such as <<../list-box#,List Box>>.
+It can also be used to provide a label, helper, and the other field features, for components that don't have them built-in, such as <<../list-box#,List Box>>.
 
 == Native Input Fields
 
@@ -104,14 +87,11 @@ include::{root}/src/main/java/com/vaadin/demo/component/customfield/PaymentInfor
 ----
 --
 
-// TODO: restore after porting remaining docs
-////
 == Supported Features
 
 * <<../input-fields#label,Label>>
 * <<../input-fields#helper,Helper>>
 * <<../input-fields#required,Required>>
-////
 
 == Size Variants
 

--- a/articles/ds/components/date-picker/index.asciidoc
+++ b/articles/ds/components/date-picker/index.asciidoc
@@ -28,12 +28,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerBas
 The date can be entered directly using the keyboard in the format of the current locale or through the date picker overlay.
 The overlay opens when the field is clicked and/or any input is entered when the field is focused.
 
-// TODO: restore after porting remaining docs
-////
 :component-name: Date Picker
 :text-field-features: true
 include::../_shared.asciidoc[tag=field-features]
-////
 
 == Date Format
 
@@ -322,8 +319,6 @@ Helpers are preferable to placeholders, as they are always visible.
 Fields with placeholders are also less noticeable than empty fields and susceptible to being skipped.
 Use placeholders when space is limited, for example, when Date Picker is used as a filter in a data grid header.
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 |===
@@ -335,4 +330,3 @@ Use placeholders when space is limited, for example, when Date Picker is used as
 |<<../date-time-picker#,Date Time Picker>>
 |Input field for selecting both a date and a time.
 |===
-////

--- a/articles/ds/components/date-time-picker/index.asciidoc
+++ b/articles/ds/components/date-time-picker/index.asciidoc
@@ -27,12 +27,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimeP
 The date and time can be entered directly using a keyboard in the format of the current locale or through the Date Time Picker's two overlays.
 The overlays open when their respective fields are clicked or any input is entered when the fields are focused.
 
-// TODO: restore after porting remaining docs
-////
 :component-name: Date Time Picker
 :text-field-features: true
 include::../_shared.asciidoc[tag=field-features]
-////
 
 == Step
 
@@ -40,9 +37,7 @@ Date Time Picker's step parameter defines the time interval (in seconds) between
 It also specifies the amount by which the time increases/decreases using the Up/Down arrow keys (when the overlays are disabled).
 
 The default step is one hour (that is `3600`).
-Note that, unlike with Number Field, Date Time Picker accepts values that do not align with the specified step.
-// TODO: restore after porting remaining docs, replace line above
-// Note that, unlike with <<../number-field#,Number Field>>, Date Time Picker accepts values that do not align with the specified step.
+Note that, unlike with <<../number-field#,Number Field>>, Date Time Picker accepts values that do not align with the specified step.
 
 [.example]
 --
@@ -206,9 +201,7 @@ To disable the days before the start date in the end date picker, you need to ha
 == Best Practises
 
 Use Date Time Picker when the user needs to choose both a date and time of day.
-If you only need a date or time of day, use Date Picker and Time Picker respectively.
-// TODO: restore after porting remaining docs, replace line above
-// If you only need a date or time of day, use <<../date-picker#,Date Picker>> and <<../time-picker#,Time Picker>> respectively.
+If you only need a date or time of day, use <<../date-picker#,Date Picker>> and <<../time-picker#,Time Picker>> respectively.
 
 === Picking vs Typing
 
@@ -248,8 +241,6 @@ Fields with placeholders are also less noticeable than empty fields and suscepti
 Use placeholders when space is limited, for example, when Date Time Picker is used as a grid filter.
 
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 [cols="1,2"]
@@ -262,4 +253,3 @@ Use placeholders when space is limited, for example, when Date Time Picker is us
 |<<../date-picker#,Date Picker>>
 |Input field for entering or selecting a specific date.
 |===
-////

--- a/articles/ds/components/details/index.asciidoc
+++ b/articles/ds/components/details/index.asciidoc
@@ -155,8 +155,6 @@ Otherwise, the user might not notice it.
 
 Details can be used instead of Accordion if there is a need to see content from multiple collapsible content areas simultaneously.
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 [cols="1,2"]
@@ -168,4 +166,3 @@ Details can be used instead of Accordion if there is a need to see content from 
 |<<../tabs#,Tabs>>|Component for organising and grouping content into navigable sections.
 
 |===
-////

--- a/articles/ds/components/dialog/index.asciidoc
+++ b/articles/ds/components/dialog/index.asciidoc
@@ -144,9 +144,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogClosing.jav
 
 == Layout and Scrolling
 Dialogs automatically become scrollable when their content overflows.
-Custom scrollable areas can be created using the Scroller component.
-// TODO: restore after porting remaining docs, replace line above
-// Custom scrollable areas can be created using the <<../scroller#,Scroller>> component.
+Custom scrollable areas can be created using the <<../scroller#,Scroller>> component.
 
 // TODO: restore after no-padding theme is available in 14.x
 ////
@@ -178,12 +176,8 @@ include::{root}/frontend/themes/docs/dialog.css[tags=dialog-no-padding,indent=0]
 
 Dialogs are disruptive by nature and should be used sparingly.
 Do not use them to communicate nonessential information, such as success messages like “Logged in”, “Copied”, and so on.
-Instead, use Notifications when appropriate.
-// TODO: restore after porting remaining docs, replace line above
-// Instead, use <<../notification#,Notifications>> when appropriate.
+Instead, use <<../notification#,Notifications>> when appropriate.
 
-// TODO: restore after porting remaining docs
-////
 === Button Placement
 
 See <<../button#buttons-in-dialogs, Buttons in Dialogs>>.
@@ -196,4 +190,3 @@ See <<../button#buttons-in-dialogs, Buttons in Dialogs>>.
 |<<../confirm-dialog#,Confirm Dialog>>|Dialog for confirming user actions and decisions
 
 |===
-////

--- a/articles/ds/components/email-field/index.asciidoc
+++ b/articles/ds/components/email-field/index.asciidoc
@@ -26,12 +26,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldBas
 
 Validity of the email addresses is checked according to the https://tools.ietf.org/html/rfc5322#[RFC 5322] standard, which includes the format for email addresses.
 
-// TODO: restore after porting remaining docs
-////
 :component-name: Email Field
 :text-field-features: true
 include::../_shared.asciidoc[tag=field-features]
-////
 
 == Pattern for Additional Validation
 

--- a/articles/ds/components/form-layout/index.asciidoc
+++ b/articles/ds/components/form-layout/index.asciidoc
@@ -152,9 +152,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutNat
 
 === Sectioning
 
-Longer forms should be split into smaller, more manageable and user-friendly sections using subheadings, Tabs, Details or separate views when possible.
-// TODO: restore after porting remaining docs, replace line above
-// Longer forms should be split into smaller, more manageable and user-friendly sections using subheadings, <<../tabs#,Tabs>>, <<../details#,Details>> or separate views when possible.
+Longer forms should be split into smaller, more manageable and user-friendly sections using subheadings, <<../tabs#,Tabs>>, <<../details#,Details>> or separate views when possible.
 Each section should consist of related content and/or fields.
 
 === Button Placement

--- a/articles/ds/components/grid-pro/index.asciidoc
+++ b/articles/ds/components/grid-pro/index.asciidoc
@@ -33,9 +33,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProBasic.jav
 .Features shared with Grid
 [NOTE]
 ====
-Grid Pro is an extension of the Grid component and all Grid's features are applicable to Grid Pro as well.
-// TODO: restore after porting remaining docs, replace line above
-// Grid Pro is an extension of the <<../grid#,Grid>> component and all Grid's features are applicable to Grid Pro as well.
+Grid Pro is an extension of the <<../grid#,Grid>> component and all Grid's features are applicable to Grid Pro as well.
 ====
 
 == Usage
@@ -226,8 +224,6 @@ Non-inline editing is preferable
 
 If your use case would benefit more from non-inline editing, consider using <<../crud#, CRUD>>.
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 |===
@@ -239,8 +235,7 @@ If your use case would benefit more from non-inline editing, consider using <<..
 |<<../grid#, Grid>>
 |Component for showing tabular data.
 
-// |<<../tree-grid#, Tree Grid>>
-// |Component for showing hierarchical data.
+|<<../tree-grid#, Tree Grid>>
+|Component for showing hierarchical data.
 
 |===
-////

--- a/articles/ds/components/grid/index.asciidoc
+++ b/articles/ds/components/grid/index.asciidoc
@@ -35,9 +35,7 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[tags=snippet]
 
 A basic Grid uses plain text to display information in rows and columns.
 Rich content can be used to provide additional information in a more legible fashion.
-Components such as input fields and Button are also supported.
-// TODO: restore after porting remaining docs, replace line above
-// Components such as <<../input-fields#,input fields>> and <<../button#,Button>> are also supported.
+Components such as <<../input-fields#,input fields>> and <<../button#,Button>> are also supported.
 
 [.example]
 --
@@ -608,9 +606,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/ValidationMessage.j
 ----
 --
 
-Alternatively, use Grid Pro for more streamlined inline-editing, or CRUD for editing in a separate side panel or dialog.
-// TODO: restore after porting remaining docs, replace line above
-// Alternatively, use <<../grid-pro#,Grid Pro>> for more streamlined inline-editing, or <<../crud#,CRUD>> for editing in a separate side panel or dialog.
+Alternatively, use <<../grid-pro#,Grid Pro>> for more streamlined inline-editing, or <<../crud#,CRUD>> for editing in a separate side panel or dialog.
 
 == Styling Rows and Columns
 
@@ -758,9 +754,9 @@ include::{root}/frontend/demo/component/grid/grid-wrap-cell-content.ts[preimport
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridWrapCellContent.java[render,tags=snippet,indent=0]
 ----
 --
-// TODO: restore after porting remaining docs
+// TODO: restore after porting cell focus event to 14.8
 ////
-[role="since:com.vaadin:vaadin@V21"]
+[role="since:com.vaadin:vaadin@V14.8"]
 == Cell Focus
 
 Cells can be focused by clicking on a cell or with the keyboard.
@@ -803,8 +799,6 @@ include::{root}/frontend/themes/docs/components/vaadin-grid-cell-focus.css[]
 --
 ////
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 |===
@@ -831,4 +825,3 @@ include::{root}/frontend/themes/docs/components/vaadin-grid-cell-focus.css[]
 }
 </style>
 ++++
-////

--- a/articles/ds/components/input-fields/index.asciidoc
+++ b/articles/ds/components/input-fields/index.asciidoc
@@ -4,9 +4,7 @@ title: Input Fields
 
 = Input Fields
 
-The following features are available in all input field components.
-// TODO: restore after porting remaining docs, replace line above
-// The following features are available in all <<input-field-components,input field components>>.
+The following features are available in all <<input-field-components,input field components>>.
 
 == Label
 
@@ -180,8 +178,6 @@ Please note that the focus style is different for keyboards and pointing devices
 include::{root}/frontend/demo/component/inputfields/input-field-focus-styles.ts[render]
 ----
 
-// TODO: restore after porting remaining docs
-////
 == Input Field Components
 
 A variety of components is available for different types of input:
@@ -226,4 +222,3 @@ A variety of components is available for different types of input:
 |<<../checkbox#,Checkbox>>
 |For selecting multiple options from a list, or a single binary toggle.
 |===
-////

--- a/articles/ds/components/list-box/index.asciidoc
+++ b/articles/ds/components/list-box/index.asciidoc
@@ -25,9 +25,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxBasic.jav
 ----
 --
 
-Although functionally similar to Checkbox Group and Radio Button Group, List Box is designed to be used as a lightweight scrollable selection list rather than a form input field.
-// TODO: restore after porting remaining docs, replace line above
-// Although functionally similar to <<../checkbox#,Checkbox Group>> and <<../radio-button#,Radio Button Group>>, List Box is designed to be used as a lightweight scrollable selection list rather than a form input field.
+Although functionally similar to <<../checkbox#,Checkbox Group>> and <<../radio-button#,Radio Button Group>>, List Box is designed to be used as a lightweight scrollable selection list rather than a form input field.
 
 == Dividers
 
@@ -138,8 +136,6 @@ List Box is not designed to be used as an input field in forms, and lacks featur
 See related components below for better options for use in forms.
 List Box is best suited to be used as a lightweight, scrollable, single-column list for single or multi-selection of items.
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 |===
@@ -160,4 +156,3 @@ List Box is best suited to be used as a lightweight, scrollable, single-column l
 |<<../grid#,Grid>>
 |A more advanced list component for cases where multiple columns, filtering or lazy loading is required.
 |===
-////

--- a/articles/ds/components/menu-bar/index.asciidoc
+++ b/articles/ds/components/menu-bar/index.asciidoc
@@ -64,7 +64,7 @@ Can be combined with Tertiary and Primary.
 .Default menu button styles can be customized
 [TIP]
 Note that the standard Menu Button styles can be adjusted using theme features, so these variants should only be used to differentiate special instances of the component.
-// TODO: restore after porting remaining docs, replace line above
+// TODO: restore after porting foundation docs, replace line above
 // Note that the standard Menu Button styles can be adjusted using <<../../foundation/color#,theme features>>, so these variants should only be used to differentiate special instances of the component.
 
 == Overflow
@@ -182,9 +182,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarCheckable
 
 .Not a replacement for radio buttons
 [NOTE]
-A Menu Bar with checkable items should not be used as a replacement for radio buttons in a form.
-// TODO: restore after porting remaining docs, replace line above
-// A Menu Bar with checkable items should not be used as a replacement for <<../radio-button#,radio buttons>> in a form.
+A Menu Bar with checkable items should not be used as a replacement for <<../radio-button#,radio buttons>> in a form.
 
 == Dividers
 
@@ -307,15 +305,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarComboButt
 
 == Best Practices
 
-* Menu Bar should not be used for navigation. Use tabs for switching between content, or anchor elements for regular navigation.
-// TODO: restore after porting remaining docs, replace line above
-// * Menu Bar should not be used for navigation. Use <<../tabs#,tabs>> for switching between content, or anchor elements for regular navigation.
-* Menu Bar is not an input field. Use Select, <<../combo-box#,Combo Box>>, or Radio Button instead.
-// TODO: restore after porting remaining docs, replace line above
-// * Menu Bar is not an input field. Use <<../select#,Select>>, <<../combo-box#,Combo Box>>, or <<../radio-button#,Radio Button>> instead.
+* Menu Bar should not be used for navigation. Use <<../tabs#,tabs>> for switching between content, or anchor elements for regular navigation.
+* Menu Bar is not an input field. Use <<../select#,Select>>, <<../combo-box#,Combo Box>>, or <<../radio-button#,Radio Button>> instead.
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 |===
@@ -333,4 +325,3 @@ include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarComboButt
 |<<../context-menu#,Context Menu>>
 |A generic drop-down menu that can be triggered from any component.
 |===
-////

--- a/articles/ds/components/number-field/index.asciidoc
+++ b/articles/ds/components/number-field/index.asciidoc
@@ -29,12 +29,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldB
 ----
 --
 
-// TODO: restore after porting remaining docs
-////
 :component-name: Number Field
 :text-field-features: true
 include::../_shared.asciidoc[tag=field-features]
-////
 
 == Stepper Controls
 
@@ -58,9 +55,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldS
 
 The valid input range of a Number Field can be set by defining minimum and maximum values.
 
-You can set the Helper text to instruct about the range.
-// TODO: restore after porting remaining docs, replace line above
-// You can set the <<../input-fields#helper,Helper>> text to instruct about the range.
+You can set the <<../input-fields#helper,Helper>> text to instruct about the range.
 
 [.example]
 --

--- a/articles/ds/components/password-field/index.asciidoc
+++ b/articles/ds/components/password-field/index.asciidoc
@@ -26,12 +26,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFi
 ----
 --
 
-// TODO: restore after porting remaining docs
-////
 :component-name: Password Field
 :text-field-features: true
 include::../_shared.asciidoc[tag=field-features]
-////
 
 == Reveal Button
 

--- a/articles/ds/components/progress-bar/index.asciidoc
+++ b/articles/ds/components/progress-bar/index.asciidoc
@@ -191,8 +191,6 @@ Placing a Progress Bar in a dialog, details panel or an otherwise defined sectio
 Depending on the user case, the user may or may not be able to interact with the UI.
 
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 [cols="1,2"]
@@ -202,4 +200,3 @@ Depending on the user case, the user may or may not be able to interact with the
 |<<../upload#,Upload>>
 |Component for uploading files.
 |===
-////

--- a/articles/ds/components/radio-button/index.asciidoc
+++ b/articles/ds/components/radio-button/index.asciidoc
@@ -26,11 +26,8 @@ include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonB
 --
 
 
-// TODO: restore after porting remaining docs
-////
 :component-name: Radio Button Group
 include::../_shared.asciidoc[tag=field-features]
-////
 
 == States
 
@@ -193,8 +190,6 @@ include::{root}/frontend/demo/component/radiobutton/radio-button-checkbox-altern
 
 In a Horizontal Layout, Radio Button Groups also align more easily with other input fields than a single checkbox.
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 [cols="1,2"]
@@ -213,4 +208,3 @@ In a Horizontal Layout, Radio Button Groups also align more easily with other in
 |<<../checkbox#,Checkbox>>
 |Corresponding component for multi-select options.
 |===
-////

--- a/articles/ds/components/rich-text-editor/index.asciidoc
+++ b/articles/ds/components/rich-text-editor/index.asciidoc
@@ -292,8 +292,6 @@ a|https://vaadin.com/[Creates a hyperlink]
 
 |===
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 |===
@@ -306,7 +304,6 @@ a|https://vaadin.com/[Creates a hyperlink]
 |Basic multi-line text input.
 
 |===
-////
 
 ++++
 <style>

--- a/articles/ds/components/select/index.asciidoc
+++ b/articles/ds/components/select/index.asciidoc
@@ -28,12 +28,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/select/SelectBasic.java[
 
 The dropdown can be opened with a click, up/down arrow keys, or by typing the initial character for one of the options.
 
-// TODO: restore after porting remaining docs
-////
 :component-name: Select
 :text-field-features: true
 include::../_shared.asciidoc[tag=field-features]
-////
 
 == Dividers
 
@@ -233,8 +230,6 @@ When applicable, set the most common choice as the default value.
 Select is an input field component, not a generic menu component.
 Use <<../menu-bar#,Menu Bar>> to create overlays for actions.
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 [cols="1,2"]
@@ -252,4 +247,3 @@ Supports single and multi-select.
 
 |<<../menu-bar#,Menu Bar>>|Overlay menus for items that trigger actions.
 |===
-////

--- a/articles/ds/components/text-area/index.asciidoc
+++ b/articles/ds/components/text-area/index.asciidoc
@@ -25,12 +25,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaBasic.j
 
 Text Area is typically used for descriptions, comments, and other longer free-form content.
 
-// TODO: restore after porting remaining docs
-////
 :component-name: Text Area
 :text-field-features: true
 include::../_shared.asciidoc[tag=field-features]
-////
 
 == Automatic Height Adjustment
 
@@ -85,8 +82,6 @@ include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaHelper.
 ----
 --
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 [cols="1,2"]
@@ -99,4 +94,3 @@ include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaHelper.
 |<<../rich-text-editor#,Rich Text Editor>>
 |Multi-line text entry with rich formatting support.
 |===
-////

--- a/articles/ds/components/text-field/index.asciidoc
+++ b/articles/ds/components/text-field/index.asciidoc
@@ -27,9 +27,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldBasic
 :component-name: Text Field
 include::../_shared.asciidoc[tag=field-features]
 
-The features described here for Text Field are generally also available for other single-line text input components.
-// TODO: restore after porting remaining docs, replace line above
-// The features described here for Text Field are generally also available for <<related-components,other single-line text input components>>.
+The features described here for Text Field are generally also available for <<related-components,other single-line text input components>>.
 
 == Placeholder
 
@@ -180,7 +178,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldSmall
 .Avoid overuse
 [NOTE]
 Size variants should be used sparingly.
-// TODO: restore after porting remaining docs
+// TODO: restore after porting foundation docs
 // See <<../../foundation/size-space#,Size and Space>> for details on how to change the default text field size.
 
 == Autoselect
@@ -200,8 +198,6 @@ Use autoselect when the user might to want to replace the entire value rather th
 |===
 
 
-// TODO: restore after porting remaining docs
-////
 == Related Components
 
 A variety of components is available for different types of input:
@@ -225,4 +221,3 @@ Allows filtering and entering custom values.
 
 |<<../time-picker#,Time Picker>>|Input field for entering or selecting a specific time.
 |===
-////


### PR DESCRIPTION
## Description

Restores cross-references in component docs. Note that there are still some remaining TODOs that can only be resolved after porting the foundation docs, or porting certain features.
