### PR TITLE
Use `latest`, not `prerelease` for Flow tutorial download

### DIFF
--- a/articles/flow/tutorial/project-setup.adoc
+++ b/articles/flow/tutorial/project-setup.adoc
@@ -32,7 +32,7 @@ https://start.vaadin.com/?preset=flow-crm-tutorial&preset=partial-prerelease&dl
 endif::[]
 
 ifndef::print[]
-https://start.vaadin.com/?preset=flow-crm-tutorial&preset=partial-prerelease&dl[Download starter^,role="button primary water"]
+https://start.vaadin.com/?preset=flow-crm-tutorial&preset=partial-latest&dl[Download starter^,role="button primary water"]
 endif::[]
 
 == Importing a Maven Project Into IntelliJ


### PR DESCRIPTION
Latest was using `prerelease` when we had separate V21 and latest branches. Now it needs to point to latest. 