### PR TITLE
docs: add tabindex limitation to upgrading guide

### DIFF
--- a/articles/ds/upgrading.asciidoc
+++ b/articles/ds/upgrading.asciidoc
@@ -39,6 +39,8 @@ Most of the changes are caused by accessibility fixes to field components like <
 
 - Updated components that support validation to use the https://github.com/vaadin/web-components/pull/2624[`required-indicator`] part.
 
+- Removed support for using https://github.com/vaadin/web-components/issues/3275[positive `tabindex` attribute] on field components.
+
 - Custom themes should be updated to not rely on `:empty` CSS selector:
 
 [source,diff]


### PR DESCRIPTION
## Description

As described in https://github.com/vaadin/web-components/issues/3275#issuecomment-1014517409, one regression that we didn't consider when switching to slotted `<input>` is the fact that it breaks setting `tabindex` attribute with positive value. This PR is intended to document it.

## Type of change

- Docs