### PR TITLE
fix: use correct route for GridPro theme demos

### DIFF
--- a/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightEditableCells.java
+++ b/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightEditableCells.java
@@ -10,7 +10,7 @@ import com.vaadin.demo.domain.DataService;
 
 import java.util.List;
 
-@Route("vaadin-grid-pro-highligh-editable-cells")
+@Route("vaadin-grid-pro-highlight-editable-cells")
 public class GridProThemeHighlightEditableCells extends Div {
 
     public GridProThemeHighlightEditableCells() {
@@ -36,6 +36,3 @@ public class GridProThemeHighlightEditableCells extends Div {
     public static class Exporter extends DemoExporter<GridProStylingEditableCells> { // hidden-source-line
     } // hidden-source-line
 }
-
-
-

--- a/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightReadOnlyCells.java
+++ b/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightReadOnlyCells.java
@@ -10,7 +10,7 @@ import com.vaadin.demo.domain.DataService;
 
 import java.util.List;
 
-@Route("vaadin-grid-pro-highligh-read-only-cells")
+@Route("vaadin-grid-pro-highlight-read-only-cells")
 public class GridProThemeHighlightReadOnlyCells extends Div {
 
     public GridProThemeHighlightReadOnlyCells() {
@@ -36,6 +36,3 @@ public class GridProThemeHighlightReadOnlyCells extends Div {
     public static class Exporter extends DemoExporter<GridProStylingEditableCells> { // hidden-source-line
     } // hidden-source-line
 }
-
-
-


### PR DESCRIPTION
Fixed typo in the route for newly added GridPro theme variants examples.