### PR TITLE
docs: remove fixed vaadin version from the upgrade guide

### DIFF
--- a/articles/v14-23-upgrade/essential-steps/instructions/_common.adoc
+++ b/articles/v14-23-upgrade/essential-steps/instructions/_common.adoc
@@ -3,8 +3,7 @@
 
 * Delete the `node_modules` folder and either lock file: `package-lock.json` (with npm) or `pnpm-lock.yaml` (with pnpm)
 
-* Edit the `pom.xml` file and change the Vaadin version to `23.0.2`.
-
+* Edit the `pom.xml` file and change the Vaadin version to the latest Vaadin 23 version available.
 
 == Update to Java 11
 


### PR DESCRIPTION
The version number in the asciidoc doesn't get updated automatically.

Another option would be to use `...change the Vaadin version to {moduleMavenVersion:com.vaadin:vaadin}` but then the version would automatically get bumped to the next major (24, sometime in the future) together with the docs project.