### PR TITLE
Remove link to vaadin.com/vaadin-8

### DIFF
--- a/articles/upgrading/essential-steps/index.adoc
+++ b/articles/upgrading/essential-steps/index.adoc
@@ -18,8 +18,6 @@ The <<../recommended-changes#,Recommended Changes>> page lists further changes t
 
 * Upgrading from a version prior to Vaadin 14? Follow link:https://vaadin.com/docs/v14/flow/upgrading/[the older guides] to upgrade to V14 first, and then continue with this guide.
 
-* Upgrading from Vaadin 7 or 8? link:https://vaadin.com/vaadin-8/[Here’s a guide about moving forward from V8].
-
 * You can also use components and views developed with Vaadin 7 or 8 inside an application written for the latest version using <<{articles}/tools/mpr/overview#,Multiplatform Runtime>>.
 
 


### PR DESCRIPTION
This link mentions a guide that is not really a guide; it's a marketing page. And in any case, in the point just above that, we are also linking to the migration guides of versions prior to V14 (which include V7 and V8). 