### PR TITLE
fix: fix links to Figma documents

### DIFF
--- a/articles/ds/figma.asciidoc
+++ b/articles/ds/figma.asciidoc
@@ -24,14 +24,14 @@ https://www.figma.com/community/file/843042473942860131[View in Figma Community]
 image::_images/vaadin-charts-library.png[role="icon"]
 Configurable charts which correspond to the chart types that are available in the official Vaadin Charts component.
 
-https://www.figma.com/community/file/972026846591993843[View in Figma Community]
+https://www.figma.com/community/file/1030435514000803214[View in Figma Community]
 
 
 === Icons
 image::_images/vaadin-icons-library.png[role="icon"]
 The components in this library are interchangeable with the icons that are bundled in the main library.
 
-https://www.figma.com/community/file/1030435514000803214[View in Figma Community]
+https://www.figma.com/community/file/972026846591993843[View in Figma Community]
 
 
 ++++


### PR DESCRIPTION
## Description

Fixes links for Vaadin Charts + Vaadin Icons Figma documents, which were reversed.

