### PR TITLE
chore: use horizontal layout in avatar examples

### DIFF
--- a/frontend/demo/component/avatar/avatar-abbreviation.ts
+++ b/frontend/demo/component/avatar/avatar-abbreviation.ts
@@ -2,6 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import '@vaadin/avatar';
+import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-abbreviation')
@@ -15,10 +16,13 @@ export class Example extends LitElement {
 
   render() {
     return html`
-      <!-- tag::snippet[] -->
-      <vaadin-avatar name="Augusta Ada King"></vaadin-avatar>
-      <vaadin-avatar name="Augusta Ada King" abbr="AK"></vaadin-avatar>
-      <!-- end::snippet[] -->
+      <vaadin-horizontal-layout theme="spacing">
+        <!-- tag::snippet[] -->
+        <vaadin-avatar name="Augusta Ada King"></vaadin-avatar>
+
+        <vaadin-avatar name="Augusta Ada King" abbr="AK"></vaadin-avatar>
+        <!-- end::snippet[] -->
+      </vaadin-horizontal-layout>
     `;
   }
 }

--- a/frontend/demo/component/avatar/avatar-basic.ts
+++ b/frontend/demo/component/avatar/avatar-basic.ts
@@ -2,6 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
+import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
@@ -25,15 +26,19 @@ export class Example extends LitElement {
 
   render() {
     return html`
-      <!-- tag::snippet[] -->
-      <vaadin-avatar></vaadin-avatar>
-      <vaadin-avatar .name="${`${this.person?.firstName} ${this.person?.lastName}`}">
-      </vaadin-avatar>
-      <vaadin-avatar
-        .img="${this.person?.pictureUrl}"
-        .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
-      ></vaadin-avatar>
-      <!-- end::snippet[] -->
+      <vaadin-horizontal-layout theme="spacing">
+        <!-- tag::snippet[] -->
+        <vaadin-avatar></vaadin-avatar>
+
+        <vaadin-avatar .name="${`${this.person?.firstName} ${this.person?.lastName}`}">
+        </vaadin-avatar>
+
+        <vaadin-avatar
+          .img="${this.person?.pictureUrl}"
+          .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
+        ></vaadin-avatar>
+        <!-- end::snippet[] -->
+      </vaadin-horizontal-layout>
     `;
   }
 }

--- a/frontend/demo/component/avatar/avatar-basic.ts
+++ b/frontend/demo/component/avatar/avatar-basic.ts
@@ -30,8 +30,9 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <vaadin-avatar></vaadin-avatar>
 
-        <vaadin-avatar .name="${`${this.person?.firstName} ${this.person?.lastName}`}">
-        </vaadin-avatar>
+        <vaadin-avatar
+          .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
+        ></vaadin-avatar>
 
         <vaadin-avatar
           .img="${this.person?.pictureUrl}"

--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -2,6 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
+import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from '../../domain/DataService';
 import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
@@ -26,13 +27,16 @@ export class Example extends LitElement {
 
   render() {
     return html`
-      <!-- tag::snippet[] -->
-      <vaadin-avatar
-        .img="${this.person?.pictureUrl}"
-        .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
-      ></vaadin-avatar>
-      <vaadin-avatar .img="${companyLogo}" name="Company Inc."></vaadin-avatar>
-      <!-- end::snippet[] -->
+      <vaadin-horizontal-layout theme="spacing">
+        <!-- tag::snippet[] -->
+        <vaadin-avatar
+          .img="${this.person?.pictureUrl}"
+          .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
+        ></vaadin-avatar>
+
+        <vaadin-avatar .img="${companyLogo}" name="Company Inc."></vaadin-avatar>
+        <!-- end::snippet[] -->
+      </vaadin-horizontal-layout>
     `;
   }
 }

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -36,8 +36,7 @@ export class Example extends LitElement {
         <vaadin-avatar
           .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
           theme="large"
-        >
-        </vaadin-avatar>
+        ></vaadin-avatar>
 
         <vaadin-avatar
           .name="${`${this.person?.firstName} ${this.person?.lastName}`}"

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -2,6 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
+import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
@@ -25,16 +26,33 @@ export class Example extends LitElement {
 
   render() {
     return html`
-      <!-- tag::snippet[] -->
-      <vaadin-avatar .name="${`${this.person?.firstName} ${this.person?.lastName}`}" theme="xlarge">
-      </vaadin-avatar>
-      <vaadin-avatar .name="${`${this.person?.firstName} ${this.person?.lastName}`}" theme="large">
-      </vaadin-avatar>
-      <vaadin-avatar .name="${`${this.person?.firstName} ${this.person?.lastName}`}" theme="small">
-      </vaadin-avatar>
-      <vaadin-avatar .name="${`${this.person?.firstName} ${this.person?.lastName}`}" theme="xsmall">
-      </vaadin-avatar>
-      <!-- end::snippet[] -->
+      <vaadin-horizontal-layout theme="spacing">
+        <!-- tag::snippet[] -->
+        <vaadin-avatar
+          .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
+          theme="xlarge"
+        >
+        </vaadin-avatar>
+
+        <vaadin-avatar
+          .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
+          theme="large"
+        >
+        </vaadin-avatar>
+
+        <vaadin-avatar
+          .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
+          theme="small"
+        >
+        </vaadin-avatar>
+
+        <vaadin-avatar
+          .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
+          theme="xsmall"
+        >
+        </vaadin-avatar>
+        <!-- end::snippet[] -->
+      </vaadin-horizontal-layout>
     `;
   }
 }

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -46,8 +46,7 @@ export class Example extends LitElement {
         <vaadin-avatar
           .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
           theme="xsmall"
-        >
-        </vaadin-avatar>
+        ></vaadin-avatar>
         <!-- end::snippet[] -->
       </vaadin-horizontal-layout>
     `;

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -31,8 +31,7 @@ export class Example extends LitElement {
         <vaadin-avatar
           .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
           theme="xlarge"
-        >
-        </vaadin-avatar>
+        ></vaadin-avatar>
 
         <vaadin-avatar
           .name="${`${this.person?.firstName} ${this.person?.lastName}`}"

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -41,8 +41,7 @@ export class Example extends LitElement {
         <vaadin-avatar
           .name="${`${this.person?.firstName} ${this.person?.lastName}`}"
           theme="small"
-        >
-        </vaadin-avatar>
+        ></vaadin-avatar>
 
         <vaadin-avatar
           .name="${`${this.person?.firstName} ${this.person?.lastName}`}"

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarAbbreviation.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarAbbreviation.java
@@ -2,11 +2,11 @@ package com.vaadin.demo.component.avatar;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.avatar.Avatar;
-import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 
 @Route("avatar-abbreviation")
-public class AvatarAbbreviation extends Div {
+public class AvatarAbbreviation extends HorizontalLayout {
 
   public AvatarAbbreviation() {
     // tag::snippet[]

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarBasic.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarBasic.java
@@ -4,11 +4,11 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.avatar.Avatar;
-import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 
 @Route("avatar-basic")
-public class AvatarBasic extends Div {
+public class AvatarBasic extends HorizontalLayout {
 
   private Person person = DataService.getPeople(1).get(0);
 

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarImage.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarImage.java
@@ -4,12 +4,12 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.avatar.Avatar;
-import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.StreamResource;
 
 @Route("avatar-image")
-public class AvatarImage extends Div {
+public class AvatarImage extends HorizontalLayout {
 
   private Person person = DataService.getPeople(1).get(0);
 

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarSizes.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarSizes.java
@@ -5,11 +5,11 @@ import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.avatar.Avatar;
 import com.vaadin.flow.component.avatar.AvatarVariant;
-import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 
 @Route("avatar-sizes")
-public class AvatarSizes extends Div {
+public class AvatarSizes extends HorizontalLayout {
 
   private Person person = DataService.getPeople(1).get(0);
 


### PR DESCRIPTION
Toggling between the Java/TypeScript source in the Avatar examples shows a mismatch with layouting. The TS example has spacing between the avatars while the Java example does not.

https://user-images.githubusercontent.com/1222264/191939897-1773ebcf-97ea-47b7-9c6d-e4018d955e04.mp4

This PR makes the Avatar examples use the same approach as we use with many other examples to align the spacing = wrap the individual instances in a `HorizontalLayout`.