### PR TITLE
fix: update TypeScript links to use new packages

### DIFF
--- a/articles/components/accordion/index.asciidoc
+++ b/articles/components/accordion/index.asciidoc
@@ -2,7 +2,7 @@
 title: Accordion
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-accordion}/#/elements/vaadin-accordion[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/accordion/Accordion.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-accordion}/packages/vaadin-accordion[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-accordion-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-accordion}/packages/accordion[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-accordion-flow-parent[Java]'
 ---
 
 = Accordion

--- a/articles/components/app-layout/index.asciidoc
+++ b/articles/components/app-layout/index.asciidoc
@@ -2,7 +2,7 @@
 title: App Layout
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-app-layout}/#/elements/vaadin-app-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/applayout/AppLayout.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-app-layout}/packages/vaadin-app-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-app-layout-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-app-layout}/packages/app-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-app-layout-flow-parent[Java]'
 ---
 
 = App Layout

--- a/articles/components/avatar/index.asciidoc
+++ b/articles/components/avatar/index.asciidoc
@@ -2,7 +2,7 @@
 title: Avatar
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-avatar}/#/elements/vaadin-avatar[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/avatar/Avatar.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-avatar}/packages/vaadin-avatar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-avatar-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-avatar}/packages/avatar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-avatar-flow-parent[Java]'
 ---
 
 = Avatar

--- a/articles/components/basic-layouts/index.asciidoc
+++ b/articles/components/basic-layouts/index.asciidoc
@@ -2,7 +2,7 @@
 title: Basic Layouts
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-ordered-layout}/#/elements/vaadin-vertical-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/orderedlayout/VerticalLayout.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-ordered-layout}/packages/vaadin-ordered-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-ordered-layout-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-ordered-layout}/packages/vertical-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-ordered-layout-flow-parent[Java]'
 ---
 
 = Basic Layouts

--- a/articles/components/board/index.asciidoc
+++ b/articles/components/board/index.asciidoc
@@ -2,7 +2,7 @@
 title: Board
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-board}/#/elements/vaadin-board[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/board/Board.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-board}/packages/vaadin-board[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-board-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-board}/packages/board[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-board-flow-parent[Java]'
 section-nav: commercial
 ---
 

--- a/articles/components/button/index.asciidoc
+++ b/articles/components/button/index.asciidoc
@@ -2,7 +2,7 @@
 title: Button
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-button}/#/elements/vaadin-button[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/button/Button.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-button}/packages/vaadin-button[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-button-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-button}/packages/button[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-button-flow-parent[Java]'
 ---
 
 = Button

--- a/articles/components/checkbox/index.asciidoc
+++ b/articles/components/checkbox/index.asciidoc
@@ -2,7 +2,7 @@
 title: Checkbox
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-checkbox}/#/elements/vaadin-checkbox[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/checkbox/Checkbox.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-checkbox}/packages/vaadin-checkbox[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-checkbox-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-checkbox}/packages/checkbox[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-checkbox-flow-parent[Java]'
 ---
 
 = Checkbox

--- a/articles/components/combo-box/index.asciidoc
+++ b/articles/components/combo-box/index.asciidoc
@@ -2,7 +2,7 @@
 title: Combo Box
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-combo-box}/#/elements/vaadin-combo-box[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/combobox/ComboBox.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-combo-box}/packages/vaadin-combo-box[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-combo-box-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-combo-box}/packages/combo-box[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-combo-box-flow-parent[Java]'
 ---
 
 = Combo Box

--- a/articles/components/confirm-dialog/index.asciidoc
+++ b/articles/components/confirm-dialog/index.asciidoc
@@ -2,7 +2,7 @@
 title: Confirm Dialog
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-confirm-dialog}/#/elements/vaadin-confirm-dialog[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/confirmdialog/ConfirmDialog.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-confirm-dialog}/packages/vaadin-confirm-dialog[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-confirm-dialog-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-confirm-dialog}/packages/confirm-dialog[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-confirm-dialog-flow-parent[Java]'
 section-nav: commercial
 ---
 

--- a/articles/components/context-menu/index.asciidoc
+++ b/articles/components/context-menu/index.asciidoc
@@ -2,7 +2,7 @@
 title: Context Menu
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-context-menu}/#/elements/vaadin-context-menu[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/contextmenu/ContextMenu.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-context-menu}/packages/vaadin-context-menu[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-context-menu-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-context-menu}/packages/context-menu[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-context-menu-flow-parent[Java]'
 ---
 
 = Context Menu

--- a/articles/components/cookie-consent/index.asciidoc
+++ b/articles/components/cookie-consent/index.asciidoc
@@ -2,7 +2,7 @@
 title: Cookie Consent
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-cookie-consent}/#/elements/vaadin-cookie-consent[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/cookieconsent/CookieConsent.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-cookie-consent}/packages/vaadin-cookie-consent[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-cookie-consent-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-cookie-consent}/packages/cookie-consent[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-cookie-consent-flow-parent[Java]'
 section-nav: commercial
 ---
 

--- a/articles/components/crud/index.asciidoc
+++ b/articles/components/crud/index.asciidoc
@@ -2,7 +2,7 @@
 title: CRUD
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-crud}/#/elements/vaadin-crud[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/crud/Crud.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-crud}/packages/vaadin-crud[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-crud-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-crud}/packages/crud[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-crud-flow-parent[Java]'
 section-nav: commercial
 ---
 

--- a/articles/components/custom-field/index.asciidoc
+++ b/articles/components/custom-field/index.asciidoc
@@ -2,7 +2,7 @@
 title: Custom Field
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-custom-field}/#/elements/vaadin-custom-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/customfield/CustomField.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-custom-field}/packages/vaadin-custom-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-custom-field-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-custom-field}/packages/custom-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-custom-field-flow-parent[Java]'
 ---
 
 = Custom Field

--- a/articles/components/date-picker/index.asciidoc
+++ b/articles/components/date-picker/index.asciidoc
@@ -2,7 +2,7 @@
 title: Date Picker
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-date-picker}/#/elements/vaadin-date-picker[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/datepicker/DatePicker.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-date-picker}/packages/vaadin-date-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-date-picker-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-date-picker}/packages/date-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-date-picker-flow-parent[Java]'
 ---
 
 = Date Picker

--- a/articles/components/date-time-picker/index.asciidoc
+++ b/articles/components/date-time-picker/index.asciidoc
@@ -2,7 +2,7 @@
 title: Date Time Picker
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-date-time-picker}/#/elements/vaadin-date-time-picker[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/datetimepicker/DateTimePicker.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-date-time-picker}/packages/vaadin-date-time-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-date-time-picker-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-date-time-picker}/packages/date-time-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-date-time-picker-flow-parent[Java]'
 ---
 
 = Date Time Picker

--- a/articles/components/details/index.asciidoc
+++ b/articles/components/details/index.asciidoc
@@ -2,7 +2,7 @@
 title: Details
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-details}/#/elements/vaadin-details[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/details/Details.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-details}/packages/vaadin-details[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-details-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-details}/packages/details[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-details-flow-parent[Java]'
 ---
 
 = Details

--- a/articles/components/dialog/index.asciidoc
+++ b/articles/components/dialog/index.asciidoc
@@ -2,7 +2,7 @@
 title: Dialog
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-dialog}/#/elements/vaadin-dialog[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/dialog/Dialog.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-dialog}/packages/vaadin-dialog[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-dialog-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-dialog}/packages/dialog[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-dialog-flow-parent[Java]'
 ---
 
 = Dialog

--- a/articles/components/email-field/index.asciidoc
+++ b/articles/components/email-field/index.asciidoc
@@ -2,7 +2,7 @@
 title: Email Field
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-email-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/EmailField.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/vaadin-text-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/email-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
 ---
 = Email Field
 

--- a/articles/components/form-layout/index.asciidoc
+++ b/articles/components/form-layout/index.asciidoc
@@ -2,7 +2,7 @@
 title: Form Layout
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-form-layout}/#/elements/vaadin-form-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/formlayout/FormLayout.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-form-layout}/packages/vaadin-form-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-form-layout-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-form-layout}/packages/form-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-form-layout-flow-parent[Java]'
 ---
 
 = Form Layout

--- a/articles/components/grid-pro/index.asciidoc
+++ b/articles/components/grid-pro/index.asciidoc
@@ -2,7 +2,7 @@
 title: Grid Pro
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-grid-pro}/#/elements/vaadin-grid-pro[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/gridpro/GridPro.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-grid-pro}/packages/vaadin-grid-pro[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-grid-pro-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-grid-pro}/packages/grid-pro[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-grid-pro-flow-parent[Java]'
 section-nav: commercial
 ---
 

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -4,7 +4,7 @@ tab-title: Usage
 layout: tabbed-page
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-grid}/#/elements/vaadin-grid[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/grid/Grid.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-grid}/packages/vaadin-grid[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-grid-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-grid}/packages/grid[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-grid-flow-parent[Java]'
 ---
 
 :experimental:

--- a/articles/components/list-box/index.asciidoc
+++ b/articles/components/list-box/index.asciidoc
@@ -2,7 +2,7 @@
 title: List Box
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-list-box}/#/elements/vaadin-list-box[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/listbox/ListBox.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-list-box}/packages/vaadin-list-box[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-list-box-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-list-box}/packages/list-box[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-list-box-flow-parent[Java]'
 ---
 
 = List Box

--- a/articles/components/login/index.asciidoc
+++ b/articles/components/login/index.asciidoc
@@ -2,7 +2,7 @@
 title: Login
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-login}/#/elements/vaadin-login-overlay[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/login/LoginOverlay.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-login}/packages/vaadin-login[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-login-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-login}/packages/login[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-login-flow-parent[Java]'
 ---
 
 = Login

--- a/articles/components/menu-bar/index.asciidoc
+++ b/articles/components/menu-bar/index.asciidoc
@@ -2,7 +2,7 @@
 title: Menu Bar
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-menu-bar}/#/elements/vaadin-menu-bar[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/menubar/MenuBar.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-menu-bar}/packages/vaadin-menu-bar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-menu-bar-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-menu-bar}/packages/menu-bar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-menu-bar-flow-parent[Java]'
 ---
 
 = Menu Bar

--- a/articles/components/message-input/index.asciidoc
+++ b/articles/components/message-input/index.asciidoc
@@ -2,7 +2,7 @@
 title: Message Input
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-messages}/#/elements/vaadin-message-input[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/messages/MessageInput.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-messages}/packages/vaadin-messages[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-messages-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-messages}/packages/message-input[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-messages-flow-parent[Java]'
 ---
 
 = Message Input

--- a/articles/components/message-list/index.asciidoc
+++ b/articles/components/message-list/index.asciidoc
@@ -2,7 +2,7 @@
 title: Message List
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-messages}/#/elements/vaadin-message-list[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/messages/MessageList.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-messages}/packages/vaadin-messages[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-messages-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-messages}/packages/message-list[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-messages-flow-parent[Java]'
 ---
 
 = Message List

--- a/articles/components/notification/index.asciidoc
+++ b/articles/components/notification/index.asciidoc
@@ -2,7 +2,7 @@
 title: Notification
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-notification}/#/elements/vaadin-notification[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/notification/Notification.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-notification}/packages/vaadin-notification[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-notification-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-notification}/packages/notification[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-notification-flow-parent[Java]'
 ---
 
 = Notification

--- a/articles/components/number-field/index.asciidoc
+++ b/articles/components/number-field/index.asciidoc
@@ -2,7 +2,7 @@
 title: Number Field
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-number-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/NumberField.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/vaadin-text-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/number-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
 ---
 
 = Number Field

--- a/articles/components/password-field/index.asciidoc
+++ b/articles/components/password-field/index.asciidoc
@@ -2,7 +2,7 @@
 title: Password Field
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-password-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/PasswordField.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/vaadin-text-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/password-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
 ---
 = Password Field
 

--- a/articles/components/progress-bar/index.asciidoc
+++ b/articles/components/progress-bar/index.asciidoc
@@ -2,7 +2,7 @@
 title: Progress Bar
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-progress-bar}/#/elements/vaadin-progress-bar[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/progressbar/ProgressBar.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-progress-bar}/packages/vaadin-progress-bar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-progress-bar-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-progress-bar}/packages/progress-bar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-progress-bar-flow-parent[Java]'
 ---
 
 = Progress Bar

--- a/articles/components/radio-button/index.asciidoc
+++ b/articles/components/radio-button/index.asciidoc
@@ -2,7 +2,7 @@
 title: Radio Button
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-radio-button}/#/elements/vaadin-radio-group[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/radiobutton/RadioButtonGroup.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-radio-button}/packages/vaadin-radio-button[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-radio-button-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-radio-button}/packages/radio-group[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-radio-button-flow-parent[Java]'
 ---
 
 = Radio Button

--- a/articles/components/rich-text-editor/index.asciidoc
+++ b/articles/components/rich-text-editor/index.asciidoc
@@ -2,7 +2,7 @@
 title: Rich Text Editor
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-rich-text-editor}/#/elements/vaadin-rich-text-editor[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/richtexteditor/RichTextEditor.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-rich-text-editor}/packages/vaadin-rich-text-editor[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-rich-text-editor-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-rich-text-editor}/packages/rich-text-editor[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-rich-text-editor-flow-parent[Java]'
 section-nav: commercial
 ---
 

--- a/articles/components/scroller/index.asciidoc
+++ b/articles/components/scroller/index.asciidoc
@@ -2,7 +2,7 @@
 title: Scroller
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-ordered-layout}/#/elements/vaadin-scroller[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/orderedlayout/Scroller.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-ordered-layout}/packages/vaadin-ordered-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-ordered-layout-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-ordered-layout}/packages/scroller[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-ordered-layout-flow-parent[Java]'
 ---
 = Scroller
 

--- a/articles/components/select/index.asciidoc
+++ b/articles/components/select/index.asciidoc
@@ -2,7 +2,7 @@
 title: Select
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-select}/#/elements/vaadin-select[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/select/Select.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-select}/packages/vaadin-select[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-select-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-select}/packages/select[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-select-flow-parent[Java]'
 ---
 
 = Select

--- a/articles/components/split-layout/index.asciidoc
+++ b/articles/components/split-layout/index.asciidoc
@@ -2,7 +2,7 @@
 title: Split Layout
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-split-layout}/#/elements/vaadin-split-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/splitlayout/SplitLayout.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-split-layout}/packages/vaadin-split-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-split-layout-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-split-layout}/packages/split-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-split-layout-flow-parent[Java]'
 ---
 
 = Split Layout

--- a/articles/components/tabs/index.asciidoc
+++ b/articles/components/tabs/index.asciidoc
@@ -2,7 +2,7 @@
 title: Tabs
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-tabs}/#/elements/vaadin-tabs[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/tabs/Tabs.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-tabs}/packages/vaadin-tabs[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-tabs-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-tabs}/packages/tabs[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-tabs-flow-parent[Java]'
 ---
 
 = Tabs

--- a/articles/components/text-area/index.asciidoc
+++ b/articles/components/text-area/index.asciidoc
@@ -2,7 +2,7 @@
 title: Text Area
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-text-area[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/TextArea.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/vaadin-text-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/text-area[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
 ---
 = Text Area
 

--- a/articles/components/text-field/index.asciidoc
+++ b/articles/components/text-field/index.asciidoc
@@ -2,7 +2,7 @@
 title: Text Field
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-text-field}/#/elements/vaadin-text-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/TextField.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/vaadin-text-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-text-field}/packages/text-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'
 ---
 = Text Field
 

--- a/articles/components/time-picker/index.asciidoc
+++ b/articles/components/time-picker/index.asciidoc
@@ -2,7 +2,7 @@
 title: Time Picker
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-time-picker}/#/elements/vaadin-time-picker[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/timepicker/TimePicker.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-time-picker}/packages/vaadin-time-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-time-picker-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-time-picker}/packages/time-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-time-picker-flow-parent[Java]'
 ---
 
 = Time Picker

--- a/articles/components/tree-grid/index.asciidoc
+++ b/articles/components/tree-grid/index.asciidoc
@@ -2,7 +2,7 @@
 title: Tree Grid
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-grid}/#/elements/vaadin-grid-tree-column[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/treegrid/TreeGrid.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-grid}/packages/vaadin-grid[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-grid-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-grid}/packages/grid[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-grid-flow-parent[Java]'
 ---
 
 = Tree Grid

--- a/articles/components/upload/index.asciidoc
+++ b/articles/components/upload/index.asciidoc
@@ -4,7 +4,7 @@ tab-title: Usage
 layout: tabbed-page
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-upload}/#/elements/vaadin-upload[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/upload/Upload.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-upload}/packages/vaadin-upload[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-upload-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-upload}/packages/upload[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-upload-flow-parent[Java]'
 ---
 
 = Upload

--- a/articles/components/virtual-list/index.asciidoc
+++ b/articles/components/virtual-list/index.asciidoc
@@ -2,7 +2,7 @@
 title: Virtual List
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-virtual-list}/#/elements/vaadin-virtual-list[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/virtuallist/VirtualList.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-virtual-list}/packages/vaadin-virtual-list[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-virtual-list-flow-parent[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-virtual-list}/packages/virtual-list[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-virtual-list-flow-parent[Java]'
 ---
 = Virtual List
 


### PR DESCRIPTION
## Description

Updated links to web components sources not use deprecated `@vaadin/vaadin-` packages.