### PR TITLE
chore: update package.json overrides section

### DIFF
--- a/package.json
+++ b/package.json
@@ -323,7 +323,7 @@
       "workbox-precaching": "6.5.0",
       "workbox-webpack-plugin": "6.5.0"
     },
-    "hash": "51196bb15138e47809b684f8e714d8e7000917a55f64f7fc205b2b7fa9417702"
+    "hash": "9516acb372921d0cc57226afb7852127f3572c9df36f587c2f5e8e1a222c8dab"
   },
   "overrides": {
     "@vaadin/accordion": "$@vaadin/accordion",
@@ -362,6 +362,7 @@
     "@vaadin/menu-bar": "$@vaadin/menu-bar",
     "@vaadin/message-input": "$@vaadin/message-input",
     "@vaadin/message-list": "$@vaadin/message-list",
+    "@vaadin/multi-select-combo-box": "$@vaadin/multi-select-combo-box",
     "@vaadin/notification": "$@vaadin/notification",
     "@vaadin/number-field": "$@vaadin/number-field",
     "@vaadin/password-field": "$@vaadin/password-field",


### PR DESCRIPTION
For some reason the `"overrides"` entry was missing for `@vaadin/multi-select-combo-box` so I added it.