### PR TITLE
docs: add since admonitions to dialog

### DIFF
--- a/articles/ds/components/dialog/index.asciidoc
+++ b/articles/ds/components/dialog/index.asciidoc
@@ -41,6 +41,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogBasic.java[
 The Dialog component has static header and footer areas, and a scrolling content area in between.
 The header and footer are optional, and automatically hidden if empty and not explicitly enabled.
 
+[role="since:com.vaadin:vaadin@V23.1"]
 === Header
 The header contains an optional title element, and a slot next to it for custom header content, such as a close button.
 
@@ -59,6 +60,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogHeader.java
 ----
 --
 
+[role="since:com.vaadin:vaadin@V23.1"]
 === Footer
 Buttons for closure actions, such as _Save_, _Cancel_, _Delete_, and so on, should be placed in the footer. 
 See <<../button#buttons-in-dialogs,Button>> component for guidelines for the placement of buttons in dialogs. Footer content is right-aligned by default.


### PR DESCRIPTION
We missed to add a note indicating that new features are only supported in pre-release.