### PR TITLE
Hilla: update the boolean binding example for `<vaadin-select>`

### DIFF
--- a/articles/data-binding/vaadin-components.asciidoc
+++ b/articles/data-binding/vaadin-components.asciidoc
@@ -102,9 +102,33 @@ render() {
 
 === Binding Data to Boolean Fields
 
-There are three elements in Hilla to deal with booleans: `vaadin-select`, `vaadin-checkbox`, and `vaadin-radio-button`.
+There are three elements in Hilla to deal with booleans: `vaadin-checkbox`, `vaadin-radio-button`, and `vaadin-select`.
 
-The former can be bound to a boolean as in the following snippet:
+The former two work fine with form binders, but neither of them has validation and failure styling.
+Hence, you need to do some extra work to give error feedback.
+In the following snippet, the background color is changed on validation error.
+
+[source,typescript]
+----
+import '@vaadin/checkbox';
+import '@vaadin/radio-button';
+...
+static get styles() {
+  return css`
+    vaadin-checkbox[invalid], vaadin-radio-button[invalid] {
+      background: var(--lumo-error-color-10pct);
+    }`;
+}
+...
+render() {
+  return html`
+  <vaadin-checkbox ${field(this.binder.model.myBooleanField)} label="checkbox"></vaadin-checkbox>
+  <vaadin-radio-button ${field(this.binder.model.myBooleanField)} label="radio-button"></vaadin-radio-button>
+  `;
+}
+----
+
+The latter can be bound to a boolean as in the following snippet:
 
 [source,typescript]
 ----
@@ -119,30 +143,6 @@ import '@vaadin/item';
     <vaadin-item value="false">Value is false</vaadin-item>
   </vaadin-list-box>`)}>
 </vaadin-select>
-----
-
-The latter two work fine with form binders, but neither of them has validation and failure styling.
-Hence, you need to do some extra work to give error feedback.
-In the following snippet, the background color is changed on validation error.
-
-[source,typescript]
-----
-import '@vaadin/checkbox';
-import '@vaadin/radio-button';
-...
-static get styles() {
-  return css`
-    vaadin-checkbox[invalid], vaadin-radio-button[invalid],
-      background: var(--lumo-error-color-10pct);
-    }`;
-}
-...
-render() {
-  return html`
-  <vaadin-checkbox ${field(this.binder.model.myBooleanField)} label="checkbox"></vaadin-checkbox>
-  <vaadin-radio-button ${field(this.binder.model.myBooleanField)} label="radio-button"></vaadin-radio-button>
-  `;
-}
 ----
 
 === Binding Data to List Fields

--- a/articles/data-binding/vaadin-components.asciidoc
+++ b/articles/data-binding/vaadin-components.asciidoc
@@ -102,8 +102,26 @@ render() {
 
 === Binding Data to Boolean Fields
 
-There are two elements in Hilla to deal with booleans: `vaadin-checkbox` and `vaadin-radio-button`.
-Both work fine with form binders, but neither of them has validation and failure styling.
+There are three elements in Hilla to deal with booleans: `vaadin-select`, `vaadin-checkbox`, and `vaadin-radio-button`.
+
+The former can be bound to a boolean as in the following snippet:
+
+[source,typescript]
+----
+import { selectRenderer } from '@vaadin/select/lit';
+import '@vaadin/select';
+import '@vaadin/list-box';
+import '@vaadin/item';
+...
+<vaadin-select ${field(this.binder.model.myBooleanField)} ${selectRenderer(() => html`
+  <vaadin-list-box>
+    <vaadin-item value="true">Value is true</vaadin-item>
+    <vaadin-item value="false">Value is false</vaadin-item>
+  </vaadin-list-box>`)}>
+</vaadin-select>
+----
+
+The latter two work fine with form binders, but neither of them has validation and failure styling.
 Hence, you need to do some extra work to give error feedback.
 In the following snippet, the background color is changed on validation error.
 

--- a/articles/data-binding/vaadin-components.asciidoc
+++ b/articles/data-binding/vaadin-components.asciidoc
@@ -128,7 +128,7 @@ render() {
 }
 ----
 
-The latter can be bound to a boolean as in the following snippet:
+`vaadin-select` can be bound to a boolean, as in the following snippet:
 
 [source,typescript]
 ----

--- a/articles/data-binding/vaadin-components.asciidoc
+++ b/articles/data-binding/vaadin-components.asciidoc
@@ -104,7 +104,7 @@ render() {
 
 There are three elements in Hilla to deal with booleans: `vaadin-checkbox`, `vaadin-radio-button`, and `vaadin-select`.
 
-The former two work fine with form binders, but neither of them has validation and failure styling.
+`vaadin-checkbox` and `vaadin-radio-button` work fine with form binders, but neither of them has validation and failure styling.
 Hence, you need to do some extra work to give error feedback.
 In the following snippet, the background color is changed on validation error.
 


### PR DESCRIPTION
Add a code snippet to demonstrate how to bind a boolean to a `select`.

Closes #1474