### PR TITLE
fix: add missing annotations dependency

### DIFF
--- a/articles/tools/observability/advanced/custom-instrumentation.asciidoc
+++ b/articles/tools/observability/advanced/custom-instrumentation.asciidoc
@@ -12,14 +12,20 @@ Writing custom instrumentation allows the collection of application-specific tel
 
 Custom instrumentation allows the execution of a specific pieces of code to be recorded as spans, which get automatically added to the current trace, and to provide additional details such as attributes and errors.
 
-Start by adding the OpenTelemetry API dependency to the project:
+Custom spans can be added either by using annotations, or by using the OpenTelemetry API to create and end spans manually.
+The following sections provide instructions for each of these methods.
+
+=== Using Annotations
+
+The easiest way to add custom spans is to annotate methods whose executions should be recorded.
+Annotations require the OpenTelemetry instrumentation annotations dependency to be in the project.
 
 .pom.xml
 [source, xml]
 ----
 <dependency>
     <groupId>io.opentelemetry</groupId>
-    <artifactId>opentelemetry-api</artifactId>
+    <artifactId>opentelemetry-instrumentation-annotations</artifactId>
     <version>1.17.0</version>
 </dependency>
 ----
@@ -28,13 +34,9 @@ Start by adding the OpenTelemetry API dependency to the project:
 The OpenTelemetry API version should match the version that is used by the Vaadin Observability agent.
 The used version is available in the release notes and can be seen when running the JavaAgent.
 
-Custom spans can be added either by using annotations, or by using the OpenTelemetry API to create and end spans manually.
-The following sections provide instructions for each of these methods.
+Now methods that should be recorded can be annotated with the `@WithSpan` annotation.
 
-=== Using Annotations
-
-The easiest way to add custom spans is to annotate methods whose executions should be recorded with the `@WithSpan` annotation:
-
+.Record Image Fetch
 [source,java]
 ----
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -49,6 +51,7 @@ public class ImageListView {
 
 Method parameters can be added as attributes to the span by using the `@SpanAttibute` annotation:
 
+.Store Fetch URL As Annotation
 [source,java]
 ----
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
@@ -67,6 +70,22 @@ For more details see the https://opentelemetry.io/docs/instrumentation/java/auto
 === Creating Spans Manually
 
 Spans can be created manually using the OpenTelemetry API, which gives more fine-grained control over when spans are started, ended, and what data they should contain.
+
+Creating manual spans requires adding the OpenTelemetry API dependency to the project:
+
+.pom.xml
+[source, xml]
+----
+<dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-api</artifactId>
+    <version>1.17.0</version>
+</dependency>
+----
+
+[NOTE]
+The OpenTelemetry API version should match the version that is used by the Vaadin Observability agent.
+The used version is available in the release notes and can be seen when running the JavaAgent.
 
 To create a span manually, acquire a tracer instance from the OpenTelemetry API, and then start and end a span around the code that should be traced:
 


### PR DESCRIPTION
The instrumentation-annotation was mistakenly
dropped during refactoring. Re add  required
dependencies to correct parts of the document.

`opentelemetry-api` only brings in `opentelemetry-context`
and `opentelemetry-instrumentation-annotations` has no dependencies
