### PR TITLE
chore: reindent Java examples using 4 spaces (part 4)

### DIFF
--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxBasic.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxBasic.java
@@ -8,15 +8,15 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("checkbox-basic")
 public class CheckboxBasic extends Div {
 
-  public CheckboxBasic() {
-    // tag::snippet[]
-    Checkbox checkbox = new Checkbox();
-    checkbox.setLabel("I accept the terms and conditions");
+    public CheckboxBasic() {
+        // tag::snippet[]
+        Checkbox checkbox = new Checkbox();
+        checkbox.setLabel("I accept the terms and conditions");
 
-    add(checkbox);
-    // end::snippet[]
-  }
+        add(checkbox);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<CheckboxBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<CheckboxBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxAutoOpen.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxAutoOpen.java
@@ -10,16 +10,16 @@ import com.vaadin.demo.domain.DataService;
 @Route("combo-box-auto-open")
 public class ComboBoxAutoOpen extends Div {
 
-  public ComboBoxAutoOpen() {
-    // tag::snippet[]
-    ComboBox<Country> comboBox = new ComboBox<>("Country");
-    comboBox.setAutoOpen(false);
-    add(comboBox);
-    // end::snippet[]
-    comboBox.setItems(DataService.getCountries());
-    comboBox.setItemLabelGenerator(Country::getName);
-  }
+    public ComboBoxAutoOpen() {
+        // tag::snippet[]
+        ComboBox<Country> comboBox = new ComboBox<>("Country");
+        comboBox.setAutoOpen(false);
+        add(comboBox);
+        // end::snippet[]
+        comboBox.setItems(DataService.getCountries());
+        comboBox.setItemLabelGenerator(Country::getName);
+    }
 
-  public static class Exporter extends DemoExporter<ComboBoxAutoOpen> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ComboBoxAutoOpen> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxBasic.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxBasic.java
@@ -10,15 +10,15 @@ import com.vaadin.demo.domain.DataService;
 @Route("combo-box-basic")
 public class ComboBoxBasic extends Div {
 
-  public ComboBoxBasic() {
-    // tag::snippet[]
-    ComboBox<Country> comboBox = new ComboBox<>("Country");
-    comboBox.setItems(DataService.getCountries());
-    comboBox.setItemLabelGenerator(Country::getName);
-    add(comboBox);
-    // end::snippet[]
-  }
+    public ComboBoxBasic() {
+        // tag::snippet[]
+        ComboBox<Country> comboBox = new ComboBox<>("Country");
+        comboBox.setItems(DataService.getCountries());
+        comboBox.setItemLabelGenerator(Country::getName);
+        add(comboBox);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<ComboBoxBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ComboBoxBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomEntry1.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomEntry1.java
@@ -8,16 +8,16 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("combo-box-custom-entry-1")
 public class ComboBoxCustomEntry1 extends Div {
 
-  public ComboBoxCustomEntry1() {
-    // tag::snippet[]
-    ComboBox<String> comboBox = new ComboBox<>("Browser");
-    comboBox.setAllowCustomValue(true);
-    add(comboBox);
-    // end::snippet[]
-    comboBox.setItems("Chrome", "Edge", "Firefox", "Safari");
-    comboBox.setHelperText("Select or type a browser");
-  }
+    public ComboBoxCustomEntry1() {
+        // tag::snippet[]
+        ComboBox<String> comboBox = new ComboBox<>("Browser");
+        comboBox.setAllowCustomValue(true);
+        add(comboBox);
+        // end::snippet[]
+        comboBox.setItems("Chrome", "Edge", "Firefox", "Safari");
+        comboBox.setHelperText("Select or type a browser");
+    }
 
-  public static class Exporter extends DemoExporter<ComboBoxCustomEntry1> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ComboBoxCustomEntry1> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomEntry2.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomEntry2.java
@@ -13,24 +13,25 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("combo-box-custom-entry-2")
 public class ComboBoxCustomEntry2 extends Div {
 
-  private List<String> items = new ArrayList<>(Arrays.asList("Chrome", "Edge", "Firefox", "Safari"));
+    private List<String> items = new ArrayList<>(
+            Arrays.asList("Chrome", "Edge", "Firefox", "Safari"));
 
-  public ComboBoxCustomEntry2() {
-    // tag::snippet[]
-    ComboBox<String> comboBox = new ComboBox<>("Browser");
-    comboBox.setAllowCustomValue(true);
-    comboBox.addCustomValueSetListener(e -> {
-      String customValue = e.getDetail();
-      items.add(customValue);
-      comboBox.setItems(items);
-      comboBox.setValue(customValue);
-    });
-    add(comboBox);
-    // end::snippet[]
-    comboBox.setItems(items);
-    comboBox.setHelperText("Select or type a browser");
-  }
+    public ComboBoxCustomEntry2() {
+        // tag::snippet[]
+        ComboBox<String> comboBox = new ComboBox<>("Browser");
+        comboBox.setAllowCustomValue(true);
+        comboBox.addCustomValueSetListener(e -> {
+            String customValue = e.getDetail();
+            items.add(customValue);
+            comboBox.setItems(items);
+            comboBox.setValue(customValue);
+        });
+        add(comboBox);
+        // end::snippet[]
+        comboBox.setItems(items);
+        comboBox.setHelperText("Select or type a browser");
+    }
 
-  public static class Exporter extends DemoExporter<ComboBoxCustomEntry2> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ComboBoxCustomEntry2> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxFiltering2.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxFiltering2.java
@@ -11,18 +11,19 @@ import com.vaadin.demo.domain.DataService;
 @Route("combo-box-filtering-2")
 public class ComboBoxFiltering2 extends Div {
 
-  public ComboBoxFiltering2() {
-    // tag::snippet[]
-    ComboBox<Country> comboBox = new ComboBox<>("Country");
+    public ComboBoxFiltering2() {
+        // tag::snippet[]
+        ComboBox<Country> comboBox = new ComboBox<>("Country");
 
-    ItemFilter<Country> filter = (country, filterString) -> country.getName().toLowerCase().startsWith(filterString.toLowerCase());
-    comboBox.setItems(filter, DataService.getCountries());
+        ItemFilter<Country> filter = (country, filterString) -> country
+                .getName().toLowerCase().startsWith(filterString.toLowerCase());
+        comboBox.setItems(filter, DataService.getCountries());
 
-    add(comboBox);
-    // end::snippet[]
-    comboBox.setItemLabelGenerator(Country::getName);
-  }
+        add(comboBox);
+        // end::snippet[]
+        comboBox.setItemLabelGenerator(Country::getName);
+    }
 
-  public static class Exporter extends DemoExporter<ComboBoxFiltering2> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ComboBoxFiltering2> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPlaceholder.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPlaceholder.java
@@ -11,19 +11,22 @@ import com.vaadin.demo.domain.Person;
 @Route("combo-box-placeholder")
 public class ComboBoxPlaceholder extends Div {
 
-  public ComboBoxPlaceholder() {
-    ItemFilter<Person> filter = (person, filterString) -> (person.getProfession() + " " +person
-    .getFirstName() + " " + person.getLastName()).toLowerCase().indexOf(filterString.toLowerCase()) > -1;
+    public ComboBoxPlaceholder() {
+        ItemFilter<Person> filter = (person,
+                filterString) -> (person.getProfession() + " "
+                        + person.getFirstName() + " " + person.getLastName())
+                        .toLowerCase().indexOf(filterString.toLowerCase()) > -1;
 
-    // tag::snippet[]
-    ComboBox<Person> comboBox = new ComboBox<>("Employee");
-    comboBox.setPlaceholder("Select employee");
-    add(comboBox);
-    // end::snippet[]
-    comboBox.setItems(filter, DataService.getPeople());
-    comboBox.setItemLabelGenerator(person -> person.getFirstName() + " " + person.getLastName());
-  }
+        // tag::snippet[]
+        ComboBox<Person> comboBox = new ComboBox<>("Employee");
+        comboBox.setPlaceholder("Select employee");
+        add(comboBox);
+        // end::snippet[]
+        comboBox.setItems(filter, DataService.getPeople());
+        comboBox.setItemLabelGenerator(
+                person -> person.getFirstName() + " " + person.getLastName());
+    }
 
-  public static class Exporter extends DemoExporter<ComboBoxPlaceholder> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ComboBoxPlaceholder> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPopupWidth.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPopupWidth.java
@@ -11,19 +11,22 @@ import com.vaadin.demo.domain.Person;
 @Route("combo-box-popup-width")
 public class ComboBoxPopupWidth extends Div {
 
-  public ComboBoxPopupWidth() {
-    // tag::snippet[]
-    ComboBox<Person> comboBox = new ComboBox<>("Employee");
-    comboBox.getStyle().set("--vaadin-combo-box-overlay-width", "350px");
-    add(comboBox);
-    // end::snippet[]
+    public ComboBoxPopupWidth() {
+        // tag::snippet[]
+        ComboBox<Person> comboBox = new ComboBox<>("Employee");
+        comboBox.getStyle().set("--vaadin-combo-box-overlay-width", "350px");
+        add(comboBox);
+        // end::snippet[]
 
-    ItemFilter<Person> filter = (person, filterString) -> (person.getProfession() + " " +person
-    .getFirstName() + " " + person.getLastName()).toLowerCase().indexOf(filterString.toLowerCase()) > -1;
-    comboBox.setItems(filter, DataService.getPeople());
-    comboBox.setItemLabelGenerator(person -> person.getProfession() + " " + person.getFirstName() + " " + person.getLastName());
-  }
+        ItemFilter<Person> filter = (person,
+                filterString) -> (person.getProfession() + " "
+                        + person.getFirstName() + " " + person.getLastName())
+                        .toLowerCase().indexOf(filterString.toLowerCase()) > -1;
+        comboBox.setItems(filter, DataService.getPeople());
+        comboBox.setItemLabelGenerator(person -> person.getProfession() + " "
+                + person.getFirstName() + " " + person.getLastName());
+    }
 
-  public static class Exporter extends DemoExporter<ComboBoxPopupWidth> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ComboBoxPopupWidth> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java
@@ -13,42 +13,49 @@ import com.vaadin.demo.domain.Person;
 @Route("combo-box-presentation")
 public class ComboBoxPresentation extends Div {
 
-  public ComboBoxPresentation() {
-    ItemFilter<Person> filter = (person, filterString) -> (person
-        .getFirstName() + " " + person.getLastName() + " " + person.getProfession()).toLowerCase().indexOf(filterString.toLowerCase()) > -1;
+    public ComboBoxPresentation() {
+        ItemFilter<Person> filter = (person,
+                filterString) -> (person.getFirstName() + " "
+                        + person.getLastName() + " " + person.getProfession())
+                        .toLowerCase().indexOf(filterString.toLowerCase()) > -1;
 
-    // tag::combobox[]
-    ComboBox<Person> comboBox = new ComboBox<>("Choose doctor");
-    comboBox.setItems(filter, DataService.getPeople());
-    comboBox.setItemLabelGenerator(person -> person.getFirstName() + " " + person.getLastName());
-    comboBox.setRenderer(createRenderer());
-    comboBox.getStyle().set("--vaadin-combo-box-overlay-width", "16em");
-    add(comboBox);
-    // end::combobox[]
-  }
+        // tag::combobox[]
+        ComboBox<Person> comboBox = new ComboBox<>("Choose doctor");
+        comboBox.setItems(filter, DataService.getPeople());
+        comboBox.setItemLabelGenerator(
+                person -> person.getFirstName() + " " + person.getLastName());
+        comboBox.setRenderer(createRenderer());
+        comboBox.getStyle().set("--vaadin-combo-box-overlay-width", "16em");
+        add(comboBox);
+        // end::combobox[]
+    }
 
-  // tag::renderer[]
-  // NOTE
-  // We are using inline styles here to keep the example simple.
-  // We recommend placing CSS in a separate style sheet and to
-  // encapsulating the styling in a new component.
+    // tag::renderer[]
+    // NOTE
+    // We are using inline styles here to keep the example simple.
+    // We recommend placing CSS in a separate style sheet and to
+    // encapsulating the styling in a new component.
 
-  private Renderer<Person> createRenderer() {
-    StringBuilder tpl = new StringBuilder();
-    tpl.append("<div style=\"display: flex;\">");
-    tpl.append("  <img style=\"height: var(--lumo-size-m); margin-right: var(--lumo-space-s);\" src=\"${item.pictureUrl}\" alt=\"Portrait of ${item.firstName} ${item.lastName}\" />");
-    tpl.append("  <div>");
-    tpl.append("    ${item.firstName} ${item.lastName}");
-    tpl.append("    <div style=\"font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);\">${item.profession}</div>");
-    tpl.append("  </div>");
-    tpl.append("</div>");
+    private Renderer<Person> createRenderer() {
+        StringBuilder tpl = new StringBuilder();
+        tpl.append("<div style=\"display: flex;\">");
+        tpl.append(
+                "  <img style=\"height: var(--lumo-size-m); margin-right: var(--lumo-space-s);\" src=\"${item.pictureUrl}\" alt=\"Portrait of ${item.firstName} ${item.lastName}\" />");
+        tpl.append("  <div>");
+        tpl.append("    ${item.firstName} ${item.lastName}");
+        tpl.append(
+                "    <div style=\"font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);\">${item.profession}</div>");
+        tpl.append("  </div>");
+        tpl.append("</div>");
 
-    return LitRenderer.<Person>of(tpl.toString()).withProperty("pictureUrl", Person::getPictureUrl)
-        .withProperty("firstName", Person::getFirstName).withProperty("lastName", Person::getLastName)
-        .withProperty("profession", Person::getProfession);
-  }
-  // end::renderer[]
+        return LitRenderer.<Person> of(tpl.toString())
+                .withProperty("pictureUrl", Person::getPictureUrl)
+                .withProperty("firstName", Person::getFirstName)
+                .withProperty("lastName", Person::getLastName)
+                .withProperty("profession", Person::getProfession);
+    }
+    // end::renderer[]
 
-  public static class Exporter extends DemoExporter<ComboBoxPresentation> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<ComboBoxPresentation> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudBasic.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudBasic.java
@@ -19,81 +19,75 @@ import java.util.List;
 @Route("crud-basic")
 public class CrudBasic extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String EMAIL = "email";
-  private String PROFESSION = "profession";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String EMAIL = "email";
+    private String PROFESSION = "profession";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  public CrudBasic() {
-    // tag::snippet[]
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
+    public CrudBasic() {
+        // tag::snippet[]
+        crud = new Crud<>(Person.class, createEditor());
 
-    setupGrid();
-    setupDataProvider();
+        setupGrid();
+        setupDataProvider();
 
-    add(crud);
-    // end::snippet[]
-  }
+        add(crud);
+        // end::snippet[]
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    EmailField email = new EmailField("Email");
-    TextField profession = new TextField("Profession");
-    FormLayout form = new FormLayout(firstName, lastName, email, profession);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        EmailField email = new EmailField("Email");
+        TextField profession = new TextField("Profession");
+        FormLayout form = new FormLayout(firstName, lastName, email,
+                profession);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
-    binder.forField(email).asRequired().bind(Person::getEmail, Person::setEmail);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
+        binder.forField(email).asRequired().bind(Person::getEmail,
+                Person::setEmail);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  private void setupGrid() {
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        Grid<Person> grid = crud.getGrid();
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      EMAIL,
-      PROFESSION,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                EMAIL, PROFESSION, EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(EMAIL),
-      grid.getColumnByKey(PROFESSION),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
-  }
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME), grid.getColumnByKey(EMAIL),
+                grid.getColumnByKey(PROFESSION),
+                grid.getColumnByKey(EDIT_COLUMN));
+    }
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
-  public static class Exporter extends DemoExporter<CrudBasic> {} // hidden-source-line
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
+
+    public static class Exporter extends DemoExporter<CrudBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudColumns.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudColumns.java
@@ -21,83 +21,78 @@ import java.util.List;
 @Route("crud-columns")
 public class CrudColumns extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  private String FIRST_NAME = "firstName";
-  private String EMAIL = "email";
-  private String PROFESSION = "profession";
-  private String BIRTHDAY = "birthday";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String EMAIL = "email";
+    private String PROFESSION = "profession";
+    private String BIRTHDAY = "birthday";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  public CrudColumns() {
-    // tag::snippet[]
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
+    public CrudColumns() {
+        // tag::snippet[]
+        crud = new Crud<>(Person.class, createEditor());
 
-    setupGrid();
-    setupDataProvider();
+        setupGrid();
+        setupDataProvider();
 
-    add(crud);
-    // end::snippet[]
-  }
+        add(crud);
+        // end::snippet[]
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    EmailField email = new EmailField("Email");
-    TextField profession = new TextField("Profession");
-    DatePicker birthday = new DatePicker("Birthday");
-    FormLayout form = new FormLayout(firstName, email, profession, birthday);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        EmailField email = new EmailField("Email");
+        TextField profession = new TextField("Profession");
+        DatePicker birthday = new DatePicker("Birthday");
+        FormLayout form = new FormLayout(firstName, email, profession,
+                birthday);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(email).asRequired().bind(Person::getEmail, Person::setEmail);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
-    binder.forField(birthday).asRequired().withConverter(new LocalDateToDateConverter()).bind(Person::getBirthday, Person::setBirthday);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(email).asRequired().bind(Person::getEmail,
+                Person::setEmail);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
+        binder.forField(birthday).asRequired()
+                .withConverter(new LocalDateToDateConverter())
+                .bind(Person::getBirthday, Person::setBirthday);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  private void setupGrid() {
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        Grid<Person> grid = crud.getGrid();
 
-    // tag::snippet[]
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      EMAIL,
-      PROFESSION,
-      BIRTHDAY,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
-    // end::snippet[]
+        // tag::snippet[]
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, EMAIL,
+                PROFESSION, BIRTHDAY, EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
+        // end::snippet[]
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(EMAIL),
-      grid.getColumnByKey(PROFESSION),
-      grid.getColumnByKey(BIRTHDAY),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
-  }
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(EMAIL), grid.getColumnByKey(PROFESSION),
+                grid.getColumnByKey(BIRTHDAY),
+                grid.getColumnByKey(EDIT_COLUMN));
+    }
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
-  public static class Exporter extends DemoExporter<CrudColumns> {} // hidden-source-line
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
+
+    public static class Exporter extends DemoExporter<CrudColumns> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudEditorAside.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudEditorAside.java
@@ -20,82 +20,76 @@ import java.util.List;
 @Route("crud-editor-aside")
 public class CrudEditorAside extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String EMAIL = "email";
-  private String PROFESSION = "profession";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String EMAIL = "email";
+    private String PROFESSION = "profession";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  public CrudEditorAside() {
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
-    // tag::snippet[]
-    crud.setEditorPosition(CrudEditorPosition.ASIDE);
-    // end::snippet[]
+    public CrudEditorAside() {
+        crud = new Crud<>(Person.class, createEditor());
+        // tag::snippet[]
+        crud.setEditorPosition(CrudEditorPosition.ASIDE);
+        // end::snippet[]
 
-    setupGrid();
-    setupDataProvider();
+        setupGrid();
+        setupDataProvider();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    EmailField email = new EmailField("Email");
-    TextField profession = new TextField("Profession");
-    FormLayout form = new FormLayout(firstName, lastName, email, profession);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        EmailField email = new EmailField("Email");
+        TextField profession = new TextField("Profession");
+        FormLayout form = new FormLayout(firstName, lastName, email,
+                profession);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
-    binder.forField(email).asRequired().bind(Person::getEmail, Person::setEmail);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
+        binder.forField(email).asRequired().bind(Person::getEmail,
+                Person::setEmail);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  private void setupGrid() {
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        Grid<Person> grid = crud.getGrid();
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      EMAIL,
-      PROFESSION,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                EMAIL, PROFESSION, EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(EMAIL),
-      grid.getColumnByKey(PROFESSION),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
-  }
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME), grid.getColumnByKey(EMAIL),
+                grid.getColumnByKey(PROFESSION),
+                grid.getColumnByKey(EDIT_COLUMN));
+    }
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
-  public static class Exporter extends DemoExporter<CrudEditorAside> {} // hidden-source-line
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
+
+    public static class Exporter extends DemoExporter<CrudEditorAside> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudEditorBottom.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudEditorBottom.java
@@ -20,82 +20,76 @@ import java.util.List;
 @Route("crud-editor-bottom")
 public class CrudEditorBottom extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String EMAIL = "email";
-  private String PROFESSION = "profession";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String EMAIL = "email";
+    private String PROFESSION = "profession";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  public CrudEditorBottom() {
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
-    // tag::snippet[]
-    crud.setEditorPosition(CrudEditorPosition.BOTTOM);
-    // end::snippet[]
+    public CrudEditorBottom() {
+        crud = new Crud<>(Person.class, createEditor());
+        // tag::snippet[]
+        crud.setEditorPosition(CrudEditorPosition.BOTTOM);
+        // end::snippet[]
 
-    setupGrid();
-    setupDataProvider();
+        setupGrid();
+        setupDataProvider();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    EmailField email = new EmailField("Email");
-    TextField profession = new TextField("Profession");
-    FormLayout form = new FormLayout(firstName, lastName, email, profession);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        EmailField email = new EmailField("Email");
+        TextField profession = new TextField("Profession");
+        FormLayout form = new FormLayout(firstName, lastName, email,
+                profession);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
-    binder.forField(email).asRequired().bind(Person::getEmail, Person::setEmail);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
+        binder.forField(email).asRequired().bind(Person::getEmail,
+                Person::setEmail);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  private void setupGrid() {
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        Grid<Person> grid = crud.getGrid();
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      EMAIL,
-      PROFESSION,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                EMAIL, PROFESSION, EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(EMAIL),
-      grid.getColumnByKey(PROFESSION),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
-  }
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME), grid.getColumnByKey(EMAIL),
+                grid.getColumnByKey(PROFESSION),
+                grid.getColumnByKey(EDIT_COLUMN));
+    }
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
-  public static class Exporter extends DemoExporter<CrudEditorBottom> {} // hidden-source-line
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
+
+    public static class Exporter extends DemoExporter<CrudEditorBottom> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudEditorContent.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudEditorContent.java
@@ -21,94 +21,86 @@ import java.util.List;
 @Route("crud-editor-content")
 public class CrudEditorContent extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String EMAIL = "email";
-  private String PROFESSION = "profession";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String EMAIL = "email";
+    private String PROFESSION = "profession";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  private List<String> professions = DataService.getProfessions();
+    private List<String> professions = DataService.getProfessions();
 
-  public CrudEditorContent() {
-    // tag::snippet1[]
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
-    // end::snippet1[]
+    public CrudEditorContent() {
+        // tag::snippet1[]
+        crud = new Crud<>(Person.class, createEditor());
+        // end::snippet1[]
 
-    setupGrid();
-    setupDataProvider();
+        setupGrid();
+        setupDataProvider();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  // tag::snippet2[]
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    EmailField email = new EmailField("Email");
-    ComboBox<String> profession = new ComboBox<>("Profession");
-    profession.setItems(professions);
+    // tag::snippet2[]
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        EmailField email = new EmailField("Email");
+        ComboBox<String> profession = new ComboBox<>("Profession");
+        profession.setItems(professions);
 
-    FormLayout form = new FormLayout(firstName, lastName, email, profession);
-    form.setColspan(email, 2);
-    form.setColspan(profession, 2);
-    form.setMaxWidth("480px");
-    form.setResponsiveSteps(
-      new FormLayout.ResponsiveStep("0", 1),
-      new FormLayout.ResponsiveStep("30em", 2)
-    );
+        FormLayout form = new FormLayout(firstName, lastName, email,
+                profession);
+        form.setColspan(email, 2);
+        form.setColspan(profession, 2);
+        form.setMaxWidth("480px");
+        form.setResponsiveSteps(new FormLayout.ResponsiveStep("0", 1),
+                new FormLayout.ResponsiveStep("30em", 2));
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
-    binder.forField(email).asRequired().bind(Person::getEmail, Person::setEmail);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
+        binder.forField(email).asRequired().bind(Person::getEmail,
+                Person::setEmail);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
-  // end::snippet2[]
+        return new BinderCrudEditor<>(binder, form);
+    }
+    // end::snippet2[]
 
-  private void setupGrid() {
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        Grid<Person> grid = crud.getGrid();
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      EMAIL,
-      PROFESSION,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                EMAIL, PROFESSION, EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(EMAIL),
-      grid.getColumnByKey(PROFESSION),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
-  }
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME), grid.getColumnByKey(EMAIL),
+                grid.getColumnByKey(PROFESSION),
+                grid.getColumnByKey(EDIT_COLUMN));
+    }
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
-  public static class Exporter extends DemoExporter<CrudEditorContent> {} // hidden-source-line
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
+
+    public static class Exporter extends DemoExporter<CrudEditorContent> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudGridReplacement.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudGridReplacement.java
@@ -16,59 +16,60 @@ import com.vaadin.flow.router.Route;
 @Route("crud-grid-replacement")
 public class CrudGridReplacement extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  public CrudGridReplacement() {
-    // tag::snippet1[]
-    crud = new Crud<>(
-      Person.class,
-      createGrid(),
-      createEditor()
-    );
-    // end::snippet1[]
+    public CrudGridReplacement() {
+        // tag::snippet1[]
+        crud = new Crud<>(Person.class, createGrid(), createEditor());
+        // end::snippet1[]
 
-    setupDataProvider();
+        setupDataProvider();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    EmailField email = new EmailField("Email");
-    TextField profession = new TextField("Profession");
-    FormLayout form = new FormLayout(firstName, lastName, email, profession);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        EmailField email = new EmailField("Email");
+        TextField profession = new TextField("Profession");
+        FormLayout form = new FormLayout(firstName, lastName, email,
+                profession);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
-    binder.forField(email).asRequired().bind(Person::getEmail, Person::setEmail);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
+        binder.forField(email).asRequired().bind(Person::getEmail,
+                Person::setEmail);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  // tag::snippet2[]
-  private Grid<Person> createGrid() {
-    Grid<Person> grid = new Grid<>();
-    Crud.addEditColumn(grid);
-    grid.addColumn(Person::getFirstName).setHeader("First name");
-    grid.addColumn(Person::getLastName).setHeader("Last name");
-    grid.addColumn(Person::getEmail).setHeader("Email");
-    grid.addColumn(Person::getProfession).setHeader("Profession");
-    return grid;
-  }
-  // end::snippet2[]
+    // tag::snippet2[]
+    private Grid<Person> createGrid() {
+        Grid<Person> grid = new Grid<>();
+        Crud.addEditColumn(grid);
+        grid.addColumn(Person::getFirstName).setHeader("First name");
+        grid.addColumn(Person::getLastName).setHeader("Last name");
+        grid.addColumn(Person::getEmail).setHeader("Email");
+        grid.addColumn(Person::getProfession).setHeader("Profession");
+        return grid;
+    }
+    // end::snippet2[]
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
-  public static class Exporter extends DemoExporter<CrudGridReplacement> {} // hidden-source-line
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
+
+    public static class Exporter extends DemoExporter<CrudGridReplacement> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudHiddenToolbar.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudHiddenToolbar.java
@@ -18,74 +18,67 @@ import java.util.List;
 @Route("crud-hidden-toolbar")
 public class CrudHiddenToolbar extends Div {
 
-  private Crud<Person> crud;
-  private PersonDataProvider dataProvider;
+    private Crud<Person> crud;
+    private PersonDataProvider dataProvider;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  public CrudHiddenToolbar() {
-    // tag::snippet[]
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
-    crud.setToolbarVisible(false);
-    // end::snippet[]
+    public CrudHiddenToolbar() {
+        // tag::snippet[]
+        crud = new Crud<>(Person.class, createEditor());
+        crud.setToolbarVisible(false);
+        // end::snippet[]
 
-    setupGrid();
-    setupDataProvider();
+        setupGrid();
+        setupDataProvider();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    FormLayout form = new FormLayout(firstName, lastName);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        FormLayout form = new FormLayout(firstName, lastName);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  private void setupGrid() {
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        Grid<Person> grid = crud.getGrid();
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
-  }
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME),
+                grid.getColumnByKey(EDIT_COLUMN));
+    }
 
-  private void setupDataProvider() {
-    dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
+    private void setupDataProvider() {
+        dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
 
-  public static class Exporter extends DemoExporter<CrudHiddenToolbar> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<CrudHiddenToolbar> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudItemInitialization.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudItemInitialization.java
@@ -19,87 +19,81 @@ import java.util.List;
 @Route("crud-item-initialization")
 public class CrudItemInitialization extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String EMAIL = "email";
-  private String PROFESSION = "profession";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String EMAIL = "email";
+    private String PROFESSION = "profession";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  public CrudItemInitialization() {
-    // tag::snippet[]
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
-    crud.addNewListener(event -> {
-      Person person = event.getItem();
-      person.setEmail("@vaadin.com");
-      person.setProfession("Developer");
-      crud.getEditor().setItem(person);
-    });
-    // end::snippet[]
+    public CrudItemInitialization() {
+        // tag::snippet[]
+        crud = new Crud<>(Person.class, createEditor());
+        crud.addNewListener(event -> {
+            Person person = event.getItem();
+            person.setEmail("@vaadin.com");
+            person.setProfession("Developer");
+            crud.getEditor().setItem(person);
+        });
+        // end::snippet[]
 
-    setupGrid();
-    setupDataProvider();
+        setupGrid();
+        setupDataProvider();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    EmailField email = new EmailField("Email");
-    TextField profession = new TextField("Profession");
-    FormLayout form = new FormLayout(firstName, lastName, email, profession);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        EmailField email = new EmailField("Email");
+        TextField profession = new TextField("Profession");
+        FormLayout form = new FormLayout(firstName, lastName, email,
+                profession);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
-    binder.forField(email).asRequired().bind(Person::getEmail, Person::setEmail);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
+        binder.forField(email).asRequired().bind(Person::getEmail,
+                Person::setEmail);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  private void setupGrid() {
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        Grid<Person> grid = crud.getGrid();
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      EMAIL,
-      PROFESSION,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                EMAIL, PROFESSION, EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(EMAIL),
-      grid.getColumnByKey(PROFESSION),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
-  }
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME), grid.getColumnByKey(EMAIL),
+                grid.getColumnByKey(PROFESSION),
+                grid.getColumnByKey(EDIT_COLUMN));
+    }
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
-  public static class Exporter extends DemoExporter<CrudItemInitialization> {} // hidden-source-line
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
+
+    public static class Exporter extends DemoExporter<CrudItemInitialization> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudLocalization.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudLocalization.java
@@ -20,113 +20,110 @@ import java.util.List;
 @Route("crud-localization")
 public class CrudLocalization extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String EMAIL = "email";
-  private String PROFESSION = "profession";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String EMAIL = "email";
+    private String PROFESSION = "profession";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  public CrudLocalization() {
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
+    public CrudLocalization() {
+        crud = new Crud<>(Person.class, createEditor());
 
-    setupGrid();
-    setupDataProvider();
-    setupI18n();
+        setupGrid();
+        setupDataProvider();
+        setupI18n();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    EmailField email = new EmailField("Email");
-    TextField profession = new TextField("Profession");
-    FormLayout form = new FormLayout(firstName, lastName, email, profession);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        EmailField email = new EmailField("Email");
+        TextField profession = new TextField("Profession");
+        FormLayout form = new FormLayout(firstName, lastName, email,
+                profession);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
-    binder.forField(email).asRequired().bind(Person::getEmail, Person::setEmail);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
+        binder.forField(email).asRequired().bind(Person::getEmail,
+                Person::setEmail);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  private void setupGrid() {
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        Grid<Person> grid = crud.getGrid();
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      EMAIL,
-      PROFESSION,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                EMAIL, PROFESSION, EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(EMAIL),
-      grid.getColumnByKey(PROFESSION),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME), grid.getColumnByKey(EMAIL),
+                grid.getColumnByKey(PROFESSION),
+                grid.getColumnByKey(EDIT_COLUMN));
 
-    // Translate headers
-    grid.getColumnByKey(FIRST_NAME).setHeader("Etunimi");
-    grid.getColumnByKey(LAST_NAME).setHeader("Sukunimi");
-    grid.getColumnByKey(EMAIL).setHeader("Sähköposti");
-    grid.getColumnByKey(PROFESSION).setHeader("Ammatti");
-  }
+        // Translate headers
+        grid.getColumnByKey(FIRST_NAME).setHeader("Etunimi");
+        grid.getColumnByKey(LAST_NAME).setHeader("Sukunimi");
+        grid.getColumnByKey(EMAIL).setHeader("Sähköposti");
+        grid.getColumnByKey(PROFESSION).setHeader("Ammatti");
+    }
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
 
-  private void setupI18n() {
-    // tag::snippet[]
-    CrudI18n i18n = CrudI18n.createDefault();
+    private void setupI18n() {
+        // tag::snippet[]
+        CrudI18n i18n = CrudI18n.createDefault();
 
-    i18n.setNewItem("Luo uusi");
-    i18n.setEditItem("Muuta tietoja");
-    i18n.setSaveItem("Tallenna");
-    i18n.setCancel("Peruuta");
-    i18n.setDeleteItem("Poista...");
-    i18n.setEditLabel("Muokkaa");
+        i18n.setNewItem("Luo uusi");
+        i18n.setEditItem("Muuta tietoja");
+        i18n.setSaveItem("Tallenna");
+        i18n.setCancel("Peruuta");
+        i18n.setDeleteItem("Poista...");
+        i18n.setEditLabel("Muokkaa");
 
-    CrudI18n.Confirmations.Confirmation delete = i18n.getConfirm().getDelete();
-    delete.setTitle("Poista kohde");
-    delete.setContent("Haluatko varmasti poistaa tämän kohteen? Poistoa ei voi perua.");
-    delete.getButton().setConfirm("Poista");
-    delete.getButton().setDismiss("Peruuta");
+        CrudI18n.Confirmations.Confirmation delete = i18n.getConfirm()
+                .getDelete();
+        delete.setTitle("Poista kohde");
+        delete.setContent(
+                "Haluatko varmasti poistaa tämän kohteen? Poistoa ei voi perua.");
+        delete.getButton().setConfirm("Poista");
+        delete.getButton().setDismiss("Peruuta");
 
-    CrudI18n.Confirmations.Confirmation cancel = i18n.getConfirm().getCancel();
-    cancel.setTitle("Hylkää muutokset");
-    cancel.setContent("Kohteessa on tallentamattomia muutoksia.");
-    cancel.getButton().setConfirm("Hylkää");
-    cancel.getButton().setDismiss("Peruuta");
+        CrudI18n.Confirmations.Confirmation cancel = i18n.getConfirm()
+                .getCancel();
+        cancel.setTitle("Hylkää muutokset");
+        cancel.setContent("Kohteessa on tallentamattomia muutoksia.");
+        cancel.getButton().setConfirm("Hylkää");
+        cancel.getButton().setDismiss("Peruuta");
 
-    crud.setI18n(i18n);
-    // end::snippet[]
-  }
-  public static class Exporter extends DemoExporter<CrudLocalization> {} // hidden-source-line
+        crud.setI18n(i18n);
+        // end::snippet[]
+    }
+
+    public static class Exporter extends DemoExporter<CrudLocalization> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudOpenEditor.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudOpenEditor.java
@@ -19,88 +19,82 @@ import java.util.List;
 @Route("crud-open-editor")
 public class CrudOpenEditor extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String EMAIL = "email";
-  private String PROFESSION = "profession";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String EMAIL = "email";
+    private String PROFESSION = "profession";
 
-  public CrudOpenEditor() {
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
+    public CrudOpenEditor() {
+        crud = new Crud<>(Person.class, createEditor());
 
-    setupGrid();
-    setupDataProvider();
+        setupGrid();
+        setupDataProvider();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    EmailField email = new EmailField("Email");
-    TextField profession = new TextField("Profession");
-    FormLayout form = new FormLayout(firstName, lastName, email, profession);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        EmailField email = new EmailField("Email");
+        TextField profession = new TextField("Profession");
+        FormLayout form = new FormLayout(firstName, lastName, email,
+                profession);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
-    binder.forField(email).asRequired().bind(Person::getEmail, Person::setEmail);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
+        binder.forField(email).asRequired().bind(Person::getEmail,
+                Person::setEmail);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  private void setupGrid() {
-    // tag::snippet[]
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        // tag::snippet[]
+        Grid<Person> grid = crud.getGrid();
 
-    // Remove edit column
-    Crud.removeEditColumn(grid);
-    // grid.removeColumnByKey(EDIT_COLUMN);
-    // grid.removeColumn(grid.getColumnByKey(EDIT_COLUMN));
+        // Remove edit column
+        Crud.removeEditColumn(grid);
+        // grid.removeColumnByKey(EDIT_COLUMN);
+        // grid.removeColumn(grid.getColumnByKey(EDIT_COLUMN));
 
-    // Open editor on double click
-    grid.addItemDoubleClickListener(event ->
-      crud.edit(event.getItem(), Crud.EditMode.EXISTING_ITEM)
-    );
-    // end::snippet[]
+        // Open editor on double click
+        grid.addItemDoubleClickListener(event -> crud.edit(event.getItem(),
+                Crud.EditMode.EXISTING_ITEM));
+        // end::snippet[]
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      EMAIL,
-      PROFESSION
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                EMAIL, PROFESSION);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(EMAIL),
-      grid.getColumnByKey(PROFESSION)
-    );
-  }
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME), grid.getColumnByKey(EMAIL),
+                grid.getColumnByKey(PROFESSION));
+    }
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
-  public static class Exporter extends DemoExporter<CrudOpenEditor> {} // hidden-source-line
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
+
+    public static class Exporter extends DemoExporter<CrudOpenEditor> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudSortingFiltering.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudSortingFiltering.java
@@ -18,86 +18,78 @@ import java.util.List;
 @Route("crud-sorting-filtering")
 public class CrudSortingFiltering extends Div {
 
-  private Crud<Person> crud;
+    private Crud<Person> crud;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String PROFESSION = "profession";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String PROFESSION = "profession";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  public CrudSortingFiltering() {
-    // tag::snippet1[]
-    crud = new Crud<>(
-      Person.class,
-      createGrid(),
-      createEditor()
-    );
-    // end::snippet1[]
+    public CrudSortingFiltering() {
+        // tag::snippet1[]
+        crud = new Crud<>(Person.class, createGrid(), createEditor());
+        // end::snippet1[]
 
-    setupDataProvider();
+        setupDataProvider();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    TextField profession = new TextField("Profession");
-    FormLayout form = new FormLayout(firstName, lastName, profession);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        TextField profession = new TextField("Profession");
+        FormLayout form = new FormLayout(firstName, lastName, profession);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
-    binder.forField(profession).asRequired().bind(Person::getProfession, Person::setProfession);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
+        binder.forField(profession).asRequired().bind(Person::getProfession,
+                Person::setProfession);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  // tag::snippet2[]
-  private CrudGrid<Person> createGrid() {
-    // Create a new CrudGrid to disable filtering (last boolean parameter)
-    CrudGrid<Person> grid = new CrudGrid<>(Person.class, false);
+    // tag::snippet2[]
+    private CrudGrid<Person> createGrid() {
+        // Create a new CrudGrid to disable filtering (last boolean parameter)
+        CrudGrid<Person> grid = new CrudGrid<>(Person.class, false);
 
-    // Disable sorting
-    grid.setSortableColumns();
-    // end::snippet2[]
+        // Disable sorting
+        grid.setSortableColumns();
+        // end::snippet2[]
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      PROFESSION,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                PROFESSION, EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(PROFESSION),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME), grid.getColumnByKey(PROFESSION),
+                grid.getColumnByKey(EDIT_COLUMN));
 
-    // tag::snippet3[]
-    return grid;
-  }
-  // end::snippet3[]
+        // tag::snippet3[]
+        return grid;
+    }
+    // end::snippet3[]
 
-  private void setupDataProvider() {
-    PersonDataProvider dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
-  public static class Exporter extends DemoExporter<CrudSortingFiltering> {} // hidden-source-line
+    private void setupDataProvider() {
+        PersonDataProvider dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
+
+    public static class Exporter extends DemoExporter<CrudSortingFiltering> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/CrudToolbar.java
+++ b/src/main/java/com/vaadin/demo/component/crud/CrudToolbar.java
@@ -24,91 +24,86 @@ import java.util.List;
 @Route("crud-toolbar")
 public class CrudToolbar extends Div {
 
-  private Crud<Person> crud;
-  private PersonDataProvider dataProvider;
+    private Crud<Person> crud;
+    private PersonDataProvider dataProvider;
 
-  private String FIRST_NAME = "firstName";
-  private String LAST_NAME = "lastName";
-  private String EDIT_COLUMN = "vaadin-crud-edit-column";
+    private String FIRST_NAME = "firstName";
+    private String LAST_NAME = "lastName";
+    private String EDIT_COLUMN = "vaadin-crud-edit-column";
 
-  public CrudToolbar() {
-    crud = new Crud<>(
-      Person.class,
-      createEditor()
-    );
+    public CrudToolbar() {
+        crud = new Crud<>(Person.class, createEditor());
 
-    setupGrid();
-    setupDataProvider();
-    setupToolbar();
+        setupGrid();
+        setupDataProvider();
+        setupToolbar();
 
-    add(crud);
-  }
+        add(crud);
+    }
 
-  private CrudEditor<Person> createEditor() {
-    TextField firstName = new TextField("First name");
-    TextField lastName = new TextField("Last name");
-    FormLayout form = new FormLayout(firstName, lastName);
+    private CrudEditor<Person> createEditor() {
+        TextField firstName = new TextField("First name");
+        TextField lastName = new TextField("Last name");
+        FormLayout form = new FormLayout(firstName, lastName);
 
-    Binder<Person> binder = new Binder<>(Person.class);
-    binder.forField(firstName).asRequired().bind(Person::getFirstName, Person::setFirstName);
-    binder.forField(lastName).asRequired().bind(Person::getLastName, Person::setLastName);
+        Binder<Person> binder = new Binder<>(Person.class);
+        binder.forField(firstName).asRequired().bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(lastName).asRequired().bind(Person::getLastName,
+                Person::setLastName);
 
-    return new BinderCrudEditor<>(binder, form);
-  }
+        return new BinderCrudEditor<>(binder, form);
+    }
 
-  private void setupGrid() {
-    Grid<Person> grid = crud.getGrid();
+    private void setupGrid() {
+        Grid<Person> grid = crud.getGrid();
 
-    // Only show these columns (all columns shown by default):
-    List<String> visibleColumns = Arrays.asList(
-      FIRST_NAME,
-      LAST_NAME,
-      EDIT_COLUMN
-    );
-    grid.getColumns().forEach(column -> {
-      String key = column.getKey();
-      if (!visibleColumns.contains(key)) {
-        grid.removeColumn(column);
-      }
-    });
+        // Only show these columns (all columns shown by default):
+        List<String> visibleColumns = Arrays.asList(FIRST_NAME, LAST_NAME,
+                EDIT_COLUMN);
+        grid.getColumns().forEach(column -> {
+            String key = column.getKey();
+            if (!visibleColumns.contains(key)) {
+                grid.removeColumn(column);
+            }
+        });
 
-    // Reorder the columns (alphabetical by default)
-    grid.setColumnOrder(
-      grid.getColumnByKey(FIRST_NAME),
-      grid.getColumnByKey(LAST_NAME),
-      grid.getColumnByKey(EDIT_COLUMN)
-    );
-  }
+        // Reorder the columns (alphabetical by default)
+        grid.setColumnOrder(grid.getColumnByKey(FIRST_NAME),
+                grid.getColumnByKey(LAST_NAME),
+                grid.getColumnByKey(EDIT_COLUMN));
+    }
 
-  private void setupDataProvider() {
-    dataProvider = new PersonDataProvider();
-    crud.setDataProvider(dataProvider);
-    crud.addDeleteListener(deleteEvent ->
-      dataProvider.delete(deleteEvent.getItem())
-    );
-    crud.addSaveListener(saveEvent ->
-      dataProvider.persist(saveEvent.getItem())
-    );
-  }
+    private void setupDataProvider() {
+        dataProvider = new PersonDataProvider();
+        crud.setDataProvider(dataProvider);
+        crud.addDeleteListener(
+                deleteEvent -> dataProvider.delete(deleteEvent.getItem()));
+        crud.addSaveListener(
+                saveEvent -> dataProvider.persist(saveEvent.getItem()));
+    }
 
-  private void setupToolbar() {
-    // tag::snippet[]
-    Html total = new Html("<span>Total: <b>" + dataProvider.DATABASE.size() + "</b> employees</span>");
+    private void setupToolbar() {
+        // tag::snippet[]
+        Html total = new Html("<span>Total: <b>" + dataProvider.DATABASE.size()
+                + "</b> employees</span>");
 
-    Button button = new Button("New employee", VaadinIcon.PLUS.create());
-    button.addClickListener(event -> {
-      crud.edit(new Person(), Crud.EditMode.NEW_ITEM);
-    });
-    button.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        Button button = new Button("New employee", VaadinIcon.PLUS.create());
+        button.addClickListener(event -> {
+            crud.edit(new Person(), Crud.EditMode.NEW_ITEM);
+        });
+        button.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
 
-    HorizontalLayout toolbar = new HorizontalLayout(total, button);
-    toolbar.setAlignItems(FlexComponent.Alignment.CENTER);
-    toolbar.setFlexGrow(1, toolbar);
-    toolbar.setJustifyContentMode(FlexComponent.JustifyContentMode.BETWEEN);
-    toolbar.setSpacing(false);
+        HorizontalLayout toolbar = new HorizontalLayout(total, button);
+        toolbar.setAlignItems(FlexComponent.Alignment.CENTER);
+        toolbar.setFlexGrow(1, toolbar);
+        toolbar.setJustifyContentMode(FlexComponent.JustifyContentMode.BETWEEN);
+        toolbar.setSpacing(false);
 
-    crud.setToolbar(toolbar);
-    // end::snippet[]
-  }
-  public static class Exporter extends DemoExporter<CrudToolbar> {} // hidden-source-line
+        crud.setToolbar(toolbar);
+        // end::snippet[]
+    }
+
+    public static class Exporter extends DemoExporter<CrudToolbar> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java
+++ b/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java
@@ -18,122 +18,112 @@ import com.vaadin.flow.data.provider.SortDirection;
 import static java.util.Comparator.naturalOrder;
 
 // Person data provider
-public class PersonDataProvider extends AbstractBackEndDataProvider<Person, CrudFilter> {
+public class PersonDataProvider
+        extends AbstractBackEndDataProvider<Person, CrudFilter> {
 
-  // A real app should hook up something like JPA
-  final List<Person> DATABASE = new ArrayList<>(DataService.getPeople());
+    // A real app should hook up something like JPA
+    final List<Person> DATABASE = new ArrayList<>(DataService.getPeople());
 
-  private Consumer<Long> sizeChangeListener;
+    private Consumer<Long> sizeChangeListener;
 
-  @Override
-  protected Stream<Person> fetchFromBackEnd(Query<Person, CrudFilter> query) {
-    int offset = query.getOffset();
-    int limit = query.getLimit();
+    @Override
+    protected Stream<Person> fetchFromBackEnd(Query<Person, CrudFilter> query) {
+        int offset = query.getOffset();
+        int limit = query.getLimit();
 
-    Stream<Person> stream = DATABASE.stream();
+        Stream<Person> stream = DATABASE.stream();
 
-    if (query.getFilter().isPresent()) {
-      stream = stream
-        .filter(predicate(query.getFilter().get()))
-        .sorted(comparator(query.getFilter().get()));
-    }
-
-    return stream.skip(offset).limit(limit);
-  }
-
-  @Override
-  protected int sizeInBackEnd(Query<Person, CrudFilter> query) {
-    // For RDBMS just execute a SELECT COUNT(*) ... WHERE query
-    long count = fetchFromBackEnd(query).count();
-
-    if (sizeChangeListener != null) {
-      sizeChangeListener.accept(count);
-    }
-
-    return (int) count;
-  }
-
-  void setSizeChangeListener(Consumer<Long> listener) {
-    sizeChangeListener = listener;
-  }
-
-  private static Predicate<Person> predicate(CrudFilter filter) {
-    // For RDBMS just generate a WHERE clause
-    return filter.getConstraints().entrySet().stream()
-      .map(constraint -> (Predicate<Person>) person -> {
-        try {
-          Object value = valueOf(constraint.getKey(), person);
-          return value != null && value.toString().toLowerCase()
-            .contains(constraint.getValue().toLowerCase());
-        } catch (Exception e) {
-          e.printStackTrace();
-          return false;
+        if (query.getFilter().isPresent()) {
+            stream = stream.filter(predicate(query.getFilter().get()))
+                    .sorted(comparator(query.getFilter().get()));
         }
-      })
-      .reduce(Predicate::and)
-      .orElse(e -> true);
-  }
 
-  private static Comparator<Person> comparator(CrudFilter filter) {
-    // For RDBMS just generate an ORDER BY clause
-    return filter.getSortOrders().entrySet().stream()
-      .map(sortClause -> {
+        return stream.skip(offset).limit(limit);
+    }
+
+    @Override
+    protected int sizeInBackEnd(Query<Person, CrudFilter> query) {
+        // For RDBMS just execute a SELECT COUNT(*) ... WHERE query
+        long count = fetchFromBackEnd(query).count();
+
+        if (sizeChangeListener != null) {
+            sizeChangeListener.accept(count);
+        }
+
+        return (int) count;
+    }
+
+    void setSizeChangeListener(Consumer<Long> listener) {
+        sizeChangeListener = listener;
+    }
+
+    private static Predicate<Person> predicate(CrudFilter filter) {
+        // For RDBMS just generate a WHERE clause
+        return filter.getConstraints().entrySet().stream()
+                .map(constraint -> (Predicate<Person>) person -> {
+                    try {
+                        Object value = valueOf(constraint.getKey(), person);
+                        return value != null && value.toString().toLowerCase()
+                                .contains(constraint.getValue().toLowerCase());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        return false;
+                    }
+                }).reduce(Predicate::and).orElse(e -> true);
+    }
+
+    private static Comparator<Person> comparator(CrudFilter filter) {
+        // For RDBMS just generate an ORDER BY clause
+        return filter.getSortOrders().entrySet().stream().map(sortClause -> {
+            try {
+                Comparator<Person> comparator = Comparator.comparing(
+                        person -> (Comparable) valueOf(sortClause.getKey(),
+                                person));
+
+                if (sortClause.getValue() == SortDirection.DESCENDING) {
+                    comparator = comparator.reversed();
+                }
+
+                return comparator;
+
+            } catch (Exception ex) {
+                return (Comparator<Person>) (o1, o2) -> 0;
+            }
+        }).reduce(Comparator::thenComparing).orElse((o1, o2) -> 0);
+    }
+
+    private static Object valueOf(String fieldName, Person person) {
         try {
-          Comparator<Person> comparator = Comparator.comparing(person ->
-            (Comparable) valueOf(sortClause.getKey(), person)
-          );
-
-          if (sortClause.getValue() == SortDirection.DESCENDING) {
-            comparator = comparator.reversed();
-          }
-
-          return comparator;
-
+            Field field = Person.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(person);
         } catch (Exception ex) {
-          return (Comparator<Person>) (o1, o2) -> 0;
+            throw new RuntimeException(ex);
         }
-      })
-      .reduce(Comparator::thenComparing)
-      .orElse((o1, o2) -> 0);
-  }
-
-  private static Object valueOf(String fieldName, Person person) {
-    try {
-      Field field = Person.class.getDeclaredField(fieldName);
-      field.setAccessible(true);
-      return field.get(person);
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
-    }
-  }
-
-  void persist(Person item) {
-    if (item.getId() == null) {
-      item.setId(DATABASE
-        .stream()
-        .map(Person::getId)
-        .max(naturalOrder())
-        .orElse(0) + 1);
     }
 
-    final Optional<Person> existingItem = find(item.getId());
-    if (existingItem.isPresent()) {
-      int position = DATABASE.indexOf(existingItem.get());
-      DATABASE.remove(existingItem.get());
-      DATABASE.add(position, item);
-    } else {
-      DATABASE.add(item);
+    void persist(Person item) {
+        if (item.getId() == null) {
+            item.setId(DATABASE.stream().map(Person::getId).max(naturalOrder())
+                    .orElse(0) + 1);
+        }
+
+        final Optional<Person> existingItem = find(item.getId());
+        if (existingItem.isPresent()) {
+            int position = DATABASE.indexOf(existingItem.get());
+            DATABASE.remove(existingItem.get());
+            DATABASE.add(position, item);
+        } else {
+            DATABASE.add(item);
+        }
     }
-  }
 
-  Optional<Person> find(Integer id) {
-    return DATABASE
-      .stream()
-      .filter(entity -> entity.getId().equals(id))
-      .findFirst();
-  }
+    Optional<Person> find(Integer id) {
+        return DATABASE.stream().filter(entity -> entity.getId().equals(id))
+                .findFirst();
+    }
 
-  void delete(Person item) {
-    DATABASE.removeIf(entity -> entity.getId().equals(item.getId()));
-  }
+    void delete(Person item) {
+        DATABASE.removeIf(entity -> entity.getId().equals(item.getId()));
+    }
 }

--- a/src/main/java/com/vaadin/demo/component/customfield/CustomFieldBasic.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/CustomFieldBasic.java
@@ -11,37 +11,39 @@ import java.time.temporal.ChronoUnit;
 @Route("custom-field-basic")
 public class CustomFieldBasic extends Div {
 
-  public CustomFieldBasic() {
-    // tag::snippet[]
-    DateRangePicker dateRangePicker = new DateRangePicker();
-    dateRangePicker.setLabel("Enrollment period");
-    dateRangePicker.setHelperText("Cannot be longer than 30 days");
-    add(dateRangePicker);
+    public CustomFieldBasic() {
+        // tag::snippet[]
+        DateRangePicker dateRangePicker = new DateRangePicker();
+        dateRangePicker.setLabel("Enrollment period");
+        dateRangePicker.setHelperText("Cannot be longer than 30 days");
+        add(dateRangePicker);
 
-    Binder<Appointment> binder = new Binder();
-    binder.forField(dateRangePicker)
-      .asRequired("Enter a start and end date")
-      .withValidator(localDateRange ->
-        localDateRange.getStartDate() == null ||
-        localDateRange.getEndDate() == null ||
-        ChronoUnit.DAYS.between(localDateRange.getStartDate(), localDateRange.getEndDate()) <= 30,
-        "Dates cannot be more than 30 days apart"
-      )
-      .withValidator(localDateRange ->
-        localDateRange.getStartDate() == null ||
-        localDateRange.getEndDate() == null ||
-        localDateRange.getStartDate().isBefore(localDateRange.getEndDate()),
-        "Start date must be earlier than end date"
-      )
-      .bind(
-        appointment ->
-          new LocalDateRange(appointment.getStartDate(), appointment.getEndDate()),
-        (appointment, localDateRange) -> {
-          appointment.setStartDate(localDateRange.getStartDate());
-          appointment.setEndDate(localDateRange.getEndDate());
-        }
-      );
-    // end::snippet[]
-  }
-  public static class Exporter extends DemoExporter<CustomFieldBasic> {} // hidden-source-line
+        Binder<Appointment> binder = new Binder();
+        binder.forField(dateRangePicker)
+                .asRequired("Enter a start and end date")
+                .withValidator(
+                        localDateRange -> localDateRange.getStartDate() == null
+                                || localDateRange.getEndDate() == null
+                                || ChronoUnit.DAYS.between(
+                                        localDateRange.getStartDate(),
+                                        localDateRange.getEndDate()) <= 30,
+                        "Dates cannot be more than 30 days apart")
+                .withValidator(
+                        localDateRange -> localDateRange.getStartDate() == null
+                                || localDateRange.getEndDate() == null
+                                || localDateRange.getStartDate()
+                                        .isBefore(localDateRange.getEndDate()),
+                        "Start date must be earlier than end date")
+                .bind(appointment -> new LocalDateRange(
+                        appointment.getStartDate(), appointment.getEndDate()),
+                        (appointment, localDateRange) -> {
+                            appointment.setStartDate(
+                                    localDateRange.getStartDate());
+                            appointment.setEndDate(localDateRange.getEndDate());
+                        });
+        // end::snippet[]
+    }
+
+    public static class Exporter extends DemoExporter<CustomFieldBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/customfield/CustomFieldNativeInput.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/CustomFieldNativeInput.java
@@ -10,27 +10,26 @@ import com.vaadin.flow.router.Route;
 @Route("custom-field-native-input")
 public class CustomFieldNativeInput extends Div {
 
-  private Span value;
+    private Span value;
 
-  public CustomFieldNativeInput() {
-    // tag::snippet[]
-    PaymentInformationField paymentInformationField = new PaymentInformationField("Payment information");
-    paymentInformationField.addValueChangeListener(event -> {
-      value.setText(
-        event.getValue().getCardholderName() + " " +
-        event.getValue().getCardNumber() + " " +
-        event.getValue().getSecurityCode()
-      );
-    });
+    public CustomFieldNativeInput() {
+        // tag::snippet[]
+        PaymentInformationField paymentInformationField = new PaymentInformationField(
+                "Payment information");
+        paymentInformationField.addValueChangeListener(event -> {
+            value.setText(event.getValue().getCardholderName() + " "
+                    + event.getValue().getCardNumber() + " "
+                    + event.getValue().getSecurityCode());
+        });
 
-    value = new Span();
-    Paragraph paragraph = new Paragraph(
-      new Html("<span><b>Payment information:</b> </span>"),
-      value
-    );
+        value = new Span();
+        Paragraph paragraph = new Paragraph(
+                new Html("<span><b>Payment information:</b> </span>"), value);
 
-    add(paymentInformationField, paragraph);
-    // end::snippet[]
-  }
-  public static class Exporter extends DemoExporter<CustomFieldNativeInput> {} // hidden-source-line
+        add(paymentInformationField, paragraph);
+        // end::snippet[]
+    }
+
+    public static class Exporter extends DemoExporter<CustomFieldNativeInput> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/customfield/CustomFieldSizeVariants.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/CustomFieldSizeVariants.java
@@ -8,12 +8,14 @@ import com.vaadin.flow.component.customfield.CustomFieldVariant;
 @Route("custom-field-size-variants")
 public class CustomFieldSizeVariants extends Div {
 
-  public CustomFieldSizeVariants() {
-    // tag::snippet[]
-    MoneyField moneyField = new MoneyField("Price");
-    moneyField.addThemeVariant(CustomFieldVariant.LUMO_SMALL);
-    // end::snippet[]
-    add(moneyField);
-  }
-  public static class Exporter extends DemoExporter<CustomFieldSizeVariants> {} // hidden-source-line
+    public CustomFieldSizeVariants() {
+        // tag::snippet[]
+        MoneyField moneyField = new MoneyField("Price");
+        moneyField.addThemeVariant(CustomFieldVariant.LUMO_SMALL);
+        // end::snippet[]
+        add(moneyField);
+    }
+
+    public static class Exporter extends DemoExporter<CustomFieldSizeVariants> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
@@ -7,45 +7,43 @@ import com.vaadin.flow.component.datepicker.DatePicker;
 // tag::snippet[]
 public class DateRangePicker extends CustomField<LocalDateRange> {
 
-  private DatePicker start;
-  private DatePicker end;
+    private DatePicker start;
+    private DatePicker end;
 
-  public DateRangePicker(String label) {
-    this();
-    setLabel(label);
-  }
+    public DateRangePicker(String label) {
+        this();
+        setLabel(label);
+    }
 
-  public DateRangePicker() {
-    start = new DatePicker();
-    start.setPlaceholder("Start date");
+    public DateRangePicker() {
+        start = new DatePicker();
+        start.setPlaceholder("Start date");
 
-    end = new DatePicker();
-    end.setPlaceholder("End date");
+        end = new DatePicker();
+        end.setPlaceholder("End date");
 
-    // aria-label for screen readers
-    start.getElement()
-      .executeJs("const start = this.inputElement;" +
-        "start.setAttribute('aria-label', 'Start date');" +
-        "start.removeAttribute('aria-labelledby');"
-      );
-    end.getElement()
-      .executeJs("const end = this.inputElement;" +
-        "end.setAttribute('aria-label', 'End date');" +
-        "end.removeAttribute('aria-labelledby');"
-      );
+        // aria-label for screen readers
+        start.getElement()
+                .executeJs("const start = this.inputElement;"
+                        + "start.setAttribute('aria-label', 'Start date');"
+                        + "start.removeAttribute('aria-labelledby');");
+        end.getElement()
+                .executeJs("const end = this.inputElement;"
+                        + "end.setAttribute('aria-label', 'End date');"
+                        + "end.removeAttribute('aria-labelledby');");
 
-    add(start, new Text(" – "), end);
-  }
+        add(start, new Text(" – "), end);
+    }
 
-  @Override
-  protected LocalDateRange generateModelValue() {
-    return new LocalDateRange(start.getValue(), end.getValue());
-  }
+    @Override
+    protected LocalDateRange generateModelValue() {
+        return new LocalDateRange(start.getValue(), end.getValue());
+    }
 
-  @Override
-  protected void setPresentationValue(LocalDateRange dateRange) {
-    start.setValue(dateRange.getStartDate());
-    end.setValue(dateRange.getEndDate());
-  }
+    @Override
+    protected void setPresentationValue(LocalDateRange dateRange) {
+        start.setValue(dateRange.getStartDate());
+        end.setValue(dateRange.getEndDate());
+    }
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/customfield/LocalDateRange.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/LocalDateRange.java
@@ -5,28 +5,28 @@ import java.time.LocalDate;
 // tag::snippet[]
 public class LocalDateRange {
 
-  private LocalDate startDate;
-  private LocalDate endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
-  public LocalDateRange(LocalDate startDate, LocalDate endDate) {
-    this.startDate = startDate;
-    this.endDate = endDate;
-  }
+    public LocalDateRange(LocalDate startDate, LocalDate endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
 
-  public LocalDate getStartDate() {
-    return startDate;
-  }
+    public LocalDate getStartDate() {
+        return startDate;
+    }
 
-  public void setStartDate(LocalDate startDate) {
-    this.startDate = startDate;
-  }
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
 
-  public LocalDate getEndDate() {
-    return endDate;
-  }
+    public LocalDate getEndDate() {
+        return endDate;
+    }
 
-  public void setEndDate(LocalDate endDate) {
-    this.endDate = endDate;
-  }
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/customfield/Money.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/Money.java
@@ -3,28 +3,28 @@ package com.vaadin.demo.component.customfield;
 // tag::snippet[]
 public class Money {
 
-  private String amount;
-  private String currency;
+    private String amount;
+    private String currency;
 
-  public Money(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
+    public Money(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
+    }
 
-  public String getAmount() {
-    return amount;
-  }
+    public String getAmount() {
+        return amount;
+    }
 
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
 
-  public String getCurrency() {
-    return currency;
-  }
+    public String getCurrency() {
+        return currency;
+    }
 
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
@@ -11,55 +11,55 @@ import com.vaadin.flow.component.textfield.TextFieldVariant;
 // tag::snippet[]
 public class MoneyField extends CustomField<Money> {
 
-  private TextField amount;
-  private Select<String> currency;
+    private TextField amount;
+    private Select<String> currency;
 
-  public MoneyField(String label) {
-    this();
-    setLabel(label);
-  }
+    public MoneyField(String label) {
+        this();
+        setLabel(label);
+    }
 
-  public MoneyField() {
-    amount = new TextField();
+    public MoneyField() {
+        amount = new TextField();
 
-    currency = new Select();
-    currency.setItems("AUD", "CAD", "CHF", "EUR", "GBP", "JPY", "USD");
-    currency.setWidth("6em");
+        currency = new Select();
+        currency.setItems("AUD", "CAD", "CHF", "EUR", "GBP", "JPY", "USD");
+        currency.setWidth("6em");
 
-    // aria-label for screen readers
-    amount.getElement()
-      .executeJs("const amount = this.inputElement;" +
-        "amount.setAttribute('aria-label', 'Amount');" +
-        "amount.removeAttribute('aria-labelledby');");
-    currency.getElement()
-      .executeJs("const currency = this.focusElement;" +
-        "currency.setAttribute('aria-label', 'Currency');" +
-        "currency.removeAttribute('aria-labelledby');");
+        // aria-label for screen readers
+        amount.getElement()
+                .executeJs("const amount = this.inputElement;"
+                        + "amount.setAttribute('aria-label', 'Amount');"
+                        + "amount.removeAttribute('aria-labelledby');");
+        currency.getElement()
+                .executeJs("const currency = this.focusElement;"
+                        + "currency.setAttribute('aria-label', 'Currency');"
+                        + "currency.removeAttribute('aria-labelledby');");
 
-    HorizontalLayout layout = new HorizontalLayout(amount, currency);
-    // Removes default spacing
-    layout.setSpacing(false);
-    // Adds small amount of space between the components
-    layout.getThemeList().add("spacing-s");
+        HorizontalLayout layout = new HorizontalLayout(amount, currency);
+        // Removes default spacing
+        layout.setSpacing(false);
+        // Adds small amount of space between the components
+        layout.getThemeList().add("spacing-s");
 
-    add(layout);
-  }
+        add(layout);
+    }
 
-  public void addThemeVariant(CustomFieldVariant variant) {
-    super.addThemeVariants(variant);
-    amount.addThemeVariants(TextFieldVariant.valueOf(variant.name()));
-    currency.addThemeVariants(SelectVariant.valueOf(variant.name()));
-  }
+    public void addThemeVariant(CustomFieldVariant variant) {
+        super.addThemeVariants(variant);
+        amount.addThemeVariants(TextFieldVariant.valueOf(variant.name()));
+        currency.addThemeVariants(SelectVariant.valueOf(variant.name()));
+    }
 
-  @Override
-  protected Money generateModelValue() {
-    return new Money(amount.getValue(), currency.getValue());
-  }
+    @Override
+    protected Money generateModelValue() {
+        return new Money(amount.getValue(), currency.getValue());
+    }
 
-  @Override
-  protected void setPresentationValue(Money money) {
-    amount.setValue(money.getAmount());
-    currency.setValue(money.getCurrency());
-  }
+    @Override
+    protected void setPresentationValue(Money money) {
+        amount.setValue(money.getAmount());
+        currency.setValue(money.getCurrency());
+    }
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/customfield/PaymentInformation.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/PaymentInformation.java
@@ -3,38 +3,39 @@ package com.vaadin.demo.component.customfield;
 // tag::snippet[]
 public class PaymentInformation {
 
-  private String cardholderName;
-  private String cardNumber;
-  private String securityCode;
+    private String cardholderName;
+    private String cardNumber;
+    private String securityCode;
 
-  public PaymentInformation(String cardholderName, String cardNumber, String securityCode) {
-    this.cardholderName = cardholderName;
-    this.cardNumber = cardNumber;
-    this.securityCode = securityCode;
-  }
+    public PaymentInformation(String cardholderName, String cardNumber,
+            String securityCode) {
+        this.cardholderName = cardholderName;
+        this.cardNumber = cardNumber;
+        this.securityCode = securityCode;
+    }
 
-  public String getCardholderName() {
-    return cardholderName;
-  }
+    public String getCardholderName() {
+        return cardholderName;
+    }
 
-  public void setCardholderName(String cardholderName) {
-    this.cardholderName = cardholderName;
-  }
+    public void setCardholderName(String cardholderName) {
+        this.cardholderName = cardholderName;
+    }
 
-  public String getCardNumber() {
-    return cardNumber;
-  }
+    public String getCardNumber() {
+        return cardNumber;
+    }
 
-  public void setCardNumber(String cardNumber) {
-    this.cardNumber = cardNumber;
-  }
+    public void setCardNumber(String cardNumber) {
+        this.cardNumber = cardNumber;
+    }
 
-  public String getSecurityCode() {
-    return securityCode;
-  }
+    public String getSecurityCode() {
+        return securityCode;
+    }
 
-  public void setSecurityCode(String securityCode) {
-    this.securityCode = securityCode;
-  }
+    public void setSecurityCode(String securityCode) {
+        this.securityCode = securityCode;
+    }
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/customfield/PaymentInformationField.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/PaymentInformationField.java
@@ -8,56 +8,54 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 // tag::snippet[]
 public class PaymentInformationField extends CustomField<PaymentInformation> {
 
-  private Input cardholderName;
-  private Input cardNumber;
-  private Input securityCode;
+    private Input cardholderName;
+    private Input cardNumber;
+    private Input securityCode;
 
-  public PaymentInformationField(String label) {
-    this();
-    setLabel(label);
-  }
+    public PaymentInformationField(String label) {
+        this();
+        setLabel(label);
+    }
 
-  public PaymentInformationField() {
-    cardholderName = createInput("Cardholder name", "[\\p{L} \\-]+");
-    cardNumber = createInput("Card number", "[\\d ]{12,23}");
-    securityCode = createInput("Security code", "[0-9]{3,4}");
+    public PaymentInformationField() {
+        cardholderName = createInput("Cardholder name", "[\\p{L} \\-]+");
+        cardNumber = createInput("Card number", "[\\d ]{12,23}");
+        securityCode = createInput("Security code", "[0-9]{3,4}");
 
-    HorizontalLayout layout = new HorizontalLayout(cardholderName, cardNumber, securityCode);
-    // Removes default spacing
-    layout.setSpacing(false);
-    // Adds small amount of space between the components
-    layout.getThemeList().add("spacing-s");
+        HorizontalLayout layout = new HorizontalLayout(cardholderName,
+                cardNumber, securityCode);
+        // Removes default spacing
+        layout.setSpacing(false);
+        // Adds small amount of space between the components
+        layout.getThemeList().add("spacing-s");
 
-    // Increases padding of field's label
-    addThemeVariants(CustomFieldVariant.LUMO_WHITESPACE);
-    
-    add(layout);
-  }
+        // Increases padding of field's label
+        addThemeVariants(CustomFieldVariant.LUMO_WHITESPACE);
 
-  private Input createInput(String label, String pattern) {
-    Input input = new Input();
-    input.getElement().setAttribute("aria-label", label);
-    input.getElement().setAttribute("pattern", pattern);
-    input.getElement().setAttribute("required", true);
-    input.setPlaceholder(label);
-    input.setType("text");
-    return input;
-  }
+        add(layout);
+    }
 
-  @Override
-  protected PaymentInformation generateModelValue() {
-    return new PaymentInformation(
-      cardholderName.getValue(),
-      cardNumber.getValue(),
-      securityCode.getValue()
-    );
-  }
+    private Input createInput(String label, String pattern) {
+        Input input = new Input();
+        input.getElement().setAttribute("aria-label", label);
+        input.getElement().setAttribute("pattern", pattern);
+        input.getElement().setAttribute("required", true);
+        input.setPlaceholder(label);
+        input.setType("text");
+        return input;
+    }
 
-  @Override
-  protected void setPresentationValue(PaymentInformation paymentInformation) {
-    cardholderName.setValue(paymentInformation.getCardholderName());
-    cardNumber.setValue(paymentInformation.getCardNumber());
-    securityCode.setValue(paymentInformation.getSecurityCode());
-  }
+    @Override
+    protected PaymentInformation generateModelValue() {
+        return new PaymentInformation(cardholderName.getValue(),
+                cardNumber.getValue(), securityCode.getValue());
+    }
+
+    @Override
+    protected void setPresentationValue(PaymentInformation paymentInformation) {
+        cardholderName.setValue(paymentInformation.getCardholderName());
+        cardNumber.setValue(paymentInformation.getCardNumber());
+        securityCode.setValue(paymentInformation.getSecurityCode());
+    }
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerBasic.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerBasic.java
@@ -8,12 +8,13 @@ import com.vaadin.flow.router.Route;
 @Route("date-picker-basic")
 public class DatePickerBasic extends Div {
 
-  public DatePickerBasic() {
-    // tag::snippet[]
-    DatePicker datePicker = new DatePicker("Start date");
-    add(datePicker);
-    // end::snippet[]
-  }
-  public static class Exporter extends DemoExporter<DatePickerBasic> { // hidden-source-line
-  } // hidden-source-line
+    public DatePickerBasic() {
+        // tag::snippet[]
+        DatePicker datePicker = new DatePicker("Start date");
+        add(datePicker);
+        // end::snippet[]
+    }
+
+    public static class Exporter extends DemoExporter<DatePickerBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarBasic.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarBasic.java
@@ -13,37 +13,38 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("menu-bar-basic")
 public class MenuBarBasic extends Div {
 
-  public MenuBarBasic() {
-    // tag::snippet[]
-    MenuBar menuBar = new MenuBar();
-    Text selected = new Text("");
-    ComponentEventListener<ClickEvent<MenuItem>> listener = e -> selected.setText(e.getSource().getText());
-    Div message = new Div(new Text("Clicked item: "), selected);
+    public MenuBarBasic() {
+        // tag::snippet[]
+        MenuBar menuBar = new MenuBar();
+        Text selected = new Text("");
+        ComponentEventListener<ClickEvent<MenuItem>> listener = e -> selected
+                .setText(e.getSource().getText());
+        Div message = new Div(new Text("Clicked item: "), selected);
 
-    menuBar.addItem("View", listener);
-    menuBar.addItem("Edit", listener);
+        menuBar.addItem("View", listener);
+        menuBar.addItem("Edit", listener);
 
-    MenuItem share = menuBar.addItem("Share");
-    SubMenu shareSubMenu = share.getSubMenu();
-    MenuItem onSocialMedia = shareSubMenu.addItem("On social media");
-    SubMenu socialMediaSubMenu = onSocialMedia.getSubMenu();
-    socialMediaSubMenu.addItem("Facebook", listener);
-    socialMediaSubMenu.addItem("Twitter", listener);
-    socialMediaSubMenu.addItem("Instagram", listener);
-    shareSubMenu.addItem("By email", listener);
-    shareSubMenu.addItem("Get Link", listener);
+        MenuItem share = menuBar.addItem("Share");
+        SubMenu shareSubMenu = share.getSubMenu();
+        MenuItem onSocialMedia = shareSubMenu.addItem("On social media");
+        SubMenu socialMediaSubMenu = onSocialMedia.getSubMenu();
+        socialMediaSubMenu.addItem("Facebook", listener);
+        socialMediaSubMenu.addItem("Twitter", listener);
+        socialMediaSubMenu.addItem("Instagram", listener);
+        shareSubMenu.addItem("By email", listener);
+        shareSubMenu.addItem("Get Link", listener);
 
-    MenuItem move = menuBar.addItem("Move");
-    SubMenu moveSubMenu = move.getSubMenu();
-    moveSubMenu.addItem("To folder", listener);
-    moveSubMenu.addItem("To trash", listener);
+        MenuItem move = menuBar.addItem("Move");
+        SubMenu moveSubMenu = move.getSubMenu();
+        moveSubMenu.addItem("To folder", listener);
+        moveSubMenu.addItem("To trash", listener);
 
-    menuBar.addItem("Duplicate", listener);
-    // end::snippet[]
+        menuBar.addItem("Duplicate", listener);
+        // end::snippet[]
 
-    add(menuBar, message);
-  }
+        add(menuBar, message);
+    }
 
-  public static class Exporter extends DemoExporter<MenuBarBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<MenuBarBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarCustomTheme.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarCustomTheme.java
@@ -10,24 +10,24 @@ import com.vaadin.flow.router.Route;
 @Route("menu-bar-custom-theme")
 public class MenuBarCustomTheme extends Div {
 
-  public MenuBarCustomTheme() {
-    MenuBar menuBar = new MenuBar();
+    public MenuBarCustomTheme() {
+        MenuBar menuBar = new MenuBar();
 
-    // tag::snippet[]
-    MenuItem view = menuBar.addItem("View");
-    view.addThemeNames("custom-theme");
+        // tag::snippet[]
+        MenuItem view = menuBar.addItem("View");
+        view.addThemeNames("custom-theme");
 
-    MenuItem edit = menuBar.addItem("Edit");
+        MenuItem edit = menuBar.addItem("Edit");
 
-    MenuItem share = menuBar.addItem("Share");
-    SubMenu shareSubMenu = share.getSubMenu();
-    shareSubMenu.addItem("By email").addThemeNames("custom-theme");
-    shareSubMenu.addItem("Get Link");
-    // end::snippet[]
+        MenuItem share = menuBar.addItem("Share");
+        SubMenu shareSubMenu = share.getSubMenu();
+        shareSubMenu.addItem("By email").addThemeNames("custom-theme");
+        shareSubMenu.addItem("Get Link");
+        // end::snippet[]
 
-    add(menuBar);
-  }
+        add(menuBar);
+    }
 
-  public static class Exporter extends DemoExporter<MenuBarCustomTheme> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<MenuBarCustomTheme> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarInternationalization.java
@@ -10,40 +10,41 @@ import com.vaadin.flow.router.Route;
 @Route("menu-bar-internationalization")
 public class MenuBarInternationalization extends Div {
 
-  public MenuBarInternationalization() {
-    // tag::snippet[]
-    MenuBar menuBar = new MenuBar();
-    MenuBar.MenuBarI18n customI18n = new MenuBar.MenuBarI18n()
-            // Provide accessible label for the overflow menu button
-            // to screen readers
-            .setMoreOptions("More actions");
+    public MenuBarInternationalization() {
+        // tag::snippet[]
+        MenuBar menuBar = new MenuBar();
+        MenuBar.MenuBarI18n customI18n = new MenuBar.MenuBarI18n()
+                // Provide accessible label for the overflow menu button
+                // to screen readers
+                .setMoreOptions("More actions");
 
-    menuBar.setI18n(customI18n);
-    // end::snippet[]
+        menuBar.setI18n(customI18n);
+        // end::snippet[]
 
-    menuBar.addItem("View");
-    menuBar.addItem("Edit");
+        menuBar.addItem("View");
+        menuBar.addItem("Edit");
 
-    MenuItem share = menuBar.addItem("Share");
-    SubMenu shareSubMenu = share.getSubMenu();
-    MenuItem onSocialMedia = shareSubMenu.addItem("On social media");
-    SubMenu socialMediaSubMenu = onSocialMedia.getSubMenu();
-    socialMediaSubMenu.addItem("Facebook");
-    socialMediaSubMenu.addItem("Twitter");
-    socialMediaSubMenu.addItem("Instagram");
-    shareSubMenu.addItem("By email");
-    shareSubMenu.addItem("Get Link");
+        MenuItem share = menuBar.addItem("Share");
+        SubMenu shareSubMenu = share.getSubMenu();
+        MenuItem onSocialMedia = shareSubMenu.addItem("On social media");
+        SubMenu socialMediaSubMenu = onSocialMedia.getSubMenu();
+        socialMediaSubMenu.addItem("Facebook");
+        socialMediaSubMenu.addItem("Twitter");
+        socialMediaSubMenu.addItem("Instagram");
+        shareSubMenu.addItem("By email");
+        shareSubMenu.addItem("Get Link");
 
-    MenuItem move = menuBar.addItem("Move");
-    SubMenu moveSubMenu = move.getSubMenu();
-    moveSubMenu.addItem("To folder");
-    moveSubMenu.addItem("To trash");
+        MenuItem move = menuBar.addItem("Move");
+        SubMenu moveSubMenu = move.getSubMenu();
+        moveSubMenu.addItem("To folder");
+        moveSubMenu.addItem("To trash");
 
-    menuBar.addItem("Duplicate");
+        menuBar.addItem("Duplicate");
 
-    add(menuBar);
-  }
+        add(menuBar);
+    }
 
-  public static class Exporter extends DemoExporter<MenuBarInternationalization> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<MenuBarInternationalization> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarRightAligned.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarRightAligned.java
@@ -11,22 +11,22 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("menu-bar-right-aligned")
 public class MenuBarRightAligned extends Div {
 
-  public MenuBarRightAligned() {
-    // tag::snippet[]
-    MenuBar menuBar = new MenuBar();
-    menuBar.addThemeVariants(MenuBarVariant.LUMO_END_ALIGNED);
-    // end::snippet[]
+    public MenuBarRightAligned() {
+        // tag::snippet[]
+        MenuBar menuBar = new MenuBar();
+        menuBar.addThemeVariants(MenuBarVariant.LUMO_END_ALIGNED);
+        // end::snippet[]
 
-    menuBar.addItem("View");
-    menuBar.addItem("Edit");
-    MenuItem share = menuBar.addItem("Share");
-    SubMenu shareSubMenu = share.getSubMenu();
-    shareSubMenu.addItem("By email");
-    shareSubMenu.addItem("Get Link");
+        menuBar.addItem("View");
+        menuBar.addItem("Edit");
+        MenuItem share = menuBar.addItem("Share");
+        SubMenu shareSubMenu = share.getSubMenu();
+        shareSubMenu.addItem("By email");
+        shareSubMenu.addItem("Get Link");
 
-    add(menuBar);
-  }
+        add(menuBar);
+    }
 
-  public static class Exporter extends DemoExporter<MenuBarRightAligned> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<MenuBarRightAligned> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorBasic.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorBasic.java
@@ -9,16 +9,16 @@ import com.vaadin.demo.domain.DataService;
 @Route("rich-text-editor-basic")
 public class RichTextEditorBasic extends Div {
 
-  public RichTextEditorBasic() {
-    // tag::snippet[]
-    RichTextEditor rte = new RichTextEditor();
-    rte.setMaxHeight("400px");
-    String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-    rte.setValue(valueAsDelta);
-    add(rte);
-    // end::snippet[]
-  }
+    public RichTextEditorBasic() {
+        // tag::snippet[]
+        RichTextEditor rte = new RichTextEditor();
+        rte.setMaxHeight("400px");
+        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
+        rte.setValue(valueAsDelta);
+        add(rte);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<RichTextEditorBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<RichTextEditorBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorMinMaxHeight.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorMinMaxHeight.java
@@ -9,17 +9,18 @@ import com.vaadin.demo.domain.DataService;
 @Route("rich-text-editor-min-max-height")
 public class RichTextEditorMinMaxHeight extends Div {
 
-  public RichTextEditorMinMaxHeight() {
-    // tag::snippet[]
-    RichTextEditor rte = new RichTextEditor();
-    rte.setMaxHeight("400px");
-    rte.setMinHeight("200px");
-    String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-    rte.setValue(valueAsDelta);
-    add(rte);
-    // end::snippet[]
-  }
+    public RichTextEditorMinMaxHeight() {
+        // tag::snippet[]
+        RichTextEditor rte = new RichTextEditor();
+        rte.setMaxHeight("400px");
+        rte.setMinHeight("200px");
+        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
+        rte.setValue(valueAsDelta);
+        add(rte);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<RichTextEditorMinMaxHeight> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<RichTextEditorMinMaxHeight> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorReadonly.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorReadonly.java
@@ -9,17 +9,17 @@ import com.vaadin.demo.domain.DataService;
 @Route("rich-text-editor-readonly")
 public class RichTextEditorReadonly extends Div {
 
-  public RichTextEditorReadonly() {
-    // tag::snippet[]
-    RichTextEditor rte = new RichTextEditor();
-    rte.setMaxHeight("400px");
-    String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-    rte.setValue(valueAsDelta);
-    rte.setReadOnly(true);
-    add(rte);
-    // end::snippet[]
-  }
+    public RichTextEditorReadonly() {
+        // tag::snippet[]
+        RichTextEditor rte = new RichTextEditor();
+        rte.setMaxHeight("400px");
+        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
+        rte.setValue(valueAsDelta);
+        rte.setReadOnly(true);
+        add(rte);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<RichTextEditorReadonly> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<RichTextEditorReadonly> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java
@@ -9,24 +9,27 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("rich-text-editor-set-get-value")
 public class RichTextEditorSetGetValue extends Div {
 
-  public RichTextEditorSetGetValue() {
-    // tag::snippet[]
-    TextArea textArea = new TextArea("Html Value", "Type html string here to set it as value to the Rich Text Editor above...");
-    textArea.setWidthFull();
+    public RichTextEditorSetGetValue() {
+        // tag::snippet[]
+        TextArea textArea = new TextArea("Html Value",
+                "Type html string here to set it as value to the Rich Text Editor above...");
+        textArea.setWidthFull();
 
-    RichTextEditor rte = new RichTextEditor();
-    rte.getStyle().set("max-height", "400px");
+        RichTextEditor rte = new RichTextEditor();
+        rte.getStyle().set("max-height", "400px");
 
-    rte.asHtml().addValueChangeListener(e -> textArea.setValue(e.getValue()));
-    textArea.addValueChangeListener(e -> {
-      if (!rte.asHtml().getValue().equals(e.getValue())) {
-        rte.asHtml().setValue(e.getValue());
-      }
-    });
-    add(rte, textArea);
-    // end::snippet[]
-  }
+        rte.asHtml()
+                .addValueChangeListener(e -> textArea.setValue(e.getValue()));
+        textArea.addValueChangeListener(e -> {
+            if (!rte.asHtml().getValue().equals(e.getValue())) {
+                rte.asHtml().setValue(e.getValue());
+            }
+        });
+        add(rte, textArea);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<RichTextEditorSetGetValue> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<RichTextEditorSetGetValue> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeCompact.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeCompact.java
@@ -10,17 +10,18 @@ import com.vaadin.demo.domain.DataService;
 @Route("rich-text-editor-theme-compact")
 public class RichTextEditorThemeCompact extends Div {
 
-  public RichTextEditorThemeCompact() {
-    // tag::snippet[]
-    RichTextEditor rte = new RichTextEditor();
-    rte.getStyle().set("max-height", "400px");
-    String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-    rte.setValue(valueAsDelta);
-    rte.addThemeVariants(RichTextEditorVariant.LUMO_COMPACT);
-    add(rte);
-    // end::snippet[]
-  }
+    public RichTextEditorThemeCompact() {
+        // tag::snippet[]
+        RichTextEditor rte = new RichTextEditor();
+        rte.getStyle().set("max-height", "400px");
+        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
+        rte.setValue(valueAsDelta);
+        rte.addThemeVariants(RichTextEditorVariant.LUMO_COMPACT);
+        add(rte);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<RichTextEditorThemeCompact> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<RichTextEditorThemeCompact> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeNoBorder.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeNoBorder.java
@@ -10,17 +10,18 @@ import com.vaadin.demo.domain.DataService;
 @Route("rich-text-editor-theme-no-border")
 public class RichTextEditorThemeNoBorder extends Div {
 
-  public RichTextEditorThemeNoBorder() {
-    // tag::snippet[]
-    RichTextEditor rte = new RichTextEditor();
-    rte.getStyle().set("max-height", "400px");
-    String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-    rte.setValue(valueAsDelta);
-    rte.addThemeVariants(RichTextEditorVariant.LUMO_NO_BORDER);
-    add(rte);
-    // end::snippet[]
-  }
+    public RichTextEditorThemeNoBorder() {
+        // tag::snippet[]
+        RichTextEditor rte = new RichTextEditor();
+        rte.getStyle().set("max-height", "400px");
+        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
+        rte.setValue(valueAsDelta);
+        rte.addThemeVariants(RichTextEditorVariant.LUMO_NO_BORDER);
+        add(rte);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<RichTextEditorThemeNoBorder> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<RichTextEditorThemeNoBorder> { // hidden-source-line
+    } // hidden-source-line
 }


### PR DESCRIPTION
## Description

Part of #1735

Fixed indentation from 2 spaces to 4 spaces for the following components examples:

- `Checkbox`
- `ComboBox`
- `CRUD`
- `CustomField`
- `DatePicker`
- `MenuBar`
- `RichTextEditor`

## Note

Use "hide whitespace" checkmark when reviewing to make PR diff smaller.