### PR TITLE
Remove mention of AppShellRegistry::getTitle

### DIFF
--- a/articles/v14-23-upgrade/essential-steps/instructions/_common.adoc
+++ b/articles/v14-23-upgrade/essential-steps/instructions/_common.adoc
@@ -73,7 +73,6 @@ see <<{articles}/flow/advanced/modifying-the-bootstrap-page#java-annotations, se
 
 A set of API breaking changes and their replacements are listed below:
 
-- `AppShellRegistry` method `getTitle()` is now removed.
 - `AbstractListDataView` now requires an extra constructor argument - a callback, which is invoked each time when the component's filter and/or sorting changes through the data view API.
 - Property synchronization methods in `Element` are replaced with similar API in `DomListenerRegistration`: `getSynchronizedPropertyEvents`, `getSynchronizedProperties`, `removeSynchronizedPropertyEvent`, `removeSynchronizedProperty`, `addSynchronizedPropertyEvent`, `addSynchronizedProperty`,  `synchronizeProperty`.
 - Methods `JsModule#loadMode()` and `Page#addJsModule(String, LoadMode)` for setting the load mode of JsModule are removed since it does not function with JavaScript modules.


### PR DESCRIPTION
V14 does not have class AppShellRegistry, 
so this is not an issue.


