### PR TITLE
Update bundle loading sequence

### DIFF
--- a/articles/framework/portal/portal-osgi.asciidoc
+++ b/articles/framework/portal/portal-osgi.asciidoc
@@ -84,14 +84,15 @@ The latest client binary can be downloaded from the link: link:https://releases.
 Here is an example script for doing that (be sure to check the versions required by your project using *mvn dependency:list* ):
 [source, shell]
 ----
-java -jar blade.jar sh start https://repo1.maven.org/maven2/org/jsoup/jsoup/1.11.2/jsoup-1.11.2.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/org/jsoup/jsoup/1.14.3/jsoup-1.14.3.jar
 java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/external/gentyref/1.2.0.vaadin1/gentyref-1.2.0.vaadin1.jar
-java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-shared/8.6.3/vaadin-shared-8.6.3.jar
-java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-server/8.6.3/vaadin-server-8.6.3.jar
-java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-osgi-integration/8.6.3/vaadin-osgi-integration-8.6.3.jar
-java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-client-compiled/8.6.3/vaadin-client-compiled-8.6.3.jar
-java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-themes/8.6.3/vaadin-themes-8.6.3.jar
-java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-liferay-integration/8.6.3/vaadin-liferay-integration-8.6.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/external/gwt/gwt-elemental/2.8.2.vaadin2/gwt-elemental-2.8.2.vaadin2.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-shared/8.14.3/vaadin-shared-8.14.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-server/8.14.3/vaadin-server-8.14.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-osgi-integration/8.14.3/vaadin-osgi-integration-8.14.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-client-compiled/8.14.3/vaadin-client-compiled-8.14.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-themes/8.14.3/vaadin-themes-8.14.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-liferay-integration/8.14.3/vaadin-liferay-integration-8.14.3.jar
 java -jar blade.jar sh start file:<path_to_liferay_portlet.jar>
 ----
 
@@ -99,15 +100,16 @@ However if you are using Vaadin 8 with compatibility libraries, the list above d
 
 [source, shell]
 ----
-blade sh start https://repo1.maven.org/maven2/org/jsoup/jsoup/1.11.3/jsoup-1.11.3.jar
+blade sh start https://repo1.maven.org/maven2/org/jsoup/jsoup/1.14.3/jsoup-1.14.3.jar
 blade sh start https://repo1.maven.org/maven2/com/vaadin/external/gentyref/1.2.0.vaadin1/gentyref-1.2.0.vaadin1.jar
-blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-shared/8.6.4/vaadin-shared-8.6.4.jar
-blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-shared/8.6.4/vaadin-compatibility-shared-8.6.4.jar
-blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-server/8.6.4/vaadin-server-8.6.4.jar
-blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-server/8.6.4/vaadin-compatibility-server-8.6.4.jar
-blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-osgi-integration/8.6.4/vaadin-osgi-integration-8.6.4.jar
-blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-client-compiled/8.6.4/vaadin-compatibility-client-compiled-8.6.4.jar
-blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-themes/8.6.4/vaadin-compatibility-themes-8.6.4.jar
-blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-liferay-integration/8.6.4/vaadin-liferay-integration-8.6.4.jar
+blade sh start https://repo1.maven.org/maven2/com/vaadin/external/gwt/gwt-elemental/2.8.2.vaadin2/gwt-elemental-2.8.2.vaadin2.jar
+blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-shared/8.14.3/vaadin-shared-8.14.3.jar
+blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-shared/8.14.3/vaadin-compatibility-shared-8.14.3.jar
+blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-server/8.14.3/vaadin-server-8.14.3.jar
+blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-server/8.14.3/vaadin-compatibility-server-8.14.3.jar
+blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-osgi-integration/8.14.3/vaadin-osgi-integration-8.14.3.jar
+blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-client-compiled/8.14.3/vaadin-compatibility-client-compiled-8.14.3.jar
+blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-themes/8.14.3/vaadin-compatibility-themes-8.14.3.jar
+blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-liferay-integration/8.14.3/vaadin-liferay-integration-8.14.3.jar
 java -jar blade.jar sh start file:<path_to_liferay_portlet.jar>
 ----


### PR DESCRIPTION
gwt-elemental is now needed to be activated separately as it is its own bundle and not static part of vaadin-shared, see

https://github.com/vaadin/framework/pull/12416
