### PR TITLE
chore: cleanup unused imports in Java demos

### DIFF
--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionBasic.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionBasic.java
@@ -1,7 +1,6 @@
 package com.vaadin.demo.component.accordion;
 
 import com.vaadin.flow.component.accordion.Accordion;
-import com.vaadin.flow.component.accordion.AccordionPanel;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;

--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionContent.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionContent.java
@@ -4,9 +4,7 @@ import com.vaadin.flow.component.accordion.Accordion;
 import com.vaadin.flow.component.accordion.AccordionPanel;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionDisabledPanels.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionDisabledPanels.java
@@ -5,7 +5,6 @@ import com.vaadin.flow.component.accordion.AccordionPanel;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 

--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionReversePanels.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionReversePanels.java
@@ -6,7 +6,6 @@ import com.vaadin.flow.component.details.DetailsVariant;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 

--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionSmallPanels.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionSmallPanels.java
@@ -6,7 +6,6 @@ import com.vaadin.flow.component.details.DetailsVariant;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
@@ -9,7 +9,6 @@ import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.Tabs;
-import com.vaadin.flow.component.tabs.TabsVariant;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
 

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxHorizontal.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxHorizontal.java
@@ -1,7 +1,6 @@
 package com.vaadin.demo.component.checkbox;
 
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
-import com.vaadin.flow.component.checkbox.CheckboxGroupVariant;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBestPractices.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBestPractices.java
@@ -6,7 +6,6 @@ import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.contextmenu.GridContextMenu;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.menubar.MenuBar;
 import com.vaadin.flow.component.menubar.MenuBarVariant;
 import com.vaadin.flow.router.Route;

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java
@@ -4,7 +4,6 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.avatar.Avatar;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.contextmenu.GridContextMenu;

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerWeekNumbers.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerWeekNumbers.java
@@ -6,8 +6,6 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
-import java.util.Arrays;
-
 @Route("date-time-picker-week-numbers")
 public class DateTimePickerWeekNumbers extends Div {
 

--- a/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldPattern.java
+++ b/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldPattern.java
@@ -1,7 +1,6 @@
 package com.vaadin.demo.component.emailfield;
 
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/grid/GridMultiSelectionMode.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridMultiSelectionMode.java
@@ -1,7 +1,6 @@
 package com.vaadin.demo.component.grid;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.grid.Grid;

--- a/src/main/java/com/vaadin/demo/component/inputfields/InputFieldRequired.java
+++ b/src/main/java/com/vaadin/demo/component/inputfields/InputFieldRequired.java
@@ -1,7 +1,6 @@
 package com.vaadin.demo.component.inputfields;
 
 import com.vaadin.flow.component.datepicker.DatePicker;
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;

--- a/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java
@@ -3,7 +3,6 @@ package com.vaadin.demo.component.login;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.login.LoginForm;
 import com.vaadin.flow.component.login.LoginI18n;
-import com.vaadin.flow.component.login.LoginOverlay;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 

--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarCustomTheme.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarCustomTheme.java
@@ -1,9 +1,6 @@
 package com.vaadin.demo.component.menubar;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
-import com.vaadin.flow.component.ClickEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/messages/MessagesBasic.java
+++ b/src/main/java/com/vaadin/demo/component/messages/MessagesBasic.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import com.vaadin.demo.DemoExporter;

--- a/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutMinMaxSize.java
+++ b/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutMinMaxSize.java
@@ -1,8 +1,6 @@
 package com.vaadin.demo.component.splitlayout;
 
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/domain/Person.java
+++ b/src/main/java/com/vaadin/demo/domain/Person.java
@@ -1,6 +1,5 @@
 package com.vaadin.demo.domain;
 
-import java.time.LocalDate;
 import java.util.Date;
 
 import javax.annotation.Nonnull;


### PR DESCRIPTION
## Description

Removed unused imports from Java examples using the following approach:

```
find . -type f -name "*.java"|xargs java -jar google-java-format-1.14.0-all-deps.jar --fix-imports-only --skip-sorting-imports -r
```