### PR TITLE
Leave /docs prefix in discussion url

### DIFF
--- a/dspublisher/theme/init-browser.ts
+++ b/dspublisher/theme/init-browser.ts
@@ -105,8 +105,7 @@ class Footer extends LitElement {
       return nothing;
     }
 
-    // Drop '/docs' from the beginning of the pathname
-    const url = encodeURI(document.location.pathname.substring('/docs'.length));
+    const url = encodeURI(document.location.pathname);
 
     let iframeSrc =
       window.location.hostname == 'preview.vaadin.com'


### PR DESCRIPTION
We're going to create notifications for new threads and we use urls from discussion component to generate links. I noticed that you drop /docs prefix from url parameter in the integrated discussion component and this causes invalid links. To avoid dirty workarounds on our side I think it's easier just to leave the prefix. 