### PR TITLE
Add warning about V8 end of life

### DIFF
--- a/articles/framework/tutorial.asciidoc
+++ b/articles/framework/tutorial.asciidoc
@@ -40,6 +40,10 @@ subnav:
 [[framework.tutorial]]
 = Vaadin 8 Tutorial
 
+.Vaadin 8 reached End of Life
+[WARNING]
+If you are just starting with Vaadin, go instead to the https://vaadin.com/docs/latest/flow/guide/quick-start[quick-start tutorial] of the latest stable version.
+
 This tutorial gives you an overview of how you can use https://vaadin.com/framework[Vaadin 8 Framework] to build single-page web UIs for your Java application.
 All you need to start with it is JDK 8 and an https://en.wikipedia.org/wiki/Integrated_development_environment[IDE], such as Eclipse.
 While this tutorial is written for Eclipse users, you can use your IDE of choice.

--- a/articles/framework/tutorial.asciidoc
+++ b/articles/framework/tutorial.asciidoc
@@ -44,7 +44,7 @@ subnav:
 [WARNING]
 If you are just starting with Vaadin, go instead to the https://vaadin.com/docs/latest/flow/guide/quick-start[quick-start tutorial] of the latest stable version.
 
-This tutorial gives you an overview of how you can use https://vaadin.com/framework[Vaadin 8 Framework] to build single-page web UIs for your Java application.
+This tutorial gives you an overview of how you can use the https://vaadin.com/framework[Vaadin 8 Framework] to build single-page web UIs for your Java application.
 All you need to start with it is JDK 8 and an https://en.wikipedia.org/wiki/Integrated_development_environment[IDE], such as Eclipse.
 While this tutorial is written for Eclipse users, you can use your IDE of choice.
 No extensive knowledge of Java is needed, only basic programming skills are required.


### PR DESCRIPTION
For whatever reason, googling "Vaadin tutorial" still delivers users to the V8 tutorial. This PR adds a warning about v8 end of life, and encourages users to go the latest quick-start guide.