### PR TITLE
mention vaadin-jandex for pro components

### DIFF
--- a/articles/flow/integrations/quarkus.asciidoc
+++ b/articles/flow/integrations/quarkus.asciidoc
@@ -57,17 +57,23 @@ For example:
     <!-- The Vaadin Quarkus extension -->
     <dependency>
         <groupId>com.vaadin</groupId>
-        <artifactId>vaadin-quarkus</artifactId>
-        <!-- NOTE: this will come from vaadin-bom when final released -->
-        <version>1.0.0.alpha1</version>
+        <artifactId>vaadin-quarkus-extension</artifactId>
+        <version>${vaadin.version}</version>
     </dependency>
 
-    <!-- This jandex dependency contains Vaadin-core annotation indexes
-         and is used as an offline reflection library. -->
+    <!-- The jandex.idx for Vaadin-core annotation indexes
+         automatically included via vaadin-quarkus-extension
+         and is used as an offline reflection library.
+
+         If you want to work with Pro components such GridPro,
+         you can uncomment the following dependency to include the
+         officially provided jandex.idx for them as well: -->
+    <!--
     <dependency>
         <groupId>com.vaadin</groupId>
-        <artifactId>vaadin-core-jandex</artifactId>
+        <artifactId>vaadin-jandex</artifactId>
     </dependency>
+    -->
 
     <!-- Quarkus always pulls in slf4j-jboss-logmanager
          into target/lib; don't use slf4j-simple -->


### PR DESCRIPTION
Pro components' jandex index is not included in vaadin-core-jandex dependency and the need for manually adding the vaadin-jandex dependency have not been mentioned anywhere.

Fixes: [#flow-components/3135](https://github.com/vaadin/flow-components/issues/3135)

