### PR TITLE
fix: ensure menu-bar column is rendered correctly

### DIFF
--- a/frontend/demo/component/contextmenu/context-menu-best-practices.ts
+++ b/frontend/demo/component/contextmenu/context-menu-best-practices.ts
@@ -3,6 +3,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/context-menu';
 import '@vaadin/grid';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { Grid } from '@vaadin/grid';
 import '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -32,15 +33,9 @@ export class Example extends LitElement {
     { name: 'Financials.xlsx', size: '42 MB' },
   ];
 
-  private menuBarRenderer = (root: HTMLElement) => {
-    if (root.firstElementChild) {
-      return;
-    }
-
-    const menuBar = document.createElement('vaadin-menu-bar');
-    menuBar.items = [{ component: this.makeIcon(), children: this.items }];
-    menuBar.setAttribute('theme', 'tertiary');
-    root.appendChild(menuBar);
+  private menuBarRenderer = () => {
+    const items = [{ component: this.makeIcon(), children: this.items }];
+    return html`<vaadin-menu-bar .items=${items} theme="tertiary"></vaadin-menu-bar>`;
   };
 
   render() {
@@ -57,7 +52,7 @@ export class Example extends LitElement {
           <vaadin-grid-column
             width="70px"
             flex-grow="0"
-            .renderer="${this.menuBarRenderer}"
+            ${columnBodyRenderer(this.menuBarRenderer, [])}
           ></vaadin-grid-column>
         </vaadin-grid>
       </vaadin-context-menu>

--- a/frontend/demo/component/contextmenu/context-menu-best-practices.ts
+++ b/frontend/demo/component/contextmenu/context-menu-best-practices.ts
@@ -55,7 +55,7 @@ export class Example extends LitElement {
           <vaadin-grid-column path="name"></vaadin-grid-column>
           <vaadin-grid-column path="size"></vaadin-grid-column>
           <vaadin-grid-column
-            auto-width
+            width="70px"
             flex-grow="0"
             .renderer="${this.menuBarRenderer}"
           ></vaadin-grid-column>
@@ -66,7 +66,7 @@ export class Example extends LitElement {
   }
 
   makeIcon() {
-    const item = window.document.createElement('vaadin-context-menu-item');
+    const item = document.createElement('vaadin-context-menu-item');
     item.textContent = '•••';
     item.setAttribute('aria-label', 'More options');
     return item;

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBestPractices.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBestPractices.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.contextmenu;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.contextmenu.MenuItem;
+import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.contextmenu.GridContextMenu;
 import com.vaadin.flow.component.html.Div;
@@ -27,12 +28,16 @@ public class ContextMenuBestPractices extends Div {
     // tag::snippet[]
     grid.addComponentColumn(file -> {
       MenuBar menuBar = new MenuBar();
-      menuBar.addThemeVariants(MenuBarVariant.LUMO_TERTIARY_INLINE);
+      menuBar.addThemeVariants(MenuBarVariant.LUMO_TERTIARY);
       MenuItem menuItem = menuBar.addItem("•••");
       menuItem.getElement().setAttribute("aria-label", "More options");
+      SubMenu subMenu = menuItem.getSubMenu();
+      subMenu.addItem("Preview", event -> {});
+      subMenu.addItem("Edit", event -> {});
+      subMenu.addItem("Delete", event -> {});
       return menuBar;
     })
-      .setAutoWidth(true)
+      .setWidth("70px")
       .setFlexGrow(0);
 
     GridContextMenu<File> menu = grid.addContextMenu();


### PR DESCRIPTION
## What I did

1. Updated the `vaadin-context-menu` [TS example](https://vaadin.com/docs/latest/components/context-menu/#best-practices) to not show the "overflow" button (caused by `auto-width`).
2. Changed the grid column in the example to use Lit renderer directive instead of creating element with JS
3. Updated Java example accordingly and changed to use `tertiary` theme instead of `tertiary-inline`.
4. Added missing sub-menu items to the `MenuBar` in the Java example to make it actually work.

## Before

![before](https://user-images.githubusercontent.com/10589913/176719852-4bc74c65-18e3-47c4-a9e6-1291c4433ad7.png)

## After

![after](https://user-images.githubusercontent.com/10589913/176725628-8b61541d-f6f2-48d5-9c64-1540d60308d2.png)