### PR TITLE
Fix Servlet version

### DIFF
--- a/articles/flow/advanced/application-lifecycle.asciidoc
+++ b/articles/flow/advanced/application-lifecycle.asciidoc
@@ -25,7 +25,7 @@ any code in the application, although static blocks in classes are executed when
 they are loaded.
 
 There is no need to define your own servlet class (which should extend
-the `VaadinServlet` class) if you are using Servlet 3.0 specification. You just need
+the `VaadinServlet` class) if you are using Servlet 3.1 specification. You just need
 to have at least one class annotated with `@Route` annotation and a
 `VaadinServlet` instance will be registered for you automatically and Vaadin will
 register all servlets required automatically.


### PR DESCRIPTION
Vaadin Flow requires Java Servlet API 3.1 (JSR-340) or newer: https://github.com/vaadin/platform/releases/tag/22.0.0