### PR TITLE
fix: import contextMenuTargetConnector manually

### DIFF
--- a/frontend/demo/init-flow-components.ts
+++ b/frontend/demo/init-flow-components.ts
@@ -14,6 +14,7 @@ import '@vaadin/flow-frontend/flow-component-renderer.js';
 // Flow component specific modules
 import '@vaadin/flow-frontend/comboBoxConnector.js';
 import '@vaadin/flow-frontend/contextMenuConnector.js';
+import '@vaadin/flow-frontend/contextMenuTargetConnector.js';
 import '@vaadin/flow-frontend/datepickerConnector.js';
 import '@vaadin/flow-frontend/gridConnector.js';
 import '@vaadin/flow-frontend/vaadin-grid-flow-selection-column.js';


### PR DESCRIPTION
https://github.com/vaadin/flow-components/commit/0edc42b5a25bdb5327c4f0e871289bb5b0c75f04 introduced `contextMenuTargetConnector.js` which was missed to be manually imported in the docs likewise `contextMenuConnector.js`.

Fixes #1376 