### PR TITLE
chore: Fix typo in charts link computation

### DIFF
--- a/articles/components/charts/index.asciidoc
+++ b/articles/components/charts/index.asciidoc
@@ -1,8 +1,8 @@
 ---
 title: Charts
 page-links:
-  - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-crud}/#/elements/vaadin-chart[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/Chart.html[Java]'
-  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-crud}/packages/charts[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-charts-flow-parent[Java]'
+  - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-charts}/#/elements/vaadin-chart[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/Chart.html[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-charts}/packages/charts[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-charts-flow-parent[Java]'
 section-nav: commercial
 layout: index
 ---


### PR DESCRIPTION
Accidentally copy-pasted `moduleNpmVersion:vaadin-crud` from another module.
Fixed to `moduleNpmVersion:vaadin-charts`
Both packages are released with same version so link was fine anyway.


