### PR TITLE
Store update config in URL

### DIFF
--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -54,7 +54,8 @@ This is the description of the classnames:
 [class*=flow]:is(div, .openblock, h3), 
 [class*=fusion]:is(div, .openblock, h3), 
 [class*=spring]:is(div, .openblock, h3), 
-[class*=ts]:is(div, .openblock, h3)
+[class*=ts]:is(div, .openblock, h3),
+[class*=styling]:is(div, .openblock, h3)
 {
     display: none;
 }

--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -46,15 +46,15 @@ This is the description of the classnames:
 
 ++++
 <style>
-[class*=all]:is(div, .openblock), 
-[class*=v1]:is(div, .openblock),
-[class*=v2]:is(div, .openblock),
-[class*=v3]:is(div, .openblock),
-[class*=v4]:is(div, .openblock),
-[class*=flow]:is(div, .openblock), 
-[class*=fusion]:is(div, .openblock), 
-[class*=spring]:is(div, .openblock), 
-[class*=ts]:is(div, .openblock)
+[class*=all]:is(div, .openblock, h3), 
+[class*=v1]:is(div, .openblock, h3),
+[class*=v2]:is(div, .openblock, h3),
+[class*=v3]:is(div, .openblock, h3),
+[class*=v4]:is(div, .openblock, h3),
+[class*=flow]:is(div, .openblock, h3), 
+[class*=fusion]:is(div, .openblock, h3), 
+[class*=spring]:is(div, .openblock, h3), 
+[class*=ts]:is(div, .openblock, h3)
 {
     display: none;
 }
@@ -62,6 +62,7 @@ This is the description of the classnames:
 ++++
 
 [.all]
+[discrete]
 === Before You Start
 
 [.all]
@@ -75,6 +76,7 @@ include::common/_before-upgrade-spring.adoc[]
 --
 
 [.v14-15]
+[discrete]
 === Upgrade Steps | 14 -> 15
 
 [.flow]
@@ -88,6 +90,7 @@ include::fusion/_14-15.adoc[]
 --
 
 [.v15-16]
+[discrete]
 === Upgrade Steps | 15 -> 16
 
 [.flow.fusion]
@@ -96,6 +99,7 @@ include::common/_15-16.adoc[]
 --
 
 [.v16-17]
+[discrete]
 === Upgrade Steps | 16 -> 17
 
 [.flow.fusion]
@@ -104,6 +108,7 @@ include::common/_16-17.adoc[]
 --
 
 [.v17-18]
+[discrete]
 === Upgrade Steps | 17 -> 18
 
 [.ts]
@@ -122,6 +127,7 @@ include::fusion/_17-18.adoc[]
 --
 
 [.v18-19]
+[discrete]
 === Upgrade Steps | 18 -> 19
 
 [.flow]
@@ -135,6 +141,7 @@ include::fusion/_18-19.adoc[]
 --
 
 [.v19-20]
+[discrete]
 === Upgrade Steps | 19 -> 20
 
 [.flow]
@@ -148,6 +155,7 @@ include::fusion/_19-20.adoc[]
 --
 
 [.v20-21]
+[discrete]
 === Upgrade Steps | 20 -> 21
 
 [.ts]
@@ -166,6 +174,7 @@ include::fusion/_20-21.adoc[]
 --
 
 [.v21-22]
+[discrete]
 === Upgrade Steps | 21 -> 22
 
 [.ts]
@@ -189,6 +198,7 @@ include::styling/_21-22.adoc[]
 --
 
 [.v22-23]
+[discrete]
 === Upgrade Steps | 22 -> 23
 
 [.flow.fusion]
@@ -207,7 +217,8 @@ include::fusion/_22-23.adoc[]
 --
 
 [.all]
-=== After you finish
+[discrete]
+=== After You Finish
 
 [.all]
 --

--- a/frontend/demo/upgrade-tool/upgrade-tool.ts
+++ b/frontend/demo/upgrade-tool/upgrade-tool.ts
@@ -341,7 +341,8 @@ export default class UpgradeTool extends LitElement {
     urlParams.set('isCustomStyling', String(this.isCustomStyling));
     urlParams.set('isInstructionsDisplayed', String(this.isInstructionsDisplayed));
 
-    window.history.replaceState({}, '', `${location.pathname}?${urlParams}`);
+    const pathname = location.pathname.replace(/\/$/, '');
+    window.history.replaceState({}, '', `${pathname}/?${urlParams}`);
   }
 
   private getParamVal(urlParams: URLSearchParams, param: string) {

--- a/frontend/demo/upgrade-tool/upgrade-tool.ts
+++ b/frontend/demo/upgrade-tool/upgrade-tool.ts
@@ -46,15 +46,17 @@ export default class UpgradeTool extends LitElement {
   @state()
   private toVersion = '';
   @state()
-  private frameworkValue = ['flow'];
+  private frameworkValue: string[] = [];
   @state()
-  private extraSettingsValue = ['spring'];
+  private extraSettingsValue: string[] = [];
 
   private isFlow = true;
   private isFusion = false;
   private isSpring = true;
-  private isTypeScript = true;
+  private isTypeScript = false;
   private isCustomStyling = false;
+  private isInstructionsDisplayed = false;
+  private isFirstUpdated = false;
 
   render() {
     return html`
@@ -166,6 +168,9 @@ export default class UpgradeTool extends LitElement {
     if (this.isFusion) {
       this.showElementsWithClassname('fusion');
     }
+
+    this.isInstructionsDisplayed = true;
+    this.updateUrlParameters();
   }
 
   private showElementsWithClassname(classname: string) {
@@ -207,6 +212,8 @@ export default class UpgradeTool extends LitElement {
         "[class*='all'], [class*='flow'], [class*='fusion'], [class*='spring'], [class*='ts'], [class*='styling'], [class*='v1'], [class*='v2'], [class*='v3'], [class*='v4']"
       )
       .forEach((elem) => this.setElementVisible(<HTMLElement>elem, false));
+
+    this.isInstructionsDisplayed = false;
   }
 
   private replaceHardCodedVersions() {
@@ -263,19 +270,27 @@ export default class UpgradeTool extends LitElement {
   }
 
   private fromVersionChanged(e: SelectValueChangedEvent) {
+    if (!this.isFirstUpdated) return;
+
     const val = e.detail.value;
     if (parseInt(val) >= parseInt(this.toVersion)) {
       const idx = SIMPLE_VERSIONS.indexOf(val);
       this.toVersion = SIMPLE_VERSIONS[idx + 1];
     }
     this.fromVersion = val;
+    this.updateUrlParameters();
   }
 
   private toVersionChanged(e: SelectValueChangedEvent) {
+    if (!this.isFirstUpdated) return;
+
     this.toVersion = e.detail.value;
+    this.updateUrlParameters();
   }
 
   private frameworkChanged(e: CheckboxGroupValueChangedEvent) {
+    if (!this.isFirstUpdated) return;
+
     const val = e.detail.value;
     this.frameworkValue = val;
 
@@ -294,15 +309,68 @@ export default class UpgradeTool extends LitElement {
     } else {
       this.isFusion = false;
     }
+
+    this.updateUrlParameters();
   }
 
   private extraSettingsChanged(e: CheckboxGroupValueChangedEvent) {
+    if (!this.isFirstUpdated) return;
+
     const val = e.detail.value;
     this.extraSettingsValue = val;
 
     this.isSpring = val.includes('spring') || this.isFusion;
     this.isTypeScript = val.includes('typescript') || this.isFusion;
     this.isCustomStyling = val.includes('styling');
+
+    this.updateUrlParameters();
+  }
+
+  private updateUrlParameters() {
+    const urlParams = new URLSearchParams(window.location.search);
+    urlParams.set('from', this.fromVersion);
+    urlParams.set('to', this.toVersion);
+    urlParams.set('isFlow', String(this.isFlow));
+    urlParams.set('isFusion', String(this.isFusion));
+    urlParams.set('isSpring', String(this.isSpring));
+    urlParams.set('isTypeScript', String(this.isTypeScript));
+    urlParams.set('isCustomStyling', String(this.isCustomStyling));
+    urlParams.set('isInstructionsDisplayed', String(this.isInstructionsDisplayed));
+
+    window.history.replaceState({}, '', `${location.pathname}?${urlParams}`);
+  }
+
+  private getParamVal(urlParams: URLSearchParams, param: string) {
+    const isParam = urlParams.get(param);
+
+    if (isParam) {
+      const property = Boolean(JSON.parse(isParam));
+      return property;
+    }
+
+    return null;
+  }
+
+  private initializeProperties() {
+    if (this.isFlow) {
+      this.frameworkValue.push('flow');
+    }
+    if (this.isFusion) {
+      this.frameworkValue.push('fusion');
+    }
+
+    if (this.isSpring) {
+      this.extraSettingsValue.push('spring');
+    }
+    if (this.isTypeScript) {
+      this.extraSettingsValue.push('typescript');
+    }
+    if (this.isCustomStyling) {
+      this.extraSettingsValue.push('styling');
+    }
+
+    this.frameworkValue = [...this.frameworkValue];
+    this.extraSettingsValue = [...this.extraSettingsValue];
   }
 
   connectedCallback() {
@@ -310,7 +378,44 @@ export default class UpgradeTool extends LitElement {
   }
 
   firstUpdated() {
-    this.fromVersion = DEFAULT_FROM;
-    this.toVersion = DEFAULT_TO;
+    const urlParams = new URLSearchParams(window.location.search);
+    const fromParam = urlParams.get('from');
+    const toParam = urlParams.get('to');
+
+    fromParam ? (this.fromVersion = fromParam) : (this.fromVersion = DEFAULT_FROM);
+    toParam ? (this.toVersion = toParam) : (this.toVersion = DEFAULT_TO);
+
+    const isFlowParam = this.getParamVal(urlParams, 'isFlow');
+    const isFusionParam = this.getParamVal(urlParams, 'isFusion');
+    const isSpringParam = this.getParamVal(urlParams, 'isSpring');
+    const isTypeScriptParam = this.getParamVal(urlParams, 'isTypeScript');
+    const isCustomStylingParam = this.getParamVal(urlParams, 'isCustomStyling');
+    const isInstructionsDisplayedParam = this.getParamVal(urlParams, 'isInstructionsDisplayed');
+
+    if (isFlowParam != null) {
+      this.isFlow = isFlowParam;
+    }
+    if (isFusionParam != null) {
+      this.isFusion = isFusionParam;
+    }
+    if (isSpringParam != null) {
+      this.isSpring = isSpringParam;
+    }
+    if (isTypeScriptParam != null) {
+      this.isTypeScript = isTypeScriptParam;
+    }
+    if (isCustomStylingParam != null) {
+      this.isCustomStyling = isCustomStylingParam;
+    }
+
+    this.initializeProperties();
+
+    this.isFirstUpdated = true;
+    this.updateUrlParameters();
+
+    if (isInstructionsDisplayedParam) {
+      this.isInstructionsDisplayed = true;
+      this.showUpdateInstructions();
+    }
   }
 }

--- a/frontend/demo/upgrade-tool/upgrade-tool.ts
+++ b/frontend/demo/upgrade-tool/upgrade-tool.ts
@@ -87,7 +87,11 @@ export default class UpgradeTool extends LitElement {
             theme="horizontal"
           >
             <vaadin-checkbox value="flow" label="Flow" id="flow-checkbox"></vaadin-checkbox>
-            <vaadin-checkbox value="fusion" label="Fusion/Hilla" id="fusion-checkbox"></vaadin-checkbox>
+            <vaadin-checkbox
+              value="fusion"
+              label="Fusion/Hilla"
+              id="fusion-checkbox"
+            ></vaadin-checkbox>
           </vaadin-checkbox-group>
         </div>
         <div>


### PR DESCRIPTION
This will enable us to share the upgrade settings for specific versions and configurations more easily. It will also preserve the configuration upon navigating forward and then backward to the tool again. 