### PR TITLE
Removal of accessibility warning for FormLayout

### DIFF
--- a/articles/ds/components/form-layout/index.asciidoc
+++ b/articles/ds/components/form-layout/index.asciidoc
@@ -119,10 +119,6 @@ Inconsistent spacing can cause slower completion rates.
 Forms using this position require more horizontal space which isn't always ideal in narrow forms.
 It's recommended to configure Form Layout to use top-positioned labels when the form's width is small.
 
-.Accessibility
-[CAUTION]
-Form Item suffers from two accessibility issues: required indicators cannot be displayed and screen readers are unable to announce a field's label.
-
 === Responsive Label Position
 
 Like the number of columns, *the label position is configurable based on the layout's width*.


### PR DESCRIPTION
FormLayout docs have a warning about accessibility issues with FormItem. As these issues have now been fixed, this PR removes the warning.