### PR TITLE
docs: add theme variants section for map component

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -7,6 +7,7 @@ autorun
 autowir(e|ed|ing)
 [bB]oldens
 [bB]oolean
+[bB]orderless
 [bB]reakpoints?
 [bB]undlers?
 [cC]acheable

--- a/articles/ds/components/map/index.asciidoc
+++ b/articles/ds/components/map/index.asciidoc
@@ -255,6 +255,25 @@ include::{root}/src/main/java/com/vaadin/demo/component/map/MapEvents.java[rende
 ----
 --
 
+== Theme Variants
+
+=== Borderless
+
+By default, Map has a visible, rounded border. The border can be removed by using the `borderless` theme variant.
+
+[.example]
+--
+[source,typescript]
+----
+include::{root}/frontend/demo/component/map/map-theme-borderless.ts[preimport,hidden]
+----
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java[render,tags=snippet,indent=0,group=Java]
+----
+--
+
 == Feature Flag
 
 In order to use Map, it must be explicitly enabled with a feature flag. There are two methods to do so:

--- a/frontend/demo/component/map/map-theme-borderless.ts
+++ b/frontend/demo/component/map/map-theme-borderless.ts
@@ -1,0 +1,4 @@
+import 'Frontend/demo/init';
+import '@vaadin/map';
+
+// This file only has the required imports for the Java-only example

--- a/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java
@@ -4,6 +4,7 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.flow.routing.Route;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.map.Map;
+import com.vaadin.flow.component.map.MapVariant;
 
 @Route("map-theme-borderless")
 public class MapThemeBorderless extends Div {
@@ -12,7 +13,7 @@ public class MapThemeBorderless extends Div {
         Map map = new Map();
         add(map);
         // tag::snippet[]
-        map.setThemeName("borderless");
+        map.addThemeVariants(MapVariant.BORDERLESS);
         // end::snippet[]
     }
 

--- a/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java
@@ -1,0 +1,20 @@
+package com.vaadin.demo.component.map;
+
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+import com.vaadin.demo.flow.routing.Route;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.map.Map;
+
+@Route("map-theme-borderless")
+public class MapThemeBorderless extends Div {
+
+    public MapThemeBorderless() {
+        Map map = new Map();
+        add(map);
+        // tag::snippet[]
+        map.setThemeName("borderless");
+        // end::snippet[]
+    }
+
+    public static class Exporter extends DemoExporter<MapThemeBorderless> {} // hidden-source-line
+}


### PR DESCRIPTION
## Description

Adds a theme variants section to the map component docs, demonstrating the borderless theme variant.

Depends on https://github.com/vaadin/flow-components/pull/2694
