### PR TITLE
fix: update aria-label logic in Java examples

### DIFF
--- a/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
@@ -24,12 +24,12 @@ public class DateRangePicker extends CustomField<LocalDateRange> {
 
     // aria-label for screen readers
     start.getElement()
-      .executeJs("const start = this.shadowRoot.querySelector('[part=\"text-field\"]').shadowRoot.querySelector('[part=\"value\"]');" +
+      .executeJs("const start = this.inputElement;" +
         "start.setAttribute('aria-label', 'Start date');" +
         "start.removeAttribute('aria-labelledby');"
       );
     end.getElement()
-      .executeJs("const end = this.shadowRoot.querySelector('[part=\"text-field\"]').shadowRoot.querySelector('[part=\"value\"]');" +
+      .executeJs("const end = this.inputElement;" +
         "end.setAttribute('aria-label', 'End date');" +
         "end.removeAttribute('aria-labelledby');"
       );

--- a/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
@@ -25,11 +25,11 @@ public class MoneyField extends CustomField<Money> {
 
     // aria-label for screen readers
     amount.getElement()
-      .executeJs("const amount = this.shadowRoot.querySelector('[part=\"value\"]');" +
+      .executeJs("const amount = this.inputElement;" +
         "amount.setAttribute('aria-label', 'Amount');" +
         "amount.removeAttribute('aria-labelledby');");
     currency.getElement()
-      .executeJs("const currency = this.shadowRoot.querySelector('vaadin-select-text-field').shadowRoot.querySelector('[part=\"input-field\"]');" +
+      .executeJs("const currency = this.focusElement;" +
         "currency.setAttribute('aria-label', 'Currency');" +
         "currency.removeAttribute('aria-labelledby');");
 


### PR DESCRIPTION
## Description

Updated Java examples for `CustomField` to use correct `querySelector` for setting `aria-label` on the slotted input.
TS examples have been updated previously but Java examples still used old, pre-V22 DOM structure.