### PR TITLE
refactor: dsp status improvements

### DIFF
--- a/dspublisher/dspublisher-scripts.js
+++ b/dspublisher/dspublisher-scripts.js
@@ -195,7 +195,7 @@ function clearLines(n) {
  * Logs to console and renders the progress bar.
  */
 function logProgress(state, output) {
-  if (this.progressLogged) {
+  if (this.progressLogged && !process.env.NO_PROGRESS_LOG) {
     // Clear the progress bar
     clearLines(2);
   }
@@ -206,16 +206,18 @@ function logProgress(state, output) {
     process.stdout.write(`${output}`);
   }
 
-  // Build the progress bar
-  const progressBarWidth = 20;
-  const progressBar = `${'█'.repeat(
-    Math.floor((state.progress / totalWeight) * progressBarWidth)
-  )}\x1b[90m${'█'.repeat(
-    progressBarWidth - Math.floor((state.progress / totalWeight) * progressBarWidth)
-  )}\x1b[0m`;
+  if (!process.env.NO_PROGRESS_LOG) {
+    // Build the progress bar
+    const progressBarWidth = 20;
+    const progressBar = `${'█'.repeat(
+      Math.floor((state.progress / totalWeight) * progressBarWidth)
+    )}\x1b[90m${'█'.repeat(
+      progressBarWidth - Math.floor((state.progress / totalWeight) * progressBarWidth)
+    )}\x1b[0m`;
 
-  // Render the state
-  process.stdout.write(`\n${state.name} ${progressBar} ${state.phase}${state.spinner}`);
+    // Render the state
+    process.stdout.write(`\n${state.name} ${progressBar} ${state.phase}${state.spinner}`);
+  }
 }
 
 // Interval for rendering the "spinner"

--- a/dspublisher/dspublisher-scripts.js
+++ b/dspublisher/dspublisher-scripts.js
@@ -6,12 +6,15 @@ const path = require('path');
 
 const DSP_VERSION = '2.0.0-alpha.6';
 
+const firstLaunch = !fs.existsSync(path.resolve(__dirname, '..', 'node_modules'));
+const firstLaunchMessage = firstLaunch ? ' (first launch may take a while)' : '';
+
 // License check helper command
 const LICENSE_CHECK = {
   shell: 'mvn -C -P dspublisher-license-check',
   phases: [
     {
-      text: 'Checking license',
+      text: `Checking license${firstLaunchMessage}`,
       readySignal: 'BUILD SUCCESS',
       doneText: 'License check passed',
       weight: 10,
@@ -27,7 +30,7 @@ const SCRIPTS = {
         shell: `npx @vaadin/dspublisher@${DSP_VERSION} --clean`,
         phases: [
           {
-            text: 'Cleaning up dspublisher cache',
+            text: `Cleaning up dspublisher cache${firstLaunchMessage}`,
             readySignal: 'Successfully deleted directories',
             weight: 5,
           },
@@ -37,7 +40,7 @@ const SCRIPTS = {
         shell: 'mvn -C clean',
         phases: [
           {
-            text: 'Cleaning up project',
+            text: `Cleaning up project${firstLaunchMessage}`,
             readySignal: 'BUILD SUCCESS',
             doneText: 'Ready. Caches cleaned up',
             weight: 5,
@@ -62,19 +65,19 @@ const SCRIPTS = {
         ],
         phases: [
           {
-            text: 'Initializing',
+            text: `Initializing${firstLaunchMessage}`,
             readySignal: 'success building schema',
             weight: 30,
           },
           {
-            text: 'Creating pages',
+            text: `Creating pages${firstLaunchMessage}`,
             readySignal: 'success createPages',
             weight: 15,
           },
           {
             text: 'Building development bundle',
             readySignal: 'You can now view',
-            doneText: 'Ready. Open http://localhost:8000 in the browser.',
+            doneText: 'Ready at http://localhost:8000. Stop the server with Ctrl+C',
             weight: 95,
             lastPhase: true,
           },


### PR DESCRIPTION
This PR adds some improvements to the DSP status bar:
- Shows the used DSP version
- Notes that the "first launch may take a while" on the first run (if `node_modules` is missing)
- Updates the appearance of the progress bar
- Instructs how to stop the dev mode "Stop the server with Ctrl+C'"
- Supports an environment variable `NO_PROGRESS_LOG` for not showing the status bar

<img width="721" alt="Screenshot 2022-05-06 at 12 05 16" src="https://user-images.githubusercontent.com/1222264/167102146-555a9167-7da2-406a-b53f-f9278e8ff158.png">

To test, use the commands:
```shell
node dspublisher/dspublisher-scripts.js --develop
node dspublisher/dspublisher-scripts.js --build
node dspublisher/dspublisher-scripts.js --clean
NO_PROGRESS_LOG=true node dspublisher/dspublisher-scripts.js --develop
```