### PR TITLE
docs: Fix endpoint mapping property name

### DIFF
--- a/articles/advanced/endpoints-urls.asciidoc
+++ b/articles/advanced/endpoints-urls.asciidoc
@@ -53,7 +53,7 @@ The endpoint name and the method name are not case-sensitive in Hilla, so the UR
 Hilla allows you to configure the following parts of the URL:
 
 * `${prefix}` &ndash; The default value is `connect`.
-To change it to some other value, provide an [filename]#application.properties# file in the project resources ([filename]#src/main/resources/application.properties#) and set the `vaadin.connect.prefix` property to the new value.
+To change it to some other value, provide an [filename]#application.properties# file in the project resources ([filename]#src/main/resources/application.properties#) and set the `vaadin.endpoint.prefix` property to the new value.
 
 * `${endpoint_name}` &ndash; By default, the simple name of the Java class is taken.
 It is possible to specify a value in the `@Endpoint` annotation to override default one (`@Endpoint("customName")`).


### PR DESCRIPTION
## Description

Updating documentation for endpoint URL configuration to reference current `vaadin.endpoint.prefix` property instead of previous `vaadin.connect.prefix`.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
