### PR TITLE
docs: charts turbo mode

### DIFF
--- a/articles/ds/components/charts/data.asciidoc
+++ b/articles/ds/components/charts/data.asciidoc
@@ -299,3 +299,30 @@ drillDownSeries.add(new DataSeriesItem("MSIE 9.0", 2.81));
 
 series.addItemWithDrilldown(mainItem, drillDownSeries);
 ----
+
+== Turbo Mode
+
+Turbo mode is a feature that optimizes performance of charts with a large amount of data items.
+If a series in the chart contains more data items than the configured turbo threshold, then turbo mode is automatically enabled.
+The default value for the turbo threshold is `1000`.
+While the mode is active, only series containing flat one-dimensional data (numeric y-values), or two-dimensional data (numeric x- and y-values), are allowed.
+That means that some types of series are not compatible with this mode, and they will not render correctly when their number of data items exceeds the configured threshold.
+
+The following series are not compatible with turbo mode:
+
+* `DataSeries`, when using series items that require more than an `x` and a `y` value
+* `HeatSeries`
+* `NodeSeries`
+* `RangeSeries`
+* `TreeSeries`
+
+The turbo threshold, which determines when the turbo mode is activated, can be configured in a series' plot options:
+
+[source,java]
+----
+PlotOptionsSeries options = new PlotOptionsSeries();
+options.setTurboThreshold(2000);
+series.setPlotOptions(options);
+----
+
+Turbo mode can be disabled by setting the turbo threshold to `0`.

--- a/articles/ds/components/charts/data.asciidoc
+++ b/articles/ds/components/charts/data.asciidoc
@@ -305,18 +305,26 @@ series.addItemWithDrilldown(mainItem, drillDownSeries);
 Turbo mode is a feature that optimizes performance of charts with a large amount of data items.
 If a series in the chart contains more data items than the configured turbo threshold, then turbo mode is automatically enabled.
 The default value for the turbo threshold is `1000`.
-While the mode is active, only series containing flat one-dimensional data (numeric y-values), or two-dimensional data (numeric x- and y-values), are allowed.
-That means that some types of series are not compatible with this mode, and they will not render correctly when their number of data items exceeds the configured threshold.
+Turbo mode only works with specific types of series, and other series that are not compatible will not render correctly when their number of data items exceeds the configured threshold.
 
 The following series are not compatible with turbo mode:
 
-* `DataSeries`, when using series items that require more than an `x` and a `y` value
+* `DataSeries`, when adding one of the following series items:
+** `BoxPlotItem`
+** `DataSeriesItem`, when setting any other property than `x` and `y`
+** `DataSeriesItem3d`
+** `DataSeriesItemBullet`
+** `DataSeriesItemTimeline`
+** `DataSeriesItemXrange`
+** `FlagItem`
+** `OhlcItem`, when setting any other property than `x`, `high`, `low`, `open`, `close`
+** `WaterFallSum`
 * `HeatSeries`
 * `NodeSeries`
 * `RangeSeries`
 * `TreeSeries`
 
-The turbo threshold, which determines when the turbo mode is activated, can be configured in a series' plot options:
+The turbo threshold, which determines when the turbo mode is activated, can be configured in a series' or the chart's plot options:
 
 [source,java]
 ----


### PR DESCRIPTION
Adds a section about the charts' turbo mode that explains what it is and how it can be configured or disabled.