### PR TITLE
Fixed incorrect Route import in Map samples.

### DIFF
--- a/src/main/java/com/vaadin/demo/component/map/MapBasic.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapBasic.java
@@ -1,7 +1,7 @@
 package com.vaadin.demo.component.map;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
-import com.vaadin.demo.flow.routing.Route;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.map.Map;
 

--- a/src/main/java/com/vaadin/demo/component/map/MapEvents.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapEvents.java
@@ -1,7 +1,7 @@
 package com.vaadin.demo.component.map;
 
 import com.vaadin.demo.DemoExporter;
-import com.vaadin.demo.flow.routing.Route;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Coordinate;
 import com.vaadin.flow.component.map.configuration.Extent;

--- a/src/main/java/com/vaadin/demo/component/map/MapLayers.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapLayers.java
@@ -1,7 +1,7 @@
 package com.vaadin.demo.component.map;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
-import com.vaadin.demo.flow.routing.Route;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.layer.Layer;

--- a/src/main/java/com/vaadin/demo/component/map/MapMarkers.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapMarkers.java
@@ -1,7 +1,7 @@
 package com.vaadin.demo.component.map;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
-import com.vaadin.demo.flow.routing.Route;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.map.Map;

--- a/src/main/java/com/vaadin/demo/component/map/MapSources.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapSources.java
@@ -1,7 +1,7 @@
 package com.vaadin.demo.component.map;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
-import com.vaadin.demo.flow.routing.Route;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.layer.TileLayer;
 import com.vaadin.flow.component.map.configuration.source.OSMSource;

--- a/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java
@@ -1,7 +1,7 @@
 package com.vaadin.demo.component.map;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
-import com.vaadin.demo.flow.routing.Route;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.MapVariant;

--- a/src/main/java/com/vaadin/demo/component/map/MapViewport.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapViewport.java
@@ -1,7 +1,7 @@
 package com.vaadin.demo.component.map;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
-import com.vaadin.demo.flow.routing.Route;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;


### PR DESCRIPTION
Some Map component samples were importing `com.vaadin.demo.flow.routing.Route` instead of `com.vaadin.flow.router.Route`.