### PR TITLE
Remove link to gitpod from quick start tutorial

### DIFF
--- a/articles/flow/guide/quick-start.adoc
+++ b/articles/flow/guide/quick-start.adoc
@@ -23,13 +23,10 @@ In this guide, you learn how to build a small but fully functional ToDo applicat
 <p>
 <a href="https://start.vaadin.com/dl?preset=flow-quickstart-tutorial" class="button primary water quickstart-download-project"
  onClick="function test(){ _hsq && _hsq.push(['trackEvent', { id: '000007517662', value: null }]); } test(); return true;">Download</a>
-<span>&nbsp;</span>
-<a href="https://gitpod.io/#https://github.com/vaadin/flow-quickstart-tutorial" class="button secondary water" target="_blank" rel="noreferrer noopener">Open in online IDE</a>
 </p>
 ++++
 
 Unpack the downloaded `ZIP` file into a folder on your computer, and <<./step-by-step/importing#, import the project into the IDE of your choice>>.
-Alternatively, open the project in an online IDE.
 
 == Step 2: Add Your Code
 


### PR DESCRIPTION
Let's test removing the gitpod link for few weeks to see whether it has any positive or negative changes on the performance of this page. I speculate that the gitpod link might actually be distracting as users are not used to online IDEs in general, and on VS Code-like IDEs in particular. 