### PR TITLE
docs: fix broken charts cross-reference

### DIFF
--- a/articles/ds/components/charts/configuration.asciidoc
+++ b/articles/ds/components/charts/configuration.asciidoc
@@ -76,7 +76,7 @@ The general [classname]`PlotOptionsSeries` class can be used to apply common opt
 To apply options that are specific to a certain type of chart, for example an area chart, specific options classes, such as [classname]`PlotOptionsArea`, can be used.
 Setting a specific options class for a series makes that series render as that type of chart.
 For example, setting a [classname]`PlotOptionsLine` on a series makes that series render as a line chart, setting a [classname]`PlotOptionsSpine` renders the series as a spline chart, and so on.
-This allows to create xref:basic-use.asciidoc#charts.basic-use.mixed[mixed type charts].
+This allows to create xref:basic-use#charts.basic-use.mixed[mixed type charts].
 
 The following table gives an overview of the available types of plot options classes, and their common base classes:
 

--- a/articles/ds/components/charts/configuration.asciidoc
+++ b/articles/ds/components/charts/configuration.asciidoc
@@ -76,7 +76,7 @@ The general [classname]`PlotOptionsSeries` class can be used to apply common opt
 To apply options that are specific to a certain type of chart, for example an area chart, specific options classes, such as [classname]`PlotOptionsArea`, can be used.
 Setting a specific options class for a series makes that series render as that type of chart.
 For example, setting a [classname]`PlotOptionsLine` on a series makes that series render as a line chart, setting a [classname]`PlotOptionsSpine` renders the series as a spline chart, and so on.
-This allows to create xref:basic-use#charts.basic-use.mixed[mixed type charts].
+This allows to create <<basic-use#charts.basic-use.mixed, mixed type charts>>.
 
 The following table gives an overview of the available types of plot options classes, and their common base classes:
 


### PR DESCRIPTION
Looks like this warning caused AWS build to fail.

```
2022-04-14T06:52:50.076Z [WARNING]: error Broken cross reference [1m/ds/components/charts/basic-use.asciidoc[0m in ds/components/charts/configuration.asciidoc
```