### PR TITLE
docs: improve chart plot options documentation

### DIFF
--- a/articles/ds/components/charts/configuration.asciidoc
+++ b/articles/ds/components/charts/configuration.asciidoc
@@ -118,7 +118,7 @@ NOTE: GaugeOptions should not be combined with other plot options.
 
 NOTE: Gauge and solid gauge series should not be combined with series of other types.
 
-NOTE: A bar series inverts the entire chart, combine with care.
+NOTE: A bar series inverts the entire chart; combine with care.
 
 Common options for specific types of charts are extracted into base classes, which allows defining options for a range of chart types.
 For example, to set the same [propertyname]`lineWidth` for [classname]`PlotOptionsLine` and [classname]`PlotOptionsSpline`, the common [classname]`PointOptions` base class can be used:

--- a/articles/ds/components/charts/configuration.asciidoc
+++ b/articles/ds/components/charts/configuration.asciidoc
@@ -44,32 +44,75 @@ For styling, see <<css-styling#css.styling,"CSS Styling">>
 [[charts.configuration.plotoptions]]
 == Plot Options
 
-The plot options are used to configure the data series in the chart.
-Plot options can be set in the configuration of the entire chart or for each data series separately with [methodname]`setPlotOptions()`.
-When the plot options are set to the entire chart, it will be applied to all the series in the chart.
+Plot options are used to configure the data series in a chart.
+They control how series are displayed (color, border, opacity, ...), and how they behave (stacking, grouping, tooltips, ...).
 
-For example, the following enables stacking in column charts:
+Plot options can be set for the entire chart, or for individual data series, using [methodname]`setPlotOptions()`.
+When the plot options are set for the entire chart, they are applied to all the series in the chart.
+For the Chart itself, multiple plot options can be added using [methodname]`addPlotOptions()`.
+
+For example, to disable animations for all series, the plot options are set for the chart:
 
 [source,java]
 ----
 Chart chart = new Chart();
 Configuration configuration = chart.getConfiguration();
-PlotOptionsColumn plotOptions = new PlotOptionsColumn();
-plotOptions.setStacking(Stacking.NORMAL);
+PlotOptionsSeries plotOptions = new PlotOptionsSeries();
+plotOptions.setAnimation(false);
 configuration.setPlotOptions(plotOptions);
 ----
 
-Chart can contain multiple plot options which can be added dynamically with [methodname]`addPlotOptions()`.
-
-The developer can specify also the plot options for the particular data series as follows:
+Alternatively, to disable animations for a specific series:
 
 [source,java]
 ----
 ListSeries series = new ListSeries(50, 60, 70, 80);
-PlotOptionsColumn plotOptions = new PlotOptionsColumn();
-plotOptions.setStacking(Stacking.NORMAL);
+PlotOptionsSeries plotOptions = new PlotOptionsSeries();
+plotOptions.setAnimation(false);
 series.setPlotOptions(plotOptions);
 ----
+
+The general [classname]`PlotOptionsSeries` class can be used to apply common options that are valid for all types of charts.
+To apply options that are specific to a certain type of chart, for example an area chart, specific options classes, such as [classname]`PlotOptionsArea`, can be used.
+Setting a specific options class for a series makes that series render as that type of chart.
+For example, setting a [classname]`PlotOptionsLine` on a series makes that series render as a line chart, setting a [classname]`PlotOptionsSpine` renders the series as a spline chart, and so on.
+This allows to create xref:basic-use.asciidoc#charts.basic-use.mixed[mixed type charts].
+
+The following table gives an overview of the available types of plot options classes, and their common base classes:
+
+[cols="1,4"]
+|===
+| Base class | Sub-classes
+
+.4+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/AreaOptions.html[AreaOptions]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsArea.html[PlotOptionsArea]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsArearange.html[PlotOptionsArearange]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsAreaspline.html[PlotOptionsAreaspline]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsAreasplinerange.html[PlotOptionsAreasplinerange]
+
+.3+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/ColumnOptions.html[ColumnOptions]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsBar.html[PlotOptionsBar]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsColumn.html[PlotOptionsColumn]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsColumnrange.html[PlotOptionsColumnrange]
+
+.2+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/GaugeOptions.html[GaugeOptions]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsGauge.html[PlotOptionsGauge]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsSolidgauge.html[PlotOptionsSolidgauge]
+
+.3+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PointOptions.html[PointOptions]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsLine.html[PlotOptionsLine]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsSpline.html[PlotOptionsSpline]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsScatter.html[PlotOptionsScatter]
+
+.2+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PyramidOptions.html[PyramidOptions]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsPyramid.html[PlotOptionsPyramid]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsFunnel.html[PlotOptionsFunnel]
+
+.2+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/OhlcOptions.html[OhlcOptions]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsOhlc.html[PlotOptionsOhlc]
+| https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/model/PlotOptionsCandlestick.html[PlotOptionsCandlestick]
+
+|===
 
 NOTE: GaugeOptions should not be combined with other plot options.
 
@@ -77,25 +120,8 @@ NOTE: Gauge and solid gauge series should not be combined with series of other t
 
 NOTE: A bar series inverts the entire chart, combine with care.
 
-The plot options are defined in type-specific options classes or in a [classname]`PlotOptionsSeries` class which contains general options for all series types.
-Type specific classes are applied to all the series with the same type in the chart.
-If [classname]`PlotOptionsSeries` is used, it will be applied to all the series in the chart regardless of the type.
-
-Chart types are divided into several groups with common properties.
-These groups are presented as abstract classes, that allow to use polymorphism for setting common properties for specific implementations.
-The abstract classes and groups are the following:
-
-* [classname]`AreaOptions` -> [classname]`PlotOptionsArea`, [classname]`PlotOptionsArearange`,
-[classname]`PlotOptionsAreaspline`, [classname]`PlotOptionsAreasplinerange`
-* [classname]`ColumnOptions` -> [classname]`PlotOptionsBar`, [classname]`PlotOptionsColumn`,
-[classname]`PlotOptionsColumnrange`
-* [classname]`GaugeOptions` -> [classname]`PlotOptionsGauge`, [classname]`PlotOptionsSolidgauge`
-* [classname]`PointOptions` -> [classname]`PlotOptionsLine`, [classname]`PlotOptionsSpline`,
-[classname]`PlotOptionsScatter`
-* [classname]`PyramidOptions` -> [classname]`PlotOptionsPyramid`, [classname]`PlotOptionsFunnel`
-* [classname]`OhlcOptions` -> [classname]`PlotOptionsOhlc`, [classname]`PlotOptionsCandlestick`
-
-For example, to set the same [propertyname]`lineWidth` for [classname]`PlotOptionsLine` and [classname]`PlotOptionsSpline` use [classname]`PointOptions`.
+Common options for specific types of charts are extracted into base classes, which allows defining options for a range of chart types.
+For example, to set the same [propertyname]`lineWidth` for [classname]`PlotOptionsLine` and [classname]`PlotOptionsSpline`, the common [classname]`PointOptions` base class can be used:
 [source,java]
 ----
 private void setCommonProperties(PointOptions options) {
@@ -110,23 +136,35 @@ setCommonProperties(splineOptions);
 configuration.setPlotOptions(lineOptions, splineOptions);
 ----
 
-See the API documentation of each chart type and its plot options class for more information about the chart-specific options.
+See the API documentation of the individual plot options classes for more information about chart-specific options.
 
-[[charts.configuration.plotoptions.other]]
-=== Other Options
+=== Practical Examples
 
-The following options are supported by some chart types.
+.Dynamically setting the color of a series
+[source,java]
+----
+ListSeries series = new ListSeries("Tokyo", 49.9, 71.5, 106.4);
 
-[parameter]#width#:: Defines the width of the chart either by pixels or as a percentual proportion of the drawing area.
-[parameter]#height#:: Defines the height of the chart either by pixels or as a percentual proportion of the drawing area.
-[parameter]#depth#:: Specifies the thickness of the chart in 3D mode.
-[parameter]#allowPointSelect#:: Specifies whether data points, in whatever way they are visualized in the particular chart type, can be selected by clicking on them. Defaults to __false__.
-[parameter]#center#:: Defines the center of the chart within the chart area by left and top coordinates, which can be specified either as pixels or as a percentage (as string) of the drawing area. The default is top 50% and left 50%.
-[parameter]#slicedOffset#:: In chart types that support slices, such as pie and pyramid charts, specifies the offset for how far a slice is detached from other items. The amount is given in pixels and defaults to 10 pixels.
-[parameter]#visible#:: Specifies whether or not a chart is visible. Defaults to __true__.
+PlotOptionsSeries options = new PlotOptionsSeries();
+options.setColor(SolidColor.CORNFLOWERBLUE);
+series.setPlotOptions(options);
+----
 
+.Custom series tooltip as Javascript function
+[source,java]
+----
+ListSeries series = new ListSeries("Tokyo", 49.9, 71.5, 106.4);
 
+SeriesTooltip seriesTooltip = new SeriesTooltip();
+seriesTooltip.setPointFormatter("function() { return this.x + ' km²' }");
 
+PlotOptionsSeries options = new PlotOptionsSeries();
+options.setTooltip(seriesTooltip);
+series.setPlotOptions(options);
+
+// Tooltip element needs to be configured on chart
+chart.setTooltip(new Toolip());
+----
 
 [[charts.configuration.axes]]
 == Axes
@@ -289,10 +327,11 @@ requires redrawing the chart with [methodname]`drawChart()`.
 [[charts.configuration.legend]]
 == Legend
 
-The legend is a box that describes the data series shown in the chart. It is
-enabled by default and is automatically populated with the names of the data
-series as defined in the series objects, and the corresponding color symbol of
-the series.
+The legend is a box that shows all series that are currently visible in the chart.
+Each series is displayed with a text label and a color dot.
+The label's text is determined by the name set in the series object, and the color dot uses the color configured in the series' plot options, or a unique color from a predefined set of colors.
+
+The legend provides the following configuration options:
 
 [parameter]#align#:: Specifies the horizontal alignment of the legend box within the chart area.
 Defaults to [constant]#HorizontalAlign.CENTER#.
@@ -302,6 +341,8 @@ Defaults to [constant]#HorizontalAlign.CENTER#.
 [parameter]#verticalAlign#:: Specifies the vertical alignment of the legend box within the chart area.
 Defaults to [constant]#VerticalAlign.BOTTOM#.
 
+The following example demonstrates how to customize the legend:
+
 [source,java]
 ----
 Legend legend = configuration.getLegend();
@@ -310,8 +351,6 @@ legend.setLayout(LayoutDirection.VERTICAL);
 legend.setAlign(HorizontalAlign.LEFT);
 legend.setVerticalAlign(VerticalAlign.TOP);
 ----
-
-The result can be seen in <<figure.charts.configuration.legend>>.
 
 [[figure.charts.configuration.legend]]
 .Legend example


### PR DESCRIPTION
This PR attempts to improve the plot options documentation in several ways:
- improve introduction to clarify that this is what you want if you are trying to customize how series are displayed
- clarify distinction between setting options on chart vs. series, use more appropriate code snippets
- cleanup section about different types of plot options, use a table for better overview, and add links to API docs
- add some practical examples (snippets only) that came up in real-world support cases, to give an idea what's possible. Addresses this BFP: https://github.com/vaadin/flow-components/issues/2669
- remove "other options" section that explained random options, half of which were wrong or do not exist

This also adds some improvement to the "Legend" section, to clarify how the color dot for series gets its color. Also addresses https://github.com/vaadin/flow-components/issues/2669.


