### PR TITLE
chore: align open and closed tags formatting

### DIFF
--- a/frontend/demo/component/accordion/accordion-summary.ts
+++ b/frontend/demo/component/accordion/accordion-summary.ts
@@ -99,17 +99,16 @@ export class Example extends LitElement {
               style="font-size: var(--lumo-font-size-s)"
             >
               <span>${this.personBinder.value.address?.street}</span>
-              <span
-                >${this.personBinder.value.address?.zip}
-                ${this.personBinder.value.address?.city}</span
-              >
+              <span>
+                ${this.personBinder.value.address?.zip} ${this.personBinder.value.address?.city}
+              </span>
 
-              <span
-                >${
+              <span>
+                ${
                   // @ts-ignore Workaround a Binder issue
                   this.personBinder.value.address?.country?.name
-                }</span
-              >
+                }
+              </span>
             </vaadin-vertical-layout>
           </div>
 

--- a/frontend/demo/component/badge/badge-counter.ts
+++ b/frontend/demo/component/badge/badge-counter.ts
@@ -31,8 +31,9 @@ export class Example extends LitElement {
             theme="badge contrast pill small"
             aria-label="12 unread messages"
             title="12 unread messages"
-            >12</span
           >
+            12
+          </span>
         </vaadin-tab>
         <vaadin-tab>
           <span>Important</span>
@@ -40,8 +41,9 @@ export class Example extends LitElement {
             theme="badge contrast pill small"
             aria-label="3 unread messages"
             title="3 unread messages"
-            >3</span
           >
+            3
+          </span>
         </vaadin-tab>
         <vaadin-tab>
           <span>Spam</span>

--- a/frontend/demo/component/button/button-labels.ts
+++ b/frontend/demo/component/button/button-labels.ts
@@ -48,8 +48,9 @@ export class Example extends LitElement {
           <vaadin-button
             arial-label="Remove primary email address"
             @click="${() => (this.primaryEmail = '')}"
-            >Remove</vaadin-button
           >
+            Remove
+          </vaadin-button>
         </vaadin-horizontal-layout>
 
         <vaadin-horizontal-layout theme="spacing">
@@ -63,8 +64,9 @@ export class Example extends LitElement {
           <vaadin-button
             arial-label="Remove secondary email address"
             @click="${() => (this.secondaryEmail = '')}"
-            >Remove</vaadin-button
           >
+            Remove
+          </vaadin-button>
         </vaadin-horizontal-layout>
       </vaadin-vertical-layout>
       <!-- end::snippet[] -->

--- a/frontend/demo/component/grid/grid-dynamic-height.ts
+++ b/frontend/demo/component/grid/grid-dynamic-height.ts
@@ -63,8 +63,9 @@ export class Example extends LitElement {
               this.selectedValue = '';
             }
           }}"
-          >Send invite</vaadin-button
         >
+          Send invite
+        </vaadin-button>
       </vaadin-horizontal-layout>
 
       ${this.invitedPeople.length === 0

--- a/frontend/demo/component/grid/grid-item-details-toggle.ts
+++ b/frontend/demo/component/grid/grid-item-details-toggle.ts
@@ -94,7 +94,8 @@ export class Example extends LitElement {
                     ? this.detailsOpenedItems.filter((p) => p != person)
                     : [...this.detailsOpenedItems, person];
                 }}"
-                >Toggle details
+              >
+                Toggle details
               </vaadin-button>
             `,
             []

--- a/frontend/demo/component/gridpro/grid-pro-editors.ts
+++ b/frontend/demo/component/gridpro/grid-pro-editors.ts
@@ -38,8 +38,7 @@ export class Example extends LitElement {
           path="membership"
           editor-type="select"
           .editorOptions="${['Regular', 'Premium', 'VIP']}"
-        >
-        </vaadin-grid-pro-edit-column>
+        ></vaadin-grid-pro-edit-column>
         <vaadin-grid-pro-edit-column path="subscriber" editor-type="checkbox">
         </vaadin-grid-pro-edit-column>
         <vaadin-grid-pro-edit-column

--- a/frontend/demo/upgrade-tool/upgrade-tool.ts
+++ b/frontend/demo/upgrade-tool/upgrade-tool.ts
@@ -67,14 +67,14 @@ export default class UpgradeTool extends LitElement {
           <div slot="summary">Earlier Versions</div>
           <ul style="margin-top: 0">
             <li>
-              <a href="https://vaadin.com/docs/v14/flow/upgrading/v10-13/"
-                >Upgrading from Vaadin 10–13 to Vaadin 14</a
-              >
+              <a href="https://vaadin.com/docs/v14/flow/upgrading/v10-13/">
+                Upgrading from Vaadin 10–13 to Vaadin 14
+              </a>
             </li>
             <li>
-              <a href="https://vaadin.com/docs/v14/flow/upgrading/v8/"
-                >Upgrading from Vaadin 8 to Vaadin 14</a
-              >
+              <a href="https://vaadin.com/docs/v14/flow/upgrading/v8/">
+                Upgrading from Vaadin 8 to Vaadin 14
+              </a>
             </li>
           </ul>
         </vaadin-details>
@@ -125,8 +125,9 @@ export default class UpgradeTool extends LitElement {
           theme="primary"
           style="width: fit-content; margin-top: 30px; margin-bottom: 30px"
           @click=${this.showUpdateInstructions}
-          >Show update instructions!</vaadin-button
         >
+          Show update instructions!
+        </vaadin-button>
       </div>
     `;
   }


### PR DESCRIPTION
## Description

Aligned formatting for open and closing HTML tags to make it look nicer (and fix some Prettier weirdness).
These elements are mostly inline (`<span>`, `<a>`, `<vaadin-button>`) so whitespace does not matter.