### PR TITLE
Yet another attempt to fix links to Input Field Components section

### DIFF
--- a/articles/upgrading/styling/_21-22.adoc
+++ b/articles/upgrading/styling/_21-22.adoc
@@ -3,6 +3,7 @@
 
 
 [discrete]
+[[styling-input-field-components, input field components]]
 ==== Input Field Components
 
 These changes apply to all input field components, except Checkbox.
@@ -117,14 +118,14 @@ Unlike most input field components, Checkboxes and Radio Buttons no longer have 
 [discrete]
 ==== Checkbox Group
 
-See changes common to all <<Input field components>>.
+See changes common to all <<styling-input-field-components>>.
 
 
 
 [discrete]
 ==== Combo Box
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<styling-input-field-components>>.
 * See changes to <<styling-text-field>>, as these also apply to Combo Box.
 
 [discrete]
@@ -168,7 +169,7 @@ Depending on the editor position, styles for the CRUD’s editor should now targ
 [discrete]
 ==== Date Picker
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<styling-input-field-components>>.
 * See changes to <<styling-text-field>>, as these also apply to Date Picker.
 
 [discrete]
@@ -188,7 +189,7 @@ This component is no longer based on Text Field, so all styles previously applie
 [discrete]
 ==== Date Time Picker
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<styling-input-field-components>>.
 * See changes to <<styling-text-field>>, as these also apply to Date Time Picker.
 
 [discrete]
@@ -250,7 +251,7 @@ Icons are now rendered as `vaadin-icon` elements instead of `iron-icon`.
 [discrete]
 ==== Number Field and Integer Field
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<styling-input-field-components>>.
 * See changes to <<styling-text-field>>, as those also apply to Number Field and Integer Field.
 
 [discrete]
@@ -272,7 +273,7 @@ All styles are still inherited from <<styling-text-field>>, so the same changes 
 [discrete]
 ==== Radio Button Group
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<styling-input-field-components>>.
 * See <<Checkbox and Radio Button>> for changes to Radio Button.
 
 
@@ -280,7 +281,7 @@ All styles are still inherited from <<styling-text-field>>, so the same changes 
 [discrete]
 ==== Select
 
-See changes common to all <<Input field components>>.
+See changes common to all <<styling-input-field-components>>.
 
 [discrete]
 ===== Styles No Longer Inherited From Text Field
@@ -349,7 +350,7 @@ The color of inactive tabs has been changed from `--lumo-contrast-60pct` to `--l
 [discrete]
 ==== Text Area
 
-See changes common to all <<Input field components>>.
+See changes common to all <<styling-input-field-components>>.
 
 [discrete]
 ===== Slotted Native Input Element
@@ -381,7 +382,7 @@ This also affects selectors for the placeholder text:
 [[styling-text-field]]
 ==== Text Field
 
-See changes common to all <<Input field components>>.
+See changes common to all <<styling-input-field-components>>.
 
 [discrete]
 ===== Other Text Input Components No Longer Based on Text Field
@@ -428,7 +429,7 @@ Placeholder text now uses the `--lumo-secondary-text-color` color property, inst
 [discrete]
 ==== Time Picker
 
-* See changes common to all <<Input field components>>.
+* See changes common to all <<styling-input-field-components>>.
 * See changes to <<styling-text-field>>, as these also apply to Number Field and Integer Field.
 
 [discrete]

--- a/articles/upgrading/styling/_21-22.adoc
+++ b/articles/upgrading/styling/_21-22.adoc
@@ -315,7 +315,7 @@ The selection checkmarks in them have been moved to their own shadow parts:
 ----
 
 [discrete]
-===== Value displayed in field
+===== Value Displayed in Field
 The value displayed in the field uses the new item element too, and is now a child of a new `vaadin-select-value-button` internal component, and is easiest to access as a regular child element of Select:
 [source,css]
 ----


### PR DESCRIPTION
Links to the "Input field components" section in the Upgrade Guide are still broken. This is yet another attempt to fix them.