### PR TITLE
chore: reindent Java examples using 4 spaces (part 3)

### DIFF
--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarAbbreviation.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarAbbreviation.java
@@ -8,15 +8,17 @@ import com.vaadin.flow.router.Route;
 @Route("avatar-abbreviation")
 public class AvatarAbbreviation extends HorizontalLayout {
 
-  public AvatarAbbreviation() {
-    // tag::snippet[]
-    Avatar avatarName = new Avatar("Augusta Ada King");
+    public AvatarAbbreviation() {
+        // tag::snippet[]
+        Avatar avatarName = new Avatar("Augusta Ada King");
 
-    Avatar avatarAbbr = new Avatar("Augusta Ada King");
-    avatarAbbr.setAbbreviation("AK");
-    // end::snippet[]
+        Avatar avatarAbbr = new Avatar("Augusta Ada King");
+        avatarAbbr.setAbbreviation("AK");
+        // end::snippet[]
 
-    add(avatarName, avatarAbbr);
-  }
-  public static class Exporter extends DemoExporter<AvatarAbbreviation> {} // hidden-source-line
+        add(avatarName, avatarAbbr);
+    }
+
+    public static class Exporter extends DemoExporter<AvatarAbbreviation> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarBasic.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarBasic.java
@@ -10,24 +10,24 @@ import com.vaadin.flow.router.Route;
 @Route("avatar-basic")
 public class AvatarBasic extends HorizontalLayout {
 
-  private Person person = DataService.getPeople(1).get(0);
+    private Person person = DataService.getPeople(1).get(0);
 
-  public AvatarBasic() {
-    String name = person.getFirstName() + " " + person.getLastName();
-    String pictureUrl = person.getPictureUrl();
+    public AvatarBasic() {
+        String name = person.getFirstName() + " " + person.getLastName();
+        String pictureUrl = person.getPictureUrl();
 
-    // tag::snippet[]
-    Avatar avatarBasic = new Avatar();
+        // tag::snippet[]
+        Avatar avatarBasic = new Avatar();
 
-    Avatar avatarName = new Avatar(name);
+        Avatar avatarName = new Avatar(name);
 
-    Avatar avatarImage = new Avatar(name);
-    avatarImage.setImage(pictureUrl);
-    // end::snippet[]
+        Avatar avatarImage = new Avatar(name);
+        avatarImage.setImage(pictureUrl);
+        // end::snippet[]
 
-    add(avatarBasic, avatarName, avatarImage);
-  }
+        add(avatarBasic, avatarName, avatarImage);
+    }
 
-  public static class Exporter extends DemoExporter<AvatarBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<AvatarBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupBasic.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupBasic.java
@@ -12,22 +12,22 @@ import java.util.List;
 @Route("avatar-group-basic")
 public class AvatarGroupBasic extends Div {
 
-  private List<Person> people = DataService.getPeople(3);
+    private List<Person> people = DataService.getPeople(3);
 
-  public AvatarGroupBasic() {
-    // tag::snippet[]
-    AvatarGroup avatarGroup = new AvatarGroup();
+    public AvatarGroupBasic() {
+        // tag::snippet[]
+        AvatarGroup avatarGroup = new AvatarGroup();
 
-    for (Person person : people) {
-      String name = person.getFirstName() + " " + person.getLastName();
-      AvatarGroupItem avatar = new AvatarGroupItem(name);
-      avatarGroup.add(avatar);
+        for (Person person : people) {
+            String name = person.getFirstName() + " " + person.getLastName();
+            AvatarGroupItem avatar = new AvatarGroupItem(name);
+            avatarGroup.add(avatar);
+        }
+        // end::snippet[]
+
+        add(avatarGroup);
     }
-    // end::snippet[]
 
-    add(avatarGroup);
-  }
-
-  public static class Exporter extends DemoExporter<AvatarGroupBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<AvatarGroupBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupBgColor.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupBgColor.java
@@ -12,25 +12,25 @@ import java.util.List;
 @Route("avatar-group-bg-color")
 public class AvatarGroupBgColor extends Div {
 
-  private List<Person> people = DataService.getPeople(6);
+    private List<Person> people = DataService.getPeople(6);
 
-  public AvatarGroupBgColor() {
-    int colorIndex = 0;
-    
-    // tag::snippet[]
-    AvatarGroup avatarGroup = new AvatarGroup();
+    public AvatarGroupBgColor() {
+        int colorIndex = 0;
 
-    for (Person person : people) {
-      String name = person.getFirstName() + " " + person.getLastName();
-      AvatarGroupItem avatar = new AvatarGroupItem(name);
-      avatar.setColorIndex(colorIndex++);
-      avatarGroup.add(avatar);
+        // tag::snippet[]
+        AvatarGroup avatarGroup = new AvatarGroup();
+
+        for (Person person : people) {
+            String name = person.getFirstName() + " " + person.getLastName();
+            AvatarGroupItem avatar = new AvatarGroupItem(name);
+            avatar.setColorIndex(colorIndex++);
+            avatarGroup.add(avatar);
+        }
+        // end::snippet[]
+
+        add(avatarGroup);
     }
-    // end::snippet[]
 
-    add(avatarGroup);
-  }
-
-  public static class Exporter extends DemoExporter<AvatarGroupBgColor> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<AvatarGroupBgColor> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupInternationalisation.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupInternationalisation.java
@@ -14,31 +14,32 @@ import java.util.List;
 @Route("avatar-group-internationalisation")
 public class AvatarGroupInternationalisation extends Div {
 
-  private List<Person> people = DataService.getPeople(2);
+    private List<Person> people = DataService.getPeople(2);
 
-  public AvatarGroupInternationalisation() {
-    // tag::snippet[]
-    AvatarGroupI18n i18n = new AvatarGroupI18n();
-    i18n.setAnonymous("Anonyymi");
-    i18n.setManyActiveUsers("Yksi käyttäjä aktiivisena");
-    i18n.setOneActiveUser("{count} käyttäjää aktiivisena");
+    public AvatarGroupInternationalisation() {
+        // tag::snippet[]
+        AvatarGroupI18n i18n = new AvatarGroupI18n();
+        i18n.setAnonymous("Anonyymi");
+        i18n.setManyActiveUsers("Yksi käyttäjä aktiivisena");
+        i18n.setOneActiveUser("{count} käyttäjää aktiivisena");
 
-    AvatarGroup avatarGroup = new AvatarGroup();
-    avatarGroup.setI18n(i18n);
+        AvatarGroup avatarGroup = new AvatarGroup();
+        avatarGroup.setI18n(i18n);
 
-    // Add anonymous user
-    avatarGroup.add(new AvatarGroupItem());
+        // Add anonymous user
+        avatarGroup.add(new AvatarGroupItem());
 
-    for (Person person : people) {
-      String name = person.getFirstName() + " " + person.getLastName();
-      AvatarGroupItem avatar = new AvatarGroupItem(name);
-      avatarGroup.add(avatar);
+        for (Person person : people) {
+            String name = person.getFirstName() + " " + person.getLastName();
+            AvatarGroupItem avatar = new AvatarGroupItem(name);
+            avatarGroup.add(avatar);
+        }
+        // end::snippet[]
+
+        add(avatarGroup);
     }
-    // end::snippet[]
 
-    add(avatarGroup);
-  }
-
-  public static class Exporter extends DemoExporter<AvatarGroupInternationalisation> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<AvatarGroupInternationalisation> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupMaxItems.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupMaxItems.java
@@ -11,23 +11,24 @@ import java.util.List;
 @Route("avatar-group-max-items")
 public class AvatarGroupMaxItems extends Div {
 
-  private List<Person> people = DataService.getPeople(6);
+    private List<Person> people = DataService.getPeople(6);
 
-  public AvatarGroupMaxItems() {
-    // tag::snippet[]
-    AvatarGroup avatarGroup = new AvatarGroup();
-    avatarGroup.setMaxItemsVisible(3);
+    public AvatarGroupMaxItems() {
+        // tag::snippet[]
+        AvatarGroup avatarGroup = new AvatarGroup();
+        avatarGroup.setMaxItemsVisible(3);
 
-    for (Person person : people) {
-      String name = person.getFirstName() + " " + person.getLastName();
-      AvatarGroup.AvatarGroupItem avatar = new AvatarGroup.AvatarGroupItem(name);
-      avatarGroup.add(avatar);
+        for (Person person : people) {
+            String name = person.getFirstName() + " " + person.getLastName();
+            AvatarGroup.AvatarGroupItem avatar = new AvatarGroup.AvatarGroupItem(
+                    name);
+            avatarGroup.add(avatar);
+        }
+        // end::snippet[]
+
+        add(avatarGroup);
     }
-    // end::snippet[]
 
-    add(avatarGroup);
-  }
-
-  public static class Exporter extends DemoExporter<AvatarGroupMaxItems> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<AvatarGroupMaxItems> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarImage.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarImage.java
@@ -11,26 +11,26 @@ import com.vaadin.flow.server.StreamResource;
 @Route("avatar-image")
 public class AvatarImage extends HorizontalLayout {
 
-  private Person person = DataService.getPeople(1).get(0);
+    private Person person = DataService.getPeople(1).get(0);
 
-  public AvatarImage() {
-    String name = person.getFirstName() + " " + person.getLastName();
-    String pictureUrl = person.getPictureUrl();
+    public AvatarImage() {
+        String name = person.getFirstName() + " " + person.getLastName();
+        String pictureUrl = person.getPictureUrl();
 
-    // tag::snippet[]
-    Avatar user = new Avatar(name);
-    user.setImage(pictureUrl);
+        // tag::snippet[]
+        Avatar user = new Avatar(name);
+        user.setImage(pictureUrl);
 
-    Avatar company = new Avatar("Company Inc.");
-    StreamResource imageResource = new StreamResource(
-      "company-logo.png",
-      () -> getClass().getResourceAsStream("/images/company-logo.png"));
-    company.setImageResource(imageResource);
-    // end::snippet[]
+        Avatar company = new Avatar("Company Inc.");
+        StreamResource imageResource = new StreamResource("company-logo.png",
+                () -> getClass()
+                        .getResourceAsStream("/images/company-logo.png"));
+        company.setImageResource(imageResource);
+        // end::snippet[]
 
-    add(user, company);
-  }
+        add(user, company);
+    }
 
-  public static class Exporter extends DemoExporter<AvatarImage> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<AvatarImage> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarMenuBar.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarMenuBar.java
@@ -14,30 +14,30 @@ import com.vaadin.flow.router.Route;
 @Route("avatar-menu-bar")
 public class AvatarMenuBar extends Div {
 
-  private Person person = DataService.getPeople(1).get(0);
+    private Person person = DataService.getPeople(1).get(0);
 
-  public AvatarMenuBar() {
-    String name = person.getFirstName() + " " + person.getLastName();
-    String pictureUrl = person.getPictureUrl();
+    public AvatarMenuBar() {
+        String name = person.getFirstName() + " " + person.getLastName();
+        String pictureUrl = person.getPictureUrl();
 
-    // tag::snippet[]
-    Avatar avatar = new Avatar(name);
-    avatar.setImage(pictureUrl);
+        // tag::snippet[]
+        Avatar avatar = new Avatar(name);
+        avatar.setImage(pictureUrl);
 
-    MenuBar menuBar = new MenuBar();
-    menuBar.addThemeVariants(MenuBarVariant.LUMO_TERTIARY_INLINE);
+        MenuBar menuBar = new MenuBar();
+        menuBar.addThemeVariants(MenuBarVariant.LUMO_TERTIARY_INLINE);
 
-    MenuItem menuItem = menuBar.addItem(avatar);
-    SubMenu subMenu = menuItem.getSubMenu();
-    subMenu.addItem("Profile");
-    subMenu.addItem("Settings");
-    subMenu.addItem("Help");
-    subMenu.addItem("Sign out");
-    // end::snippet[]
+        MenuItem menuItem = menuBar.addItem(avatar);
+        SubMenu subMenu = menuItem.getSubMenu();
+        subMenu.addItem("Profile");
+        subMenu.addItem("Settings");
+        subMenu.addItem("Help");
+        subMenu.addItem("Sign out");
+        // end::snippet[]
 
-    add(menuBar);
-  }
+        add(menuBar);
+    }
 
-  public static class Exporter extends DemoExporter<AvatarMenuBar> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<AvatarMenuBar> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarName.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarName.java
@@ -10,18 +10,18 @@ import com.vaadin.flow.router.Route;
 @Route("avatar-name")
 public class AvatarName extends Div {
 
-  private Person person = DataService.getPeople(1).get(0);
+    private Person person = DataService.getPeople(1).get(0);
 
-  public AvatarName() {
-    String name = person.getFirstName() + " " + person.getLastName();
+    public AvatarName() {
+        String name = person.getFirstName() + " " + person.getLastName();
 
-    // tag::snippet[]
-    Avatar avatarName = new Avatar(name);
-    // end::snippet[]
+        // tag::snippet[]
+        Avatar avatarName = new Avatar(name);
+        // end::snippet[]
 
-    add(avatarName);
-  }
+        add(avatarName);
+    }
 
-  public static class Exporter extends DemoExporter<AvatarName> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<AvatarName> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarSizes.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarSizes.java
@@ -11,28 +11,28 @@ import com.vaadin.flow.router.Route;
 @Route("avatar-sizes")
 public class AvatarSizes extends HorizontalLayout {
 
-  private Person person = DataService.getPeople(1).get(0);
+    private Person person = DataService.getPeople(1).get(0);
 
-  public AvatarSizes() {
-    String name = person.getFirstName() + " " + person.getLastName();
+    public AvatarSizes() {
+        String name = person.getFirstName() + " " + person.getLastName();
 
-    // tag::snippet[]
-    Avatar xl = new Avatar(name);
-    xl.addThemeVariants(AvatarVariant.LUMO_XLARGE);
+        // tag::snippet[]
+        Avatar xl = new Avatar(name);
+        xl.addThemeVariants(AvatarVariant.LUMO_XLARGE);
 
-    Avatar l = new Avatar(name);
-    l.addThemeVariants(AvatarVariant.LUMO_LARGE);
+        Avatar l = new Avatar(name);
+        l.addThemeVariants(AvatarVariant.LUMO_LARGE);
 
-    Avatar s = new Avatar(name);
-    s.addThemeVariants(AvatarVariant.LUMO_SMALL);
+        Avatar s = new Avatar(name);
+        s.addThemeVariants(AvatarVariant.LUMO_SMALL);
 
-    Avatar xs = new Avatar(name);
-    xs.addThemeVariants(AvatarVariant.LUMO_XSMALL);
-    // end::snippet[]
+        Avatar xs = new Avatar(name);
+        xs.addThemeVariants(AvatarVariant.LUMO_XSMALL);
+        // end::snippet[]
 
-    add(xl, l, s, xs);
-  }
+        add(xl, l, s, xs);
+    }
 
-  public static class Exporter extends DemoExporter<AvatarSizes> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<AvatarSizes> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogBasic.java
+++ b/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogBasic.java
@@ -12,52 +12,55 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("confirm-dialog-basic")
 public class ConfirmDialogBasic extends Div {
 
-  private Span status;
+    private Span status;
 
-  public ConfirmDialogBasic() {
-    HorizontalLayout layout = new HorizontalLayout();
-    layout.setAlignItems(FlexComponent.Alignment.CENTER);
-    layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+    public ConfirmDialogBasic() {
+        HorizontalLayout layout = new HorizontalLayout();
+        layout.setAlignItems(FlexComponent.Alignment.CENTER);
+        layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
 
-    // tag::snippet[]
-    status = new Span();
-    status.setVisible(false);
+        // tag::snippet[]
+        status = new Span();
+        status.setVisible(false);
 
-    ConfirmDialog dialog = new ConfirmDialog();
-    dialog.setHeader("Unsaved changes");
-    dialog.setText("There are unsaved changes. Do you want to discard or save them?");
+        ConfirmDialog dialog = new ConfirmDialog();
+        dialog.setHeader("Unsaved changes");
+        dialog.setText(
+                "There are unsaved changes. Do you want to discard or save them?");
 
-    dialog.setCancelable(true);
-    dialog.addCancelListener(event -> setStatus("Canceled"));
+        dialog.setCancelable(true);
+        dialog.addCancelListener(event -> setStatus("Canceled"));
 
-    dialog.setRejectable(true);
-    dialog.setRejectText("Discard");
-    dialog.addRejectListener(event -> setStatus("Discarded"));
+        dialog.setRejectable(true);
+        dialog.setRejectText("Discard");
+        dialog.addRejectListener(event -> setStatus("Discarded"));
 
-    dialog.setConfirmText("Save");
-    dialog.addConfirmListener(event -> setStatus("Saved"));
+        dialog.setConfirmText("Save");
+        dialog.addConfirmListener(event -> setStatus("Saved"));
 
-    Button button = new Button("Open confirm dialog");
-    button.addClickListener(event -> {
-      dialog.open();
-      status.setVisible(false);
-    });
-    // end::snippet[]
+        Button button = new Button("Open confirm dialog");
+        button.addClickListener(event -> {
+            dialog.open();
+            status.setVisible(false);
+        });
+        // end::snippet[]
 
-    dialog.open();
+        dialog.open();
 
-    layout.add(button, status);
-    add(layout);
+        layout.add(button, status);
+        add(layout);
 
-    // Center the button within the example
-    getStyle().set("position", "fixed").set("top","0").set("right", "0")
-            .set("bottom", "0").set("left", "0").set("display", "flex")
-            .set("align-items", "center").set("justify-content", "center");
-  }
+        // Center the button within the example
+        getStyle().set("position", "fixed").set("top", "0").set("right", "0")
+                .set("bottom", "0").set("left", "0").set("display", "flex")
+                .set("align-items", "center").set("justify-content", "center");
+    }
 
-  private void setStatus(String value) {
-    status.setText("Status: " + value);
-    status.setVisible(true);
-  }
-  public static class Exporter extends DemoExporter<ConfirmDialogBasic> {} // hidden-source-line
+    private void setStatus(String value) {
+        status.setText("Status: " + value);
+        status.setVisible(true);
+    }
+
+    public static class Exporter extends DemoExporter<ConfirmDialogBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogCancelButton.java
+++ b/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogCancelButton.java
@@ -12,42 +12,46 @@ import com.vaadin.flow.router.Route;
 @Route("confirm-dialog-cancel-button")
 public class ConfirmDialogCancelButton extends Div {
 
-  private Span status;
+    private Span status;
 
-  public ConfirmDialogCancelButton() {
-    HorizontalLayout layout = new HorizontalLayout();
-    layout.setAlignItems(FlexComponent.Alignment.CENTER);
-    layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+    public ConfirmDialogCancelButton() {
+        HorizontalLayout layout = new HorizontalLayout();
+        layout.setAlignItems(FlexComponent.Alignment.CENTER);
+        layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
 
-    // tag::snippet[]
-    status = new Span();
-    status.setVisible(false);
+        // tag::snippet[]
+        status = new Span();
+        status.setVisible(false);
 
-    ConfirmDialog dialog = new ConfirmDialog();
-    dialog.setHeader("Delete \"Report Q4\"?");
-    dialog.setText("Are you sure you want to permanently delete this item?");
+        ConfirmDialog dialog = new ConfirmDialog();
+        dialog.setHeader("Delete \"Report Q4\"?");
+        dialog.setText(
+                "Are you sure you want to permanently delete this item?");
 
-    dialog.setCancelable(true);
-    dialog.addCancelListener(event -> setStatus("Canceled"));
+        dialog.setCancelable(true);
+        dialog.addCancelListener(event -> setStatus("Canceled"));
 
-    dialog.setConfirmText("Delete");
-    dialog.setConfirmButtonTheme("error primary");
-    dialog.addConfirmListener(event -> setStatus("Deleted"));
+        dialog.setConfirmText("Delete");
+        dialog.setConfirmButtonTheme("error primary");
+        dialog.addConfirmListener(event -> setStatus("Deleted"));
 
-    Button button = new Button("Open confirm dialog");
-    button.addClickListener(event -> {
-      dialog.open();
-      status.setVisible(false);
-    });
-    // end::snippet[]
+        Button button = new Button("Open confirm dialog");
+        button.addClickListener(event -> {
+            dialog.open();
+            status.setVisible(false);
+        });
+        // end::snippet[]
 
-    layout.add(button, status);
-    add(layout);
-  }
+        layout.add(button, status);
+        add(layout);
+    }
 
-  private void setStatus(String value) {
-    status.setText("Status: " + value);
-    status.setVisible(true);
-  }
-  public static class Exporter extends DemoExporter<ConfirmDialogCancelButton> {} // hidden-source-line
+    private void setStatus(String value) {
+        status.setText("Status: " + value);
+        status.setVisible(true);
+    }
+
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ConfirmDialogCancelButton> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogConfirmButton.java
+++ b/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogConfirmButton.java
@@ -13,40 +13,42 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("confirm-dialog-confirm-button")
 public class ConfirmDialogConfirmButton extends Div {
 
-  private Span status;
+    private Span status;
 
-  public ConfirmDialogConfirmButton() {
-    HorizontalLayout layout = new HorizontalLayout();
-    layout.setAlignItems(FlexComponent.Alignment.CENTER);
-    layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+    public ConfirmDialogConfirmButton() {
+        HorizontalLayout layout = new HorizontalLayout();
+        layout.setAlignItems(FlexComponent.Alignment.CENTER);
+        layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
 
-    // tag::snippet[]
-    status = new Span();
-    status.setVisible(false);
+        // tag::snippet[]
+        status = new Span();
+        status.setVisible(false);
 
-    ConfirmDialog dialog = new ConfirmDialog();
-    dialog.setHeader("Export failed");
-    dialog.setText(
-      new Html("<p>An error occurred while exporting <b>Report Q4</b>. Please try again. If the problem persists, please contact <a href=\"mailto:support@company.com\">support@company.com</a>.</p>")
-    );
+        ConfirmDialog dialog = new ConfirmDialog();
+        dialog.setHeader("Export failed");
+        dialog.setText(new Html(
+                "<p>An error occurred while exporting <b>Report Q4</b>. Please try again. If the problem persists, please contact <a href=\"mailto:support@company.com\">support@company.com</a>.</p>"));
 
-    dialog.setConfirmText("OK");
-    dialog.addConfirmListener(event -> setStatus("Acknowledged"));
+        dialog.setConfirmText("OK");
+        dialog.addConfirmListener(event -> setStatus("Acknowledged"));
 
-    Button button = new Button("Open confirm dialog");
-    button.addClickListener(event -> {
-      dialog.open();
-      status.setVisible(false);
-    });
-    // end::snippet[]
+        Button button = new Button("Open confirm dialog");
+        button.addClickListener(event -> {
+            dialog.open();
+            status.setVisible(false);
+        });
+        // end::snippet[]
 
-    layout.add(button, status);
-    add(layout);
-  }
+        layout.add(button, status);
+        add(layout);
+    }
 
-  private void setStatus(String value) {
-    status.setText("Status: " + value);
-    status.setVisible(true);
-  }
-  public static class Exporter extends DemoExporter<ConfirmDialogConfirmButton> {} // hidden-source-line
+    private void setStatus(String value) {
+        status.setText("Status: " + value);
+        status.setVisible(true);
+    }
+
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ConfirmDialogConfirmButton> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogRejectButton.java
+++ b/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogRejectButton.java
@@ -12,45 +12,49 @@ import com.vaadin.flow.router.Route;
 @Route("confirm-dialog-reject-button")
 public class ConfirmDialogRejectButton extends Div {
 
-  private Span status;
+    private Span status;
 
-  public ConfirmDialogRejectButton() {
-    HorizontalLayout layout = new HorizontalLayout();
-    layout.setAlignItems(FlexComponent.Alignment.CENTER);
-    layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+    public ConfirmDialogRejectButton() {
+        HorizontalLayout layout = new HorizontalLayout();
+        layout.setAlignItems(FlexComponent.Alignment.CENTER);
+        layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
 
-    // tag::snippet[]
-    status = new Span();
-    status.setVisible(false);
+        // tag::snippet[]
+        status = new Span();
+        status.setVisible(false);
 
-    ConfirmDialog dialog = new ConfirmDialog();
-    dialog.setHeader("Unsaved changes");
-    dialog.setText("Do you want to discard or save your changes before navigating away?");
+        ConfirmDialog dialog = new ConfirmDialog();
+        dialog.setHeader("Unsaved changes");
+        dialog.setText(
+                "Do you want to discard or save your changes before navigating away?");
 
-    dialog.setCancelable(true);
-    dialog.addCancelListener(event -> setStatus("Canceled"));
+        dialog.setCancelable(true);
+        dialog.addCancelListener(event -> setStatus("Canceled"));
 
-    dialog.setRejectable(true);
-    dialog.setRejectText("Discard");
-    dialog.addRejectListener(event -> setStatus("Discarded"));
+        dialog.setRejectable(true);
+        dialog.setRejectText("Discard");
+        dialog.addRejectListener(event -> setStatus("Discarded"));
 
-    dialog.setConfirmText("Save");
-    dialog.addConfirmListener(event -> setStatus("Saved"));
+        dialog.setConfirmText("Save");
+        dialog.addConfirmListener(event -> setStatus("Saved"));
 
-    Button button = new Button("Open confirm dialog");
-    button.addClickListener(event -> {
-      dialog.open();
-      status.setVisible(false);
-    });
-    // end::snippet[]
+        Button button = new Button("Open confirm dialog");
+        button.addClickListener(event -> {
+            dialog.open();
+            status.setVisible(false);
+        });
+        // end::snippet[]
 
-    layout.add(button, status);
-    add(layout);
-  }
+        layout.add(button, status);
+        add(layout);
+    }
 
-  private void setStatus(String value) {
-    status.setText("Status: " + value);
-    status.setVisible(true);
-  }
-  public static class Exporter extends DemoExporter<ConfirmDialogRejectButton> {} // hidden-source-line
+    private void setStatus(String value) {
+        status.setText("Status: " + value);
+        status.setVisible(true);
+    }
+
+    public static class Exporter
+            extends DemoExporter<ConfirmDialogRejectButton> {
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBasic.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBasic.java
@@ -13,30 +13,32 @@ import java.util.List;
 @Route("context-menu-basic")
 public class ContextMenuBasic extends Div {
 
-  private List<Person> people = DataService.getPeople(5);
+    private List<Person> people = DataService.getPeople(5);
 
-  public ContextMenuBasic() {
-    Grid<Person> grid = new Grid();
-    grid.setAllRowsVisible(true);
-    grid.setItems(people);
+    public ContextMenuBasic() {
+        Grid<Person> grid = new Grid();
+        grid.setAllRowsVisible(true);
+        grid.setItems(people);
 
-    grid.addColumn(person -> person.getFirstName())
-        .setHeader("First name");
-    grid.addColumn(person -> person.getLastName())
-        .setHeader("Last name");
-    grid.addColumn(person -> person.getEmail())
-        .setHeader("Email");
-    grid.addColumn(person -> person.getAddress().getPhone())
-        .setHeader("Phone number");
+        grid.addColumn(person -> person.getFirstName()).setHeader("First name");
+        grid.addColumn(person -> person.getLastName()).setHeader("Last name");
+        grid.addColumn(person -> person.getEmail()).setHeader("Email");
+        grid.addColumn(person -> person.getAddress().getPhone())
+                .setHeader("Phone number");
 
-    // tag::snippet[]
-    GridContextMenu<Person> menu = grid.addContextMenu();
-    menu.addItem("View", event -> {});
-    menu.addItem("Edit", event -> {});
-    menu.addItem("Delete", event -> {});
-    // end::snippet[]
+        // tag::snippet[]
+        GridContextMenu<Person> menu = grid.addContextMenu();
+        menu.addItem("View", event -> {
+        });
+        menu.addItem("Edit", event -> {
+        });
+        menu.addItem("Delete", event -> {
+        });
+        // end::snippet[]
 
-    add(grid);
-  }
-  public static class Exporter extends DemoExporter<ContextMenuBasic> {} // hidden-source-line
+        add(grid);
+    }
+
+    public static class Exporter extends DemoExporter<ContextMenuBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBestPractices.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBestPractices.java
@@ -15,67 +15,70 @@ import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
 @Route("context-menu-best-practices")
 public class ContextMenuBestPractices extends Div {
 
-  public ContextMenuBestPractices() {
-    Grid<File> grid = new Grid();
-    grid.setAllRowsVisible(true);
-    grid.setItems(getFiles());
+    public ContextMenuBestPractices() {
+        Grid<File> grid = new Grid();
+        grid.setAllRowsVisible(true);
+        grid.setItems(getFiles());
 
-    grid.addColumn(File::getName)
-      .setHeader("Name");
-    grid.addColumn(File::getDisplaySize)
-      .setHeader("Size");
-    // tag::snippet[]
-    grid.addComponentColumn(file -> {
-      MenuBar menuBar = new MenuBar();
-      menuBar.addThemeVariants(MenuBarVariant.LUMO_TERTIARY);
-      MenuItem menuItem = menuBar.addItem("•••");
-      menuItem.getElement().setAttribute("aria-label", "More options");
-      SubMenu subMenu = menuItem.getSubMenu();
-      subMenu.addItem("Preview", event -> {});
-      subMenu.addItem("Edit", event -> {});
-      subMenu.addItem("Delete", event -> {});
-      return menuBar;
-    })
-      .setWidth("70px")
-      .setFlexGrow(0);
+        grid.addColumn(File::getName).setHeader("Name");
+        grid.addColumn(File::getDisplaySize).setHeader("Size");
+        // tag::snippet[]
+        grid.addComponentColumn(file -> {
+            MenuBar menuBar = new MenuBar();
+            menuBar.addThemeVariants(MenuBarVariant.LUMO_TERTIARY);
+            MenuItem menuItem = menuBar.addItem("•••");
+            menuItem.getElement().setAttribute("aria-label", "More options");
+            SubMenu subMenu = menuItem.getSubMenu();
+            subMenu.addItem("Preview", event -> {
+            });
+            subMenu.addItem("Edit", event -> {
+            });
+            subMenu.addItem("Delete", event -> {
+            });
+            return menuBar;
+        }).setWidth("70px").setFlexGrow(0);
 
-    GridContextMenu<File> menu = grid.addContextMenu();
-    menu.addItem("Preview", event -> {});
-    menu.addItem("Edit", event -> {});
-    menu.addItem("Delete", event -> {});
-    // end::snippet[]
+        GridContextMenu<File> menu = grid.addContextMenu();
+        menu.addItem("Preview", event -> {
+        });
+        menu.addItem("Edit", event -> {
+        });
+        menu.addItem("Delete", event -> {
+        });
+        // end::snippet[]
 
-    add(grid);
-  }
-
-  private File[] getFiles() {
-    return new File[] {
-      new File("Annual Report.docx", 25165824),
-      new File("Financials.xlsx", 44040192)
-    };
-  }
-
-  private class File {
-
-    private String name;
-    private long size;
-
-    File(String name, long size) {
-      this.name = name;
-      this.size = size;
+        add(grid);
     }
 
-    public String getName() {
-      return name;
+    private File[] getFiles() {
+        return new File[] { new File("Annual Report.docx", 25165824),
+                new File("Financials.xlsx", 44040192) };
     }
 
-    public long getSize() {
-      return size;
+    private class File {
+
+        private String name;
+        private long size;
+
+        File(String name, long size) {
+            this.name = name;
+            this.size = size;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public long getSize() {
+            return size;
+        }
+
+        public String getDisplaySize() {
+            return byteCountToDisplaySize(size);
+        }
     }
 
-    public String getDisplaySize() {
-      return byteCountToDisplaySize(size);
-    }
-  }
-  public static class Exporter extends DemoExporter<ContextMenuBestPractices> {} // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ContextMenuBestPractices> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuCheckable.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuCheckable.java
@@ -14,41 +14,42 @@ import java.util.List;
 @Route("context-menu-checkable")
 public class ContextMenuCheckable extends Div {
 
-  private final ContextMenu menu;
-  private final Span assignee;
+    private final ContextMenu menu;
+    private final Span assignee;
 
-  public ContextMenuCheckable() {
-    // tag::snippet1[]
-    assignee = new Span();
-    menu = new ContextMenu();
-    menu.setTarget(assignee);
+    public ContextMenuCheckable() {
+        // tag::snippet1[]
+        assignee = new Span();
+        menu = new ContextMenu();
+        menu.setTarget(assignee);
 
-    List<Person> people = DataService.getPeople(5);
-    for (Person person : people) {
-      MenuItem menuItem = menu.addItem(person.getFullName(), event -> {
-        setAssignee(person);
-      });
-      menuItem.setCheckable(true);
+        List<Person> people = DataService.getPeople(5);
+        for (Person person : people) {
+            MenuItem menuItem = menu.addItem(person.getFullName(), event -> {
+                setAssignee(person);
+            });
+            menuItem.setCheckable(true);
+        }
+
+        setAssignee(people.get(0));
+        // end::snippet1[]
+
+        Div assigneeInfo = new Div(new Span("Assignee: "), assignee);
+        assignee.getStyle().set("font-weight", "bold");
+
+        add(assigneeInfo);
     }
 
-    setAssignee(people.get(0));
-    // end::snippet1[]
+    // tag::snippet2[]
+    private void setAssignee(Person person) {
+        // Update checked state of menu items
+        menu.getItems().forEach(item -> item
+                .setChecked(item.getText().equals(person.getFullName())));
 
-    Div assigneeInfo = new Div(new Span("Assignee: "), assignee);
-    assignee.getStyle().set("font-weight", "bold");
+        assignee.setText(person.getFullName());
+    }
 
-    add(assigneeInfo);
-  }
-
-  // tag::snippet2[]
-  private void setAssignee(Person person) {
-    // Update checked state of menu items
-    menu.getItems().forEach(
-            item -> item.setChecked(item.getText().equals(person.getFullName()))
-    );
-
-    assignee.setText(person.getFullName());
-  }
-  // end::snippet2[]
-  public static class Exporter extends DemoExporter<ContextMenuCheckable> {} // hidden-source-line
+    // end::snippet2[]
+    public static class Exporter extends DemoExporter<ContextMenuCheckable> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java
@@ -14,74 +14,81 @@ import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
 @Route("context-menu-disabled")
 public class ContextMenuDisabled extends Div {
 
-  public ContextMenuDisabled() {
-    Grid<File> grid = new Grid();
-    grid.setAllRowsVisible(true);
-    grid.setItems(getFiles());
+    public ContextMenuDisabled() {
+        Grid<File> grid = new Grid();
+        grid.setAllRowsVisible(true);
+        grid.setItems(getFiles());
 
-    grid.addColumn(File::getName)
-        .setHeader("Name");
-    grid.addColumn(File::getDisplaySize)
-        .setHeader("Size");
+        grid.addColumn(File::getName).setHeader("Name");
+        grid.addColumn(File::getDisplaySize).setHeader("Size");
 
-    // tag::snippet1[]
-    GridContextMenu<File> menu = grid.addContextMenu();
-    // end::snippet1[]
-    menu.addItem("Preview", event -> {});
-    menu.addItem("Edit", event -> {});
-    menu.add(new Hr());
+        // tag::snippet1[]
+        GridContextMenu<File> menu = grid.addContextMenu();
+        // end::snippet1[]
+        menu.addItem("Preview", event -> {
+        });
+        menu.addItem("Edit", event -> {
+        });
+        menu.add(new Hr());
 
-    // tag::snippet2[]
-    GridMenuItem<File> export = menu.addItem("Export");
-    GridSubMenu<File> exportSubMenu = export.getSubMenu();
-    GridMenuItem<File> exportPDF = exportSubMenu.addItem("Portable Document Format (.pdf)", event -> {});
-    exportPDF.setEnabled(false);
-    // end::snippet2[]
-    exportSubMenu.addItem("Rich Text Format (.rtf)", event -> {});
-    exportSubMenu.addItem("Plain text (.txt)", event -> {});
+        // tag::snippet2[]
+        GridMenuItem<File> export = menu.addItem("Export");
+        GridSubMenu<File> exportSubMenu = export.getSubMenu();
+        GridMenuItem<File> exportPDF = exportSubMenu
+                .addItem("Portable Document Format (.pdf)", event -> {
+                });
+        exportPDF.setEnabled(false);
+        // end::snippet2[]
+        exportSubMenu.addItem("Rich Text Format (.rtf)", event -> {
+        });
+        exportSubMenu.addItem("Plain text (.txt)", event -> {
+        });
 
-    GridMenuItem<File> share = menu.addItem("Share");
-    GridSubMenu<File> shareSubMenu = share.getSubMenu();
-    shareSubMenu.addItem("Copy link", event -> {});
-    shareSubMenu.addItem("Email", event -> {});
-    menu.add(new Hr());
+        GridMenuItem<File> share = menu.addItem("Share");
+        GridSubMenu<File> shareSubMenu = share.getSubMenu();
+        shareSubMenu.addItem("Copy link", event -> {
+        });
+        shareSubMenu.addItem("Email", event -> {
+        });
+        menu.add(new Hr());
 
-    // tag::snippet3[]
-    GridMenuItem<File> delete = menu.addItem("Delete", event -> {});
-    delete.setEnabled(false);
-    // end::snippet3[]
+        // tag::snippet3[]
+        GridMenuItem<File> delete = menu.addItem("Delete", event -> {
+        });
+        delete.setEnabled(false);
+        // end::snippet3[]
 
-    add(grid);
-  }
-
-  private File[] getFiles() {
-    return new File[] {
-      new File("Annual Report.pdf", 25165824),
-      new File("Financials.pdf", 44040192)
-    };
-  }
-
-  private class File {
-
-    private String name;
-    private long size;
-
-    File(String name, long size) {
-      this.name = name;
-      this.size = size;
+        add(grid);
     }
 
-    public String getName() {
-      return name;
+    private File[] getFiles() {
+        return new File[] { new File("Annual Report.pdf", 25165824),
+                new File("Financials.pdf", 44040192) };
     }
 
-    public long getSize() {
-      return size;
+    private class File {
+
+        private String name;
+        private long size;
+
+        File(String name, long size) {
+            this.name = name;
+            this.size = size;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public long getSize() {
+            return size;
+        }
+
+        public String getDisplaySize() {
+            return byteCountToDisplaySize(size);
+        }
     }
 
-    public String getDisplaySize() {
-      return byteCountToDisplaySize(size);
-    }
-  }
-  public static class Exporter extends DemoExporter<ContextMenuDisabled> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<ContextMenuDisabled> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDividers.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDividers.java
@@ -14,34 +14,38 @@ import java.util.List;
 @Route("context-menu-dividers")
 public class ContextMenuDividers extends Div {
 
-  private List<Person> people = DataService.getPeople(5);
+    private List<Person> people = DataService.getPeople(5);
 
-  public ContextMenuDividers() {
-    Grid<Person> grid = new Grid();
-    grid.setAllRowsVisible(true);
-    grid.setItems(people);
+    public ContextMenuDividers() {
+        Grid<Person> grid = new Grid();
+        grid.setAllRowsVisible(true);
+        grid.setItems(people);
 
-    grid.addColumn(person -> person.getFirstName())
-        .setHeader("First name");
-    grid.addColumn(person -> person.getLastName())
-        .setHeader("Last name");
-    grid.addColumn(person -> person.getEmail())
-        .setHeader("Email");
-    grid.addColumn(person -> person.getAddress().getPhone())
-        .setHeader("Phone number");
+        grid.addColumn(person -> person.getFirstName()).setHeader("First name");
+        grid.addColumn(person -> person.getLastName()).setHeader("Last name");
+        grid.addColumn(person -> person.getEmail()).setHeader("Email");
+        grid.addColumn(person -> person.getAddress().getPhone())
+                .setHeader("Phone number");
 
-    // tag::snippet[]
-    GridContextMenu<Person> menu = grid.addContextMenu();
-    menu.addItem("View", event -> {});
-    menu.add(new Hr());
-    menu.addItem("Edit", event -> {});
-    menu.addItem("Delete", event -> {});
-    menu.add(new Hr());
-    menu.addItem("Email", event -> {});
-    menu.addItem("Call", event -> {});
-    // end::snippet[]
+        // tag::snippet[]
+        GridContextMenu<Person> menu = grid.addContextMenu();
+        menu.addItem("View", event -> {
+        });
+        menu.add(new Hr());
+        menu.addItem("Edit", event -> {
+        });
+        menu.addItem("Delete", event -> {
+        });
+        menu.add(new Hr());
+        menu.addItem("Email", event -> {
+        });
+        menu.addItem("Call", event -> {
+        });
+        // end::snippet[]
 
-    add(grid);
-  }
-  public static class Exporter extends DemoExporter<ContextMenuDividers> {} // hidden-source-line
+        add(grid);
+    }
+
+    public static class Exporter extends DemoExporter<ContextMenuDividers> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuHierarchical.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuHierarchical.java
@@ -14,70 +14,76 @@ import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
 @Route("context-menu-hierarchical")
 public class ContextMenuHierarchical extends Div {
 
-  public ContextMenuHierarchical() {
-    Grid<File> grid = new Grid();
-    grid.setAllRowsVisible(true);
-    grid.setItems(getFiles());
+    public ContextMenuHierarchical() {
+        Grid<File> grid = new Grid();
+        grid.setAllRowsVisible(true);
+        grid.setItems(getFiles());
 
-    grid.addColumn(File::getName)
-        .setHeader("Name");
-    grid.addColumn(File::getDisplaySize)
-        .setHeader("Size");
+        grid.addColumn(File::getName).setHeader("Name");
+        grid.addColumn(File::getDisplaySize).setHeader("Size");
 
-    // tag::snippet[]
-    GridContextMenu<File> menu = grid.addContextMenu();
-    // end::snippet[]
-    menu.addItem("Preview", event -> {});
-    menu.addItem("Edit", event -> {});
-    menu.add(new Hr());
+        // tag::snippet[]
+        GridContextMenu<File> menu = grid.addContextMenu();
+        // end::snippet[]
+        menu.addItem("Preview", event -> {
+        });
+        menu.addItem("Edit", event -> {
+        });
+        menu.add(new Hr());
 
-    // tag::snippet[]
-    GridMenuItem<File> export = menu.addItem("Export");
-    GridSubMenu<File> exportSubMenu = export.getSubMenu();
-    exportSubMenu.addItem("Portable Document Format (.pdf)", event -> {});
-    exportSubMenu.addItem("Rich Text Format (.rtf)", event -> {});
-    exportSubMenu.addItem("Plain text (.txt)", event -> {});
-    // end::snippet[]
+        // tag::snippet[]
+        GridMenuItem<File> export = menu.addItem("Export");
+        GridSubMenu<File> exportSubMenu = export.getSubMenu();
+        exportSubMenu.addItem("Portable Document Format (.pdf)", event -> {
+        });
+        exportSubMenu.addItem("Rich Text Format (.rtf)", event -> {
+        });
+        exportSubMenu.addItem("Plain text (.txt)", event -> {
+        });
+        // end::snippet[]
 
-    GridMenuItem<File> share = menu.addItem("Share");
-    GridSubMenu<File> shareSubMenu = share.getSubMenu();
-    shareSubMenu.addItem("Copy link", event -> {});
-    shareSubMenu.addItem("Email", event -> {});
-    menu.add(new Hr());
+        GridMenuItem<File> share = menu.addItem("Share");
+        GridSubMenu<File> shareSubMenu = share.getSubMenu();
+        shareSubMenu.addItem("Copy link", event -> {
+        });
+        shareSubMenu.addItem("Email", event -> {
+        });
+        menu.add(new Hr());
 
-    menu.addItem("Delete", event -> {});
+        menu.addItem("Delete", event -> {
+        });
 
-    add(grid);
-  }
-
-  private File[] getFiles() {
-    return new File[] {
-      new File("Annual Report.docx", 25165824),
-      new File("Financials.xlsx", 44040192)
-    };
-  }
-
-  private class File {
-
-    private String name;
-    private long size;
-
-    File(String name, long size) {
-      this.name = name;
-      this.size = size;
+        add(grid);
     }
 
-    public String getName() {
-      return name;
+    private File[] getFiles() {
+        return new File[] { new File("Annual Report.docx", 25165824),
+                new File("Financials.xlsx", 44040192) };
     }
 
-    public long getSize() {
-      return size;
+    private class File {
+
+        private String name;
+        private long size;
+
+        File(String name, long size) {
+            this.name = name;
+            this.size = size;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public long getSize() {
+            return size;
+        }
+
+        public String getDisplaySize() {
+            return byteCountToDisplaySize(size);
+        }
     }
 
-    public String getDisplaySize() {
-      return byteCountToDisplaySize(size);
-    }
-  }
-  public static class Exporter extends DemoExporter<ContextMenuHierarchical> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<ContextMenuHierarchical> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuLeftClick.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuLeftClick.java
@@ -13,31 +13,33 @@ import java.util.List;
 @Route("context-menu-left-click")
 public class ContextMenuLeftClick extends Div {
 
-  private List<Person> people = DataService.getPeople(5);
+    private List<Person> people = DataService.getPeople(5);
 
-  public ContextMenuLeftClick() {
-    Grid<Person> grid = new Grid();
-    grid.setAllRowsVisible(true);
-    grid.setItems(people);
+    public ContextMenuLeftClick() {
+        Grid<Person> grid = new Grid();
+        grid.setAllRowsVisible(true);
+        grid.setItems(people);
 
-    grid.addColumn(person -> person.getFirstName())
-        .setHeader("First name");
-    grid.addColumn(person -> person.getLastName())
-        .setHeader("Last name");
-    grid.addColumn(person -> person.getEmail())
-        .setHeader("Email");
-    grid.addColumn(person -> person.getAddress().getPhone())
-        .setHeader("Phone number");
+        grid.addColumn(person -> person.getFirstName()).setHeader("First name");
+        grid.addColumn(person -> person.getLastName()).setHeader("Last name");
+        grid.addColumn(person -> person.getEmail()).setHeader("Email");
+        grid.addColumn(person -> person.getAddress().getPhone())
+                .setHeader("Phone number");
 
-    // tag::snippet[]
-    GridContextMenu<Person> menu = grid.addContextMenu();
-    menu.setOpenOnClick(true);
-    menu.addItem("View", event -> {});
-    menu.addItem("Edit", event -> {});
-    menu.addItem("Delete", event -> {});
-    // end::snippet[]
+        // tag::snippet[]
+        GridContextMenu<Person> menu = grid.addContextMenu();
+        menu.setOpenOnClick(true);
+        menu.addItem("View", event -> {
+        });
+        menu.addItem("Edit", event -> {
+        });
+        menu.addItem("Delete", event -> {
+        });
+        // end::snippet[]
 
-    add(grid);
-  }
-  public static class Exporter extends DemoExporter<ContextMenuLeftClick> {} // hidden-source-line
+        add(grid);
+    }
+
+    public static class Exporter extends DemoExporter<ContextMenuLeftClick> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java
@@ -25,86 +25,83 @@ import java.util.Random;
 @Route("context-menu-presentation")
 public class ContextMenuPresentation extends Div {
 
-  private List<Person> people = DataService.getPeople(10);
-  private Random random = new Random(1);
+    private List<Person> people = DataService.getPeople(10);
+    private Random random = new Random(1);
 
-  public ContextMenuPresentation() {
-    Grid<Person> grid = new Grid();
-    grid.setAllRowsVisible(true);
-    grid.setItems(people.subList(0, 5));
+    public ContextMenuPresentation() {
+        Grid<Person> grid = new Grid();
+        grid.setAllRowsVisible(true);
+        grid.setItems(people.subList(0, 5));
 
-    grid.addColumn(person -> person.getFullName())
-        .setHeader("Applicant");
-    grid.addColumn(person -> person.getEmail())
-        .setHeader("Email");
-    grid.addColumn(person -> person.getAddress().getPhone())
-        .setHeader("Phone number");
+        grid.addColumn(person -> person.getFullName()).setHeader("Applicant");
+        grid.addColumn(person -> person.getEmail()).setHeader("Email");
+        grid.addColumn(person -> person.getAddress().getPhone())
+                .setHeader("Phone number");
 
-    // tag::snippet1[]
-    GridContextMenu<Person> menu = grid.addContextMenu();
-    // end::snippet1[]
+        // tag::snippet1[]
+        GridContextMenu<Person> menu = grid.addContextMenu();
+        // end::snippet1[]
 
-    GridMenuItem<Person> open = menu.addItem("Open", event -> {});
-    open.addComponentAsFirst(createIcon(VaadinIcon.FILE_SEARCH));
+        GridMenuItem<Person> open = menu.addItem("Open", event -> {
+        });
+        open.addComponentAsFirst(createIcon(VaadinIcon.FILE_SEARCH));
 
-    // tag::snippet2[]
-    GridMenuItem<Person> assign = menu.addItem("Assign");
-    assign.addComponentAsFirst(createIcon(VaadinIcon.USER_CHECK));
+        // tag::snippet2[]
+        GridMenuItem<Person> assign = menu.addItem("Assign");
+        assign.addComponentAsFirst(createIcon(VaadinIcon.USER_CHECK));
 
-    GridSubMenu<Person> assignSubMenu = assign.getSubMenu();
-    people.subList(5, 10).forEach(person -> {
-      assignSubMenu.addItem(createPersonItem(person), event -> {});
-    });
-    // end::snippet2[]
-    menu.add(new Hr());
+        GridSubMenu<Person> assignSubMenu = assign.getSubMenu();
+        people.subList(5, 10).forEach(person -> {
+            assignSubMenu.addItem(createPersonItem(person), event -> {
+            });
+        });
+        // end::snippet2[]
+        menu.add(new Hr());
 
-    GridMenuItem<Person> delete = menu.addItem("Delete", event -> {});
-    delete.addComponentAsFirst(createIcon(VaadinIcon.TRASH));
+        GridMenuItem<Person> delete = menu.addItem("Delete", event -> {
+        });
+        delete.addComponentAsFirst(createIcon(VaadinIcon.TRASH));
 
-    add(grid);
-  }
+        add(grid);
+    }
 
-  private Component createIcon(VaadinIcon vaadinIcon) {
-    Icon icon = vaadinIcon.create();
-    icon.getStyle()
-      .set("color", "var(--lumo-secondary-text-color)")
-      .set("margin-inline-end", "var(--lumo-space-s")
-      .set("padding", "var(--lumo-space-xs");
-    return icon;
-  }
+    private Component createIcon(VaadinIcon vaadinIcon) {
+        Icon icon = vaadinIcon.create();
+        icon.getStyle().set("color", "var(--lumo-secondary-text-color)")
+                .set("margin-inline-end", "var(--lumo-space-s")
+                .set("padding", "var(--lumo-space-xs");
+        return icon;
+    }
 
-  // tag::snippet3[]
-  private Component createPersonItem(Person person) {
-    Avatar avatar = new Avatar();
-    avatar.setImage(person.getPictureUrl());
-    avatar.setName(person.getFirstName());
+    // tag::snippet3[]
+    private Component createPersonItem(Person person) {
+        Avatar avatar = new Avatar();
+        avatar.setImage(person.getPictureUrl());
+        avatar.setName(person.getFirstName());
 
-    Span name = new Span(person.getFullName());
-    Span apps = new Span(getApplicationCount());
-    apps.getStyle()
-      .set("color", "var(--lumo-secondary-text-color)")
-      .set("font-size", "var(--lumo-font-size-s)");
+        Span name = new Span(person.getFullName());
+        Span apps = new Span(getApplicationCount());
+        apps.getStyle().set("color", "var(--lumo-secondary-text-color)")
+                .set("font-size", "var(--lumo-font-size-s)");
 
-    VerticalLayout verticalLayout = new VerticalLayout(
-      name,
-      apps
-    );
-    verticalLayout.setPadding(false);
-    verticalLayout.setSpacing(false);
+        VerticalLayout verticalLayout = new VerticalLayout(name, apps);
+        verticalLayout.setPadding(false);
+        verticalLayout.setSpacing(false);
 
-    HorizontalLayout horizontalLayout = new HorizontalLayout(
-      avatar,
-      verticalLayout
-    );
-    horizontalLayout.setAlignItems(FlexComponent.Alignment.CENTER);
-    horizontalLayout.getStyle().set("line-height", "var(--lumo-line-height-m)");
-    return horizontalLayout;
-  }
-  // end::snippet3[]
+        HorizontalLayout horizontalLayout = new HorizontalLayout(avatar,
+                verticalLayout);
+        horizontalLayout.setAlignItems(FlexComponent.Alignment.CENTER);
+        horizontalLayout.getStyle().set("line-height",
+                "var(--lumo-line-height-m)");
+        return horizontalLayout;
+    }
+    // end::snippet3[]
 
-  private String getApplicationCount() {
-    // Randomised dummy data
-    return random.nextInt(20) + 1 + " applications";
-  }
-  public static class Exporter extends DemoExporter<ContextMenuPresentation> {} // hidden-source-line
+    private String getApplicationCount() {
+        // Randomised dummy data
+        return random.nextInt(20) + 1 + " applications";
+    }
+
+    public static class Exporter extends DemoExporter<ContextMenuPresentation> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/scroller/ScrollerBasic.java
+++ b/src/main/java/com/vaadin/demo/component/scroller/ScrollerBasic.java
@@ -18,99 +18,100 @@ import java.time.LocalDate;
 @Route("scroller-basic")
 public class ScrollerBasic extends VerticalLayout {
 
-  public static final String PERSONAL_TITLE_ID = "personal-title";
-  public static final String EMPLOYMENT_TITLE_ID = "employment-title";
+    public static final String PERSONAL_TITLE_ID = "personal-title";
+    public static final String EMPLOYMENT_TITLE_ID = "employment-title";
 
-  public ScrollerBasic() {
-    setAlignItems(Alignment.STRETCH);
-    setHeight("400px");
-    setMaxWidth("100%");
-    setPadding(false);
-    setSpacing(false);
-    setWidth("360px");
-    getStyle().set("border", "1px solid var(--lumo-contrast-20pct)");
+    public ScrollerBasic() {
+        setAlignItems(Alignment.STRETCH);
+        setHeight("400px");
+        setMaxWidth("100%");
+        setPadding(false);
+        setSpacing(false);
+        setWidth("360px");
+        getStyle().set("border", "1px solid var(--lumo-contrast-20pct)");
 
-    // Header
-    Header header = new Header();
-    header.getStyle()
-            .set("align-items", "center")
-            .set("border-bottom", "1px solid var(--lumo-contrast-20pct)")
-            .set("display", "flex")
-            .set("padding", "var(--lumo-space-m)");
+        // Header
+        Header header = new Header();
+        header.getStyle().set("align-items", "center")
+                .set("border-bottom", "1px solid var(--lumo-contrast-20pct)")
+                .set("display", "flex").set("padding", "var(--lumo-space-m)");
 
-    H2 editEmployee = new H2("Edit employee");
-    editEmployee.getStyle().set("margin", "0");
+        H2 editEmployee = new H2("Edit employee");
+        editEmployee.getStyle().set("margin", "0");
 
-    Icon arrowLeft = VaadinIcon.ARROW_LEFT.create();
-    arrowLeft.setSize("var(--lumo-icon-size-m)");
-    arrowLeft.getElement()
-            .setAttribute("aria-hidden", "true");
-    arrowLeft.getStyle()
-            .set("box-sizing", "border-box")
-            .set("margin-right", "var(--lumo-space-m)")
-            .set("padding", "calc(var(--lumo-space-xs) / 2)");
+        Icon arrowLeft = VaadinIcon.ARROW_LEFT.create();
+        arrowLeft.setSize("var(--lumo-icon-size-m)");
+        arrowLeft.getElement().setAttribute("aria-hidden", "true");
+        arrowLeft.getStyle().set("box-sizing", "border-box")
+                .set("margin-right", "var(--lumo-space-m)")
+                .set("padding", "calc(var(--lumo-space-xs) / 2)");
 
-    Anchor goBack = new Anchor("#", arrowLeft);
+        Anchor goBack = new Anchor("#", arrowLeft);
 
-    header.add(goBack, editEmployee);
-    add(header);
+        header.add(goBack, editEmployee);
+        add(header);
 
-    // tag::snippet[]
-    // Personal information
-    H3 personalTitle = new H3("Personal information");
-    personalTitle.setId(PERSONAL_TITLE_ID);
+        // tag::snippet[]
+        // Personal information
+        H3 personalTitle = new H3("Personal information");
+        personalTitle.setId(PERSONAL_TITLE_ID);
 
-    TextField firstName = new TextField("First name");
-    firstName.setWidthFull();
+        TextField firstName = new TextField("First name");
+        firstName.setWidthFull();
 
-    TextField lastName = new TextField("Last name");
-    lastName.setWidthFull();
+        TextField lastName = new TextField("Last name");
+        lastName.setWidthFull();
 
-    DatePicker birthDate = new DatePicker("Birthdate");
-    birthDate.setInitialPosition(LocalDate.of(1990, 1, 1));
-    birthDate.setWidthFull();
+        DatePicker birthDate = new DatePicker("Birthdate");
+        birthDate.setInitialPosition(LocalDate.of(1990, 1, 1));
+        birthDate.setWidthFull();
 
-    Section personalInformation = new Section(personalTitle, firstName, lastName, birthDate);
-    personalInformation.getElement().setAttribute("aria-labelledby", PERSONAL_TITLE_ID);
+        Section personalInformation = new Section(personalTitle, firstName,
+                lastName, birthDate);
+        personalInformation.getElement().setAttribute("aria-labelledby",
+                PERSONAL_TITLE_ID);
 
-    // Employment information
-    H3 employementTitle = new H3("Employment information");
-    employementTitle.setId(EMPLOYMENT_TITLE_ID);
+        // Employment information
+        H3 employmentTitle = new H3("Employment information");
+        employmentTitle.setId(EMPLOYMENT_TITLE_ID);
 
-    TextField position = new TextField("Position");
-    position.setWidthFull();
+        TextField position = new TextField("Position");
+        position.setWidthFull();
 
-    TextArea additionalInformation = new TextArea("Additional Information");
-    additionalInformation.setWidthFull();
+        TextArea additionalInformation = new TextArea("Additional Information");
+        additionalInformation.setWidthFull();
 
-    Section employmentInformation = new Section(employementTitle, position, additionalInformation);
-    employmentInformation.getElement().setAttribute("aria-labelledby", EMPLOYMENT_TITLE_ID);
+        Section employmentInformation = new Section(employmentTitle, position,
+                additionalInformation);
+        employmentInformation.getElement().setAttribute("aria-labelledby",
+                EMPLOYMENT_TITLE_ID);
 
-    // NOTE
-    // We are using inline styles here to keep the example simple.
-    // We recommend placing CSS in a separate style sheet and to
-    // encapsulating the styling in a new component.
-    Scroller scroller = new Scroller(new Div(personalInformation, employmentInformation));
-    scroller.setScrollDirection(Scroller.ScrollDirection.VERTICAL);
-    scroller.getStyle()
-            .set("border-bottom", "1px solid var(--lumo-contrast-20pct)")
-            .set("padding", "var(--lumo-space-m)");
-    add(scroller);
-    // end::snippet[]
+        // NOTE
+        // We are using inline styles here to keep the example simple.
+        // We recommend placing CSS in a separate style sheet and to
+        // encapsulating the styling in a new component.
+        Scroller scroller = new Scroller(
+                new Div(personalInformation, employmentInformation));
+        scroller.setScrollDirection(Scroller.ScrollDirection.VERTICAL);
+        scroller.getStyle()
+                .set("border-bottom", "1px solid var(--lumo-contrast-20pct)")
+                .set("padding", "var(--lumo-space-m)");
+        add(scroller);
+        // end::snippet[]
 
-    // Footer
-    Button save = new Button("Save");
-    save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-    save.getStyle().set("margin-right", "var(--lumo-space-s)");
+        // Footer
+        Button save = new Button("Save");
+        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        save.getStyle().set("margin-right", "var(--lumo-space-s)");
 
-    Button reset = new Button("Reset");
-    reset.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        Button reset = new Button("Reset");
+        reset.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
 
-    Footer footer = new Footer(save, reset);
-    footer.getStyle().set("padding", "var(--lumo-space-wide-m)");
-    add(footer);
-  }
+        Footer footer = new Footer(save, reset);
+        footer.getStyle().set("padding", "var(--lumo-space-wide-m)");
+        add(footer);
+    }
 
-  public static class Exporter extends DemoExporter<ScrollerBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ScrollerBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/scroller/ScrollerBoth.java
+++ b/src/main/java/com/vaadin/demo/component/scroller/ScrollerBoth.java
@@ -10,22 +10,23 @@ import com.vaadin.flow.server.StreamResource;
 @Route("scroller-both")
 public class ScrollerBoth extends Div {
 
-  public ScrollerBoth() {
-    // tag::snippet[]
-    Scroller scroller = new Scroller();
-    scroller.setWidthFull();
-    scroller.setHeight("300px");
+    public ScrollerBoth() {
+        // tag::snippet[]
+        Scroller scroller = new Scroller();
+        scroller.setWidthFull();
+        scroller.setHeight("300px");
 
-    StreamResource imageResource = new StreamResource("reindeer+.jpg",
-            () -> getClass().getResourceAsStream("/images/reindeer.jpg"));
+        StreamResource imageResource = new StreamResource("reindeer+.jpg",
+                () -> getClass().getResourceAsStream("/images/reindeer.jpg"));
 
-    Image img = new Image(imageResource, "A reindeer walking on a snowy lake shore at dusk");
-    scroller.setContent(img);
+        Image img = new Image(imageResource,
+                "A reindeer walking on a snowy lake shore at dusk");
+        scroller.setContent(img);
 
-    add(scroller);
-    // end::snippet[]
-  }
+        add(scroller);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<ScrollerBoth> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ScrollerBoth> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/scroller/ScrollerMobile.java
+++ b/src/main/java/com/vaadin/demo/component/scroller/ScrollerMobile.java
@@ -13,47 +13,47 @@ import com.vaadin.flow.router.Route;
 @Route("scroller-mobile")
 public class ScrollerMobile extends Section {
 
-  public ScrollerMobile() {
-    setMaxWidth("100%");
-    setWidth("360px");
-    getStyle().set("border", "1px solid var(--lumo-contrast-20pct)");
+    public ScrollerMobile() {
+        setMaxWidth("100%");
+        setWidth("360px");
+        getStyle().set("border", "1px solid var(--lumo-contrast-20pct)");
 
-    // Header
-    H2 createNewTitle = new H2("Create new...");
-    createNewTitle.getStyle()
-            .set("margin-left", "var(--lumo-space-m)")
-            .set("margin-right", "var(--lumo-space-m)");
-    add(createNewTitle);
+        // Header
+        H2 createNewTitle = new H2("Create new...");
+        createNewTitle.getStyle().set("margin-left", "var(--lumo-space-m)")
+                .set("margin-right", "var(--lumo-space-m)");
+        add(createNewTitle);
 
-    // tag::snippet[]
-    Scroller scroller = new Scroller();
-    scroller.setScrollDirection(Scroller.ScrollDirection.HORIZONTAL);
+        // tag::snippet[]
+        Scroller scroller = new Scroller();
+        scroller.setScrollDirection(Scroller.ScrollDirection.HORIZONTAL);
 
-    Button auditBtn = new Button("Audit");
-    auditBtn.setIcon(new Icon(VaadinIcon.CLIPBOARD_CHECK));
-    auditBtn.setHeight("100px");
+        Button auditBtn = new Button("Audit");
+        auditBtn.setIcon(new Icon(VaadinIcon.CLIPBOARD_CHECK));
+        auditBtn.setHeight("100px");
 
-    Button reportBtn = new Button("Report");
-    reportBtn.setIcon(new Icon(VaadinIcon.BOOK_DOLLAR));
-    reportBtn.setHeight("100px");
+        Button reportBtn = new Button("Report");
+        reportBtn.setIcon(new Icon(VaadinIcon.BOOK_DOLLAR));
+        reportBtn.setHeight("100px");
 
-    Button dashboardBtn = new Button("Dashboard");
-    dashboardBtn.setIcon(new Icon(VaadinIcon.LINE_CHART));
-    dashboardBtn.setHeight("100px");
+        Button dashboardBtn = new Button("Dashboard");
+        dashboardBtn.setIcon(new Icon(VaadinIcon.LINE_CHART));
+        dashboardBtn.setHeight("100px");
 
-    Button invoiceBtn = new Button("Invoice");
-    invoiceBtn.setIcon(new Icon(VaadinIcon.INVOICE));
-    invoiceBtn.setHeight("100px");
+        Button invoiceBtn = new Button("Invoice");
+        invoiceBtn.setIcon(new Icon(VaadinIcon.INVOICE));
+        invoiceBtn.setHeight("100px");
 
-    HorizontalLayout buttons = new HorizontalLayout(auditBtn, reportBtn, dashboardBtn, invoiceBtn);
-    buttons.setPadding(true);
-    buttons.getStyle().set("display", "inline-flex");
+        HorizontalLayout buttons = new HorizontalLayout(auditBtn, reportBtn,
+                dashboardBtn, invoiceBtn);
+        buttons.setPadding(true);
+        buttons.getStyle().set("display", "inline-flex");
 
-    scroller.setContent(buttons);
-    add(scroller);
-    // end::snippet[]
-  }
+        scroller.setContent(buttons);
+        add(scroller);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<ScrollerMobile> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ScrollerMobile> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectBasic.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectBasic.java
@@ -8,18 +8,19 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("select-basic")
 public class SelectBasic extends Div {
 
-  public SelectBasic() {
-    // tag::snippet[]
-    Select<String> select = new Select<>();
-    select.setLabel("Sort by");
-    select.setItems("Most recent first", "Rating: high to low",
-      "Rating: low to high", "Price: high to low", "Price: low to high");
-    select.setValue("Most recent first");
+    public SelectBasic() {
+        // tag::snippet[]
+        Select<String> select = new Select<>();
+        select.setLabel("Sort by");
+        select.setItems("Most recent first", "Rating: high to low",
+                "Rating: low to high", "Price: high to low",
+                "Price: low to high");
+        select.setValue("Most recent first");
 
-    add(select);
-    // end::snippet[]
-  }
+        add(select);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<SelectBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<SelectBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectComplexValueLabel.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectComplexValueLabel.java
@@ -12,20 +12,20 @@ import java.util.List;
 @Route("select-complex-value-label")
 public class SelectComplexValueLabel extends Div {
 
-  public SelectComplexValueLabel() {
-    // tag::snippet[]
-    Select<Person> select = new Select<>();
-    select.setLabel("Assignee");
-    // Display full name of the person as item text and selected value label
-    select.setItemLabelGenerator(Person::getFullName);
+    public SelectComplexValueLabel() {
+        // tag::snippet[]
+        Select<Person> select = new Select<>();
+        select.setLabel("Assignee");
+        // Display full name of the person as item text and selected value label
+        select.setItemLabelGenerator(Person::getFullName);
 
-    List<Person> people = DataService.getPeople(5);
-    select.setItems(people);
-    // end::snippet[]
+        List<Person> people = DataService.getPeople(5);
+        select.setItems(people);
+        // end::snippet[]
 
-    add(select);
-  }
+        add(select);
+    }
 
-  public static class Exporter extends DemoExporter<SelectComplexValueLabel> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<SelectComplexValueLabel> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java
@@ -16,52 +16,55 @@ import java.util.List;
 @Route("select-custom-renderer-label")
 public class SelectCustomRendererLabel extends Div {
 
-  public SelectCustomRendererLabel() {
-    // tag::snippet[]
-    Select<Person> select = new Select<>();
-    select.setLabel("Assignee");
-    // Use a custom renderer for items in the dropdown
-    select.setRenderer(SelectCustomRendererLabel.createPersonRenderer());
-    // Display full name of the person as selected value label
-    select.setItemLabelGenerator(Person::getFullName);
+    public SelectCustomRendererLabel() {
+        // tag::snippet[]
+        Select<Person> select = new Select<>();
+        select.setLabel("Assignee");
+        // Use a custom renderer for items in the dropdown
+        select.setRenderer(SelectCustomRendererLabel.createPersonRenderer());
+        // Display full name of the person as selected value label
+        select.setItemLabelGenerator(Person::getFullName);
 
-    List<Person> people = DataService.getPeople(5);
-    select.setItems(people);
-    // end::snippet[]
+        List<Person> people = DataService.getPeople(5);
+        select.setItems(people);
+        // end::snippet[]
 
-    add(select);
-  }
+        add(select);
+    }
 
-  private static ComponentRenderer<FlexLayout, Person> createPersonRenderer() {
-    return new ComponentRenderer<>(person -> {
-      FlexLayout wrapper = new FlexLayout();
-      wrapper.setAlignItems(FlexComponent.Alignment.CENTER);
+    private static ComponentRenderer<FlexLayout, Person> createPersonRenderer() {
+        return new ComponentRenderer<>(person -> {
+            FlexLayout wrapper = new FlexLayout();
+            wrapper.setAlignItems(FlexComponent.Alignment.CENTER);
 
-      // NOTE
-      // We are using inline styles here to keep the example simple.
-      // We recommend placing CSS in a separate style sheet and to
-      // encapsulating the styling in a new component.
+            // NOTE
+            // We are using inline styles here to keep the example simple.
+            // We recommend placing CSS in a separate style sheet and to
+            // encapsulating the styling in a new component.
 
-      Image image = new Image();
-      image.setSrc(person.getPictureUrl());
-      image.setAlt("Portrait of " + person.getFirstName() + " " + person.getLastName());
-      image.setWidth("var(--lumo-size-m)");
-      image.getStyle().set("margin-right", "var(--lumo-space-s)");
+            Image image = new Image();
+            image.setSrc(person.getPictureUrl());
+            image.setAlt("Portrait of " + person.getFirstName() + " "
+                    + person.getLastName());
+            image.setWidth("var(--lumo-size-m)");
+            image.getStyle().set("margin-right", "var(--lumo-space-s)");
 
-      Div info = new Div();
-      info.setText(person.getFirstName() + " " + person.getLastName());
+            Div info = new Div();
+            info.setText(person.getFirstName() + " " + person.getLastName());
 
-      Div profession = new Div();
-      profession.setText(person.getProfession());
-      profession.getStyle().set("font-size", "var(--lumo-font-size-s)");
-      profession.getStyle().set("color", "var(--lumo-secondary-text-color)");
-      info.add(profession);
+            Div profession = new Div();
+            profession.setText(person.getProfession());
+            profession.getStyle()
+                    .set("color", "var(--lumo-secondary-text-color)")
+                    .set("font-size", "var(--lumo-font-size-s)");
+            info.add(profession);
 
-      wrapper.add(image, info);
-      return wrapper;
-    });
-  }
+            wrapper.add(image, info);
+            return wrapper;
+        });
+    }
 
-  public static class Exporter extends DemoExporter<SelectCustomRendererLabel> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<SelectCustomRendererLabel> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectDisabled.java
@@ -8,18 +8,19 @@ import com.vaadin.flow.router.Route;
 @Route("select-disabled")
 public class SelectDisabled extends Div {
 
-  public SelectDisabled() {
-    // tag::snippet[]
-    Select<String> select = new Select<>();
-    select.setLabel("Size");
-    select.setItems("XS (out of stock)", "S", "M", "L", "XL");
-    select.setItemEnabledProvider(item -> !"XS (out of stock)".equals(item));
-    select.setValue("XL");
+    public SelectDisabled() {
+        // tag::snippet[]
+        Select<String> select = new Select<>();
+        select.setLabel("Size");
+        select.setItems("XS (out of stock)", "S", "M", "L", "XL");
+        select.setItemEnabledProvider(
+                item -> !"XS (out of stock)".equals(item));
+        select.setValue("XL");
 
-    add(select);
-    // end::snippet[]
-  }
+        add(select);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<SelectDisabled> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<SelectDisabled> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectDividers.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectDividers.java
@@ -9,20 +9,21 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("select-dividers")
 public class SelectDividers extends Div {
 
-  public SelectDividers() {
-    // tag::snippet[]
-    Select<String> select = new Select<>();
-    select.setLabel("Sort by");
-    select.setItems("Most recent first", "Rating: high to low",
-      "Rating: low to high", "Price: high to low", "Price: low to high");
-    select.addComponents("Most recent first", new Hr());
-    select.addComponents("Rating: low to high", new Hr());
-    select.setValue("Most recent first");
+    public SelectDividers() {
+        // tag::snippet[]
+        Select<String> select = new Select<>();
+        select.setLabel("Sort by");
+        select.setItems("Most recent first", "Rating: high to low",
+                "Rating: low to high", "Price: high to low",
+                "Price: low to high");
+        select.addComponents("Most recent first", new Hr());
+        select.addComponents("Rating: low to high", new Hr());
+        select.setValue("Most recent first");
 
-    add(select);
-    // end::snippet[]
-  }
+        add(select);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<SelectDividers> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<SelectDividers> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectEmptySelection.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectEmptySelection.java
@@ -8,18 +8,18 @@ import com.vaadin.flow.router.Route;
 @Route("select-empty-selection")
 public class SelectEmptySelection extends Div {
 
-  public SelectEmptySelection() {
-    Select<String> select = new Select<>();
-    // tag::snippet[]
-    select.setEmptySelectionAllowed(true);
-    // end::snippet[]
-    select.setLabel("Size");
-    select.setItems("XS", "S", "M", "L", "XL");
-    select.setPlaceholder("Select size");
+    public SelectEmptySelection() {
+        Select<String> select = new Select<>();
+        // tag::snippet[]
+        select.setEmptySelectionAllowed(true);
+        // end::snippet[]
+        select.setLabel("Size");
+        select.setItems("XS", "S", "M", "L", "XL");
+        select.setPlaceholder("Select size");
 
-    add(select);
-  }
+        add(select);
+    }
 
-  public static class Exporter extends DemoExporter<SelectEmptySelection> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<SelectEmptySelection> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectEmptySelectionCaption.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectEmptySelectionCaption.java
@@ -8,18 +8,19 @@ import com.vaadin.flow.router.Route;
 @Route("select-empty-selection-caption")
 public class SelectEmptySelectionCaption extends Div {
 
-  public SelectEmptySelectionCaption() {
-    Select<String> select = new Select<>();
-    // tag::snippet[]
-    select.setEmptySelectionAllowed(true);
-    select.setEmptySelectionCaption("Unknown size");
-    // end::snippet[]
-    select.setLabel("Size");
-    select.setItems("XS", "S", "M", "L", "XL");
+    public SelectEmptySelectionCaption() {
+        Select<String> select = new Select<>();
+        // tag::snippet[]
+        select.setEmptySelectionAllowed(true);
+        select.setEmptySelectionCaption("Unknown size");
+        // end::snippet[]
+        select.setLabel("Size");
+        select.setItems("XS", "S", "M", "L", "XL");
 
-    add(select);
-  }
+        add(select);
+    }
 
-  public static class Exporter extends DemoExporter<SelectEmptySelectionCaption> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<SelectEmptySelectionCaption> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectPlaceholder.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectPlaceholder.java
@@ -8,17 +8,17 @@ import com.vaadin.flow.router.Route;
 @Route("select-placeholder")
 public class SelectPlaceholder extends Div {
 
-  public SelectPlaceholder() {
-    // tag::snippet[]
-    Select<String> select = new Select<>();
-    select.setLabel("Size");
-    select.setItems("XS", "S", "M", "L", "XL");
-    select.setPlaceholder("Select size");
+    public SelectPlaceholder() {
+        // tag::snippet[]
+        Select<String> select = new Select<>();
+        select.setLabel("Size");
+        select.setItems("XS", "S", "M", "L", "XL");
+        select.setPlaceholder("Select size");
 
-    add(select);
-    // end::snippet[]
-  }
+        add(select);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<SelectPlaceholder> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<SelectPlaceholder> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java
@@ -16,44 +16,46 @@ import java.util.List;
 @Route("select-presentation")
 public class SelectPresentation extends Div {
 
-  private List<Person> items = DataService.getPeople(5);
+    private List<Person> items = DataService.getPeople(5);
 
-  public SelectPresentation() {
-    // tag::snippet[]
-    Select<Person> select = new Select<>();
-    select.setLabel("Choose doctor");
-    select.setRenderer(new ComponentRenderer<>(person -> {
-        FlexLayout wrapper = new FlexLayout();
-        wrapper.setAlignItems(Alignment.CENTER);
+    public SelectPresentation() {
+        // tag::snippet[]
+        Select<Person> select = new Select<>();
+        select.setLabel("Choose doctor");
+        select.setRenderer(new ComponentRenderer<>(person -> {
+            FlexLayout wrapper = new FlexLayout();
+            wrapper.setAlignItems(Alignment.CENTER);
 
-        // NOTE
-        // We are using inline styles here to keep the example simple.
-        // We recommend placing CSS in a separate style sheet and to
-        // encapsulating the styling in a new component.
+            // NOTE
+            // We are using inline styles here to keep the example simple.
+            // We recommend placing CSS in a separate style sheet and to
+            // encapsulating the styling in a new component.
 
-        Image image = new Image();
-        image.setSrc(person.getPictureUrl());
-        image.setAlt("Portrait of " + person.getFirstName() + " " + person.getLastName());
-        image.setWidth("var(--lumo-size-m)");
-        image.getStyle().set("margin-right", "var(--lumo-space-s)");
+            Image image = new Image();
+            image.setSrc(person.getPictureUrl());
+            image.setAlt("Portrait of " + person.getFirstName() + " "
+                    + person.getLastName());
+            image.setWidth("var(--lumo-size-m)");
+            image.getStyle().set("margin-right", "var(--lumo-space-s)");
 
-        Div info = new Div();
-        info.setText(person.getFirstName() + " " + person.getLastName());
+            Div info = new Div();
+            info.setText(person.getFirstName() + " " + person.getLastName());
 
-        Div profession = new Div();
-        profession.setText(person.getProfession());
-        profession.getStyle().set("font-size", "var(--lumo-font-size-s)");
-        profession.getStyle().set("color", "var(--lumo-secondary-text-color)");
-        info.add(profession);
+            Div profession = new Div();
+            profession.setText(person.getProfession());
+            profession.getStyle().set("font-size", "var(--lumo-font-size-s)");
+            profession.getStyle().set("color",
+                    "var(--lumo-secondary-text-color)");
+            info.add(profession);
 
-        wrapper.add(image, info);
-        return wrapper;
-    }));
-    select.setItems(items);
-    add(select);
-    // end::snippet[]
-  }
+            wrapper.add(image, info);
+            return wrapper;
+        }));
+        select.setItems(items);
+        add(select);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<SelectPresentation> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<SelectPresentation> { // hidden-source-line
+    } // hidden-source-line
 }


### PR DESCRIPTION
## Description

Part of #1735

Fixed indentation from 2 spaces to 4 spaces for the following components examples:

- `Avatar`
- `ConfirmDialog`
- `ContextMenu`
- `Scroller`
- `Select`

## Note

Use "hide whitespace" checkmark when reviewing to make PR diff smaller.