### PR TITLE
Clarifying empty wildcard parameter default value

### DIFF
--- a/articles/routing/route-parameters.asciidoc
+++ b/articles/routing/route-parameters.asciidoc
@@ -100,7 +100,7 @@ public class WildcardGreeting extends Div
 ----
 
 Note that more specific route always takes precedence over wildcard route.
-Note also that the wildcard parameter will never be `null`.
+Note also that if no value was passed to the wildcard route parameter, then its value will be an empty String.
 
 == Alternatives to Route Parameters
 


### PR DESCRIPTION
I was not able to find any concrete information regarding this information from the sources below.

https://vaadin.com/api/platform/23.1.0/com/vaadin/flow/router/Route.html
https://vaadin.com/api/platform/23.1.0/com/vaadin/flow/router/WildcardParameter.html

Further confirmation from Vaadin team is needed.


