### PR TITLE
docs: fix typos detected by cspell

### DIFF
--- a/articles/binding-data/data-provider.asciidoc
+++ b/articles/binding-data/data-provider.asciidoc
@@ -162,7 +162,7 @@ grid.setItems(query -> // <1>
 <1> To create a lazy binding, use an overloaded version of the [methodname]`setItems()` method that uses a callback instead of passing data directly to the component.
 <2> Typically, you call your service layer from the callback, as is done here.
 <3> The link:https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/data/provider/Query.html#getOffset()[_offset_] refers to the first index of the item to fetch.
-<4> The link:https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/data/provider/Query.html#getLimit()[_limit_] refers to the number of items to fetch. When fetching for more data, you should utilize [classname]`Query` properties to litmit the amount of data to fetch.
+<4> The link:https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/data/provider/Query.html#getLimit()[_limit_] refers to the number of items to fetch. When fetching for more data, you should utilize [classname]`Query` properties to limit the amount of data to fetch.
 <5> In this example, it is assumed that the back end returns a [classname]`List`, so we need to convert it to a [classname]`Stream`.
 
 The example above works well with JDBC back ends, where you can request a set of rows from a given index.

--- a/articles/components/charts/configuration.asciidoc
+++ b/articles/components/charts/configuration.asciidoc
@@ -163,7 +163,7 @@ options.setTooltip(seriesTooltip);
 series.setPlotOptions(options);
 
 // Tooltip element needs to be configured on chart
-chart.setTooltip(new Toolip());
+chart.setTooltip(new Tooltip());
 ----
 
 [[charts.configuration.axes]]

--- a/articles/create-ui/templates/and-binder.asciidoc
+++ b/articles/create-ui/templates/and-binder.asciidoc
@@ -141,7 +141,7 @@ public void setBean(User user) {
 }
 
 /**
- * Clears the form and disconnnect any bean.
+ * Clears the form and disconnects any bean.
  */
 public void removeBean() {
     binder.removeBean();

--- a/articles/integrations/quarkus.asciidoc
+++ b/articles/integrations/quarkus.asciidoc
@@ -86,7 +86,7 @@ For example:
 
 <build>
     <plugins>
-        <!-- For indepth information on quarkus-maven-plugin
+        <!-- For in-depth information on quarkus-maven-plugin
              see https://quarkus.io/guides/maven-tooling#build-tool-maven -->
         <plugin>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## Description

Fixed a few typos discovered using [`cspell`](https://www.npmjs.com/package/cspell) CLI utility.