### PR TITLE
Added info for TestBench 8/Quarkus guava dependency conflict

### DIFF
--- a/articles/flow/integrations/quarkus.asciidoc
+++ b/articles/flow/integrations/quarkus.asciidoc
@@ -169,3 +169,30 @@ pass:[<!-- vale Vale.Spelling = NO -->]
 pass:[<!-- vale Vale.Terms = NO -->]
 [NOTE]
 When running in development mode (quarkus:dev), changes in Java or front-end files compile after saving and will show up after the browser page is refreshed.
+
+[[quarkus.vaadin.knownissues]]
+== Known issues
+
+Quarkus BOM pins google guava library to a version that conflicts with Vaadin TestBench 8+, resulting in test failures due to changes in method signatures.
+This can be fixed by adding an explicit entry for guava version `31.0.1-jre` in the dependency management section of project POM file immediately above the reference to quarkus BOM.
+
+[source,xml]
+---
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bom</artifactId>
+            <version>${quarkus.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        ...
+    </dependencies>
+</dependencyManagement>
+---

--- a/articles/flow/integrations/quarkus.asciidoc
+++ b/articles/flow/integrations/quarkus.asciidoc
@@ -171,7 +171,7 @@ pass:[<!-- vale Vale.Terms = NO -->]
 When running in development mode (quarkus:dev), changes in Java or front-end files compile after saving and will show up after the browser page is refreshed.
 
 [[quarkus.vaadin.knownissues]]
-== Known issues
+== Known Issues
 
 Quarkus BOM pins google guava library to a version that conflicts with Vaadin TestBench 8+, resulting in test failures due to changes in method signatures.
 This can be fixed by adding an explicit entry for guava version `31.0.1-jre` in the dependency management section of project POM file immediately above the reference to quarkus BOM.

--- a/articles/flow/integrations/quarkus.asciidoc
+++ b/articles/flow/integrations/quarkus.asciidoc
@@ -173,11 +173,11 @@ When running in development mode (quarkus:dev), changes in Java or front-end fil
 [[quarkus.vaadin.knownissues]]
 == Known Issues
 
-Quarkus BOM pins google guava library to a version that conflicts with Vaadin TestBench 8+, resulting in test failures due to changes in method signatures.
-This can be fixed by adding an explicit entry for guava version `31.0.1-jre` in the dependency management section of project POM file immediately above the reference to quarkus BOM.
+Quarkus BOM pins Google Guava library to a version that conflicts with Vaadin TestBench 8 and later, resulting in test failures because of changes in method signatures.
+This can be fixed by adding an explicit entry for Guava version `31.0.1-jre` in the dependency management section of the project’s [filename]#pom.xml# file, immediately above the reference to Quarkus BOM.
 
 [source,xml]
----
+----
 <dependencyManagement>
     <dependencies>
         <dependency>
@@ -195,4 +195,4 @@ This can be fixed by adding an explicit entry for guava version `31.0.1-jre` in 
         ...
     </dependencies>
 </dependencyManagement>
----
+----


### PR DESCRIPTION
## Description

TestBench requires guava 31.0.1-jre, but Quarkus BOM pins a prior version.
The more recent version must be added in project POM dependency management section.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
