### PR TITLE
Fix Upgrade page flicker

### DIFF
--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -45,15 +45,15 @@ This is the description of the classnames:
 
 ++++
 <style>
-[class*="all"]:is(div, .openblock), 
-[class*='v1']:is(div, .openblock),
-[class*='v2']:is(div, .openblock),
-[class*='v3']:is(div, .openblock),
-[class*='v4']:is(div, .openblock),
-[class*='flow']:is(div, .openblock), 
-[class*='fusion']:is(div, .openblock), 
-[class*='spring']:is(div, .openblock), 
-[class*='ts']:is(div, .openblock)
+[class*=all]:is(div, .openblock), 
+[class*=v1]:is(div, .openblock),
+[class*=v2]:is(div, .openblock),
+[class*=v3]:is(div, .openblock),
+[class*=v4]:is(div, .openblock),
+[class*=flow]:is(div, .openblock), 
+[class*=fusion]:is(div, .openblock), 
+[class*=spring]:is(div, .openblock), 
+[class*=ts]:is(div, .openblock)
 {
     display: none;
 }


### PR DESCRIPTION
The new [upgrade page](https://vaadin.com/docs/latest/upgrading) momentarily shows all the upgrade content before they are hidden. This PR removes quotation marks from attribute selectors in an attempt to fix this.