### PR TITLE
chore: reindent Java examples using 4 spaces (part 5)

### DIFF
--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionBasic.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionBasic.java
@@ -10,44 +10,45 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("accordion-basic")
 public class AccordionBasic extends Div {
 
-  public AccordionBasic() {
-    // tag::snippet[]
-    Accordion accordion = new Accordion();
+    public AccordionBasic() {
+        // tag::snippet[]
+        Accordion accordion = new Accordion();
 
-    Span name = new Span("Sophia Williams");
-    Span email = new Span("sophia.williams@company.com");
-    Span phone = new Span("(501) 555-9128");
-    
-    VerticalLayout personalInformationLayout = new VerticalLayout(name, email, phone);
-    personalInformationLayout.setSpacing(false);
-    personalInformationLayout.setPadding(false);
+        Span name = new Span("Sophia Williams");
+        Span email = new Span("sophia.williams@company.com");
+        Span phone = new Span("(501) 555-9128");
 
-    accordion.add("Personal information", personalInformationLayout);
-    // end::snippet[]
+        VerticalLayout personalInformationLayout = new VerticalLayout(name,
+                email, phone);
+        personalInformationLayout.setSpacing(false);
+        personalInformationLayout.setPadding(false);
 
-    Span street = new Span("4027 Amber Lake Canyon");
-    Span zipCode = new Span("72333-5884 Cozy Nook");
-    Span city = new Span("Arkansas");
+        accordion.add("Personal information", personalInformationLayout);
+        // end::snippet[]
 
-    VerticalLayout billingAddressLayout = new VerticalLayout();
-    billingAddressLayout.setSpacing(false);
-    billingAddressLayout.setPadding(false);
-    billingAddressLayout.add(street, zipCode, city);
-    accordion.add("Billing address", billingAddressLayout);
+        Span street = new Span("4027 Amber Lake Canyon");
+        Span zipCode = new Span("72333-5884 Cozy Nook");
+        Span city = new Span("Arkansas");
 
-    Span cardBrand = new Span("Mastercard");
-    Span cardNumber = new Span("1234 5678 9012 3456");
-    Span expiryDate = new Span("Expires 06/21");
+        VerticalLayout billingAddressLayout = new VerticalLayout();
+        billingAddressLayout.setSpacing(false);
+        billingAddressLayout.setPadding(false);
+        billingAddressLayout.add(street, zipCode, city);
+        accordion.add("Billing address", billingAddressLayout);
 
-    VerticalLayout paymentLayout = new VerticalLayout();
-    paymentLayout.setSpacing(false);
-    paymentLayout.setPadding(false);
-    paymentLayout.add(cardBrand, cardNumber, expiryDate);
-    accordion.add("Payment", paymentLayout);
+        Span cardBrand = new Span("Mastercard");
+        Span cardNumber = new Span("1234 5678 9012 3456");
+        Span expiryDate = new Span("Expires 06/21");
 
-    add(accordion);
-  }
+        VerticalLayout paymentLayout = new VerticalLayout();
+        paymentLayout.setSpacing(false);
+        paymentLayout.setPadding(false);
+        paymentLayout.add(cardBrand, cardNumber, expiryDate);
+        accordion.add("Payment", paymentLayout);
 
-  public static class Exporter extends DemoExporter<AccordionBasic> { // hidden-source-line
-  } // hidden-source-line
+        add(accordion);
+    }
+
+    public static class Exporter extends DemoExporter<AccordionBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/board/BoardBasic.java
+++ b/src/main/java/com/vaadin/demo/component/board/BoardBasic.java
@@ -8,22 +8,20 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("board-basic")
 public class BoardBasic extends Div {
 
-  public BoardBasic() {
-    // tag::snippet[]
-    Board board = new Board();
-    board.addRow(
-            new ExampleIndicator("Current users", "745", "+33.7"),
-            new ExampleIndicator("View events", "54.6k", "-112.45"),
-            new ExampleIndicator("Conversion rate", "18%", "+3.9"),
-            new ExampleIndicator("Custom metric", "-123.45")
-    );
-    board.addRow(new ExampleChart());
-    // end::snippet[]
+    public BoardBasic() {
+        // tag::snippet[]
+        Board board = new Board();
+        board.addRow(new ExampleIndicator("Current users", "745", "+33.7"),
+                new ExampleIndicator("View events", "54.6k", "-112.45"),
+                new ExampleIndicator("Conversion rate", "18%", "+3.9"),
+                new ExampleIndicator("Custom metric", "-123.45"));
+        board.addRow(new ExampleChart());
+        // end::snippet[]
 
-    add(board);
-    addClassName("basic-board");
-  }
+        add(board);
+        addClassName("basic-board");
+    }
 
-  public static class Exporter extends DemoExporter<BoardBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<BoardBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/gridpro/GridProBasic.java
+++ b/src/main/java/com/vaadin/demo/component/gridpro/GridProBasic.java
@@ -11,32 +11,28 @@ import java.util.List;
 @Route("grid-pro-basic")
 public class GridProBasic extends Div {
 
-  public GridProBasic() {
-    // tag::snippet[]
-    GridPro<Person> grid = new GridPro<>();
+    public GridProBasic() {
+        // tag::snippet[]
+        GridPro<Person> grid = new GridPro<>();
 
-    grid.addEditColumn(Person::getFirstName)
-            .text(Person::setFirstName)
-            .setHeader("First name");
+        grid.addEditColumn(Person::getFirstName).text(Person::setFirstName)
+                .setHeader("First name");
 
-    grid.addEditColumn(Person::getLastName)
-            .text(Person::setLastName)
-            .setHeader("Last name");
+        grid.addEditColumn(Person::getLastName).text(Person::setLastName)
+                .setHeader("Last name");
 
-    grid.addEditColumn(Person::getEmail)
-            .text(Person::setEmail)
-            .setHeader("Email");
+        grid.addEditColumn(Person::getEmail).text(Person::setEmail)
+                .setHeader("Email");
 
-    grid.addEditColumn(Person::getProfession)
-            .text(Person::setProfession)
-            .setHeader("Profession");
-    // end::snippet[]
+        grid.addEditColumn(Person::getProfession).text(Person::setProfession)
+                .setHeader("Profession");
+        // end::snippet[]
 
-    List<Person> people = DataService.getPeople();
-    grid.setItems(people);
-    add(grid);
-  }
+        List<Person> people = DataService.getPeople();
+        grid.setItems(people);
+        add(grid);
+    }
 
-  public static class Exporter extends DemoExporter<GridProBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<GridProBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxBasic.java
+++ b/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxBasic.java
@@ -10,16 +10,18 @@ import com.vaadin.flow.router.Route;
 @Route("multi-select-combo-box-basic")
 public class MultiSelectComboBoxBasic extends Div {
 
-  public MultiSelectComboBoxBasic() {
-    // tag::snippet[]
-    MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>("Countries");
-    comboBox.setItems(DataService.getCountries());
-    comboBox.setItemLabelGenerator(Country::getName);
-    add(comboBox);
-    // end::snippet[]
-    comboBox.setWidth("300px");
-  }
+    public MultiSelectComboBoxBasic() {
+        // tag::snippet[]
+        MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>(
+                "Countries");
+        comboBox.setItems(DataService.getCountries());
+        comboBox.setItemLabelGenerator(Country::getName);
+        add(comboBox);
+        // end::snippet[]
+        comboBox.setWidth("300px");
+    }
 
-  public static class Exporter extends DemoExporter<MultiSelectComboBoxBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<MultiSelectComboBoxBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxI18nDemo.java
+++ b/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxI18nDemo.java
@@ -11,25 +11,27 @@ import com.vaadin.flow.router.Route;
 @Route("multi-select-combo-box-i18n")
 public class MultiSelectComboBoxI18nDemo extends Div {
 
-  public MultiSelectComboBoxI18nDemo() {
-    MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>("Länder");
-    comboBox.setItems(DataService.getCountries());
-    comboBox.setItemLabelGenerator(Country::getName);
-    comboBox.setWidth("300px");
-    add(comboBox);
+    public MultiSelectComboBoxI18nDemo() {
+        MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>(
+                "Länder");
+        comboBox.setItems(DataService.getCountries());
+        comboBox.setItemLabelGenerator(Country::getName);
+        comboBox.setWidth("300px");
+        add(comboBox);
 
-    // tag::snippet[]
-    MultiSelectComboBoxI18n i18n = new MultiSelectComboBoxI18n();
-    i18n.setCleared("Alle Einträge entfernt");
-    i18n.setFocused(" ausgewählt. Drücke Rücktaste zum Entfernen");
-    i18n.setSelected(" hinzugefügt");
-    i18n.setDeselected(" entfernt");
-    i18n.setTotal("{count} Einträge ausgewählt");
+        // tag::snippet[]
+        MultiSelectComboBoxI18n i18n = new MultiSelectComboBoxI18n();
+        i18n.setCleared("Alle Einträge entfernt");
+        i18n.setFocused(" ausgewählt. Drücke Rücktaste zum Entfernen");
+        i18n.setSelected(" hinzugefügt");
+        i18n.setDeselected(" entfernt");
+        i18n.setTotal("{count} Einträge ausgewählt");
 
-    comboBox.setI18n(i18n);
-    // end::snippet[]
-  }
+        comboBox.setI18n(i18n);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<MultiSelectComboBoxI18nDemo> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<MultiSelectComboBoxI18nDemo> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxReadOnly.java
+++ b/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxReadOnly.java
@@ -12,19 +12,21 @@ import java.util.List;
 @Route("multi-select-combo-box-read-only")
 public class MultiSelectComboBoxReadOnly extends Div {
 
-  public MultiSelectComboBoxReadOnly() {
-    MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>("Countries");
-    List<Country> countries = DataService.getCountries();
-    comboBox.setItems(countries);
-    comboBox.select(countries.subList(0, 4));
-    comboBox.setItemLabelGenerator(Country::getName);
-    // tag::snippet[]
-    comboBox.setReadOnly(true);
-    // end::snippet[]
-    comboBox.setWidth("300px");
-    add(comboBox);
-  }
+    public MultiSelectComboBoxReadOnly() {
+        MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>(
+                "Countries");
+        List<Country> countries = DataService.getCountries();
+        comboBox.setItems(countries);
+        comboBox.select(countries.subList(0, 4));
+        comboBox.setItemLabelGenerator(Country::getName);
+        // tag::snippet[]
+        comboBox.setReadOnly(true);
+        // end::snippet[]
+        comboBox.setWidth("300px");
+        add(comboBox);
+    }
 
-  public static class Exporter extends DemoExporter<MultiSelectComboBoxReadOnly> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<MultiSelectComboBoxReadOnly> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelection.java
+++ b/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelection.java
@@ -12,18 +12,20 @@ import java.util.List;
 @Route("multi-select-combo-box-selection")
 public class MultiSelectComboBoxSelection extends Div {
 
-  public MultiSelectComboBoxSelection() {
-    MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>("Countries");
-    List<Country> countries = DataService.getCountries();
-    comboBox.setItems(countries);
-    // tag::snippet[]
-    comboBox.select(countries.subList(0, 4));
-    // end::snippet[]
-    comboBox.setItemLabelGenerator(Country::getName);
-    comboBox.setWidth("300px");
-    add(comboBox);
-  }
+    public MultiSelectComboBoxSelection() {
+        MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>(
+                "Countries");
+        List<Country> countries = DataService.getCountries();
+        comboBox.setItems(countries);
+        // tag::snippet[]
+        comboBox.select(countries.subList(0, 4));
+        // end::snippet[]
+        comboBox.setItemLabelGenerator(Country::getName);
+        comboBox.setWidth("300px");
+        add(comboBox);
+    }
 
-  public static class Exporter extends DemoExporter<MultiSelectComboBoxSelection> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<MultiSelectComboBoxSelection> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectionChange.java
+++ b/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectionChange.java
@@ -15,29 +15,31 @@ import java.util.stream.Collectors;
 @Route("multi-select-combo-box-selection-change")
 public class MultiSelectComboBoxSelectionChange extends Div {
 
-  public MultiSelectComboBoxSelectionChange() {
-    MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>("Countries");
-    List<Country> countries = DataService.getCountries();
-    comboBox.setItems(countries);
-    comboBox.setItemLabelGenerator(Country::getName);
+    public MultiSelectComboBoxSelectionChange() {
+        MultiSelectComboBox<Country> comboBox = new MultiSelectComboBox<>(
+                "Countries");
+        List<Country> countries = DataService.getCountries();
+        comboBox.setItems(countries);
+        comboBox.setItemLabelGenerator(Country::getName);
 
-    // tag::snippet[]
-    TextArea selectedCountries = new TextArea("Selected Countries");
-    selectedCountries.setReadOnly(true);
+        // tag::snippet[]
+        TextArea selectedCountries = new TextArea("Selected Countries");
+        selectedCountries.setReadOnly(true);
 
-    comboBox.addValueChangeListener(e -> {
-      String selectedCountriesText = e.getValue().stream()
-              .map(Country::getName)
-              .collect(Collectors.joining(", "));
+        comboBox.addValueChangeListener(e -> {
+            String selectedCountriesText = e.getValue().stream()
+                    .map(Country::getName).collect(Collectors.joining(", "));
 
-      selectedCountries.setValue(selectedCountriesText);
-    });
-    // end::snippet[]
+            selectedCountries.setValue(selectedCountriesText);
+        });
+        // end::snippet[]
 
-    HorizontalLayout layout = new HorizontalLayout(comboBox, selectedCountries);
-    add(layout);
-  }
+        HorizontalLayout layout = new HorizontalLayout(comboBox,
+                selectedCountries);
+        add(layout);
+    }
 
-  public static class Exporter extends DemoExporter<MultiSelectComboBoxSelectionChange> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+                DemoExporter<MultiSelectComboBoxSelectionChange> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationBasic.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationBasic.java
@@ -10,24 +10,26 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-basic")
 public class NotificationBasic extends Div {
 
-  public NotificationBasic() {
-    Button button = new Button("Try it");
-    button.addClickListener(clickEvent -> {
-      button.setEnabled(false);
+    public NotificationBasic() {
+        Button button = new Button("Try it");
+        button.addClickListener(clickEvent -> {
+            button.setEnabled(false);
 
-      // tag::snippet[]
-      // When creating a notification using the `show` static method,
-      // the duration is 5-sec by default.
-      Notification notification = Notification.show("Financial report generated");
-      // end::snippet[]
-      notification.setPosition(Notification.Position.MIDDLE);
+            // tag::snippet[]
+            // When creating a notification using the `show` static method,
+            // the duration is 5-sec by default.
+            Notification notification = Notification
+                    .show("Financial report generated");
+            // end::snippet[]
+            notification.setPosition(Notification.Position.MIDDLE);
 
-      notification.addDetachListener(detachEvent -> button.setEnabled(true));
-    });
+            notification
+                    .addDetachListener(detachEvent -> button.setEnabled(true));
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  public static class Exporter extends DemoExporter<NotificationBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<NotificationBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationContrast.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationContrast.java
@@ -10,23 +10,24 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-contrast")
 public class NotificationContrast extends Div {
 
-  public NotificationContrast() {
-    Button button = new Button("Try it");
-    button.addClickListener(clickEvent -> {
-      button.setEnabled(false);
+    public NotificationContrast() {
+        Button button = new Button("Try it");
+        button.addClickListener(clickEvent -> {
+            button.setEnabled(false);
 
-      // tag::snippet[]
-      Notification notification = Notification.show("5 tasks deleted");
-      notification.addThemeVariants(NotificationVariant.LUMO_CONTRAST);
-      // end::snippet[]
-      notification.setPosition(Notification.Position.MIDDLE);
+            // tag::snippet[]
+            Notification notification = Notification.show("5 tasks deleted");
+            notification.addThemeVariants(NotificationVariant.LUMO_CONTRAST);
+            // end::snippet[]
+            notification.setPosition(Notification.Position.MIDDLE);
 
-      notification.addDetachListener(detachEvent -> button.setEnabled(true));
-    });
+            notification
+                    .addDetachListener(detachEvent -> button.setEnabled(true));
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  public static class Exporter extends DemoExporter<NotificationContrast> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<NotificationContrast> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationError.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationError.java
@@ -15,47 +15,48 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-error")
 public class NotificationError extends Div {
 
-  public NotificationError() {
-    Button button = new Button("Try it");
-    button.addClickListener(clickEvent -> {
-      button.setEnabled(false);
+    public NotificationError() {
+        Button button = new Button("Try it");
+        button.addClickListener(clickEvent -> {
+            button.setEnabled(false);
 
-      Notification notification = show();
-      notification.addDetachListener(detachEvent -> button.setEnabled(true));
-    });
+            Notification notification = show();
+            notification
+                    .addDetachListener(detachEvent -> button.setEnabled(true));
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  public Notification show() {
-    // tag::snippet[]
-    // When creating a notification using the constructor,
-    // the duration is 0-sec by default which means that
-    // the notification does not close automatically.
-    Notification notification = new Notification();
-    notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+    public Notification show() {
+        // tag::snippet[]
+        // When creating a notification using the constructor,
+        // the duration is 0-sec by default which means that
+        // the notification does not close automatically.
+        Notification notification = new Notification();
+        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
 
-    Div text = new Div(new Text("Failed to generate report"));
+        Div text = new Div(new Text("Failed to generate report"));
 
-    Button closeButton = new Button(new Icon("lumo", "cross"));
-    closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-    closeButton.getElement().setAttribute("aria-label", "Close");
-    closeButton.addClickListener(event -> {
-      notification.close();
-    });
+        Button closeButton = new Button(new Icon("lumo", "cross"));
+        closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+        closeButton.getElement().setAttribute("aria-label", "Close");
+        closeButton.addClickListener(event -> {
+            notification.close();
+        });
 
-    HorizontalLayout layout = new HorizontalLayout(text, closeButton);
-    layout.setAlignItems(Alignment.CENTER);
+        HorizontalLayout layout = new HorizontalLayout(text, closeButton);
+        layout.setAlignItems(Alignment.CENTER);
 
-    notification.add(layout);
-    notification.open();
-    // end::snippet[]
+        notification.add(layout);
+        notification.open();
+        // end::snippet[]
 
-    notification.setPosition(Notification.Position.MIDDLE);
+        notification.setPosition(Notification.Position.MIDDLE);
 
-    return notification;
-  }
+        return notification;
+    }
 
-  public static class Exporter extends DemoExporter<NotificationError> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<NotificationError> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java
@@ -15,59 +15,63 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-keyboard-a11y")
 public class NotificationKeyboardA11y extends Div {
 
-  public NotificationKeyboardA11y() {
-    Button button = new Button("Try it");
-    button.addClickListener(clickEvent -> {
-      button.setEnabled(false);
+    public NotificationKeyboardA11y() {
+        Button button = new Button("Try it");
+        button.addClickListener(clickEvent -> {
+            button.setEnabled(false);
 
-      Notification notification = show();
-      notification.addDetachListener(detachEvent -> button.setEnabled(true));
-      setupUndoShortcut(notification);
-    });
+            Notification notification = show();
+            notification
+                    .addDetachListener(detachEvent -> button.setEnabled(true));
+            setupUndoShortcut(notification);
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  // tag::snippet[]
-  public Notification show() {
-    Notification notification = new Notification();
-    notification.setDuration(10000);
-    notification.addThemeVariants(NotificationVariant.LUMO_CONTRAST);
+    // tag::snippet[]
+    public Notification show() {
+        Notification notification = new Notification();
+        notification.setDuration(10000);
+        notification.addThemeVariants(NotificationVariant.LUMO_CONTRAST);
 
-    Div statusText = new Div(new Text("5 tasks deleted"));
+        Div statusText = new Div(new Text("5 tasks deleted"));
 
-    Button undoButton = new Button();
-    undoButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-    undoButton.getElement().getStyle().set("margin-left", "var(--lumo-space-xl)");
-    undoButton.getElement().executeJs(
-      "const isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(window.navigator.platform);" +
-      "this.textContent = `Undo ${isMac ? '⌘' : 'Ctrl-'}Z`;"
-    );
-    undoButton.addClickListener(event -> {
-      notification.close();
-    });
+        Button undoButton = new Button();
+        undoButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        undoButton.getElement().getStyle().set("margin-left",
+                "var(--lumo-space-xl)");
+        undoButton.getElement().executeJs(
+                "const isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(window.navigator.platform);"
+                        + "this.textContent = `Undo ${isMac ? '⌘' : 'Ctrl-'}Z`;");
+        undoButton.addClickListener(event -> {
+            notification.close();
+        });
 
-    HorizontalLayout layout = new HorizontalLayout(statusText, undoButton);
-    layout.setAlignItems(Alignment.CENTER);
+        HorizontalLayout layout = new HorizontalLayout(statusText, undoButton);
+        layout.setAlignItems(Alignment.CENTER);
 
-    notification.add(layout);
-    notification.open();
+        notification.add(layout);
+        notification.open();
+        // end::snippet[]
+
+        notification.setPosition(Notification.Position.MIDDLE);
+        // tag::snippet[]
+
+        return notification;
+    }
     // end::snippet[]
 
-    notification.setPosition(Notification.Position.MIDDLE);
-    // tag::snippet[]
+    // tag::setupUndoShortcut[]
+    public void setupUndoShortcut(Notification notification) {
+        Shortcuts.addShortcutListener(notification, notification::close,
+                Key.of("z"), KeyModifier.META);
+        Shortcuts.addShortcutListener(notification, notification::close,
+                Key.of("z"), KeyModifier.CONTROL);
+    }
+    // end::setupUndoShortcut[]
 
-    return notification;
-  }
-  // end::snippet[]
-
-  // tag::setupUndoShortcut[]
-  public void setupUndoShortcut(Notification notification) {
-    Shortcuts.addShortcutListener(notification, notification::close, Key.of("z"), KeyModifier.META);
-    Shortcuts.addShortcutListener(notification, notification::close, Key.of("z"), KeyModifier.CONTROL);
-  }
-  // end::setupUndoShortcut[]
-
-  public static class Exporter extends DemoExporter<NotificationKeyboardA11y> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter
+            extends DemoExporter<NotificationKeyboardA11y> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationLink.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationLink.java
@@ -15,49 +15,48 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-link")
 public class NotificationLink extends Div {
 
-  public NotificationLink() {
-    Button button = new Button("Try it");
-    button.addClickListener(clickEvent -> {
-      button.setEnabled(false);
+    public NotificationLink() {
+        Button button = new Button("Try it");
+        button.addClickListener(clickEvent -> {
+            button.setEnabled(false);
 
-      Notification notification = show();
-      notification.addDetachListener(detachEvent -> button.setEnabled(true));
-    });
+            Notification notification = show();
+            notification
+                    .addDetachListener(detachEvent -> button.setEnabled(true));
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  public Notification show() {
-    // tag::snippet[]
-    // When creating a notification using the constructor,
-    // the duration is 0-sec by default which means that
-    // the notification does not close automatically.
-    Notification notification = new Notification();
+    public Notification show() {
+        // tag::snippet[]
+        // When creating a notification using the constructor,
+        // the duration is 0-sec by default which means that
+        // the notification does not close automatically.
+        Notification notification = new Notification();
 
-    Div text = new Div(
-      new Text("Jason Bailey mentioned you in "),
-      new Anchor("#", "Project Q4")
-    );
+        Div text = new Div(new Text("Jason Bailey mentioned you in "),
+                new Anchor("#", "Project Q4"));
 
-    Button closeButton = new Button(new Icon("lumo", "cross"));
-    closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-    closeButton.getElement().setAttribute("aria-label", "Close");
-    closeButton.addClickListener(event -> {
-      notification.close();
-    });
+        Button closeButton = new Button(new Icon("lumo", "cross"));
+        closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+        closeButton.getElement().setAttribute("aria-label", "Close");
+        closeButton.addClickListener(event -> {
+            notification.close();
+        });
 
-    HorizontalLayout layout = new HorizontalLayout(text, closeButton);
-    layout.setAlignItems(Alignment.CENTER);
+        HorizontalLayout layout = new HorizontalLayout(text, closeButton);
+        layout.setAlignItems(Alignment.CENTER);
 
-    notification.add(layout);
-    notification.open();
-    // end::snippet[]
+        notification.add(layout);
+        notification.open();
+        // end::snippet[]
 
-    notification.setPosition(Notification.Position.MIDDLE);
+        notification.setPosition(Notification.Position.MIDDLE);
 
-    return notification;
-  }
+        return notification;
+    }
 
-  public static class Exporter extends DemoExporter<NotificationLink> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<NotificationLink> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java
@@ -11,38 +11,35 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-position")
 public class NotificationPosition extends Div {
 
-  public NotificationPosition() {
-    setClassName("notification-position-example");
+    public NotificationPosition() {
+        setClassName("notification-position-example");
 
-    // tag::snippet[]
-    add(
-      createButton(Position.TOP_STRETCH),
-      createButton(Position.TOP_START),
-      createButton(Position.TOP_CENTER),
-      createButton(Position.TOP_END),
-      createButton(Position.MIDDLE),
-      createButton(Position.BOTTOM_START),
-      createButton(Position.BOTTOM_CENTER),
-      createButton(Position.BOTTOM_END),
-      createButton(Position.BOTTOM_STRETCH)
-    );
-    // end::snippet[]
-  }
+        // tag::snippet[]
+        add(createButton(Position.TOP_STRETCH),
+                createButton(Position.TOP_START),
+                createButton(Position.TOP_CENTER),
+                createButton(Position.TOP_END), createButton(Position.MIDDLE),
+                createButton(Position.BOTTOM_START),
+                createButton(Position.BOTTOM_CENTER),
+                createButton(Position.BOTTOM_END),
+                createButton(Position.BOTTOM_STRETCH));
+        // end::snippet[]
+    }
 
-  // tag::createButton[]
-  private Button createButton(Notification.Position position) {
-    Button button = new Button(position.getClientName());
-    button.addClickListener(event -> show(position));
-    return button;
-  }
-  // end::createButton[]
+    // tag::createButton[]
+    private Button createButton(Notification.Position position) {
+        Button button = new Button(position.getClientName());
+        button.addClickListener(event -> show(position));
+        return button;
+    }
+    // end::createButton[]
 
-  // tag::show[]
-  private void show(Notification.Position position) {
-    Notification.show(position.getClientName(), 5000, position);
-  }
-  // end::show[]
+    // tag::show[]
+    private void show(Notification.Position position) {
+        Notification.show(position.getClientName(), 5000, position);
+    }
+    // end::show[]
 
-  public static class Exporter extends DemoExporter<NotificationPosition> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<NotificationPosition> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationPrimary.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationPrimary.java
@@ -10,23 +10,25 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-primary")
 public class NotificationPrimary extends Div {
 
-  public NotificationPrimary() {
-    Button button = new Button("Try it");
-    button.addClickListener(clickEvent -> {
-      button.setEnabled(false);
+    public NotificationPrimary() {
+        Button button = new Button("Try it");
+        button.addClickListener(clickEvent -> {
+            button.setEnabled(false);
 
-      // tag::snippet[]
-      Notification notification = Notification.show("New project plan available");
-      notification.addThemeVariants(NotificationVariant.LUMO_PRIMARY);
-      // end::snippet[]
-      notification.setPosition(Notification.Position.MIDDLE);
+            // tag::snippet[]
+            Notification notification = Notification
+                    .show("New project plan available");
+            notification.addThemeVariants(NotificationVariant.LUMO_PRIMARY);
+            // end::snippet[]
+            notification.setPosition(Notification.Position.MIDDLE);
 
-      notification.addDetachListener(detachEvent -> button.setEnabled(true));
-    });
+            notification
+                    .addDetachListener(detachEvent -> button.setEnabled(true));
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  public static class Exporter extends DemoExporter<NotificationPrimary> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<NotificationPrimary> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationRetry.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationRetry.java
@@ -16,54 +16,57 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-retry")
 public class NotificationRetry extends Div {
 
-  public NotificationRetry() {
-    Button button = new Button("Try it");
-    button.addClickListener(clickEvent -> {
-      button.setEnabled(false);
+    public NotificationRetry() {
+        Button button = new Button("Try it");
+        button.addClickListener(clickEvent -> {
+            button.setEnabled(false);
 
-      Notification notification = show();
-      notification.addDetachListener(detachEvent -> button.setEnabled(true));
-    });
+            Notification notification = show();
+            notification
+                    .addDetachListener(detachEvent -> button.setEnabled(true));
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  private Notification show() {
-    // tag::snippet[]
-    // When creating a notification using the constructor,
-    // the duration is 0-sec by default which means that
-    // the notification does not close automatically.
-    Notification notification = new Notification();
-    notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+    private Notification show() {
+        // tag::snippet[]
+        // When creating a notification using the constructor,
+        // the duration is 0-sec by default which means that
+        // the notification does not close automatically.
+        Notification notification = new Notification();
+        notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
 
-    Div statusText = new Div(new Text("Failed to generate report"));
+        Div statusText = new Div(new Text("Failed to generate report"));
 
-    Button retryButton = new Button("Retry");
-    retryButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-    retryButton.getElement().getStyle().set("margin-left", "var(--lumo-space-xl)");
-    retryButton.addClickListener(event -> {
-      notification.close();
-    });
+        Button retryButton = new Button("Retry");
+        retryButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+        retryButton.getElement().getStyle().set("margin-left",
+                "var(--lumo-space-xl)");
+        retryButton.addClickListener(event -> {
+            notification.close();
+        });
 
-    Button closeButton = new Button(new Icon("lumo", "cross"));
-    closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-    closeButton.getElement().setAttribute("aria-label", "Close");
-    closeButton.addClickListener(event -> {
-      notification.close();
-    });
+        Button closeButton = new Button(new Icon("lumo", "cross"));
+        closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+        closeButton.getElement().setAttribute("aria-label", "Close");
+        closeButton.addClickListener(event -> {
+            notification.close();
+        });
 
-    HorizontalLayout layout = new HorizontalLayout(statusText, retryButton, closeButton);
-    layout.setAlignItems(Alignment.CENTER);
+        HorizontalLayout layout = new HorizontalLayout(statusText, retryButton,
+                closeButton);
+        layout.setAlignItems(Alignment.CENTER);
 
-    notification.add(layout);
-    notification.open();
-    // end::snippet[]
+        notification.add(layout);
+        notification.open();
+        // end::snippet[]
 
-    notification.setPosition(Notification.Position.MIDDLE);
+        notification.setPosition(Notification.Position.MIDDLE);
 
-    return notification;
-  }
+        return notification;
+    }
 
-  public static class Exporter extends DemoExporter<NotificationRetry> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<NotificationRetry> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java
@@ -9,19 +9,21 @@ import com.vaadin.flow.router.Route;
 @Route("notification-static-helper")
 public class NotificationStaticHelper extends Div {
 
-  public NotificationStaticHelper() {
-    Button button = new Button("Show text notification");
-    button.addClickListener(clickEvent -> {
-      // tag::snippet[]
-      // Show a simple text-based notification
-      Notification notification = Notification.show("Financial report generated");
-      notification.setPosition(Notification.Position.MIDDLE);
-      // end::snippet[]
-    });
+    public NotificationStaticHelper() {
+        Button button = new Button("Show text notification");
+        button.addClickListener(clickEvent -> {
+            // tag::snippet[]
+            // Show a simple text-based notification
+            Notification notification = Notification
+                    .show("Financial report generated");
+            notification.setPosition(Notification.Position.MIDDLE);
+            // end::snippet[]
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  public static class Exporter extends DemoExporter<NotificationStaticHelper> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<NotificationStaticHelper> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationSuccess.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationSuccess.java
@@ -10,23 +10,25 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-success")
 public class NotificationSuccess extends Div {
 
-  public NotificationSuccess() {
-    Button button = new Button("Try it");
-    button.addClickListener(clickEvent -> {
-      button.setEnabled(false);
+    public NotificationSuccess() {
+        Button button = new Button("Try it");
+        button.addClickListener(clickEvent -> {
+            button.setEnabled(false);
 
-      // tag::snippet[]
-      Notification notification = Notification.show("Application submitted!");
-      notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
-      // end::snippet[]
-      notification.setPosition(Notification.Position.MIDDLE);
+            // tag::snippet[]
+            Notification notification = Notification
+                    .show("Application submitted!");
+            notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+            // end::snippet[]
+            notification.setPosition(Notification.Position.MIDDLE);
 
-      notification.addDetachListener(detachEvent -> button.setEnabled(true));
-    });
+            notification
+                    .addDetachListener(detachEvent -> button.setEnabled(true));
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  public static class Exporter extends DemoExporter<NotificationSuccess> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<NotificationSuccess> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationUndo.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationUndo.java
@@ -16,52 +16,55 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 @Route("notification-undo")
 public class NotificationUndo extends Div {
 
-  public NotificationUndo() {
-    Button button = new Button("Try it");
-    button.addClickListener(clickEvent -> {
-      button.setEnabled(false);
+    public NotificationUndo() {
+        Button button = new Button("Try it");
+        button.addClickListener(clickEvent -> {
+            button.setEnabled(false);
 
-      Notification notification = show();
-      notification.addDetachListener(detachEvent -> button.setEnabled(true));
-    });
+            Notification notification = show();
+            notification
+                    .addDetachListener(detachEvent -> button.setEnabled(true));
+        });
 
-    add(button);
-  }
+        add(button);
+    }
 
-  public Notification show() {
-    // tag::snippet[]
-    Notification notification = new Notification();
-    notification.setDuration(10000);
-    notification.addThemeVariants(NotificationVariant.LUMO_CONTRAST);
+    public Notification show() {
+        // tag::snippet[]
+        Notification notification = new Notification();
+        notification.setDuration(10000);
+        notification.addThemeVariants(NotificationVariant.LUMO_CONTRAST);
 
-    Div statusText = new Div(new Text("5 tasks deleted"));
+        Div statusText = new Div(new Text("5 tasks deleted"));
 
-    Button undoButton = new Button("Undo");
-    undoButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-    undoButton.getElement().getStyle().set("margin-left", "var(--lumo-space-xl)");
-    undoButton.addClickListener(event -> {
-      notification.close();
-    });
+        Button undoButton = new Button("Undo");
+        undoButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+        undoButton.getElement().getStyle().set("margin-left",
+                "var(--lumo-space-xl)");
+        undoButton.addClickListener(event -> {
+            notification.close();
+        });
 
-    Button closeButton = new Button(new Icon("lumo", "cross"));
-    closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-    closeButton.getElement().setAttribute("aria-label", "Close");
-    closeButton.addClickListener(event -> {
-      notification.close();
-    });
+        Button closeButton = new Button(new Icon("lumo", "cross"));
+        closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+        closeButton.getElement().setAttribute("aria-label", "Close");
+        closeButton.addClickListener(event -> {
+            notification.close();
+        });
 
-    HorizontalLayout layout = new HorizontalLayout(statusText, undoButton, closeButton);
-    layout.setAlignItems(Alignment.CENTER);
+        HorizontalLayout layout = new HorizontalLayout(statusText, undoButton,
+                closeButton);
+        layout.setAlignItems(Alignment.CENTER);
 
-    notification.add(layout);
-    notification.open();
-    // end::snippet[]
+        notification.add(layout);
+        notification.open();
+        // end::snippet[]
 
-    notification.setPosition(Notification.Position.MIDDLE);
+        notification.setPosition(Notification.Position.MIDDLE);
 
-    return notification;
-  }
+        return notification;
+    }
 
-  public static class Exporter extends DemoExporter<NotificationUndo> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<NotificationUndo> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/virtuallist/VirtualListBasic.java
+++ b/src/main/java/com/vaadin/demo/component/virtuallist/VirtualListBasic.java
@@ -21,42 +21,47 @@ import com.vaadin.demo.domain.Person;
 @Route("virtual-list-basic")
 public class VirtualListBasic extends Div {
 
-  private List<Person> people = DataService.getPeople();
+    private List<Person> people = DataService.getPeople();
 
-  private ComponentRenderer<Component, Person> personCardRenderer = new ComponentRenderer<>(person -> {
-    HorizontalLayout cardLayout = new HorizontalLayout();
-    cardLayout.setMargin(true);
+    private ComponentRenderer<Component, Person> personCardRenderer = new ComponentRenderer<>(
+            person -> {
+                HorizontalLayout cardLayout = new HorizontalLayout();
+                cardLayout.setMargin(true);
 
-    Avatar avatar = new Avatar(person.getFullName(), person.getPictureUrl());
-    avatar.setHeight("64px");
-    avatar.setWidth("64px");
+                Avatar avatar = new Avatar(person.getFullName(),
+                        person.getPictureUrl());
+                avatar.setHeight("64px");
+                avatar.setWidth("64px");
 
-    VerticalLayout infoLayout = new VerticalLayout();
-    infoLayout.setSpacing(false);
-    infoLayout.setPadding(false);
-    infoLayout.getElement().appendChild(ElementFactory.createStrong(person.getFullName()));
-    infoLayout.add(new Div(new Text(person.getProfession())));
+                VerticalLayout infoLayout = new VerticalLayout();
+                infoLayout.setSpacing(false);
+                infoLayout.setPadding(false);
+                infoLayout.getElement().appendChild(
+                        ElementFactory.createStrong(person.getFullName()));
+                infoLayout.add(new Div(new Text(person.getProfession())));
 
-    VerticalLayout contactLayout = new VerticalLayout();
-    contactLayout.setSpacing(false);
-    contactLayout.setPadding(false);
-    contactLayout.add(new Div(new Text(person.getEmail())));
-    contactLayout.add(new Div(new Text(person.getAddress().getPhone())));
-    infoLayout.add(new Details("Contact information", contactLayout));
+                VerticalLayout contactLayout = new VerticalLayout();
+                contactLayout.setSpacing(false);
+                contactLayout.setPadding(false);
+                contactLayout.add(new Div(new Text(person.getEmail())));
+                contactLayout
+                        .add(new Div(new Text(person.getAddress().getPhone())));
+                infoLayout
+                        .add(new Details("Contact information", contactLayout));
 
-    cardLayout.add(avatar, infoLayout);
-    return cardLayout;
-  });
+                cardLayout.add(avatar, infoLayout);
+                return cardLayout;
+            });
 
-  public VirtualListBasic() {
-    // tag::snippet[]
-    VirtualList<Person> list = new VirtualList<>();
-    list.setItems(people);
-    list.setRenderer(personCardRenderer);
-    add(list);
-    // end::snippet[]
-  }
+    public VirtualListBasic() {
+        // tag::snippet[]
+        VirtualList<Person> list = new VirtualList<>();
+        list.setItems(people);
+        list.setRenderer(personCardRenderer);
+        add(list);
+        // end::snippet[]
+    }
 
-  public static class Exporter extends DemoExporter<VirtualListBasic> { // hidden-source-line
-  } // hidden-source-line
+    public static class Exporter extends DemoExporter<VirtualListBasic> { // hidden-source-line
+    } // hidden-source-line
 }


### PR DESCRIPTION
## Description

Part of #1735

Fixed indentation from 2 spaces to 4 spaces for the following components examples:

- `Accordion`
- `Board`
- `GridPro`
- `MultiSelectComboBox`
- `Notification`
- `VirtualList`

## Note

Use "hide whitespace" checkmark when reviewing to make PR diff smaller.