### PR TITLE
Add mysql-connector-java version

### DIFF
--- a/articles/integrations/databases/mysql.adoc
+++ b/articles/integrations/databases/mysql.adoc
@@ -12,6 +12,7 @@ MySQL is a popular relational database from Oracle. You should https://dev.mysql
 For an existing Vaadin project, you can connect to MySQL by following the steps below:
 
 . Add the `mysql-connector-java` dependency to the [filename]#pom.xml# file.
+You can find the latest version of the `mysql-connector-java` dependency from this https://search.maven.org/artifact/mysql/mysql-connector-java[link].
 +
 .`pom.xml`
 [source, xml]
@@ -19,6 +20,7 @@ For an existing Vaadin project, you can connect to MySQL by following the steps 
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
+      <version>8.0.30</version>
       <scope>runtime</scope>
     </dependency>
 ----


### PR DESCRIPTION
Without the version explicitly set, the project doesn't run with an error: `[Cannot load driver class: com.mysql.jdbc.Driver Spring](https://stackoverflow.com/questions/33123985/cannot-load-driver-class-com-mysql-jdbc-driver-spring)`.