### PR TITLE
docs: observability integrations polish

### DIFF
--- a/articles/tools/observability/integrations/datadog.asciidoc
+++ b/articles/tools/observability/integrations/datadog.asciidoc
@@ -1,7 +1,7 @@
 ---
 title: Datadog
 tab-tile: Datadog
-order: 5
+order: 2
 layout: page
 ---
 
@@ -187,6 +187,7 @@ Then add a new TCP appender to your Logback configuration, using the encoder cre
 ----
 
 The configuration contains two variables that need to be passed as system variables when running the Java agent:
+
 - `DD_SITE` - The domain of the Datadog region that you signed up for. This should have the same value as in the collector configuration from above.
 - `DD_API_KEY` - An API key for authenticating against the Datadog API. This should have the same value as in the collector configuration from above.
 
@@ -262,7 +263,7 @@ Please refer to the https://docs.datadoghq.com/metrics/explorer/[Datadog documen
 
 === Viewing Logs
 
-In the Datadog web UI, select `Logs from the menu on the left.
+In the Datadog web UI, select `Logs` from the menu on the left.
 
 The view shows a list of recent log entries, which can be filtered by text or log level.
 

--- a/articles/tools/observability/integrations/grafana.asciidoc
+++ b/articles/tools/observability/integrations/grafana.asciidoc
@@ -1,7 +1,7 @@
 ---
 title: Grafana
 tab-tile: Grafana
-order: 4
+order: 3
 layout: page
 ---
 
@@ -22,7 +22,7 @@ Please refer to the Grafana documentation on how to properly configure and secur
 
 Start by cloning https://github.com/vaadin/observability-grafana-setup[this git repository] that contains the setup:
 ```Shell
-git clone git@github.com:vaadin/observability-grafana-setup.git
+git clone https://github.com/vaadin/observability-grafana-setup.git
 ```
 
 From the setup folder, run:
@@ -70,6 +70,7 @@ include::./_run-app.asciidoc[opts=optional]
 == Viewing Data
 
 The Grafana setup provides a http://localhost:3000/d/6_bNYpGVz/vaadin-dashboard?orgId=1[sample dashboard] that shows basic metrics, like JVM memory usage and CPU utilization, traces and errors, as well as logs.
+To log in, use the default credentials `admin` / `admin`.
 
 [NOTE]
 The service name needs to be configured as `vaadin` in the agent properties file, otherwise the dashboard will not show any data.

--- a/articles/tools/observability/integrations/index.asciidoc
+++ b/articles/tools/observability/integrations/index.asciidoc
@@ -1,21 +1,39 @@
 ---
-title: Vendor Integrations
+title: Integrations
 order: 3
 ---
 
 = Observability Kit Integrations
 
-The Observability Kit agent can be used with any vendors that natively support OpenTelemetry.
+The Observability Kit agent can be used with any vendor that natively support the https://opentelemetry.io/[OpenTelemetry standard].
 
-For others, there is the possibility to use an OpenTelemetry collector with a service-specific exporter to forward the telemetry data.
+For others, there is the possibility to use the https://opentelemetry.io/docs/collector/[OpenTelemetry collector] with a service-specific exporter to forward the telemetry data.
 
-For simple development-time testing locally, we propose using xref:jaeger-prometheus#[Jaeger and Prometheus].
+We have explicitly tested and provide support for the following vendors:
+
+[cols="1,2"]
+|===
+|Vendor |Description
+
+|xref:newrelic#[New Relic]
+|Observability SaaS platform with support for metrics, traces and logs
+
+|xref:datadog#[Datadog]
+|Observability SaaS platform with support for metrics, traces, as well as limited support for logs
+
+|xref:grafana#[Grafana]
+|Observability stack with support for metrics, traces and logs. Can be self-hosted and also provides managed hosting.
+
+|xref:jaeger-prometheus#[Jaeger and Prometheus]
+|A simple local setup that can be used for testing, with support for metrics and traces.
+
+|===
+
+
+For simple development-time testing locally, we propose using xref:jaeger-prometheus#[Jaeger and Prometheus] or xref:grafana#[Grafana]:
+
+- Jaeger and Prometheus can be easily downloaded, and run standalone without any further dependencies.
 Jaeger is used to process traces and Prometheus to process metrics.
-
-== Vendor Specific Integration Documentation
-
-xref:newrelic#[New Relic] Observability SaaS platform with support for metrics, traces and logs
-
-xref:datadog#[Datadog] Observability SaaS platform with support for metrics, traces, as well as limited support for logs
-
-xref:grafana#[Grafana] Observability stack with support for metrics, traces and logs. Can be self-hosted and also provides managed hosting.
+This setup has the downside that it does not support logs, and data is viewed from two different tools.
+- The Grafana setup requires Docker and docker-compose to be installed.
+The setup has the benefit that it supports logs and all data is viewable from a single tool.

--- a/articles/tools/observability/integrations/jaeger-prometheus.asciidoc
+++ b/articles/tools/observability/integrations/jaeger-prometheus.asciidoc
@@ -1,10 +1,10 @@
 ---
-title: Setup Exports to Jaeger and Prometheus
-order: 2
+title: Jaeger and Prometheus
+order: 4
 layout: page
 ---
 
-== Setup Exports to Jaeger and Prometheus
+== Jaeger and Prometheus Integration
 
 https://www.jaegertracing.io/[Jaeger] is a tool for collecting traces.
 https://prometheus.io/[Prometheus] is a tool for collecting metrics.

--- a/articles/tools/observability/integrations/newrelic.asciidoc
+++ b/articles/tools/observability/integrations/newrelic.asciidoc
@@ -1,11 +1,11 @@
 ---
-title: Setup Export to New Relic
+title: New Relic
 tab-title: New Relic
-order: 3
+order: 1
 layout: page
 ---
 
-= Setup Export to New Relic
+= New Relic Integration
 
 https://newrelic.com[New Relic] supports the export of metrics, traces and logs.
 


### PR DESCRIPTION
- simplify and align page titles
- switch page order to prefer production-ready setups and targeted customer base
- mention explicitly supported integrations in overview, add links to OpenTelemetry
- mention Grafana as alternative for local development, explain upsides, downsides


