### PR TITLE
Fix Node installation page

### DIFF
--- a/articles/shared/guide/install/_node-js.asciidoc
+++ b/articles/shared/guide/install/_node-js.asciidoc
@@ -15,7 +15,6 @@ If Node.js is found globally, Vaadin validates that it is a supported version; i
 We recommend using the latest LTS version.
 A project-local installation will always take precedence over a global or `~/.vaadin` installation.
 
-[[node.installation]]
 You can force Node.js installation to the `~/.vaadin` folder via the `require.home.node` property.
 This property sets the Maven `requireHomeNodeExec` parameter value, so you can configure the Maven goal using `<requireHomeNodeExec>true</requireHomeNodeExec>`.
 To force node installation into the home directory in development mode, you should use the `vaadin.require.home.node` system property or the `require.home.node` web init parameter.
@@ -74,6 +73,6 @@ If you are using https://travis-ci.org/[Travis] as a Continuous Integration serv
 . Specify the version via Travis configuration in [filename]#.travis.yml#
 . Install Node.js automatically through Vaadin
 
-Refer to https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions[Specifying Node.js versions] in the Travis documentation for how to specify the Node version via the [filename]#.travis.yml# file.
+Refer to https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions[Specifying Node.js versions] in the Travis documentation for how to specify the Node version via the [filename]`.travis.yml` file.
 
 You can force Node.js installation to the `~/.vaadin` folder, as described in the section <<node.installation>>.

--- a/articles/shared/guide/install/_node-js.asciidoc
+++ b/articles/shared/guide/install/_node-js.asciidoc
@@ -73,6 +73,7 @@ If you are using https://travis-ci.org/[Travis] as a Continuous Integration serv
 . Specify the version via Travis configuration in [filename]#.travis.yml#
 . Install Node.js automatically through Vaadin
 
-Refer to https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions[Specifying Node.js versions] in the Travis documentation for how to specify the Node version via the [filename]`.travis.yml` file.
+Refer to link:https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions[Specifying Node.js versions] in the Travis documentation for how to specify the Node version via the [filename]#.travis.yml# file.
+
 
 You can force Node.js installation to the `~/.vaadin` folder, as described in the section <<node.installation>>.


### PR DESCRIPTION
The shared document is using an id that is already used in` articles/flow/configuration/node-js.asciidoc`. There is also one erroneous display of the filename 

![image](https://user-images.githubusercontent.com/42799254/163331970-cb9c461a-6b9f-4b42-a0f6-5b25046fe0f7.png)
