### PR TITLE
docs: fix more typos, use US writing style

### DIFF
--- a/articles/contributing-docs/style-guide/grammar.asciidoc
+++ b/articles/contributing-docs/style-guide/grammar.asciidoc
@@ -497,7 +497,7 @@ We had to *completely* rebuild the library. +++[+++Instead of, for example, _to 
 Although split infinitives are generally considered to be acceptable these days, it is worth considering whether you could easily write your sentence so as to avoid it.
 
 However, there may be some cases where strictly imposing the ideal of avoiding split infinitives could result in an awkward sentence or even introduce ambiguity.
-Clearly, we need to prioritise simplicity, clarity, and accuracy at all times, even if it means we have to compromise on elegance.
+Clearly, we need to prioritize simplicity, clarity, and accuracy at all times, even if it means we have to compromise on elegance.
 
 [[grammar.time_clauses_in_future]]
 == Time Clauses in the Future

--- a/articles/contributing-docs/style-guide/punctuation.asciidoc
+++ b/articles/contributing-docs/style-guide/punctuation.asciidoc
@@ -178,7 +178,7 @@ Select a number in the range 0&#8211;255.
 
 The parameter should be a string of 8&#8211;10 characters.
 
-The licence enables you to use the software on 1&#8211;3 computers.
+The license enables you to use the software on 1&#8211;3 computers.
 
 He was chief designer (2003&#8211;9), and subsequently CEO of the company (2009&#8211;12).
 
@@ -192,7 +192,7 @@ For example:
 
 [example]
 ====
-You can use the licence on between 1 and 3 workstations. +
+You can use the license on between 1 and 3 workstations. +
 +++[+++Not _between 1&#8211;3 workstations_.+++]+++
 
 The parameter should be a string of from 8 to 10 characters. +

--- a/articles/contributing-docs/style-guide/style.asciidoc
+++ b/articles/contributing-docs/style-guide/style.asciidoc
@@ -487,7 +487,7 @@ The inverse of 8 is *0.125*.
 Although split infinitives are generally considered to be acceptable these days, it is worth considering whether you could easily write your sentence so as to avoid it.
 
 However, there may be some cases where strictly imposing the ideal of avoiding split infinitives could result in an awkward sentence or even introduce ambiguity.
-Clearly, we need to prioritise simplicity, clarity, and accuracy at all times, even if it means we have to compromise on elegance.
+Clearly, we need to prioritize simplicity, clarity, and accuracy at all times, even if it means we have to compromise on elegance.
 
 == Underscore
 The character "&lowbar;" is called the _underscore_ character.

--- a/articles/contributing-docs/style-guide/word-list.asciidoc
+++ b/articles/contributing-docs/style-guide/word-list.asciidoc
@@ -780,7 +780,7 @@ For example:
 
 [example]
 ====
-_The choice of licence depends on the number of *end users*._ +
+_The choice of license depends on the number of *end users*._ +
 _This will minimize the level of *end-user* support that you need to provide._
 ====
 
@@ -1786,8 +1786,8 @@ For example:
 
 [example]
 ====
-_**[line-through]#While#** it is possible to write code using an ordinary text editor, using an IDE has signficant advantages._ +
-_**Although** it is possible to write code using an ordinary text editor, using an IDE has signficant advantages._
+_**[line-through]#While#** it is possible to write code using an ordinary text editor, using an IDE has significant advantages._ +
+_**Although** it is possible to write code using an ordinary text editor, using an IDE has significant advantages._
 
 _The previous version was written in C+\+, *[line-through]#while#* the current version is Java-based._ +
 _The previous version was written in C++, *whereas* the current version is Java-based._

--- a/articles/contributing/overview.asciidoc
+++ b/articles/contributing/overview.asciidoc
@@ -56,7 +56,7 @@ Describe the problem::
 +
 Whether your patch is a one-line bug fix or 5000 lines of a new feature, there must be an underlying problem that motivated you to do this work.
 Convince the reviewer that there is a problem worth fixing and that it makes sense for them to read past the first paragraph.
-This is often already described in bug/enhancement issue, but also summarise it in your commit message.
+This is often already described in bug/enhancement issue, but also summarize it in your commit message.
 +
 .Example problem explanation
 ----

--- a/articles/contributing/web-component-testing.asciidoc
+++ b/articles/contributing/web-component-testing.asciidoc
@@ -31,8 +31,8 @@ The best way to track what is used at the moment is to go through README file of
 When creating new test, there is no need to run all of the tests each time.
 You can isolate the test case during development and run it in conjunction with other tests in the end.
 
-.Example of technologies used: 
-* `mocha` for test language 
+.Example of technologies used:
+* `mocha` for test language
 * `fixture` from open-wc for rendering the component
 * `sinon` for stubs and mocks
 
@@ -90,7 +90,7 @@ The easiest way to check is to remove lines of the contribution one by one and c
 
 == Avoid Asynchronous Tests
 
-If possible try to avoid asynchrounous tests.
+If possible try to avoid asynchronous tests.
 It simplifies reviewing of the test and helps future contributors.
 If it is impossible, the delays should be explained in the comments and no magic numbers used (for example timeout for explicitly *300* milliseconds).
 

--- a/articles/ds/components/badge/index.asciidoc
+++ b/articles/ds/components/badge/index.asciidoc
@@ -299,7 +299,7 @@ Assistive technologies, such as screen readers, interpret badges solely based on
 Without proper context, they may end up confusing the user.
 To provide context for people using screen readers, set the badge's `aria-label` attribute.
 
-== Best Practises
+== Best Practices
 
 === Badge vs Button
 

--- a/articles/ds/components/board/index.asciidoc
+++ b/articles/ds/components/board/index.asciidoc
@@ -14,7 +14,7 @@ include::{articles}/_commercial-banner.asciidoc[opts=optional]
 // tag::description[]
 Board is a powerful and easy to use layout element for building responsive views.
 // end::description[]
-It reorders the components inside it on different screen sizes while maximising the use of available space.
+It reorders the components inside it on different screen sizes while maximizing the use of available space.
 
 
 [.example]
@@ -36,7 +36,7 @@ Use Board to create responsive views and dashboards that work on any screen size
 == Responsive
 
 Board is responsive by default meaning it doesn't require any custom development.
-Its layout is automatically optimized and adjusted based on the screen size, ensuring the components utilise all available space.
+Its layout is automatically optimized and adjusted based on the screen size, ensuring the components utilize all available space.
 
 == Rows & Columns
 

--- a/articles/ds/components/charts/java-api/charttypes.asciidoc
+++ b/articles/ds/components/charts/java-api/charttypes.asciidoc
@@ -2079,7 +2079,7 @@ String url = "frontend/img/smiley.png";
 marker.setSymbol(new MarkerSymbolUrl(url));
 ----
 
-You can use [paramater]#width# and [parameter]#height# to resize the marker. The radius property are not applicable to image symbols.
+You can use [parameter]#width# and [parameter]#height# to resize the marker. The radius property are not applicable to image symbols.
 
 [[charts.charttypes.3d]]
 == 3D Charts

--- a/articles/ds/components/charts/java-api/charttypes.asciidoc
+++ b/articles/ds/components/charts/java-api/charttypes.asciidoc
@@ -2079,7 +2079,7 @@ String url = "frontend/img/smiley.png";
 marker.setSymbol(new MarkerSymbolUrl(url));
 ----
 
-You can use [parameter]#width# and [parameter]#height# to resize the marker. The radius property are not applicable to image symbols.
+You can use [parameter]#width# and [parameter]#height# to resize the marker. The radius property is not applicable to image symbols.
 
 [[charts.charttypes.3d]]
 == 3D Charts

--- a/articles/ds/components/combo-box/index.asciidoc
+++ b/articles/ds/components/combo-box/index.asciidoc
@@ -83,7 +83,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomE
 
 See <<../select#custom-item-presentation, Select, Custom Item Presentation.>>
 
-Items can be customised to display more information than a single line of text.
+Items can be customized to display more information than a single line of text.
 
 [.example]
 --

--- a/articles/ds/components/crud/index.asciidoc
+++ b/articles/ds/components/crud/index.asciidoc
@@ -187,7 +187,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.
 == Grid Replacement
 
 CRUD's default Grid is replaceable.
-This is useful when you wish to customise the Grid, for example, to place the edit Button in the first column.
+This is useful when you wish to customize the Grid, for example, to place the edit Button in the first column.
 See <<../grid#,Grid documentation>> for details on configuring grids.
 
 [.example]

--- a/articles/ds/components/custom-field/index.asciidoc
+++ b/articles/ds/components/custom-field/index.asciidoc
@@ -46,7 +46,7 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Appointment.java[tags=snipp
 
 == Basic Usage
 
-Custom Field is optimised for wrapping the following components:
+Custom Field is optimized for wrapping the following components:
 
 * <<../text-field#,Text Field>>
 * <<../number-field#,Number Filed>>

--- a/articles/ds/components/date-picker/index.asciidoc
+++ b/articles/ds/components/date-picker/index.asciidoc
@@ -216,7 +216,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerWee
 Date Picker's initial position parameter defines which date is focused in the calendar overlay when the overlay is opened.
 The default initial position is the selected or current date.
 
-Use this feature to minimise the need for unnecessary navigation and/or scrolling when the user's input is expected to be within a certain time.
+Use this feature to minimize the need for unnecessary navigation and/or scrolling when the user's input is expected to be within a certain time.
 
 [.example]
 --
@@ -274,7 +274,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDat
 
 To disable the days before the start date in the end date picker, you need to handle the selection in the start date picker and change the range in the end date picker.
 
-== Best Practises
+== Best Practices
 
 === Picking vs Typing
 

--- a/articles/ds/components/date-time-picker/index.asciidoc
+++ b/articles/ds/components/date-time-picker/index.asciidoc
@@ -162,7 +162,7 @@ The week numbers are displayed according to https://www.iso.org/iso-8601-date-an
 == Initial Position
 
 Date Time Picker's initial position parameter defines which date is focused in the calendar overlay when the overlay is opened.
-Use this feature to minimise the need for any additional navigation and/or scrolling when the user's input is expected to be within a certain time frame.
+Use this feature to minimize the need for any additional navigation and/or scrolling when the user's input is expected to be within a certain time frame.
 
 [.example]
 --
@@ -198,7 +198,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimeP
 
 To disable the days before the start date in the end date picker, you need to handle the selection in the start date picker and change the range in the end date picker.
 
-== Best Practises
+== Best Practices
 
 Use Date Time Picker when the user needs to choose both a date and time of day.
 If you only need a date or time of day, use <<../date-picker#,Date Picker>> and <<../time-picker#,Time Picker>> respectively.

--- a/articles/ds/components/details/index.asciidoc
+++ b/articles/ds/components/details/index.asciidoc
@@ -34,7 +34,7 @@ The Summary is the part that is always visible, and typically describes the cont
 Clicking on the summary toggles the content area's visibility.
 
 The summary supports rich content and can contain any component.
-This can be utilised for example to indicate the status of the corresponding content.
+This can be utilized for example to indicate the status of the corresponding content.
 
 [.example]
 --
@@ -168,6 +168,6 @@ Details can be used instead of Accordion if there is a need to see content from 
 
 |<<../accordion#,Accordion>>|Vertically stacked set of expandable panels, in which only one panel can be expanded at a time.
 
-|<<../tabs#,Tabs>>|Component for organising and grouping content into navigable sections.
+|<<../tabs#,Tabs>>|Component for organizing and grouping content into navigable sections.
 
 |===

--- a/articles/ds/components/dialog/index.asciidoc
+++ b/articles/ds/components/dialog/index.asciidoc
@@ -184,7 +184,7 @@ include::{root}/frontend/themes/docs/dialog.css[tags=dialog-no-padding,indent=0,
 ----
 --
 
-== Best Practises
+== Best Practices
 
 === Use Sparingly
 

--- a/articles/ds/components/form-layout/index.asciidoc
+++ b/articles/ds/components/form-layout/index.asciidoc
@@ -148,7 +148,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutNat
 --
 
 
-== Best Practises
+== Best Practices
 
 === Sectioning
 

--- a/articles/ds/components/grid-pro/index.asciidoc
+++ b/articles/ds/components/grid-pro/index.asciidoc
@@ -210,7 +210,7 @@ include::{root}/frontend/themes/docs/components/vaadin-grid-pro-editable-cells.c
 ----
 --
 
-== Best Practises
+== Best Practices
 
 === Inline vs Non-Inline Editing
 

--- a/articles/ds/components/grid/flow.asciidoc
+++ b/articles/ds/components/grid/flow.asciidoc
@@ -273,7 +273,7 @@ grid.addColumn("address.postalCode");
 
 ==== Defining and Ordering Automatically-Added Columns
 
-You can define which columns display, and the order in which they disaply, in the grid, using the `setColumns` method.
+You can define which columns display, and the order in which they disapply, in the grid, using the `setColumns` method.
 
 *Example*: Defining columns and their order using the `setColumns` method.
 
@@ -824,7 +824,7 @@ The sections that follow detail options you can use to set up sorting for your g
 
 ==== Using a Sort Property Name
 
-By using a sort property, you can override or customise the property or multiple properties that are used for sorting the column. This option includes both in-memory and backend sorting. The property is defined at the time of column construction and uses a sort property name.
+By using a sort property, you can override or customize the property or multiple properties that are used for sorting the column. This option includes both in-memory and backend sorting. The property is defined at the time of column construction and uses a sort property name.
 
 You can use the `addColumn` method to set a sort property to be used for backend sorting when the column is added to the grid.
 

--- a/articles/ds/components/grid/flow.asciidoc
+++ b/articles/ds/components/grid/flow.asciidoc
@@ -273,7 +273,7 @@ grid.addColumn("address.postalCode");
 
 ==== Defining and Ordering Automatically-Added Columns
 
-You can define which columns display, and the order in which they disapply, in the grid, using the `setColumns` method.
+You can define which columns display, and the order in which they display, in the grid, using the `setColumns` method.
 
 *Example*: Defining columns and their order using the `setColumns` method.
 

--- a/articles/ds/components/grid/index.asciidoc
+++ b/articles/ds/components/grid/index.asciidoc
@@ -215,7 +215,7 @@ While it’s technically possible to freeze any column, this feature should prim
 
 It is possible to group columns together.
 Grouped columns share a common header and footer.
-Use this feature to better visualise and organise related or hierarchical data.
+Use this feature to better visualize and organize related or hierarchical data.
 
 [.example]
 --

--- a/articles/ds/components/radio-button/index.asciidoc
+++ b/articles/ds/components/radio-button/index.asciidoc
@@ -106,7 +106,7 @@ In cases where more options need to be provided, the Select component can be use
 
 == Custom Item Presentation
 
-Items can be customised to include more than a single line of text:
+Items can be customized to include more than a single line of text:
 
 [.example]
 --

--- a/articles/ds/components/time-picker/index.asciidoc
+++ b/articles/ds/components/time-picker/index.asciidoc
@@ -140,7 +140,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerCus
 ----
 --
 
-== Best Practises
+== Best Practices
 
 Use Time Picker when the user needs to choose a time of day.
 Do not use it for durations, such as for a stopwatch or timer.

--- a/articles/ds/components/tree-grid/index.asciidoc
+++ b/articles/ds/components/tree-grid/index.asciidoc
@@ -83,7 +83,7 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags
 ----
 --
 
-== Best Practises
+== Best Practices
 
 Tree Grid is not meant to be used as a navigation menu.
 

--- a/articles/flow/advanced/css-loading-order.asciidoc
+++ b/articles/flow/advanced/css-loading-order.asciidoc
@@ -12,9 +12,9 @@ That is, the priority they are computed in the browser and possibly override eac
 To keep the application theming and styles consistent and well-formed, it's important to consider the loading order of the following CSS sources:
 
 . `Lumo` theme
-. Application-specific bundled CSS added with a [classname]#@CssImport#, as descibed in <<{articles}/flow/application/styling#importing.bundled,Importing Bundled Style Sheets>> (_if used_)
+. Application-specific bundled CSS added with a [classname]#@CssImport#, as described in <<{articles}/flow/application/styling#importing.bundled,Importing Bundled Style Sheets>> (_if used_)
 . Styles added on Java side via `Page::addStylesheet` (_if used_)
-. Application-specific unbundled CSS added with [classname]#@StyleSheet#, as descibed in <<{articles}/flow/application/styling#importing.external,Importing External Style Sheets>>  (_if used_)
+. Application-specific unbundled CSS added with [classname]#@StyleSheet#, as described in <<{articles}/flow/application/styling#importing.external,Importing External Style Sheets>>  (_if used_)
 . Parent theme (_if used_)
 . Current theme
 

--- a/articles/flow/advanced/history-api.asciidoc
+++ b/articles/flow/advanced/history-api.asciidoc
@@ -10,7 +10,7 @@ layout: page
 
 The _History API_ allows you to access the browser navigation history from the server-side.
 It also allow you to modify the navigation history by adding a new entry to it or changing the current entry.
-E.g. you can change the current URL that is shown in the browser address bar without invoke any navigation.
+E.g. you can change the current URL that is shown in the browser address bar without invoking any navigation.
 The history is always bound to the current browser window / frame, so you can access it
 through the _Page_ object (available through the _UI_).
 

--- a/articles/flow/advanced/history-api.asciidoc
+++ b/articles/flow/advanced/history-api.asciidoc
@@ -8,9 +8,9 @@ layout: page
 = History API
 :toc:
 
-The _History API_ allows you to access the browser navigation history from the server-side. 
-It also allow you to modify the navigation history by adding a new entry to it or chaging the current entry.
-E.g. you can change the current URL that is shown in the brower address bar without invoke any navigation.
+The _History API_ allows you to access the browser navigation history from the server-side.
+It also allow you to modify the navigation history by adding a new entry to it or changing the current entry.
+E.g. you can change the current URL that is shown in the browser address bar without invoke any navigation.
 The history is always bound to the current browser window / frame, so you can access it
 through the _Page_ object (available through the _UI_).
 

--- a/articles/flow/advanced/history-api.asciidoc
+++ b/articles/flow/advanced/history-api.asciidoc
@@ -8,8 +8,8 @@ layout: page
 = History API
 :toc:
 
-The _History API_ allows you to access the browser navigation history from the server-side.
-It also allow you to modify the navigation history by adding a new entry to it or changing the current entry.
+The _History API_ allows you to access the browser navigation history from the server side.
+It also allows you to modify the navigation history by adding a new entry to it or changing the current entry.
 E.g. you can change the current URL that is shown in the browser address bar without invoking any navigation.
 The history is always bound to the current browser window / frame, so you can access it
 through the _Page_ object (available through the _UI_).

--- a/articles/flow/advanced/modifying-the-bootstrap-page.asciidoc
+++ b/articles/flow/advanced/modifying-the-bootstrap-page.asciidoc
@@ -75,8 +75,8 @@ Override `configurePage` for adding content to the `index.html` template by call
 - `AppShellSettings#addInlineWithContents` to add arbitrary content.
 - `AppShellSettings#addLink` to add links to the head.
 - `AppShellSettings#addFavIcon` to configure the favicon.
-- `AppShellSettings#getLoadingIndicatorConfiguration` for configuring loading indicator when legacy bootstrapping is used (deprecated, see details after code example). 
-- `AppShellSettings#getReconnectDialogConfiguration` for configuring the reconnect dialog when legacy bootstrapping is used (deprecated, see details after code example). 
+- `AppShellSettings#getLoadingIndicatorConfiguration` for configuring loading indicator when legacy bootstrapping is used (deprecated, see details after code example).
+- `AppShellSettings#getReconnectDialogConfiguration` for configuring the reconnect dialog when legacy bootstrapping is used (deprecated, see details after code example).
 - `AppShellSettings#getPushConfiguration` to customize the push mechanism when legacy bootstrapping is used (deprecated, see details after code example).
 
 [source,java]
@@ -141,7 +141,7 @@ public class AppShell implements AppShellConfigurator {
 Modifications in the  `AppShellConfigurator#configurePage` do have priority over the equivalent annotations.
 
 [NOTE]
-Annotations do not cover all the cases that can be done when overridding the `AppShellConfigurator#configurePage` method
+Annotations do not cover all the cases that can be done when overriding the `AppShellConfigurator#configurePage` method
 
 === The IndexHtmlRequestListener Interface [[IndexHtmlRequestListener-interface]]
 

--- a/articles/flow/advanced/servlet-container-authentication.asciidoc
+++ b/articles/flow/advanced/servlet-container-authentication.asciidoc
@@ -14,7 +14,7 @@ As a reference, we provide configuration examples custom session based authentic
 
 == Session Based Authentication
 
-=== Configuring a Custom Servet Filter
+=== Configuring a Custom Servlet Filter
 
 For customized authentication, it is needed to implement a custom `HttpServletRequest` to wrap the default one through a `WebFilter`.
 

--- a/articles/flow/application/resources.asciidoc
+++ b/articles/flow/application/resources.asciidoc
@@ -39,7 +39,7 @@ It is also used in assistive technologies.
 The location of static image resources in the project depends on the deployment method:
 
 Web Archive (WAR) packaging::
-  Under `/src/main/webapp`, such as `/src/main/wepapp/images/myimage.png`.
+  Under `/src/main/webapp`, such as `/src/main/webapp/images/myimage.png`.
 
 JAR packaging (Spring Boot applications)::
   Under `/src/main/resources/META-INF/resources`, such as `/src/main/resources/META-INF/resources/images/myimage.png`.

--- a/articles/flow/binding-data/components-binder-load.asciidoc
+++ b/articles/flow/binding-data/components-binder-load.asciidoc
@@ -13,7 +13,7 @@ Changes can be written to business objects automatically or manually.
 
 == Reading and Writing Automatically
 
-Writing to business objects automatically when the user makes changes in the UI is ususally the most convenient option.
+Writing to business objects automatically when the user makes changes in the UI is usually the most convenient option.
 
 You can bind the values directly to an instance, by allowing `Binder` to automatically save values from the fields.
 

--- a/articles/flow/components/enabled-state.asciidoc
+++ b/articles/flow/components/enabled-state.asciidoc
@@ -184,7 +184,7 @@ customElements.define(RegistrationForm.is,
 * The checkbox is implicitly disabled if the template (which is its parent) is disabled. As a result, no RPC is allowed for the checkbox.
 * The `addPropertyChangeListener` method (with the extra "checked-changed" argument) is used to synchronize the `checked` property.
 
-* The folowing RPC communications are blocked for the disabled element:
+* The following RPC communications are blocked for the disabled element:
 ** Property changes.
 ** DOM events.
 ** Event handler methods (annotated with `@EventHandler`). For example, the `register()` method is an event handler method that is blocked when the component is disabled.

--- a/articles/flow/components/shortcut.asciidoc
+++ b/articles/flow/components/shortcut.asciidoc
@@ -198,7 +198,7 @@ ShortcutEventListener listener = event -> {
        // do something G-related
    }
    else if (event.matches(Key.KEY_J, KeyModifier.ALT)) {
-       // do something J-releated
+       // do something J-related
    }
 };
 

--- a/articles/flow/dnd/drag-source.asciidoc
+++ b/articles/flow/dnd/drag-source.asciidoc
@@ -103,7 +103,7 @@ card1.addDragStartListener(event -> {
 ----
 
 When the user stops dragging the component by either dropping it or by canceling the drag with, for example, the escape key, the `DragEndEvent` is fired.
-The `isSucceful()` method returns `true` if the drop occurred on a drop target that accepted the drop, but only for Chrome and Firefox (read the note after the sample).
+The `isSuccessful()` method returns `true` if the drop occurred on a drop target that accepted the drop, but only for Chrome and Firefox (read the note after the sample).
 
 [source,java]
 ----
@@ -137,7 +137,7 @@ The value will be determined in priority order by:
 * The modifier keys the user had pressed and hold when dropping
 
 When the drop effect is `MOVE`, you should move / remove the drag source component from its original location.
-When the drop effect is `NONE`, the drop did not occur and `dropEvent.isSuccesful()` will return `false`.
+When the drop effect is `NONE`, the drop did not occur and `dropEvent.isSuccessful()` will return `false`.
 
 === Customizing the Draggable Element
 

--- a/articles/flow/routing/lifecycle.asciidoc
+++ b/articles/flow/routing/lifecycle.asciidoc
@@ -133,7 +133,7 @@ public class BlogList extends Div
 There are several `rerouteTo` overload methods that can be used for different use cases.
 
 [NOTE]
-`rerouteTo` keeps the original URL in the browser's adress bar and doesn't change it to a new URL based on the new target.
+`rerouteTo` keeps the original URL in the browser's address bar and doesn't change it to a new URL based on the new target.
 
 === Forward
 

--- a/articles/flow/routing/templates.asciidoc
+++ b/articles/flow/routing/templates.asciidoc
@@ -299,7 +299,7 @@ public static class ShowAllView extends Div {
 
 Same is valid when using `@RouteAlias` on the same navigation target.
 
-*Example*: Folowing URLs are resolved by different routes registered on the same navigation target.
+*Example*: Following URLs are resolved by different routes registered on the same navigation target.
 
 * `thread/last` is resolved by `@RouteAlias("last")`.
 * `thread/123` is resolved by `@RouteAlias(":messageID(" + RouteParameterRegex.INTEGER + ")")` and parameter `messageID` will be provided with value `"123"`.

--- a/articles/flow/security/intro.asciidoc
+++ b/articles/flow/security/intro.asciidoc
@@ -61,7 +61,7 @@ These are the known libraries where this is the case:
 - `org.codehaus.plexus`
 ////
 
-// tag::security-pactices[]
+// tag::security-practices[]
 == Security Practices at Vaadin
 
 === Releasing Security Patches
@@ -84,4 +84,4 @@ Each change is also ran against our existing battery of tens of thousands of uni
 Developers are also encouraged to actively think about security issues while developing the framework and its parts.
 At Vaadin, we take security extremely seriously.
 Anyone can escalate an issue that they think might be a security issue, and investigating the issue is given priority over other tasks.
-// end::security-pactices[]
+// end::security-practices[]

--- a/articles/flow/security/vulnerabilities.asciidoc
+++ b/articles/flow/security/vulnerabilities.asciidoc
@@ -74,7 +74,7 @@ This is strongly discouraged when running in production.
 
 Vaadin has built-in protection against cross-site scripting (XSS) attacks.
 Vaadin uses Browser APIs that make the browser render content as text instead of HTML, such as using `innerText` instead of `innerHTML`.
-This negates the chance to accidentally inserting for example, `<script>` tags into the DOM by binding insecure string values.
+This negates the chance of accidentally inserting for example, `<script>` tags into the DOM by binding insecure string values.
 
 Some Vaadin components explicitly allow HTML content for certain attributes, in which case your application needs to ensure that the data does not contain XSS payloads.
 Allowing insecure HTML content is never the default, it is an explicit choice by developers.

--- a/articles/flow/security/vulnerabilities.asciidoc
+++ b/articles/flow/security/vulnerabilities.asciidoc
@@ -74,7 +74,7 @@ This is strongly discouraged when running in production.
 
 Vaadin has built-in protection against cross-site scripting (XSS) attacks.
 Vaadin uses Browser APIs that make the browser render content as text instead of HTML, such as using `innerText` instead of `innerHTML`.
-This negates the chance to accidentally inserting for example, `<script>` tags into the DOM by binding unsecure string values.
+This negates the chance to accidentally inserting for example, `<script>` tags into the DOM by binding insecure string values.
 
 Some Vaadin components explicitly allow HTML content for certain attributes, in which case your application needs to ensure that the data does not contain XSS payloads.
 Allowing insecure HTML content is never the default, it is an explicit choice by developers.

--- a/articles/flow/templates/polymer/bindings.asciidoc
+++ b/articles/flow/templates/polymer/bindings.asciidoc
@@ -167,7 +167,8 @@ public class PolymerTwoWayBindingTemplate
 }
 ----
 
-* The `Element::addPropertyChangeListener` method gets immediate updates when the property values change. As an alternative, you could define an `@EventHandler` method on the server side and add appropriate event handers in the template.
+* The `Element::addPropertyChangeListener` method gets immediate updates when the property values change.
+As an alternative, you could define an `@EventHandler` method on the server side and add appropriate event handlers in the template.
 * On the client, we use the following methods to bind the model data (see JavaScript template below):
 
 ** `name` string to an input using:
@@ -176,7 +177,7 @@ public class PolymerTwoWayBindingTemplate
 
 ** `accepted` boolean to a checkbox using:
 *** Native checkbox input.
-*** Polymer element `paper-check-box`.
+*** Polymer element `paper-checkbox`.
 
 ** `size` string to a select element using:
 *** Native select.

--- a/articles/flow/templates/polymer/event-handlers.asciidoc
+++ b/articles/flow/templates/polymer/event-handlers.asciidoc
@@ -182,7 +182,7 @@ customElements.define(ModelItemHandler.is, ModelItemHandler);
 
 [NOTE]
 You can use the `@ModelItem` annotation with any value provided as a data path.
-By default, the data path is `event.model.item`, but you should declare your data type in some manmer via the model definition, so that it can be referenced from the model.
+By default, the data path is `event.model.item`, but you should declare your data type in some manner via the model definition, so that it can be referenced from the model.
 
 === Modifying Model Items Before Events
 

--- a/articles/fusion/advanced/custom-serialization.asciidoc
+++ b/articles/fusion/advanced/custom-serialization.asciidoc
@@ -10,7 +10,7 @@ When serializing/deserializing data in Java Endpoints, developer might be intere
 excluding certain properties and types.
 
 Omitting properties helps the application avoid putting sensitive data in the wire like password fields.
-Leaving out types helps to simplify the typescript exported classes, and to avoid circular dependencies in the serialzed JSON output.
+Leaving out types helps to simplify the typescript exported classes, and to avoid circular dependencies in the serialized JSON output.
 
 == Annotations
 
@@ -153,7 +153,7 @@ public class Sale {
    private Client client;
 
    private Product product;
-   private int ammount;
+   private int amount;
    private double total;
 
    ...

--- a/articles/fusion/advanced/custom-serialization.asciidoc
+++ b/articles/fusion/advanced/custom-serialization.asciidoc
@@ -10,7 +10,7 @@ When serializing/deserializing data in Java Endpoints, developer might be intere
 excluding certain properties and types.
 
 Omitting properties helps the application avoid putting sensitive data in the wire like password fields.
-Leaving out types helps to simplify the typescript exported classes, and to avoid circular dependencies in the serialized JSON output.
+Leaving out types helps to simplify the TypeScript exported classes, and to avoid circular dependencies in the serialized JSON output.
 
 == Annotations
 

--- a/articles/fusion/forms/appendix-client-side-form-binding-reference.asciidoc
+++ b/articles/fusion/forms/appendix-client-side-form-binding-reference.asciidoc
@@ -218,7 +218,7 @@ All models subclass from the [classname]#AbstractModel<T># TypeScript class, whe
 
 ==== The Empty Value Definition
 
-Model classes define an empty value, which is used to initialise `binder.defaultValue` and `binder.value` properties, and also for [methodname]#binder.clear()#.
+Model classes define an empty value, which is used to initialize `binder.defaultValue` and `binder.value` properties, and also for [methodname]#binder.clear()#.
 
 For that purpose, [classname]#AbstractModel<T>#, as well as every subclass, has a method `static createEmptyValue(): T`, that returns the empty value of the subject model type.
 
@@ -293,16 +293,16 @@ Reset the form to the previous value.
 Sets the form to empty value, as defined in the Model.
 `getFieldStrategy(element: any): FieldStrategy`::
 Determines and returns the `field` directive strategy for the bound element.
-Override to customise the binding strategy for a component.
+Override to customize the binding strategy for a component.
 The [classname]#Binder# extends [classname]#BinderNode#, see the inherited properties and methods below.
 
 == Binder Nodes [[binder-node]]
 
-The [classnamen]#BinderNode<T, M># class provides the form binding related APIs with respect to a particular model instance.
+The [classname]#BinderNode<T, M># class provides the form binding related APIs with respect to a particular model instance.
 
 Structurally, model instances form a tree, in which the object and array models have child nodes of field and array item model instances.
 
-Every model instance has a one-to-one mapping to a corresponding [classname]#BinderNode# instance. The [classname]#Binder# itself is a [classnamne]#BinderNode# for the top-level form model.
+Every model instance has a one-to-one mapping to a corresponding [classname]#BinderNode# instance. The [classname]#Binder# itself is a [classname]#BinderNode# for the top-level form model.
 
 Use the [methodname]#binderNode.for()# method to obtain the binder node related with the model.
 

--- a/articles/fusion/pwa/cache-client-side-data.asciidoc
+++ b/articles/fusion/pwa/cache-client-side-data.asciidoc
@@ -47,7 +47,7 @@ Now you can use the cacheable wrapper in your client-side view.
 // import the cacheable function from the path to cacheable.ts file (without the suffix)
 import { cacheable } from 'path-to-cacheable';
 
-// instead of always relying on the backend to retrive the data. e.g.
+// instead of always relying on the backend to retrieve the data. e.g.
 // const stats = await getStats();
 // you can now wrap getStats into the cacheable helper.
 const stats = await cacheable(() => getStats(), 'stats', {});

--- a/articles/fusion/security/intro.asciidoc
+++ b/articles/fusion/security/intro.asciidoc
@@ -69,4 +69,4 @@ The CSRF token is included in each endpoint call and validated to be matching by
 Fusion-based PWAs may choose to cache data retrieved from the server on the client side, using for example browser local storage, in order for a data-centric application to work offline.
 The developer must make an informed decision on whether the data is safe to store or not, and implement the cleanup of such stored local data (for example at logout), if necessary.
 
-include::{articles}/flow/security/intro.asciidoc[tag=security-pactices]
+include::{articles}/flow/security/intro.asciidoc[tag=security-practices]

--- a/articles/fusion/security/spring-login.asciidoc
+++ b/articles/fusion/security/spring-login.asciidoc
@@ -99,7 +99,7 @@ include::{root}/frontend/demo/fusion/authentication/login-view.ts[]
 ----
 
 The authentication helper methods in the code examples are grouped in a separate TypeScript file, as shown below.
-It utilises a Fusion [methodname]#login()# helper method for authentication based on Spring Security.
+It utilizes a Fusion [methodname]#login()# helper method for authentication based on Spring Security.
 
 .`frontend/auth.ts`
 [source,typescript]

--- a/articles/tools/designer/getting-started/build-your-main-view.asciidoc
+++ b/articles/tools/designer/getting-started/build-your-main-view.asciidoc
@@ -67,7 +67,7 @@ We'll disregard the form for now, as we build it separately after adding the oth
 [#add-the-components]
 == Adding the components
 
-. On the paper, click *Vertical* to get a vertical layout as your starting point. Your view now constists of an empty layout.
+. On the paper, click *Vertical* to get a vertical layout as your starting point. Your view now consists of an empty layout.
 . Find *Horizontal Layout Spacing* in the palette and drag it onto the vaadin-vertical-layout on the paper *twice*. You can use the search field at the top to find components easily.
 . Find *Vaadin Text Field* in the palette and drag it onto the *first* vaadin-horizontal-layout.
 . Find *Button* in the palette and drag it onto the *first* vaadin-horizontal-layout.

--- a/articles/tools/designer/getting-started/connecting-your-main-view-to-java.asciidoc
+++ b/articles/tools/designer/getting-started/connecting-your-main-view-to-java.asciidoc
@@ -68,7 +68,7 @@ public class MainView extends PolymerTemplate<MainView.MainViewModel> {
      * Creates a new MainView.
      */
     public MainView() {
-        // You can initialise any data required for the connected UI components here.
+        // You can initialize any data required for the connected UI components here.
     }
 
     /**
@@ -114,7 +114,7 @@ public class MainView extends PolymerTemplate<MainView.MainViewModel> {
 
     public MainView(ContactService contactService) { <3>
         this.contactService = contactService; <4>
-        // You can initialise any data required for the connected UI components here.
+        // You can initialize any data required for the connected UI components here.
         grid.addColumn(Contact::getFirstName).setHeader("First name"); <5>
         grid.addColumn(Contact::getLastName).setHeader("Last name");
         grid.addColumn(Contact::getEmail).setHeader("Email");
@@ -171,7 +171,7 @@ public class MainView extends PolymerTemplate<MainView.MainViewModel> {
 
     public MainView(ContactService contactService) {
         this.contactService = contactService;
-        // You can initialise any data required for the connected UI components here.
+        // You can initialize any data required for the connected UI components here.
         grid.addColumn(Contact::getFirstName).setHeader("First name");
         grid.addColumn(Contact::getLastName).setHeader("Last name");
         grid.addColumn(Contact::getEmail).setHeader("Email");

--- a/articles/tools/designer/using-designer/java.asciidoc
+++ b/articles/tools/designer/using-designer/java.asciidoc
@@ -56,7 +56,7 @@ import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
 public class MyDesign extends PolymerTemplate<MyDesign.MyDesignModel> {
 
     public MyDesign() {
-        // You can initialise any data required for the connected UI components here.
+        // You can initialize any data required for the connected UI components here.
     }
 
     public interface MyDesignModel extends TemplateModel {

--- a/articles/tools/testbench/bdd.asciidoc
+++ b/articles/tools/testbench/bdd.asciidoc
@@ -71,7 +71,7 @@ public class CalculatorSteps extends TestBenchTestCase {
 ----
 
 The demo employs the page object defined for the application UI, as described in
-<<maintainable-tests-using-page-objects#,Creating Maintainble Tests using Page Objects>>.
+<<maintainable-tests-using-page-objects#,Creating Maintainable Tests using Page Objects>>.
 
 Such scenarios are included in one or more stories, which need to be configured
 in a class extending `JUnitStory` or `JUnitStories`. In

--- a/articles/tools/testbench/creating-tests.asciidoc
+++ b/articles/tools/testbench/creating-tests.asciidoc
@@ -88,4 +88,4 @@ public void fillForm() {
 }
 ----
 
-Do be aware that if you write tests in this manner, you will have a hard time maintaining the tests. A good way to stucture tests is to have only the high level logic in the test itself (your manager should be able to read and understand the test method) and extract the `ElementQuery` parts to a separate *Page Object* class. See <<maintainable-tests-using-page-objects.asciidoc#,Creating Maintainble Tests using Page Objects>> for more information.
+Do be aware that if you write tests in this manner, you will have a hard time maintaining the tests. A good way to structure tests is to have only the high level logic in the test itself (your manager should be able to read and understand the test method) and extract the `ElementQuery` parts to a separate *Page Object* class. See <<maintainable-tests-using-page-objects.asciidoc#,Creating Maintainable Tests using Page Objects>> for more information.

--- a/articles/tools/testbench/running-with-maven.asciidoc
+++ b/articles/tools/testbench/running-with-maven.asciidoc
@@ -118,7 +118,8 @@ This will download the webdrivers defined in `webdrivers.xml` (called a reposito
 [TIP]
 There is a repository map which is kept quite up to date available at https://github.com/Ardesco/selenium-standalone-server-plugin
 
-In addition to downloading the webdrivers, the location of the unpacked drivers must be passed to the `maven-failsafe-plugin` so that the TestBench tests can find them during execution. This can be done by defining system propertys for in the `<configuration>` section of the `maven-failsafe-plugin`:
+In addition to downloading the webdrivers, the location of the unpacked drivers must be passed to the `maven-failsafe-plugin` so that the TestBench tests can find them during execution.
+This can be done by defining system properties in the `<configuration>` section of the `maven-failsafe-plugin`:
 
 ----
 <configuration>

--- a/articles/upgrading/fusion/_17-18.adoc
+++ b/articles/upgrading/fusion/_17-18.adoc
@@ -1,4 +1,4 @@
 [discrete]
 ==== Fusion Breaking Changes
 
-- The `value` property of `BinderNode` now has optionally `undefined` type for non-initialised optional fields.
+- The `value` property of `BinderNode` now has optionally `undefined` type for non-initialized optional fields.

--- a/articles/upgrading/fusion/_18-19.adoc
+++ b/articles/upgrading/fusion/_18-19.adoc
@@ -93,7 +93,7 @@ The `SecurityUtils::isFrameworkInternalRequest()` can be updated as follows to a
 static boolean isFrameworkInternalRequest(HttpServletRequest request) {
     final String parameterValue = request
         .getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER);
-    // Use Referer in header to check if it is a sevice worker
+    // Use Referer in header to check if it is a service worker
     // initiated request
     String referer = request.getHeader("Referer");
     boolean isServiceWorkInitiated = (referer != null

--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionDisabledPanels.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionDisabledPanels.java
@@ -35,10 +35,10 @@ public class AccordionDisabledPanels extends Div {
         billingAddressLayout.setSpacing(false);
         billingAddressLayout.setPadding(false);
         billingAddressLayout.add(street, zipCode, city);
-        
+
         // tag::snippet[]
-        AccordionPanel billingAdressPanel = accordion.add("Billing address", billingAddressLayout);
-        billingAdressPanel.setEnabled(false);
+        AccordionPanel billingAddressPanel = accordion.add("Billing address", billingAddressLayout);
+        billingAddressPanel.setEnabled(false);
         // end::snippet[]
 
         Span cardBrand = new Span("Mastercard");
@@ -49,7 +49,7 @@ public class AccordionDisabledPanels extends Div {
         paymentLayout.setSpacing(false);
         paymentLayout.setPadding(false);
         paymentLayout.add(cardBrand, cardNumber, expiryDate);
-        
+
         AccordionPanel paymentPanel = accordion.add("Payment", paymentLayout);
         paymentPanel.setEnabled(false);
 

--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionSmallPanels.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionSmallPanels.java
@@ -35,9 +35,9 @@ public class AccordionSmallPanels extends Div {
         billingAddressLayout.setSpacing(false);
         billingAddressLayout.setPadding(false);
         billingAddressLayout.add(street, zipCode, city);
-        
-        AccordionPanel billingAdressPanel = accordion.add("Billing address", billingAddressLayout);
-        billingAdressPanel.addThemeVariants(DetailsVariant.SMALL);
+
+        AccordionPanel billingAddressPanel = accordion.add("Billing address", billingAddressLayout);
+        billingAddressPanel.addThemeVariants(DetailsVariant.SMALL);
 
         Span cardBrand = new Span("Mastercard");
         Span cardNumber = new Span("1234 5678 9012 3456");
@@ -47,7 +47,7 @@ public class AccordionSmallPanels extends Div {
         paymentLayout.setSpacing(false);
         paymentLayout.setPadding(false);
         paymentLayout.add(cardBrand, cardNumber, expiryDate);
-        
+
         // tag::snippet[]
         AccordionPanel paymentPanel = accordion.add("Payment", paymentLayout);
         paymentPanel.addThemeVariants(DetailsVariant.SMALL);

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogClosing.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogClosing.java
@@ -31,7 +31,7 @@ public class DialogClosing extends Div {
                 .set("font-size", "1.5em").set("font-weight", "bold");
 
         Paragraph paragraph = new Paragraph(
-                "System maintenance will begin at 3 PM. It is schedule to conclude at 5PM. We apologise for any inconvenience.");
+                "System maintenance will begin at 3 PM. It is schedule to conclude at 5PM. We apologize for any inconvenience.");
 
         // tag::snippet[]
         Button closeButton = new Button("Close");

--- a/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupLabels.java
+++ b/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupLabels.java
@@ -21,12 +21,12 @@ public class RadioButtonGroupLabels extends VerticalLayout {
     jobTitleGroup.setValue("Analyst");
     add(jobTitleGroup);
 
-    RadioButtonGroup<String> deparmentGroup = new RadioButtonGroup<>();
-    deparmentGroup.addThemeVariants(RadioGroupVariant.LUMO_VERTICAL);
-    deparmentGroup.setLabel("Department");
-    deparmentGroup.setItems("Engineering", "Human Resources", "Marketing");
-    deparmentGroup.setValue("Engineering");
-    add(deparmentGroup);
+    RadioButtonGroup<String> departmentGroup = new RadioButtonGroup<>();
+    departmentGroup.addThemeVariants(RadioGroupVariant.LUMO_VERTICAL);
+    departmentGroup.setLabel("Department");
+    departmentGroup.setItems("Engineering", "Human Resources", "Marketing");
+    departmentGroup.setValue("Engineering");
+    add(depatrmentGroup);
     // end::snippet[]
   }
 

--- a/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupLabels.java
+++ b/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupLabels.java
@@ -26,7 +26,7 @@ public class RadioButtonGroupLabels extends VerticalLayout {
     departmentGroup.setLabel("Department");
     departmentGroup.setItems("Engineering", "Human Resources", "Marketing");
     departmentGroup.setValue("Engineering");
-    add(depatrmentGroup);
+    add(departmentGroup);
     // end::snippet[]
   }
 


### PR DESCRIPTION
## Description

1. Fixed another batch of typos detected using [`cspell`](https://www.npmjs.com/package/cspell) tool
2. Changed some words to US writing style for consistency:

- `licence` -> `license`
- `organise -> `organize`
- `practise` - `practice`

## Type of change

- Docs