### PR TITLE
docs: add internationalization documentation for DatePicker

### DIFF
--- a/articles/components/date-picker/index.asciidoc
+++ b/articles/components/date-picker/index.asciidoc
@@ -251,6 +251,23 @@ include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerAut
 ----
 --
 
+== Internationalization (i18n)
+
+Date Picker provides an API for internationalization.
+
+[.example]
+--
+[source,html]
+----
+include::{root}/frontend/demo/component/datepicker/date-picker-internationalization.ts[render,tags=snippet,indent=0,group=TypeScript]
+----
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInternationalization.java[render,tags=snippet,indent=0,group=Java]
+----
+--
+
 == Usage Patterns
 
 === Date Range

--- a/frontend/demo/component/datepicker/date-picker-internationalization.ts
+++ b/frontend/demo/component/datepicker/date-picker-internationalization.ts
@@ -1,0 +1,55 @@
+import 'Frontend/demo/init'; // hidden-source-line
+
+import { DatePicker } from '@vaadin/date-picker';
+
+import { html, LitElement } from 'lit';
+import { customElement, query } from 'lit/decorators.js';
+import '@vaadin/date-picker';
+import { applyTheme } from 'Frontend/generated/theme';
+
+@customElement('date-picker-internationalization')
+export class Example extends LitElement {
+  protected createRenderRoot() {
+    const root = super.createRenderRoot();
+    // Apply custom theme (only supported if your app uses one)
+    applyTheme(root);
+    return root;
+  }
+
+  // tag::snippet[]
+  @query('vaadin-date-picker')
+  private datePicker?: DatePicker;
+
+  firstUpdated() {
+    if (this.datePicker) {
+      this.datePicker.i18n = {
+        ...this.datePicker.i18n,
+        monthNames: [
+          'Januar',
+          'Februar',
+          'März',
+          'April',
+          'Mai',
+          'Juni',
+          'Juli',
+          'August',
+          'September',
+          'Oktober',
+          'November',
+          'Dezember',
+        ],
+        weekdays: ['Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag', 'Sonntag'],
+        weekdaysShort: ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'],
+        week: 'Woche',
+        today: 'Heute',
+        cancel: 'Abbrechen',
+        firstDayOfWeek: 0,
+      };
+    }
+  }
+
+  render() {
+    return html` <vaadin-date-picker label="Sitzungsdatum"></vaadin-date-picker> `;
+  }
+  // end::snippet[]
+}

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInternationalization.java
@@ -1,0 +1,33 @@
+package com.vaadin.demo.component.datepicker;
+
+import java.util.List;
+
+import com.vaadin.demo.DemoExporter;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.router.Route;
+
+@Route("date-picker-internationalization")
+public class DatePickerInternationalization extends Div {
+
+    public DatePickerInternationalization() {
+        DatePicker datePicker = new DatePicker("Sitzungsdatum");
+
+        // tag::snippet[]
+        DatePicker.DatePickerI18n customI18n = new DatePicker.DatePickerI18n();
+        customI18n.setMonthNames(List.of("Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"));
+        customI18n.setWeekdays(List.of("Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"));
+        customI18n.setWeekdaysShort(List.of("So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"));        
+        customI18n.setWeek("Woche");
+        customI18n.setToday("Heute");
+        customI18n.setCancel("Abbrechen");
+
+        datePicker.setI18n(customI18n);
+        // end::snippet[]
+
+        add(datePicker);
+    }
+
+    public static class Exporter extends DemoExporter<DatePickerInternationalization> { // hidden-source-line
+    } // hidden-source-line
+}


### PR DESCRIPTION
Add internationalization documentation for DatePicker using German language. Provide examples in TypeScript and Java.

Fixes https://github.com/vaadin/docs/issues/1360
