### PR TITLE
docs: use setEnabled API in menu bar disabled demo

### DIFF
--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarDisabled.java
@@ -15,13 +15,12 @@ public class MenuBarDisabled extends Div {
 
         menuBar.addItem("View");
         MenuItem edit = menuBar.addItem("Edit");
-        edit.getElement().setAttribute("disabled", true);
+        edit.setEnabled(false);
 
         MenuItem share = menuBar.addItem("Share");
         SubMenu shareSubMenu = share.getSubMenu();
         shareSubMenu.addItem("By email")
-                .getElement()
-                .setAttribute("disabled", true);
+                .setEnabled(false);
         shareSubMenu.addItem("Get Link");
         // end::snippet[]
 


### PR DESCRIPTION
## Description

Use `setEnabled` API to disable menu bar items.

Fixes https://github.com/vaadin/web-components/issues/3203
