### PR TITLE
Remove extra spaces from Route template parameters

### DIFF
--- a/articles/flow/routing/templates.asciidoc
+++ b/articles/flow/routing/templates.asciidoc
@@ -12,7 +12,7 @@ At least one segment must be a parameter segment.
 
 Route template parameters must use the following syntax:
 
-``:``_parameter_name[modifier][_``(``_regex_``)``_]_
+_``:parameter_name[modifier][(regex)]``_
 
 where:
 


### PR DESCRIPTION
Remove what appears currently as spaces in the the route template parameters: 

![image](https://user-images.githubusercontent.com/42799254/171986713-e8c81b84-432c-4441-98e4-7d1187dabf77.png)
