### PR TITLE
fix: move applyTheme to createRenderRoot

### DIFF
--- a/frontend/demo/component/tabs/tabs-content.ts
+++ b/frontend/demo/component/tabs/tabs-content.ts
@@ -14,10 +14,11 @@ export class Example extends LitElement {
   @state()
   private pages = ['Dashboard', 'Payment', 'Shipping'];
 
-  constructor() {
-    super();
+  protected createRenderRoot() {
+    const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
-    applyTheme(this.shadowRoot);
+    applyTheme(root);
+    return root;
   }
 
   render() {


### PR DESCRIPTION
## Description

Fixed the error in [Switching Between Content](https://vaadin.com/docs/latest/components/tabs/#switching-between-content) TS example:

```
Uncaught TypeError: Cannot read properties of null (reading 'adoptedStyleSheets')
    at L (commons-cb7494fc173cb1a6ae9d.js:7056:66146)
    at R (commons-cb7494fc173cb1a6ae9d.js:7056:66471)
    at new s (350-4341b9acaec60b4aacbc.js:1:7906)
    at i.<anonymous> (commons-cb7494fc173cb1a6ae9d.js:5638:5560)
    at new i (commons-cb7494fc173cb1a6ae9d.js:5638:6059)
    at GddB.customElements.define (app-01dd008c8c882daa6248.js:2:164990)
    at commons-cb7494fc173cb1a6ae9d.js:5638:5968
```

This was the only component that used `applyTheme()` in the `constructor()` and had this error.
Moved the `applyTheme()` call to `createRenderRoot()`, same as in other TS examples.