### PR TITLE
chore: add missing comments to DemoExporter imports

### DIFF
--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBottomNavbar.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBottomNavbar.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.applayout;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.applayout;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.applayout.DrawerToggle;
 import com.vaadin.flow.component.html.H1;

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbar.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbar.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.applayout;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.tabs.Tab;

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.applayout;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.applayout.DrawerToggle;
 import com.vaadin.flow.component.html.H1;

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.applayout;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.applayout.DrawerToggle;
 import com.vaadin.flow.component.html.H1;

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.applayout;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.applayout.DrawerToggle;
 import com.vaadin.flow.component.html.H1;

--- a/src/main/java/com/vaadin/demo/component/avatar/AvatarSizes.java
+++ b/src/main/java/com/vaadin/demo/component/avatar/AvatarSizes.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.avatar;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.avatar.Avatar;

--- a/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogCancelButton.java
+++ b/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogCancelButton.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.confirmdialog;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogRejectButton.java
+++ b/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogRejectButton.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.confirmdialog;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.contextmenu;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.contextmenu.GridContextMenu;
 import com.vaadin.flow.component.grid.contextmenu.GridMenuItem;

--- a/src/main/java/com/vaadin/demo/component/map/MapEvents.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapEvents.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.map;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Coordinate;

--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarInternationalization.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.menubar;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.contextmenu.SubMenu;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/messages/MessageInputComponent.java
+++ b/src/main/java/com/vaadin/demo/component/messages/MessageInputComponent.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.messages;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.messages.MessageInput;
 import com.vaadin.flow.component.notification.Notification;

--- a/src/main/java/com/vaadin/demo/component/messages/MessageListComponent.java
+++ b/src/main/java/com/vaadin/demo/component/messages/MessageListComponent.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/messages/MessageListWithThemeComponent.java
+++ b/src/main/java/com/vaadin/demo/component/messages/MessageListWithThemeComponent.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/messages/MessagesBasic.java
+++ b/src/main/java/com/vaadin/demo/component/messages/MessagesBasic.java
@@ -6,7 +6,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.notification;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.notification.Notification;

--- a/src/main/java/com/vaadin/demo/component/scroller/ScrollerBasic.java
+++ b/src/main/java/com/vaadin/demo/component/scroller/ScrollerBasic.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.scroller;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.datepicker.DatePicker;

--- a/src/main/java/com/vaadin/demo/component/scroller/ScrollerBoth.java
+++ b/src/main/java/com/vaadin/demo/component/scroller/ScrollerBoth.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.scroller;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.orderedlayout.Scroller;

--- a/src/main/java/com/vaadin/demo/component/scroller/ScrollerMobile.java
+++ b/src/main/java/com/vaadin/demo/component/scroller/ScrollerMobile.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.scroller;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Section;

--- a/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.select;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/select/SelectDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectDisabled.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.select;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.router.Route;

--- a/src/main/java/com/vaadin/demo/component/select/SelectPlaceholder.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectPlaceholder.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.select;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.router.Route;

--- a/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.select;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/flow/application/resources/ImageClassResource.java
+++ b/src/main/java/com/vaadin/demo/flow/application/resources/ImageClassResource.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.flow.application.resources;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.router.Route;
@@ -21,5 +21,5 @@ public class ImageClassResource extends Div {
     }
 
     public static class ImageClassResourceExporter extends DemoExporter<ImageClassResource> { // hidden-source-line
-    } // hidden-source-line    
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/flow/binding/DataBinding.java
+++ b/src/main/java/com/vaadin/demo/flow/binding/DataBinding.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.flow.binding;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;

--- a/src/main/java/com/vaadin/demo/flow/routing/LoginScreen.java
+++ b/src/main/java/com/vaadin/demo/flow/routing/LoginScreen.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.flow.routing;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.login.LoginForm;
 


### PR DESCRIPTION
## Description

Added missing `// hidden-source-line` comments to some `DemoExporter` imports in Java examples.