### PR TITLE
docs: map coordinate systems

### DIFF
--- a/articles/components/map/index.asciidoc
+++ b/articles/components/map/index.asciidoc
@@ -278,7 +278,7 @@ The default view projection is EPSG:3857, also known as https://en.wikipedia.org
 
 The user projection can be changed, for example when working with coordinates that are not in the EPSG:4326 projection.
 Out of the box the component only has support for the EPSG:4326 and EPSG:3857 projections, however the component allows <<#defining-custom-projections, defining custom projections>>.
-As mentioned above, changing the user projection affects *all* coordinates, using coordinates with different projections is not allowed.
+As mentioned above, changing the user projection affects *all* coordinates, using coordinates with different projections is not supported.
 
 .Example for setting a different user projection
 [.example]
@@ -300,17 +300,15 @@ map.setZoom(10);
 [NOTE]
 ====
 The user projection setting is valid for the lifetime of the current browser page, which means it stays defined when navigating using the router, but not when doing a hard location change, or reloading the page.
-In practice, we recommend setting the user projection on every page where it is used.
+In practice, it is advisable to set the user projection on every page where it is used.
 
 The user projection affects all maps on the browser page, and should be set before creating any maps.
-Changing the user projection does not affect existing maps, specifically coordinates configured in an existing map are not automatically converted into the new projection.
-Instead, maps should be recreated after changing this setting.
 ====
 
 === Defining Custom Projections
 
-Custom projections can be defined when working with coordinates that are neither in the EPSG:4326 nor EPSG:3857 projection.
-Defining a custom projection requires a name, which can later be referenced, as well as a projection definition in the Well Known Text (WKT) format.
+Custom projections can be defined when working with coordinates that are neither in EPSG:4326 nor EPSG:3857 projection.
+Defining a custom projection requires a name, which can later be referenced, as well as a projection definition in the https://www.iso.org/standard/76496.html[Well Known Text^] (WKT) format.
 https://epsg.io[epsg.io^] is a handy resource for looking up WKT definitions of projections, as well as converting coordinates between specific projections. After a custom projection has been defined, it can be used as either user projection or view projection.
 
 .Example for defining a custom projection
@@ -363,7 +361,7 @@ map.setZoom(10);
 [NOTE]
 ====
 Custom projections are valid for the lifetime of the current browser page, which means they stay defined when navigating using the router, but not when doing a hard location change, or reloading the page.
-In practice, we recommend defining projections on every page where they are used.
+In practice, it is advisable to define projections on every page where they are used.
 
 Custom projections must be defined before using them as either user projection or view projection.
 ====

--- a/articles/components/map/index.asciidoc
+++ b/articles/components/map/index.asciidoc
@@ -24,7 +24,7 @@ See the <<Feature Flag>> section for how to do this.
 [IMPORTANT]
 ====
 This documentation has already been updated to Vaadin 23.2.
-Please note about the <<#breaking-changes-since-23-1, Breaking Changes Since 23.1>> and how they relate to this documentation.
+Please note about the <<#breaking-changes-since-23-1, breaking changes to the default coordinate system>> and how they relate to this documentation.
 ====
 
 // tag::description[]
@@ -366,6 +366,22 @@ In practice, it is advisable to define projections on every page where they are 
 Custom projections must be defined before using them as either user projection or view projection.
 ====
 
+=== Breaking Changes Since 23.1
+
+In 23.2, the default coordinate system has been changed to EPSG:4326, also referred to as GPS coordinates, or latitude and longitude.
+As this documentation has already been updated to the 23.2, all documentation sections refer to the new coordinate system, and examples have been adapted to create coordinates using latitude and longitude.
+
+If you are still using 23.1, note that the default coordinate system is EPSG:3857, and all coordinates provided to the map must be in that projection.
+If you want to create coordinates from latitude and longitude in 23.1, use the static `Coordinate.fromLonLat(longitude, latitude)` helper.
+You can easily adapt the examples from this documentation to work with 23.1 by changing code that constructs coordinates from:
+```java
+new Coordinate(longitude, latitude)
+```
+to:
+```java
+Coordinate.fromLonLat(longitude, latitude)
+```
+
 == Theme Variants
 
 === Borderless
@@ -405,22 +421,6 @@ image::enable-feature-flag.png[]
 1. Create a [filename]#src/main/resources/vaadin-featureflags.properties# file in your application folder
 2. Add the following content: `com.vaadin.experimental.mapComponent=true`
 3. Restart the application.
-
-== Breaking Changes Since 23.1
-
-In 23.2, the default coordinate system has been changed to EPSG:4326, also referred to as GPS coordinates, or latitude and longitude.
-As this documentation has already been updated to the 23.2, all documentation sections refer to the new coordinate system, and examples have been adapted to create coordinates using latitude and longitude.
-
-If you are still using 23.1, note that the default coordinate system is EPSG:3857, and all coordinates provided to the map must be in that projection.
-If you want to create coordinates from latitude and longitude in 23.1, use the static `Coordinate.fromLonLat(longitude, latitude)` helper.
-You can easily adapt the examples from this documentation to work with 23.1 by changing code that constructs coordinates from:
-```java
-new Coordinate(longitude, latitude)
-```
-to:
-```java
-Coordinate.fromLonLat(longitude, latitude)
-```
 
 
 [.discussion-id]

--- a/articles/components/map/index.asciidoc
+++ b/articles/components/map/index.asciidoc
@@ -52,8 +52,8 @@ include::{root}/src/main/java/com/vaadin/demo/component/map/MapBasic.java[render
 Map provides interactions, controls, and APIs to control the viewport.
 This includes setting the center, the zoom level, and the rotation.
 
-By default, map coordinates, such as the view's center, are specified in https://en.wikipedia.org/wiki/Web_Mercator_projection[EPSG:3857 / Web Mercator Projection^], unless the map service uses a custom projection.
-As coordinates are often provided as latitude and longitude, Map provides utilities for converting these into Web Mercator projection.
+By default, map coordinates such as the view's center are specified in EPSG:4326 projection, also known as latitude and longitude, unless a custom user projection is configured.
+See <<#coordinate-systems, Coordinate Systems>> for more information.
 
 The zoom level is a decimal number that starts at zero as the most zoomed-out level, and then progressively increases to zoom further in.
 By default, the maximum zoom level is currently restricted to `28`.
@@ -188,8 +188,8 @@ A marker is defined by a coordinate and an icon.
 Icons can be configured as either a URL or a <<{articles}/advanced/dynamic-content#using-streamresource,StreamResource>>.
 If no custom icon is provided, the marker will use a default icon.
 
-By default, map coordinates, such as a marker's location, are specified in https://en.wikipedia.org/wiki/Web_Mercator_projection[EPSG:3857 / Web Mercator Projection^], unless the map service uses a custom projection.
-As coordinates are often provided as latitude and longitude, Map provides utilities for converting these into Web Mercator projection.
+By default, map coordinates such as a marker's location are specified in EPSG:4326 projection, also known as latitude and longitude, unless a custom user projection is configured.
+See <<#coordinate-systems, Coordinate Systems>> for more information.
 
 [.example]
 --
@@ -256,6 +256,110 @@ include::{root}/frontend/demo/component/map/map-events.ts[preimport,hidden]
 include::{root}/src/main/java/com/vaadin/demo/component/map/MapEvents.java[render,tags=snippet,indent=0,group=Java]
 ----
 --
+
+[role="since:com.vaadin:vaadin@V23.2"]
+== Coordinate Systems
+
+The default coordinate system, or projection, for all coordinates passed to, or received from the component is EPSG:4326, also referred to as GPS coordinates or latitude and longitude.
+This is called the user projection, as it affects all the coordinates that the user of the component, in this case the developer, is working with.
+That means when setting coordinates, for example of the viewport or for a marker, coordinates must be specified in EPSG:4326 by default, and coordinates received from events are guaranteed to be in that projection.
+
+Internally, the component converts all coordinates into the projection that is used by the map's view, which is called the view projection.
+The default view projection is EPSG:3857, also known as https://en.wikipedia.org/wiki/Web_Mercator_projection[Web Mercator Projection^].
+
+=== Changing the User Projection
+
+The user projection can be changed, for example when working with coordinates that are not in the EPSG:4326 projection.
+Out of the box the component only has support for the EPSG:4326 and EPSG:3857 projections, however the component allows <<#defining-custom-projections, defining custom projections>>.
+As mentioned above, changing the user projection affects *all* coordinates, using coordinates with different projections is not allowed.
+
+.Example for setting a different user projection
+[.example]
+--
+[source,Java]
+----
+// Set user projection to EPSG:3857
+Map.setUserProjection("EPSG:3857");
+
+// Create a map, center viewport on New York using
+// coordinates in EPSG:3857 projection
+Map map = new Map();
+map.setCenter(new Coordinate(-8235375.352932, 4967773.457877));
+map.setZoom(10);
+----
+--
+
+.User Projection Scope
+[NOTE]
+====
+The user projection setting is valid for the lifetime of the current browser page, which means it stays defined when navigating using the router, but not when doing a hard location change, or reloading the page.
+In practice, we recommend setting the user projection on every page where it is used.
+
+The user projection affects all maps on the browser page, and should be set before creating any maps.
+Changing the user projection does not affect existing maps, specifically coordinates configured in an existing map are not automatically converted into the new projection.
+Instead, maps should be recreated after changing this setting.
+====
+
+=== Defining Custom Projections
+
+Custom projections can be defined when working with coordinates that are neither in the EPSG:4326 nor EPSG:3857 projection.
+Defining a custom projection requires a name, which can later be referenced, as well as a projection definition in the Well Known Text (WKT) format.
+https://epsg.io[epsg.io^] is a handy resource for looking up WKT definitions of projections, as well as converting coordinates between specific projections. After a custom projection has been defined, it can be used as either user projection or view projection.
+
+.Example for defining a custom projection
+[.example]
+--
+[source,Java]
+----
+// Define EPSG:3067, which is a projection specifically for use in Finland
+String wkt = ""
+    + "PROJCS[\"ETRS89 / TM35FIN(E,N)\",\n"
+    + "    GEOGCS[\"ETRS89\",\n"
+    + "        DATUM[\"European_Terrestrial_Reference_System_1989\",\n"
+    + "            SPHEROID[\"GRS 1980\",6378137,298.257222101,\n"
+    + "                AUTHORITY[\"EPSG\",\"7019\"]],\n"
+    + "            TOWGS84[0,0,0,0,0,0,0],\n"
+    + "            AUTHORITY[\"EPSG\",\"6258\"]],\n"
+    + "        PRIMEM[\"Greenwich\",0,\n"
+    + "            AUTHORITY[\"EPSG\",\"8901\"]],\n"
+    + "        UNIT[\"degree\",0.0174532925199433,\n"
+    + "            AUTHORITY[\"EPSG\",\"9122\"]],\n"
+    + "        AUTHORITY[\"EPSG\",\"4258\"]],\n"
+    + "    PROJECTION[\"Transverse_Mercator\"],\n"
+    + "    PARAMETER[\"latitude_of_origin\",0],\n"
+    + "    PARAMETER[\"central_meridian\",27],\n"
+    + "    PARAMETER[\"scale_factor\",0.9996],\n"
+    + "    PARAMETER[\"false_easting\",500000],\n"
+    + "    PARAMETER[\"false_northing\",0],\n"
+    + "    UNIT[\"metre\",1,\n"
+    + "        AUTHORITY[\"EPSG\",\"9001\"]],\n"
+    + "    AXIS[\"Easting\",EAST],\n"
+    + "    AXIS[\"Northing\",NORTH],\n"
+    + "    AUTHORITY[\"EPSG\",\"3067\"]]";
+Map.defineProjection("EPSG:3067", wkt);
+
+// Set user projection to EPSG:3067
+Map.setUserProjection("EPSG:3067");
+
+// Create a map, change view projection to EPSG:3067 as well
+Map map = new Map();
+map.setView(new View("EPSG:3067"));
+
+// Center viewport on Helsinki using
+// coordinates in EPSG:3067 projection
+map.setCenter(new Coordinate(385725.63, 6671616.89));
+map.setZoom(10);
+----
+--
+
+.Custom Projection Scope
+[NOTE]
+====
+Custom projections are valid for the lifetime of the current browser page, which means they stay defined when navigating using the router, but not when doing a hard location change, or reloading the page.
+In practice, we recommend defining projections on every page where they are used.
+
+Custom projections must be defined before using them as either user projection or view projection.
+====
 
 == Theme Variants
 

--- a/articles/components/map/index.asciidoc
+++ b/articles/components/map/index.asciidoc
@@ -20,6 +20,13 @@ In order to use Map, it must be explicitly enabled with a feature flag.
 See the <<Feature Flag>> section for how to do this.
 ====
 
+.Breaking Changes Since 23.1
+[IMPORTANT]
+====
+This documentation has already been updated to Vaadin 23.2.
+Please note about the <<#breaking-changes-since-23-1, Breaking Changes Since 23.1>> and how they relate to this documentation.
+====
+
 // tag::description[]
 Map is a component for displaying geographical maps from various sources.
 // end::description[]
@@ -400,6 +407,22 @@ image::enable-feature-flag.png[]
 1. Create a [filename]#src/main/resources/vaadin-featureflags.properties# file in your application folder
 2. Add the following content: `com.vaadin.experimental.mapComponent=true`
 3. Restart the application.
+
+== Breaking Changes Since 23.1
+
+In 23.2, the default coordinate system has been changed to EPSG:4326, also referred to as GPS coordinates, or latitude and longitude.
+As this documentation has already been updated to the 23.2, all documentation sections refer to the new coordinate system, and examples have been adapted to create coordinates using latitude and longitude.
+
+If you are still using 23.1, note that the default coordinate system is EPSG:3857, and all coordinates provided to the map must be in that projection.
+If you want to create coordinates from latitude and longitude in 23.1, use the static `Coordinate.fromLonLat(longitude, latitude)` helper.
+You can easily adapt the examples from this documentation to work with 23.1 by changing code that constructs coordinates from:
+```java
+new Coordinate(longitude, latitude)
+```
+to:
+```java
+Coordinate.fromLonLat(longitude, latitude)
+```
 
 
 [.discussion-id]

--- a/articles/components/map/index.asciidoc
+++ b/articles/components/map/index.asciidoc
@@ -373,7 +373,8 @@ As this documentation has already been updated to 23.2, all documentation sectio
 
 If you are still using 23.1, note that the default coordinate system is EPSG:3857, and all coordinates provided to the map must be in that projection.
 If you want to create coordinates from latitude and longitude in 23.1, use the static `Coordinate.fromLonLat(longitude, latitude)` helper.
-You can easily adapt the examples from this documentation to work with 23.1 by changing code that constructs coordinates from:
+You can easily adapt the examples from this documentation to work with 23.1 by changing code that constructs coordinates:
+
 [source,java,role="before"]
 ----
 new Coordinate(longitude, latitude)

--- a/articles/components/map/index.asciidoc
+++ b/articles/components/map/index.asciidoc
@@ -267,7 +267,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/map/MapEvents.java[rende
 [role="since:com.vaadin:vaadin@V23.2"]
 == Coordinate Systems
 
-The default coordinate system, or projection, for all coordinates passed to, or received from the component is EPSG:4326, also referred to as GPS coordinates or latitude and longitude.
+The default coordinate system, or projection, for all coordinates passed to, or received from, the component is EPSG:4326, also referred to as GPS coordinates or latitude and longitude.
 This is called the user projection, as it affects all the coordinates that the user of the component, in this case the developer, is working with.
 That means when setting coordinates, for example of the viewport or for a marker, coordinates must be specified in EPSG:4326 by default, and coordinates received from events are guaranteed to be in that projection.
 
@@ -277,8 +277,8 @@ The default view projection is EPSG:3857, also known as https://en.wikipedia.org
 === Changing the User Projection
 
 The user projection can be changed, for example when working with coordinates that are not in the EPSG:4326 projection.
-Out of the box the component only has support for the EPSG:4326 and EPSG:3857 projections, however the component allows <<#defining-custom-projections, defining custom projections>>.
-As mentioned above, changing the user projection affects *all* coordinates, using coordinates with different projections is not supported.
+Out of the box, the component only has support for the EPSG:4326 and EPSG:3857 projections; however, the component allows <<#defining-custom-projections, defining custom projections>>.
+As mentioned above, changing the user projection affects *all* coordinates; using coordinates with different projections is not supported.
 
 .Example for setting a different user projection
 [.example]
@@ -307,7 +307,7 @@ The user projection affects all maps on the browser page, and should be set befo
 
 === Defining Custom Projections
 
-Custom projections can be defined when working with coordinates that are neither in EPSG:4326 nor EPSG:3857 projection.
+Custom projections can be defined when working with coordinates that are in neither EPSG:4326 nor EPSG:3857 projection.
 Defining a custom projection requires a name, which can later be referenced, as well as a projection definition in the https://www.iso.org/standard/76496.html[Well Known Text^] (WKT) format.
 https://epsg.io[epsg.io^] is a handy resource for looking up WKT definitions of projections, as well as converting coordinates between specific projections. After a custom projection has been defined, it can be used as either user projection or view projection.
 
@@ -369,7 +369,7 @@ Custom projections must be defined before using them as either user projection o
 === Breaking Changes Since 23.1
 
 In 23.2, the default coordinate system has been changed to EPSG:4326, also referred to as GPS coordinates, or latitude and longitude.
-As this documentation has already been updated to the 23.2, all documentation sections refer to the new coordinate system, and examples have been adapted to create coordinates using latitude and longitude.
+As this documentation has already been updated to 23.2, all documentation sections refer to the new coordinate system, and examples have been adapted to create coordinates using latitude and longitude.
 
 If you are still using 23.1, note that the default coordinate system is EPSG:3857, and all coordinates provided to the map must be in that projection.
 If you want to create coordinates from latitude and longitude in 23.1, use the static `Coordinate.fromLonLat(longitude, latitude)` helper.

--- a/articles/components/map/index.asciidoc
+++ b/articles/components/map/index.asciidoc
@@ -374,13 +374,15 @@ As this documentation has already been updated to the 23.2, all documentation se
 If you are still using 23.1, note that the default coordinate system is EPSG:3857, and all coordinates provided to the map must be in that projection.
 If you want to create coordinates from latitude and longitude in 23.1, use the static `Coordinate.fromLonLat(longitude, latitude)` helper.
 You can easily adapt the examples from this documentation to work with 23.1 by changing code that constructs coordinates from:
-```java
+[source,java,role="before"]
+----
 new Coordinate(longitude, latitude)
-```
-to:
-```java
+----
+
+[source,java,role="after"]
+----
 Coordinate.fromLonLat(longitude, latitude)
-```
+----
 
 == Theme Variants
 

--- a/src/main/java/com/vaadin/demo/component/map/MapEvents.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapEvents.java
@@ -15,16 +15,16 @@ import java.util.List;
 
 @Route("map-events")
 public class MapEvents extends VerticalLayout {
-    private static final City BERLIN = new City("Berlin", Coordinate.fromLonLat(13.404954, 52.520008));
-    private static final City HONG_KONG = new City("Hong Kong", Coordinate.fromLonLat(114.162813, 22.279328));
-    private static final City MOSCOW = new City("Moscow", Coordinate.fromLonLat(37.617298, 55.755825));
-    private static final City NEW_YORK = new City("New York", Coordinate.fromLonLat(-74.005974, 40.712776));
-    private static final City RIO = new City("Rio de Janeiro", Coordinate.fromLonLat(-43.2093727, -22.9110137));
+    private static final City BERLIN = new City("Berlin", new Coordinate(13.404954, 52.520008));
+    private static final City HONG_KONG = new City("Hong Kong", new Coordinate(114.162813, 22.279328));
+    private static final City MOSCOW = new City("Moscow", new Coordinate(37.617298, 55.755825));
+    private static final City NEW_YORK = new City("New York", new Coordinate(-74.005974, 40.712776));
+    private static final City RIO = new City("Rio de Janeiro", new Coordinate(-43.2093727, -22.9110137));
     private static final List<City> CITIES = List.of(BERLIN, HONG_KONG, MOSCOW, NEW_YORK, RIO);
 
     public MapEvents() {
         Map map = new Map();
-        map.getView().setCenter(new Coordinate(-441077.2276714613, 5166904.667008546));
+        map.setCenter(new Coordinate(-3.9622642, 42.0395433));
         add(map);
 
         // Setup text areas for logging event data

--- a/src/main/java/com/vaadin/demo/component/map/MapEvents.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapEvents.java
@@ -15,6 +15,8 @@ import java.util.List;
 
 @Route("map-events")
 public class MapEvents extends VerticalLayout {
+    // For Vaadin 23.1, use Coordinate.fromLonLat to create coordinates
+    // from longitude and latitude
     private static final City BERLIN = new City("Berlin", new Coordinate(13.404954, 52.520008));
     private static final City HONG_KONG = new City("Hong Kong", new Coordinate(114.162813, 22.279328));
     private static final City MOSCOW = new City("Moscow", new Coordinate(37.617298, 55.755825));
@@ -24,6 +26,8 @@ public class MapEvents extends VerticalLayout {
 
     public MapEvents() {
         Map map = new Map();
+        // For Vaadin 23.1, use Coordinate.fromLonLat to create coordinates
+        // from longitude and latitude
         map.setCenter(new Coordinate(-3.9622642, 42.0395433));
         add(map);
 

--- a/src/main/java/com/vaadin/demo/component/map/MapMarkers.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapMarkers.java
@@ -18,17 +18,17 @@ public class MapMarkers extends Div {
         add(title);
 
         Map map = new Map();
-        map.getView().setCenter(new Coordinate(-441077.2276714613, 5166904.667008546));
+        map.setCenter(new Coordinate(-3.9622642, 42.0395433));
         add(map);
 
         // tag::snippet[]
         // Add marker for Vaadin HQ, using default marker image
-        Coordinate vaadinHqCoordinates = Coordinate.fromLonLat(22.29985, 60.45234);
+        Coordinate vaadinHqCoordinates = new Coordinate(22.29985, 60.45234);
         MarkerFeature vaadinHq = new MarkerFeature(vaadinHqCoordinates);
         map.getFeatureLayer().addFeature(vaadinHq);
 
         // Add marker for Vaadin office in Germany, using image from URL
-        Coordinate germanOfficeCoordinates = Coordinate.fromLonLat(13.45489, 52.51390);
+        Coordinate germanOfficeCoordinates = new Coordinate(13.45489, 52.51390);
         Icon.Options germanFlagIconOptions = new Icon.Options();
         germanFlagIconOptions.setSrc("images/german_flag.png");
         Icon germanFlagIcon = new Icon(germanFlagIconOptions);
@@ -36,7 +36,7 @@ public class MapMarkers extends Div {
         map.getFeatureLayer().addFeature(germanOffice);
 
         // Add marker for Vaadin office in the US, using image from a StreamResource
-        Coordinate usOfficeCoordinates = Coordinate.fromLonLat(-121.92163, 37.36821);
+        Coordinate usOfficeCoordinates = new Coordinate(-121.92163, 37.36821);
         StreamResource streamResource = new StreamResource("us-flag.png",
                 () -> getClass().getResourceAsStream("/META-INF/resources/images/us-flag.png"));
         Icon.Options usFlagIconOptions = new Icon.Options();

--- a/src/main/java/com/vaadin/demo/component/map/MapMarkers.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapMarkers.java
@@ -18,17 +18,23 @@ public class MapMarkers extends Div {
         add(title);
 
         Map map = new Map();
+        // For Vaadin 23.1, use Coordinate.fromLonLat to create coordinates
+        // from longitude and latitude
         map.setCenter(new Coordinate(-3.9622642, 42.0395433));
         add(map);
 
         // tag::snippet[]
-        // Add marker for Vaadin HQ, using default marker image
+        // For Vaadin 23.1, use Coordinate.fromLonLat to create coordinates
+        // from longitude and latitude
         Coordinate vaadinHqCoordinates = new Coordinate(22.29985, 60.45234);
+        Coordinate germanOfficeCoordinates = new Coordinate(13.45489, 52.51390);
+        Coordinate usOfficeCoordinates = new Coordinate(-121.92163, 37.36821);
+
+        // Add marker for Vaadin HQ, using default marker image
         MarkerFeature vaadinHq = new MarkerFeature(vaadinHqCoordinates);
         map.getFeatureLayer().addFeature(vaadinHq);
 
         // Add marker for Vaadin office in Germany, using image from URL
-        Coordinate germanOfficeCoordinates = new Coordinate(13.45489, 52.51390);
         Icon.Options germanFlagIconOptions = new Icon.Options();
         germanFlagIconOptions.setSrc("images/german_flag.png");
         Icon germanFlagIcon = new Icon(germanFlagIconOptions);
@@ -36,7 +42,6 @@ public class MapMarkers extends Div {
         map.getFeatureLayer().addFeature(germanOffice);
 
         // Add marker for Vaadin office in the US, using image from a StreamResource
-        Coordinate usOfficeCoordinates = new Coordinate(-121.92163, 37.36821);
         StreamResource streamResource = new StreamResource("us-flag.png",
                 () -> getClass().getResourceAsStream("/META-INF/resources/images/us-flag.png"));
         Icon.Options usFlagIconOptions = new Icon.Options();

--- a/src/main/java/com/vaadin/demo/component/map/MapViewport.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapViewport.java
@@ -26,45 +26,45 @@ public class MapViewport extends VerticalLayout {
 
         // Add menu items for moving the viewport to different cities
         moveToSubMenu.addItem("Berlin", e -> {
-            Coordinate coordinate = Coordinate.fromLonLat(13.404954, 52.520008);
-            map.getView().setCenter(coordinate);
-            map.getView().setZoom(10);
+            Coordinate coordinate = new Coordinate(13.404954, 52.520008);
+            map.setCenter(coordinate);
+            map.setZoom(10);
         });
         // end::snippet1[]
 
         moveToSubMenu.addItem("Hong Kong", e -> {
-            Coordinate coordinate = Coordinate.fromLonLat(114.162813, 22.279328);
-            map.getView().setCenter(coordinate);
-            map.getView().setZoom(10);
+            Coordinate coordinate = new Coordinate(114.162813, 22.279328);
+            map.setCenter(coordinate);
+            map.setZoom(10);
         });
 
         moveToSubMenu.addItem("Moscow", e -> {
-            Coordinate coordinate = Coordinate.fromLonLat(37.617298, 55.755825);
-            map.getView().setCenter(coordinate);
-            map.getView().setZoom(10);
+            Coordinate coordinate = new Coordinate(37.617298, 55.755825);
+            map.setCenter(coordinate);
+            map.setZoom(10);
         });
 
         moveToSubMenu.addItem("New York", e -> {
-            Coordinate coordinate = Coordinate.fromLonLat(-74.005974, 40.712776);
-            map.getView().setCenter(coordinate);
-            map.getView().setZoom(10);
+            Coordinate coordinate = new Coordinate(-74.005974, 40.712776);
+            map.setCenter(coordinate);
+            map.setZoom(10);
         });
 
         moveToSubMenu.addItem("Rio de Janeiro", e -> {
-            Coordinate coordinate = Coordinate.fromLonLat(-43.2093727, -22.9110137);
-            map.getView().setCenter(coordinate);
-            map.getView().setZoom(10);
+            Coordinate coordinate = new Coordinate(-43.2093727, -22.9110137);
+            map.setCenter(coordinate);
+            map.setZoom(10);
         });
 
         // tag::snippet2[]
         // Add menu items for zooming
         menuBar.addItem(zoomInIcon, e -> {
             float zoom = map.getView().getZoom();
-            map.getView().setZoom(zoom + 1);
+            map.setZoom(zoom + 1);
         });
         menuBar.addItem(zoomOutIcon, e -> {
             float zoom = map.getView().getZoom();
-            map.getView().setZoom(zoom - 1);
+            map.setZoom(zoom - 1);
         });
         // end::snippet2[]
         add(menuBar);

--- a/src/main/java/com/vaadin/demo/component/map/MapViewport.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapViewport.java
@@ -26,6 +26,8 @@ public class MapViewport extends VerticalLayout {
 
         // Add menu items for moving the viewport to different cities
         moveToSubMenu.addItem("Berlin", e -> {
+            // For Vaadin 23.1, use Coordinate.fromLonLat to create coordinates
+            // from longitude and latitude
             Coordinate coordinate = new Coordinate(13.404954, 52.520008);
             map.setCenter(coordinate);
             map.setZoom(10);


### PR DESCRIPTION
Adds a section about coordinate systems, and how to set user projections or define custom projections. As the docs already use 23.2, while most users are still using 23.1, this also adds a section about the breaking changes since 23.1 explaining how users on 23.1 can still make use of the documentation.

Todo:
- [x] Update example code to remove coordinate conversions

Marked as draft: This should only be merged after updating to the next 23.2 alpha (should be `23.2.0.alpha2`).