### PR TITLE
Docs/upgrade guide fixes to component notes

### DIFF
--- a/articles/upgrading/flow/_21-22.adoc
+++ b/articles/upgrading/flow/_21-22.adoc
@@ -1,1 +1,9 @@
-- Vaadin Flow doesn't involve any API breaking changes between versions 21 and 22. See the release notes at https://github.com/vaadin/platform/releases/tag/22.0.0.
+[discrete]
+===== Input fields: Removed support for tabindex > 0
+
+The following general changes have been made to all input field components:
+
+* https://github.com/vaadin/web-components/issues/3275[Removed support for using positive tabindex values] (for example, `setTabIndex(1)`) on all input field components. 
+This will not cause errors but has no effect.
+However, setting tabindex to `0` or `-1` is still supported.
+It is recommended to ensure that input fields are in the correct order in the DOM, instead of overriding the tab order with tabindex.

--- a/articles/upgrading/styling/_21-22.adoc
+++ b/articles/upgrading/styling/_21-22.adoc
@@ -3,6 +3,7 @@
 
 
 [discrete]
+[[input-field-components, input field components]]
 ==== Input field components
 
 These changes apply to all input field components, with the exception of Checkbox. Please see sections for individual components for details and other component-specific changes.
@@ -112,14 +113,14 @@ Unlike most input field components, Checkboxes and Radio Buttons no longer have 
 [discrete]
 ==== Checkbox Group
 
-See changes common to all <<Input field components>>.
+See changes common to all <<input-field-components>>.
 
 
 
 [discrete]
 ==== Combo Box
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<input-field-components>>.
 * See changes to <<styling-text-field>>, as these also apply to Combo Box.
 
 [discrete]
@@ -163,7 +164,7 @@ Depending on the editor position, styles for the CRUD’s editor should now targ
 [discrete]
 ==== Date Picker
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<input-field-components>>.
 * See changes to <<styling-text-field>>, as these also apply to Date Picker.
 
 [discrete]
@@ -183,7 +184,7 @@ This component is no longer based on Text Field, so all styles previously applie
 [discrete]
 ==== Date Time Picker
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<input-field-components>>.
 * See changes to <<styling-text-field>>, as these also apply to Date Time Picker.
 
 [discrete]
@@ -245,7 +246,7 @@ Icons are now rendered as `vaadin-icon` elements instead of `iron-icon`.
 [discrete]
 ==== Number Field and Integer Field
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<input-field-components>>.
 * See changes to <<styling-text-field>>, as those also apply to Number Field and Integer Field.
 
 [discrete]
@@ -267,7 +268,7 @@ All styles are still inherited from <<styling-text-field>>, so the same changes 
 [discrete]
 ==== Radio Button Group
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<input-field-components>>.
 * See <<Checkbox and Radio Button>> for changes to Radio Button.
 
 
@@ -275,7 +276,7 @@ All styles are still inherited from <<styling-text-field>>, so the same changes 
 [discrete]
 ==== Select
 
-See changes common to all <<Input field components>>.
+See changes common to all <<input-field-components>>.
 
 [discrete]
 ===== Styles no longer inherited from Text Field
@@ -344,7 +345,7 @@ The color of inactive tabs has been changed from `--lumo-contrast-60pct` to `--l
 [discrete]
 ==== Text Area
 
-See changes common to all <<Input field components>>.
+See changes common to all <<input-field-components>>.
 
 [discrete]
 ===== Slotted native input element
@@ -376,7 +377,7 @@ This also affects selectors for the placeholder text:
 [[styling-text-field]]
 ==== Text Field
 
-See changes common to all <<Input field components>>.
+See changes common to all <<input-field-components>>.
 
 [discrete]
 ===== Other text input components no longer based on Text Field
@@ -423,7 +424,7 @@ Placeholder text now uses the `--lumo-secondary-text-color` color property, inst
 [discrete]
 ==== Time Picker
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<input-field-components>>.
 * See changes to <<styling-text-field>>, as these also apply to Number Field and Integer Field.
 
 [discrete]

--- a/articles/upgrading/styling/_21-22.adoc
+++ b/articles/upgrading/styling/_21-22.adoc
@@ -120,7 +120,7 @@ See changes common to all <<Input field components>>.
 ==== Combo Box
 
 * See changes common to all <<Input field components>>.
-* See changes to <<Text Field>>, as these also apply to Combo Box.
+* See changes to <<styling-text-field>>, as these also apply to Combo Box.
 
 [discrete]
 ===== Styles no longer inherited from Text Field
@@ -164,7 +164,7 @@ Depending on the editor position, styles for the CRUD’s editor should now targ
 ==== Date Picker
 
 * See changes common to all <<Input field components>>.
-* See changes to <<Text Field>>, as these also apply to Date Picker.
+* See changes to <<styling-text-field>>, as these also apply to Date Picker.
 
 [discrete]
 ===== Styles no longer inherited from Text Field
@@ -184,7 +184,7 @@ This component is no longer based on Text Field, so all styles previously applie
 ==== Date Time Picker
 
 * See changes common to all <<Input field components>>.
-* See changes to <<Text Field>>, as these also apply to Date Time Picker.
+* See changes to <<styling-text-field>>, as these also apply to Date Time Picker.
 
 [discrete]
 ===== Styles no longer inherited from Custom Field
@@ -246,7 +246,7 @@ Icons are now rendered as `vaadin-icon` elements instead of `iron-icon`.
 ==== Number Field and Integer Field
 
 * See changes common to all <<Input field components>>.
-* See changes to <<Text Field>>, as those also apply to Number Field and Integer Field.
+* See changes to <<styling-text-field>>, as those also apply to Number Field and Integer Field.
 
 [discrete]
 ===== Styles no longer inherited from Text Field
@@ -260,7 +260,7 @@ This component is no longer based on Text Field, so all styles previously applie
 [discrete]
 ==== Password Field
 
-All styles are still inherited from <<Text Field>>, so the same changes apply to it.
+All styles are still inherited from <<styling-text-field>>, so the same changes apply to it.
 
 
 
@@ -373,6 +373,7 @@ This also affects selectors for the placeholder text:
 
 
 [discrete]
+[[styling-text-field]]
 ==== Text Field
 
 See changes common to all <<Input field components>>.
@@ -423,7 +424,7 @@ Placeholder text now uses the `--lumo-secondary-text-color` color property, inst
 ==== Time Picker
 
 * See changes common to all <<Input field components>>.
-* See changes to <<Text Field>>, as these also apply to Number Field and Integer Field.
+* See changes to <<styling-text-field>>, as these also apply to Number Field and Integer Field.
 
 [discrete]
 ===== Styles no longer inherited from Text Field

--- a/articles/upgrading/typescript/_21-22.adoc
+++ b/articles/upgrading/typescript/_21-22.adoc
@@ -3,7 +3,7 @@
 
 
 [discrete]
-===== Input field components
+===== Input fields: Removed support for tabindex > 0
 
 The following general changes have been made to all input field components:
 


### PR DESCRIPTION
Links to the "Input field components" section in the Upgrading guide are still broken. This is yet another attempt to fix it.