### PR TITLE
refactor: use radio-group value instead of checked

### DIFF
--- a/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private size!: string;
+  private size = '0';
 
   render() {
     return html`
@@ -34,9 +34,10 @@ export class Example extends LitElement {
       </vaadin-horizontal-layout>
       <vaadin-radio-group
         label="Item sizing"
+        .value="${this.size}"
         @value-changed="${(e: RadioGroupValueChangedEvent) => (this.size = e.detail.value)}"
       >
-        <vaadin-radio-button value="0" label="Default size" checked></vaadin-radio-button>
+        <vaadin-radio-button value="0" label="Default size"></vaadin-radio-button>
         <vaadin-radio-button value="1" label="Expand"></vaadin-radio-button>
       </vaadin-radio-group>
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private justifyContent?: string;
+  private justifyContent = 'flex-start';
 
   render() {
     return html`
@@ -37,14 +37,11 @@ export class Example extends LitElement {
       </vaadin-horizontal-layout>
       <vaadin-radio-group
         label="Horizontal alignment"
+        .value="${this.justifyContent}"
         @value-changed="${(e: RadioGroupValueChangedEvent) =>
           (this.justifyContent = e.detail.value)}"
       >
-        <vaadin-radio-button
-          value="flex-start"
-          label="Start (default)"
-          checked
-        ></vaadin-radio-button>
+        <vaadin-radio-button value="flex-start" label="Start (default)"></vaadin-radio-button>
         <vaadin-radio-button value="center" label="Center"></vaadin-radio-button>
         <vaadin-radio-button value="flex-end" label="End"></vaadin-radio-button>
         <vaadin-radio-button value="space-between" label="Between"></vaadin-radio-button>

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
@@ -23,10 +23,10 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private alignLayoutItems?: string;
+  private alignLayoutItems = 'stretch';
 
   @state()
-  private alignFirstItem?: string;
+  private alignFirstItem = 'auto';
 
   render() {
     return html`
@@ -44,14 +44,11 @@ export class Example extends LitElement {
       </vaadin-horizontal-layout>
       <vaadin-radio-group
         label="Vertical alignment"
+        .value="${this.alignLayoutItems}"
         @value-changed="${(e: RadioGroupValueChangedEvent) =>
           (this.alignLayoutItems = e.detail.value)}"
       >
-        <vaadin-radio-button
-          value="stretch"
-          label="Stretch (default)"
-          checked
-        ></vaadin-radio-button>
+        <vaadin-radio-button value="stretch" label="Stretch (default)"></vaadin-radio-button>
         <vaadin-radio-button value="flex-start" label="Start"></vaadin-radio-button>
         <vaadin-radio-button value="center" label="Center"></vaadin-radio-button>
         <vaadin-radio-button value="flex-end" label="End"></vaadin-radio-button>
@@ -59,10 +56,11 @@ export class Example extends LitElement {
       </vaadin-radio-group>
       <vaadin-radio-group
         label="Item 1: alignment"
+        .value="${this.alignFirstItem}"
         @value-changed="${(e: RadioGroupValueChangedEvent) =>
           (this.alignFirstItem = e.detail.value)}"
       >
-        <vaadin-radio-button value="auto" checked label="Auto (default)"></vaadin-radio-button>
+        <vaadin-radio-button value="auto" label="Auto (default)"></vaadin-radio-button>
         <vaadin-radio-button value="stretch" label="Stretch"></vaadin-radio-button>
         <vaadin-radio-button value="flex-start" label="Start"></vaadin-radio-button>
         <vaadin-radio-button value="center" label="Center"></vaadin-radio-button>

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private alignItems?: string;
+  private alignItems = 'stretch';
 
   render() {
     return html`
@@ -38,13 +38,10 @@ export class Example extends LitElement {
       </vaadin-horizontal-layout>
       <vaadin-radio-group
         label="Vertical alignment"
+        .value="${this.alignItems}"
         @value-changed="${(e: RadioGroupValueChangedEvent) => (this.alignItems = e.detail.value)}"
       >
-        <vaadin-radio-button
-          value="stretch"
-          label="Stretch (default)"
-          checked
-        ></vaadin-radio-button>
+        <vaadin-radio-button value="stretch" label="Stretch (default)"></vaadin-radio-button>
         <vaadin-radio-button value="flex-start" label="Start"></vaadin-radio-button>
         <vaadin-radio-button value="center" label="Center"></vaadin-radio-button>
         <vaadin-radio-button value="flex-end" label="End"></vaadin-radio-button>

--- a/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private theme!: string;
+  private theme = 'margin';
 
   render() {
     return html`
@@ -36,9 +36,10 @@ export class Example extends LitElement {
       </div>
       <vaadin-radio-group
         label="Margin"
+        .value="${this.theme}"
         @value-changed="${(e: RadioGroupValueChangedEvent) => (this.theme = e.detail.value)}"
       >
-        <vaadin-radio-button value="margin" label="Enabled" checked></vaadin-radio-button>
+        <vaadin-radio-button value="margin" label="Enabled"></vaadin-radio-button>
         <vaadin-radio-button value="" label="Disabled"></vaadin-radio-button>
       </vaadin-radio-group>
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private theme!: string;
+  private theme = 'padding';
 
   render() {
     return html`
@@ -38,9 +38,10 @@ export class Example extends LitElement {
       </vaadin-vertical-layout>
       <vaadin-radio-group
         label="Padding"
+        .value="${this.theme}"
         @value-changed="${(e: RadioGroupValueChangedEvent) => (this.theme = e.detail.value)}"
       >
-        <vaadin-radio-button value="padding" label="Enabled" checked></vaadin-radio-button>
+        <vaadin-radio-button value="padding" label="Enabled"></vaadin-radio-button>
         <vaadin-radio-button value="" label="Disabled"></vaadin-radio-button>
       </vaadin-radio-group>
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private themeVariant!: string;
+  private themeVariant = 'spacing-xl';
 
   render() {
     return html`
@@ -38,13 +38,14 @@ export class Example extends LitElement {
       </vaadin-vertical-layout>
       <vaadin-radio-group
         label="Spacing variant"
+        .value="${this.themeVariant}"
         @value-changed="${(e: RadioGroupValueChangedEvent) => (this.themeVariant = e.detail.value)}"
       >
         <vaadin-radio-button value="spacing-xs" label="spacing-xs"></vaadin-radio-button>
         <vaadin-radio-button value="spacing-s" label="spacing-s"></vaadin-radio-button>
         <vaadin-radio-button value="spacing" label="spacing"></vaadin-radio-button>
         <vaadin-radio-button value="spacing-l" label="spacing-l"></vaadin-radio-button>
-        <vaadin-radio-button value="spacing-xl" label="spacing-xl" checked></vaadin-radio-button>
+        <vaadin-radio-button value="spacing-xl" label="spacing-xl"></vaadin-radio-button>
       </vaadin-radio-group>
     `;
   }

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private theme!: string;
+  private theme = 'spacing';
 
   render() {
     return html`
@@ -38,9 +38,10 @@ export class Example extends LitElement {
       </vaadin-vertical-layout>
       <vaadin-radio-group
         label="Spacing"
+        .value="${this.theme}"
         @value-changed="${(e: RadioGroupValueChangedEvent) => (this.theme = e.detail.value)}"
       >
-        <vaadin-radio-button value="spacing" label="Enabled" checked></vaadin-radio-button>
+        <vaadin-radio-button value="spacing" label="Enabled"></vaadin-radio-button>
         <vaadin-radio-button value="" label="Disabled"></vaadin-radio-button>
       </vaadin-radio-group>
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private alignItems?: string;
+  private alignItems = 'flex-start';
 
   render() {
     return html`
@@ -34,13 +34,10 @@ export class Example extends LitElement {
       </vaadin-vertical-layout>
       <vaadin-radio-group
         label="Horizontal alignment"
+        .value="${this.alignItems}"
         @value-changed="${(e: RadioGroupValueChangedEvent) => (this.alignItems = e.detail.value)}"
       >
-        <vaadin-radio-button
-          value="flex-start"
-          label="Start (default)"
-          checked
-        ></vaadin-radio-button>
+        <vaadin-radio-button value="flex-start" label="Start (default)"></vaadin-radio-button>
         <vaadin-radio-button value="center" label="Center"></vaadin-radio-button>
         <vaadin-radio-button value="flex-end" label="End"></vaadin-radio-button>
         <vaadin-radio-button value="stretch" label="Stretch"></vaadin-radio-button>

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
@@ -23,10 +23,10 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  alignLayoutItems?: string;
+  alignLayoutItems = 'flex-start';
 
   @state()
-  alignFirstItem?: string;
+  alignFirstItem = 'auto';
 
   render() {
     return html`
@@ -39,24 +39,22 @@ export class Example extends LitElement {
       </vaadin-vertical-layout>
       <vaadin-radio-group
         label="Layout alignment"
+        .value="${this.alignLayoutItems}"
         @value-changed="${(e: RadioGroupValueChangedEvent) =>
           (this.alignLayoutItems = e.detail.value)}"
       >
-        <vaadin-radio-button
-          value="flex-start"
-          label="Start (default)"
-          checked
-        ></vaadin-radio-button>
+        <vaadin-radio-button value="flex-start" label="Start (default)"></vaadin-radio-button>
         <vaadin-radio-button value="center" label="Center"></vaadin-radio-button>
         <vaadin-radio-button value="flex-end" label="End"></vaadin-radio-button>
         <vaadin-radio-button value="stretch" label="Stretch"></vaadin-radio-button>
       </vaadin-radio-group>
       <vaadin-radio-group
         label="Item 1: alignment"
+        .value="${this.alignFirstItem}"
         @value-changed="${(e: RadioGroupValueChangedEvent) =>
           (this.alignFirstItem = e.detail.value)}"
       >
-        <vaadin-radio-button value="auto" label="Auto (default)" checked></vaadin-radio-button>
+        <vaadin-radio-button value="auto" label="Auto (default)"></vaadin-radio-button>
         <vaadin-radio-button value="flex-start" label="Start"></vaadin-radio-button>
         <vaadin-radio-button value="center" label="Center"></vaadin-radio-button>
         <vaadin-radio-button value="flex-end" label="End"></vaadin-radio-button>

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  justifyContent?: string;
+  justifyContent = 'flex-start';
 
   render() {
     return html`
@@ -38,14 +38,11 @@ export class Example extends LitElement {
       </vaadin-vertical-layout>
       <vaadin-radio-group
         label="Vertical alignment"
+        .value="${this.justifyContent}"
         @value-changed="${(e: RadioGroupValueChangedEvent) =>
           (this.justifyContent = e.detail.value)}"
       >
-        <vaadin-radio-button
-          value="flex-start"
-          label="Start (default)"
-          checked
-        ></vaadin-radio-button>
+        <vaadin-radio-button value="flex-start" label="Start (default)"></vaadin-radio-button>
         <vaadin-radio-button value="center" label="Center"></vaadin-radio-button>
         <vaadin-radio-button value="flex-end" label="End"></vaadin-radio-button>
         <vaadin-radio-button value="space-between" label="Between"></vaadin-radio-button>


### PR DESCRIPTION
## Description

Change the `vaadin-radio-group` usage in basic layouts TS demos to bind `.value` property.
This makes the code a bit more readable and is aligned with other field components demos.