### PR TITLE
refactor: simplify setting i18n property in TS examples

### DIFF
--- a/frontend/demo/component/crud/crud-localization.ts
+++ b/frontend/demo/component/crud/crud-localization.ts
@@ -1,7 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/crud';
+import { Crud } from '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -18,38 +19,38 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
+  @query('vaadin-crud')
+  private crud!: Crud<Person>;
+
   async firstUpdated() {
     this.items = (await getPeople()).people;
     // tag::snippet[]
-    const crud = this.shadowRoot?.querySelector('vaadin-crud');
-    if (crud) {
-      crud.i18n = {
-        newItem: 'Luo uusi',
-        editItem: 'Muuta tietoja',
-        saveItem: 'Tallenna',
-        cancel: 'Peruuta',
-        deleteItem: 'Poista...',
-        editLabel: 'Muokkaa',
-        confirm: {
-          delete: {
-            title: 'Poista kohde',
-            content: 'Haluatko varmasti poistaa tämän kohteen? Poistoa ei voi perua.',
-            button: {
-              confirm: 'Poista',
-              dismiss: 'Peruuta',
-            },
-          },
-          cancel: {
-            title: 'Hylkää muutokset',
-            content: 'Kohteessa on tallentamattomia muutoksia',
-            button: {
-              confirm: 'Hylkää',
-              dismiss: 'Peruuta',
-            },
+    this.crud.i18n = {
+      newItem: 'Luo uusi',
+      editItem: 'Muuta tietoja',
+      saveItem: 'Tallenna',
+      cancel: 'Peruuta',
+      deleteItem: 'Poista...',
+      editLabel: 'Muokkaa',
+      confirm: {
+        delete: {
+          title: 'Poista kohde',
+          content: 'Haluatko varmasti poistaa tämän kohteen? Poistoa ei voi perua.',
+          button: {
+            confirm: 'Poista',
+            dismiss: 'Peruuta',
           },
         },
-      };
-    }
+        cancel: {
+          title: 'Hylkää muutokset',
+          content: 'Kohteessa on tallentamattomia muutoksia',
+          button: {
+            confirm: 'Hylkää',
+            dismiss: 'Peruuta',
+          },
+        },
+      },
+    };
     // end::snippet[]
   }
 

--- a/frontend/demo/component/datepicker/date-picker-custom-functions.ts
+++ b/frontend/demo/component/datepicker/date-picker-custom-functions.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-date-picker')
-  private datePicker?: DatePicker;
+  private datePicker!: DatePicker;
 
   @state()
   private selectedDateValue: string = dateFnsFormat(new Date(), 'yyyy-MM-dd');
@@ -38,13 +38,11 @@ export class Example extends LitElement {
       return { year: date.getFullYear(), month: date.getMonth(), day: date.getDate() };
     };
 
-    if (this.datePicker) {
-      this.datePicker.i18n = {
-        ...this.datePicker.i18n,
-        formatDate: formatDateIso8601,
-        parseDate: parseDateIso8601,
-      };
-    }
+    this.datePicker.i18n = {
+      ...this.datePicker.i18n,
+      formatDate: formatDateIso8601,
+      parseDate: parseDateIso8601,
+    };
   }
 
   // end::snippet[]

--- a/frontend/demo/component/datepicker/date-picker-internationalization.ts
+++ b/frontend/demo/component/datepicker/date-picker-internationalization.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
 
-import { DatePicker } from '@vaadin/date-picker';
-
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import '@vaadin/date-picker';
+import { DatePicker } from '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-internationalization')
@@ -18,33 +17,31 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-date-picker')
-  private datePicker?: DatePicker;
+  private datePicker!: DatePicker;
 
   firstUpdated() {
-    if (this.datePicker) {
-      this.datePicker.i18n = {
-        ...this.datePicker.i18n,
-        monthNames: [
-          'Januar',
-          'Februar',
-          'März',
-          'April',
-          'Mai',
-          'Juni',
-          'Juli',
-          'August',
-          'September',
-          'Oktober',
-          'November',
-          'Dezember',
-        ],
-        weekdays: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
-        weekdaysShort: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
-        week: 'Woche',
-        today: 'Heute',
-        cancel: 'Abbrechen',
-      };
-    }
+    this.datePicker.i18n = {
+      ...this.datePicker.i18n,
+      monthNames: [
+        'Januar',
+        'Februar',
+        'März',
+        'April',
+        'Mai',
+        'Juni',
+        'Juli',
+        'August',
+        'September',
+        'Oktober',
+        'November',
+        'Dezember',
+      ],
+      weekdays: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
+      weekdaysShort: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
+      week: 'Woche',
+      today: 'Heute',
+      cancel: 'Abbrechen',
+    };
   }
 
   render() {

--- a/frontend/demo/component/datepicker/date-picker-week-numbers.ts
+++ b/frontend/demo/component/datepicker/date-picker-week-numbers.ts
@@ -16,16 +16,14 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-date-picker')
-  private datePicker?: DatePicker;
+  private datePicker!: DatePicker;
 
   // tag::snippet[]
   firstUpdated() {
-    if (this.datePicker) {
-      this.datePicker.i18n = {
-        ...this.datePicker.i18n,
-        firstDayOfWeek: 1,
-      };
-    }
+    this.datePicker.i18n = {
+      ...this.datePicker.i18n,
+      firstDayOfWeek: 1,
+    };
   }
 
   render() {

--- a/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
 
-import { DateTimePicker } from '@vaadin/date-time-picker';
-
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import '@vaadin/date-time-picker';
+import { DateTimePicker } from '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-internationalization')
@@ -18,33 +17,31 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-date-time-picker')
-  private dateTimePicker?: DateTimePicker;
+  private dateTimePicker!: DateTimePicker;
 
   firstUpdated() {
-    if (this.dateTimePicker) {
-      this.dateTimePicker.i18n = {
-        ...this.dateTimePicker.i18n,
-        monthNames: [
-          'Januar',
-          'Februar',
-          'März',
-          'April',
-          'Mai',
-          'Juni',
-          'Juli',
-          'August',
-          'September',
-          'Oktober',
-          'November',
-          'Dezember',
-        ],
-        weekdays: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
-        weekdaysShort: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
-        week: 'Woche',
-        today: 'Heute',
-        cancel: 'Abbrechen',
-      };
-    }
+    this.dateTimePicker.i18n = {
+      ...this.dateTimePicker.i18n,
+      monthNames: [
+        'Januar',
+        'Februar',
+        'März',
+        'April',
+        'Mai',
+        'Juni',
+        'Juli',
+        'August',
+        'September',
+        'Oktober',
+        'November',
+        'Dezember',
+      ],
+      weekdays: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
+      weekdaysShort: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
+      week: 'Woche',
+      today: 'Heute',
+      cancel: 'Abbrechen',
+    };
   }
 
   render() {

--- a/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
@@ -17,15 +17,13 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-date-time-picker')
-  private dateTimePicker?: DateTimePicker;
+  private dateTimePicker!: DateTimePicker;
 
   firstUpdated() {
-    if (this.dateTimePicker) {
-      this.dateTimePicker.i18n = {
-        ...this.dateTimePicker.i18n,
-        firstDayOfWeek: 1,
-      };
-    }
+    this.dateTimePicker.i18n = {
+      ...this.dateTimePicker.i18n,
+      firstDayOfWeek: 1,
+    };
   }
 
   render() {

--- a/frontend/demo/component/login/login-additional-information-preview.ts
+++ b/frontend/demo/component/login/login-additional-information-preview.ts
@@ -15,15 +15,13 @@ export class Example extends LitElement {
   }
 
   @query('login-overlay-mockup')
-  private login?: LoginOverlayMockupElement;
+  private login!: LoginOverlayMockupElement;
 
   firstUpdated() {
-    if (this.login && this.login.i18n) {
-      this.login.i18n = {
-        ...this.login.i18n,
-        additionalInformation: `Please, contact admin@company.com if you're experiencing issues logging into your account`,
-      };
-    }
+    this.login.i18n = {
+      ...this.login.i18n,
+      additionalInformation: `Please, contact admin@company.com if you're experiencing issues logging into your account`,
+    };
   }
 
   render() {

--- a/frontend/demo/component/login/login-additional-information.ts
+++ b/frontend/demo/component/login/login-additional-information.ts
@@ -16,15 +16,13 @@ export class Example extends LitElement {
 
   //tag::snippet[]
   @query('vaadin-login-overlay')
-  private login?: LoginOverlay;
+  private login!: LoginOverlay;
 
   firstUpdated() {
-    if (this.login && this.login.i18n) {
-      this.login.i18n = {
-        ...this.login.i18n,
-        additionalInformation: `Please, contact admin@company.com if you're experiencing issues logging into your account`,
-      };
-    }
+    this.login.i18n = {
+      ...this.login.i18n,
+      additionalInformation: `Please, contact admin@company.com if you're experiencing issues logging into your account`,
+    };
   }
 
   render() {

--- a/frontend/demo/component/upload/upload-all-files.ts
+++ b/frontend/demo/component/upload/upload-all-files.ts
@@ -18,14 +18,12 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-upload')
-  private upload?: Upload;
+  private upload!: Upload;
 
   // end::snippet[]
   firstUpdated() {
-    if (this.upload?.i18n) {
-      this.upload.i18n.addFiles.many = 'Select Files...';
-      this.upload.i18n = { ...this.upload.i18n };
-    }
+    this.upload.i18n.addFiles.many = 'Select Files...';
+    this.upload.i18n = { ...this.upload.i18n };
   }
 
   // tag::snippet[]

--- a/frontend/demo/component/upload/upload-auto-upload-disabled.ts
+++ b/frontend/demo/component/upload/upload-auto-upload-disabled.ts
@@ -18,13 +18,11 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-upload')
-  private upload?: Upload;
+  private upload!: Upload;
 
   firstUpdated() {
-    if (this.upload?.i18n) {
-      this.upload.i18n.addFiles.many = 'Select Files...';
-      this.upload.i18n = { ...this.upload.i18n };
-    }
+    this.upload.i18n.addFiles.many = 'Select Files...';
+    this.upload.i18n = { ...this.upload.i18n };
   }
 
   render() {

--- a/frontend/demo/component/upload/upload-button-theme-variant.ts
+++ b/frontend/demo/component/upload/upload-button-theme-variant.ts
@@ -22,16 +22,14 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private upload?: Upload;
+  private upload!: Upload;
 
   @state()
   private maxFilesReached = false;
 
   firstUpdated() {
-    if (this.upload?.i18n) {
-      this.upload.i18n.dropFiles.one = 'Drop PDF here';
-      this.upload.i18n = { ...this.upload.i18n };
-    }
+    this.upload.i18n.dropFiles.one = 'Drop PDF here';
+    this.upload.i18n = { ...this.upload.i18n };
   }
 
   render() {

--- a/frontend/demo/component/upload/upload-file-count.ts
+++ b/frontend/demo/component/upload/upload-file-count.ts
@@ -29,13 +29,11 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private upload?: Upload;
+  private upload!: Upload;
 
   firstUpdated() {
-    if (this.upload?.i18n) {
-      this.upload.i18n.error.tooManyFiles = 'You may only upload a maximum of three files at once.';
-      this.upload.i18n = { ...this.upload.i18n };
-    }
+    this.upload.i18n.error.tooManyFiles = 'You may only upload a maximum of three files at once.';
+    this.upload.i18n = { ...this.upload.i18n };
   }
 
   // tag::snippet[]

--- a/frontend/demo/component/upload/upload-file-format.ts
+++ b/frontend/demo/component/upload/upload-file-format.ts
@@ -29,16 +29,14 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private upload?: Upload;
+  private upload!: Upload;
 
   firstUpdated() {
-    if (this.upload?.i18n) {
-      this.upload.i18n.addFiles.one = 'Upload Report...';
-      this.upload.i18n.dropFiles.one = 'Drop report here';
-      this.upload.i18n.error.incorrectFileType =
-        'The provided file does not have the correct format. Please provide a PDF document.';
-      this.upload.i18n = { ...this.upload.i18n };
-    }
+    this.upload.i18n.addFiles.one = 'Upload Report...';
+    this.upload.i18n.dropFiles.one = 'Drop report here';
+    this.upload.i18n.error.incorrectFileType =
+      'The provided file does not have the correct format. Please provide a PDF document.';
+    this.upload.i18n = { ...this.upload.i18n };
   }
 
   render() {

--- a/frontend/demo/component/upload/upload-file-size.ts
+++ b/frontend/demo/component/upload/upload-file-size.ts
@@ -29,13 +29,11 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private upload?: Upload;
+  private upload!: Upload;
 
   firstUpdated() {
-    if (this.upload?.i18n) {
-      this.upload.i18n.error.fileIsTooBig = 'The file exceeds the maximum allowed size of 10MB.';
-      this.upload.i18n = { ...this.upload.i18n };
-    }
+    this.upload.i18n.error.fileIsTooBig = 'The file exceeds the maximum allowed size of 10MB.';
+    this.upload.i18n = { ...this.upload.i18n };
   }
 
   // tag::snippet[]

--- a/frontend/demo/component/upload/upload-helper.ts
+++ b/frontend/demo/component/upload/upload-helper.ts
@@ -29,17 +29,15 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private upload?: Upload;
+  private upload!: Upload;
 
   // tag::snippet[]
   firstUpdated() {
-    if (this.upload?.i18n) {
-      this.upload.i18n.addFiles.one = 'Upload Spreadsheet...';
-      this.upload.i18n.dropFiles.one = 'Drop spreadsheet here';
-      this.upload.i18n.error.incorrectFileType =
-        'Please provide the file in one of the supported formats (.xls, .xlsx, .csv).';
-      this.upload.i18n = { ...this.upload.i18n };
-    }
+    this.upload.i18n.addFiles.one = 'Upload Spreadsheet...';
+    this.upload.i18n.dropFiles.one = 'Drop spreadsheet here';
+    this.upload.i18n.error.incorrectFileType =
+      'Please provide the file in one of the supported formats (.xls, .xlsx, .csv).';
+    this.upload.i18n = { ...this.upload.i18n };
   }
 
   render() {

--- a/frontend/demo/component/upload/upload-labelling.ts
+++ b/frontend/demo/component/upload/upload-labelling.ts
@@ -17,17 +17,15 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private upload?: Upload;
+  private upload!: Upload;
 
   // tag::snippet[]
   firstUpdated() {
-    if (this.upload?.i18n) {
-      this.upload.i18n.addFiles.one = 'Upload PDF...';
-      this.upload.i18n.dropFiles.one = 'Drop PDF here';
-      this.upload.i18n.error.incorrectFileType =
-        'The provided file does not have the correct format. Please provide a PDF document.';
-      this.upload.i18n = { ...this.upload.i18n };
-    }
+    this.upload.i18n.addFiles.one = 'Upload PDF...';
+    this.upload.i18n.dropFiles.one = 'Drop PDF here';
+    this.upload.i18n.error.incorrectFileType =
+      'The provided file does not have the correct format. Please provide a PDF document.';
+    this.upload.i18n = { ...this.upload.i18n };
   }
 
   render() {


### PR DESCRIPTION
## Description

Follow-up to #1549 and #1552.

Updated all the examples that set `i18n` property to use definite assignment assertion.
This makes the code a bit cleaner as we don't need to check if the element is there.