### PR TITLE
docs: use correct quotes in code examples

### DIFF
--- a/articles/upgrading/essential-steps/instructions/_styling.adoc
+++ b/articles/upgrading/essential-steps/instructions/_styling.adoc
@@ -76,7 +76,7 @@ Selectors that use it need to be rewritten to use the `has-label` attribute inst
 [discrete]
 ==== Error Messages
 Error messages have been changed to slotted child elements.
-Although the `[part=”error-message”]` selector still works, some derived selectors may need to be adjusted.
+Although the `[part="error-message"]` selector still works, some derived selectors may need to be adjusted.
 The `:empty` selector no longer works correctly on these and should be replaced by attribute selectors for the appropriate states:
 [source,css,role="before"]
 ----

--- a/articles/upgrading/essential-steps/instructions/_typescript.adoc
+++ b/articles/upgrading/essential-steps/instructions/_typescript.adoc
@@ -53,7 +53,7 @@ pass:[<!-- vale Vale.Spelling = YES -->]
 
 The following general changes have been made to all input field components:
 
-* https://github.com/vaadin/web-components/issues/3275[Removed support for using positive `tabindex` values] (for example, `tabindex=”1”`) on all input field components.
+* https://github.com/vaadin/web-components/issues/3275[Removed support for using positive `tabindex` values] (for example, `tabindex="1"`) on all input field components.
 This will not cause errors but has no effect.
 However, setting `tabindex` to `0` or `-1` is still supported.
 It is recommended to ensure that input fields are in the correct order in the DOM, instead of overriding the tab order with `tabindex`.
@@ -69,7 +69,7 @@ It is recommended to ensure that input fields are in the correct order in the DO
 +
 [source, html, role="after"]
 ----
-<vaadin-checkbox label=”Foo”>
+<vaadin-checkbox label="Foo">
 ----
 
 * Similarly, rich (HTML) labels should be applied using the new `label` slot:
@@ -84,7 +84,7 @@ It is recommended to ensure that input fields are in the correct order in the DO
 [source,html,role="after"]
 ----
 <vaadin-checkbox>
-  <label slot=”label”>Foo <b>Bar</b></label>
+  <label slot="label">Foo <b>Bar</b></label>
 </vaadin-checkbox>
 ----
 
@@ -145,10 +145,10 @@ See <<Text Field>> changes for details.
 +
 [source,html,role="after"]
 ----
-<vaadin-radio-button label=”Label”></vaadin-radio-button>
+<vaadin-radio-button label="Label"></vaadin-radio-button>
 
 <vaadin-radio-button>
-  <label slot=”label”>
+  <label slot="label">
     <b>This</b> is a <i>rich</i> label
   </label>
 </vaadin-radio-button>

--- a/articles/upgrading/upgrade-tool/styling/_21-22.adoc
+++ b/articles/upgrading/upgrade-tool/styling/_21-22.adoc
@@ -39,7 +39,7 @@ Selectors using it need to be rewritten to use the `has-label` attribute instead
 
 [discrete]
 ==== Error Messages
-Error messages have been changed to slotted child elements. While the `[part=”error-message”]` selector still works, some derived selectors may need to be adjusted. The `:empty` selector no longer works correctly on these and should be replaced with attribute selectors for the appropriate states:
+Error messages have been changed to slotted child elements. While the `[part="error-message"]` selector still works, some derived selectors may need to be adjusted. The `:empty` selector no longer works correctly on these and should be replaced with attribute selectors for the appropriate states:
 [source,css]
 ----
 /* Before */

--- a/articles/upgrading/upgrade-tool/typescript/_21-22.adoc
+++ b/articles/upgrading/upgrade-tool/typescript/_21-22.adoc
@@ -10,7 +10,7 @@ pass:[<!-- vale Vale.Spelling = YES -->]
 
 The following general changes have been made to all input field components:
 
-* https://github.com/vaadin/web-components/issues/3275[Removed support for using positive `tabindex` values] (for example, `tabindex=”1”`) on all input field components. 
+* https://github.com/vaadin/web-components/issues/3275[Removed support for using positive `tabindex` values] (for example, `tabindex="1"`) on all input field components.
 This will not cause errors but has no effect.
 However, setting `tabindex` to `0` or `-1` is still supported.
 It is recommended to ensure that input fields are in the correct order in the DOM, instead of overriding the tab order with `tabindex`.
@@ -29,7 +29,7 @@ It is recommended to ensure that input fields are in the correct order in the DO
 <vaadin-checkbox>Foo</vaadin-checkbox>
 
 <!-- After -->
-<vaadin-checkbox label=”Foo”>
+<vaadin-checkbox label="Foo">
 ----
 
 * Similarly, rich (HTML) labels should be applied using the new `label` slot:
@@ -44,7 +44,7 @@ It is recommended to ensure that input fields are in the correct order in the DO
 
 <!-- After -->
 <vaadin-checkbox>
-  <label slot=”label”>Foo <b>Bar</b></label>
+  <label slot="label">Foo <b>Bar</b></label>
 </vaadin-checkbox>
 ----
 
@@ -114,10 +114,10 @@ It is recommended to ensure that input fields are in the correct order in the DO
 
 <!-- After -->
 
-<vaadin-radio-button label=”Label”></vaadin-radio-button>
+<vaadin-radio-button label="Label"></vaadin-radio-button>
 
 <vaadin-radio-button>
-  <label slot=”label”>
+  <label slot="label">
     <b>This</b> is a <i>rich</i> label
   </label>
 </vaadin-radio-button>


### PR DESCRIPTION
## Description

Replaced `“` and `”` (left and right double quotation marks) with correct `"` quotation marks.
This is needed to make sure these HTML and CSS examples work when copying to editor.