### PR TITLE
chore: set target in tsconfig.json to es2021

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "sourceMap": true,
     "inlineSources": true,
     "module": "esNext",
-    "target": "es2017",
+    "target": "es2021",
     "moduleResolution": "node",
     "strict": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Now when Vaadin supports latest versions of browsers, it makes sense to also enable ES2021 features.
In particular, this includes [String.prototype.replaceAll()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) used in #1612

This feature is supported in [Safari 13.1 and later](https://caniuse.com/mdn-javascript_builtins_string_replaceall) so it should be safe for us to use it.