### PR TITLE
Add support menu item to hilla nav

### DIFF
--- a/dspublisher/theme/global.css
+++ b/dspublisher/theme/global.css
@@ -233,9 +233,17 @@ dspublisher-header {
 }
 
 .hilla-header--nav {
+  margin-left: 1.5rem;
   list-style: none;
   display: flex;
   align-items: center;
+  overflow-x: auto;
+}
+
+@media (min-width: 768px) {
+  .hilla-header--nav {
+    overflow: hidden;
+  }
 }
 
 .hilla-header--nav > li > a {

--- a/dspublisher/theme/header.ts
+++ b/dspublisher/theme/header.ts
@@ -11,6 +11,10 @@ export default class Example extends LitElement {
       label: 'Docs',
     },
     {
+      href: '/support',
+      label: 'Support',
+    },
+    {
       href: '/blog',
       label: 'Blog',
     },


### PR DESCRIPTION
We are adding a new menu item "Support" to Hilla website. I know `overflow-x: auto` is a lousy mobile nav workaround but hope it is ok for now.