### PR TITLE
docs: port Figma docs to 14

### DIFF
--- a/articles/ds/figma.asciidoc
+++ b/articles/ds/figma.asciidoc
@@ -1,0 +1,59 @@
+---
+title: Figma Libraries
+order: 150
+layout: index
+---
+
+= Figma Libraries
+
+Designers can use these libraries to create pixel perfect UI designs and prototypes that can be handed over to developers with ease.
+The components in the libraries use the default Lumo styling, and you can adapt them to suit your branding and vision.
+
+
+[.cards.quiet.large.hide-title]
+== Libraries
+
+=== Foundation & Components
+image::_images/vaadin-ds-library.png[role="icon"]
+The main library includes typography, color, and other visual styles, and configurable components that cover the same components which are available for developers.
+
+https://www.figma.com/community/file/843042473942860131[View in Figma Community]
+
+
+=== Charts
+image::_images/vaadin-charts-library.png[role="icon"]
+Configurable charts which correspond to the chart types that are available in the official Vaadin Charts component.
+
+https://www.figma.com/community/file/1030435514000803214[View in Figma Community]
+
+
+=== Icons
+image::_images/vaadin-icons-library.png[role="icon"]
+The components in this library are interchangeable with the icons that are bundled in the main library.
+
+https://www.figma.com/community/file/972026846591993843[View in Figma Community]
+
+
+++++
+<style>
+iframe {
+  border: 1px solid var(--docs-divider-color-1);
+  width: 100%;
+  height: 240px;
+  margin: var(--docs-space-s) 0 var(--docs-space-m);
+}
+</style>
+++++
+
+
+== Figma Community
+
+You can follow Vaadin in the Figma community as well as duplicate, like, and comment the libraries.
+
+https://www.figma.com/@vaadin[Vaadin in Figma Community, role="button water primary"]
+
+
+
+== How to Use
+
+If you are unfamiliar with Figma libraries, you can start by reading https://help.figma.com/hc/en-us/articles/360041051154-Guide-to-libraries-in-Figma[Figma’s official guide to libraries].

--- a/articles/ds/material-theme-demo.asciidoc
+++ b/articles/ds/material-theme-demo.asciidoc
@@ -1,0 +1,5 @@
+---
+title: Material Theme Demo
+url: https://cdn.vaadin.com/vaadin-material-styles/1.3.2/demo/buttons.html
+order: 1000
+---

--- a/articles/ds/overview.asciidoc
+++ b/articles/ds/overview.asciidoc
@@ -28,13 +28,11 @@ Inputs, controls, and layouts for user interfaces.
 <<components#, Browse Components>>
 
 
-////
 === Figma Libraries
 image::_images/figma-logo.svg[opts=inline, role=icon]
 Prototype and design application layouts in Figma using official Vaadin libraries.
 
 <<figma#, See Figma Libraries>>
-////
 
 
 === Custom Themes

--- a/articles/index.asciidoc
+++ b/articles/index.asciidoc
@@ -53,12 +53,6 @@ https://vaadin.com/comparison?compare=flow_vs_fusion[View Comparison]
 [.cards.quiet.large]
 == Design System
 
-[.breakout.hide-title]
-=== Work In Progress
-.Design System documentation is in development
-[NOTE]
-The Design System documentation section is currently in progress for Vaadin 14. You can browse some of these sections in the link:../latest/ds#[newer documentation versions, role=skip-xref-check].
-
 [.card.large.tag-group]
 === Components
 image::_images/components.svg[opts=inline, role=icon, width=48]
@@ -71,7 +65,7 @@ Reference documentation for the visual foundation, including colors, typography,
 link:ds/foundation#[Foundation Overview]
 
 [.card.tag-group]
-=== Customization [tag]#Vaadin 20+#
+=== Customization
 Learn how to customize the design system to fit your brand, and how to package it for reuse across multiple applications.
 link:../latest/ds/customization#[Customization Overview, role=skip-xref-check]
 


### PR DESCRIPTION
## Description

- adds Figma page
- adds Material Theme demo link
- removes WIP hints for Design System from root index page

