### PR TITLE
fix: change server check path for V14 session verification

### DIFF
--- a/frontend/demo/session-verification.ts
+++ b/frontend/demo/session-verification.ts
@@ -18,7 +18,7 @@ const initialListener = ((e: CustomEvent<string>) => {
   // Make sure flow example is upgraded and requested content from server
   customElements.whenDefined(e.detail).then(() => {
     // Make sure server is up and running
-    fetch(withPrefix('/vaadin/index.html')).then((serverData) => {
+    fetch(withPrefix('/vaadin/?v-r=uidl')).then((serverData) => {
       if (serverData.ok) {
         window.addEventListener('included-example-loaded', () => testHeartbeat());
         testHeartbeat();


### PR DESCRIPTION
Seems there's a difference in how the V23 and V14 versions respond to the current server online check:

https://vaadin.com/docs/latest/vaadin/index : 200

https://vaadin.com/docs/v14/vaadin/index : 404

Change the path to something that returns 200 on V14