### PR TITLE
fix: add missing vaadin-button import to layout example

### DIFF
--- a/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
@@ -2,6 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
+import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/radio-group';
 import { RadioGroupValueChangedEvent } from '@vaadin/radio-group';


### PR DESCRIPTION
Added a missing import for `@vaadin/button`.