### PR TITLE
docs: observability jaeger and prometheus data viewing

### DIFF
--- a/articles/tools/observability/getting-started.asciidoc
+++ b/articles/tools/observability/getting-started.asciidoc
@@ -42,3 +42,12 @@ Start your application using one of the methods provided below.
 If you don't have an application to use, you can download an app from https://start.vaadin.com[Vaadin Start], and run a production build using `mvn package -Pproduction`. Then run the packaged Jar file from the `target` folder as described below.
 
 include::./integrations/_run-app.asciidoc[]
+
+== Viewing Data
+
+First, generate some data by opening your application and using it for a bit.
+Then open Jaeger and Prometheus to view the data that has been collected.
+
+include::./integrations/jaeger-prometheus.asciidoc[tag=viewing-traces]
+
+include::./integrations/jaeger-prometheus.asciidoc[tag=viewing-metrics]

--- a/articles/tools/observability/integrations/jaeger-prometheus.asciidoc
+++ b/articles/tools/observability/integrations/jaeger-prometheus.asciidoc
@@ -85,3 +85,31 @@ otel.exporter.prometheus.port=9464
 == Running the App
 
 include::./_run-app.asciidoc[opts=optional]
+
+== Viewing Data
+
+// tag::viewing-traces[]
+
+=== Viewing Traces
+
+To view traces, open the http://localhost:16686/search[Jaeger search view].
+From the menu on the left side, select the name of your service, which is `vaadin` by default.
+Then click on `Find Traces` to search for traces.
+
+The graph at the top shows the duration of individual traces from the search result.
+The list below displays all the traces that have been found.
+
+Clicking on a trace brings up a view that shows detailed information about a trace, such as nested spans, and their attributes and events.
+
+// end::viewing-traces[]
+
+// tag::viewing-metrics[]
+
+=== Viewing Metrics
+
+To view metrics, open the http://localhost:9090/graph[Prometheus Graph view].
+In the search bar, click on the metrics explorer icon (world icon), which opens a dialog with all available metrics.
+Select a metric, for example `process_runtime_jvm_memory_usage` to view JVM memory usage.
+Then click on `Execute` to query the metric data, and switch to the `Graph` tab below the search bar to view the chart for the metric.
+
+// end::viewing-metrics[]


### PR DESCRIPTION
Adds basic instructions on how to view data in Jaeger and Prometheus, and includes those instructions in the getting started page.