### PR TITLE
chore: fix Polymer and Lit templates indentation

### DIFF
--- a/articles/advanced/servlet-container-authentication.asciidoc
+++ b/articles/advanced/servlet-container-authentication.asciidoc
@@ -108,8 +108,8 @@ export class MyLogin extends LitElement {
 
   render() {
     return html`
-      <input id="username" name="username"></input>
-      <input id="password" name="password" type="password"></input>
+      <input id="username" name="username" />
+      <input id="password" name="password" type="password" />
       <button @click="${this.login}">login</button>
     `;
   }

--- a/articles/create-ui/creating-components/mixins.asciidoc
+++ b/articles/create-ui/creating-components/mixins.asciidoc
@@ -69,12 +69,13 @@ public class Tooltip extends Component
 [source,javascript]
 ----
 class Tooltip extends PolymerElement {
-    static get template() {
-        return html`
-            <div part="content" theme="dark">
-                <slot></slot>
-            </div>`;
-    }
+  static get template() {
+    return html`
+      <div part="content" theme="dark">
+        <slot></slot>
+      </div>
+    `;
+  }
 }
 ----
 

--- a/articles/create-ui/enabled-state.asciidoc
+++ b/articles/create-ui/enabled-state.asciidoc
@@ -159,31 +159,24 @@ Here is its template file:
 ----
 class RegistrationForm extends PolymerElement {
 
-    static get template() {
-        return html`
-            <vaadin-text-field id='name'>
-                {{name}}
-            </vaadin-text-field>
-            <vaadin-text-field id='email'>
-                {{email}}
-            </vaadin-text-field>
-            <vaadin-button id='submit'
-                on-click='register'>
-                Register
-            </vaadin-button>
-            <vaadin-checkbox
-                id='enable'
-                label='Accept License Agreement'>
-            </vaadin-checkbox>`;
-    }
+  static get template() {
+    return html`
+      <vaadin-text-field id="name" value="{{name}}"></vaadin-text-field>
+      <vaadin-text-field id="email" value="{{email}}"></vaadin-text-field>
+      <vaadin-button id="submit" on-click="register">Register</vaadin-button>
+      <vaadin-checkbox
+        id="enable"
+        label="Accept License Agreement"
+      ></vaadin-checkbox>
+    `;
+  }
 
-    static get is() {
-        return 'registration-form';
-    }
+  static get is() {
+    return 'registration-form';
+  }
 }
 
-customElements.define(RegistrationForm.is,
-        RegistrationForm);
+customElements.define(RegistrationForm.is, RegistrationForm);
 ----
 
 * The checkbox is implicitly disabled if the template (which is its parent) is disabled.

--- a/articles/create-ui/templates/and-binder.asciidoc
+++ b/articles/create-ui/templates/and-binder.asciidoc
@@ -28,16 +28,17 @@ import '@vaadin/text-field';
 import './form-buttons-bar.js'
 
 class UserForm extends LitElement {
-    render() {
-        return html`
-            <vaadin-form-layout id="form">
-                <vaadin-text-field id="email" label="Email (login)" colspan="2"></vaadin-text-field>
-                <vaadin-text-field id="first-name" label="First Name"></vaadin-text-field>
-                <vaadin-text-field id="last-name" label="Last Name"></vaadin-text-field>
-                <vaadin-text-area id="comments" label="Comments"></vaadin-text-area>
-            </vaadin-form-layout>
-            <form-buttons-bar id="action-buttons"></form-buttons-bar>`;
-    }
+  render() {
+    return html`
+      <vaadin-form-layout id="form">
+        <vaadin-text-field id="email" label="Email (login)" colspan="2"></vaadin-text-field>
+        <vaadin-text-field id="first-name" label="First Name"></vaadin-text-field>
+        <vaadin-text-field id="last-name" label="Last Name"></vaadin-text-field>
+        <vaadin-text-area id="comments" label="Comments"></vaadin-text-area>
+      </vaadin-form-layout>
+      <form-buttons-bar id="action-buttons"></form-buttons-bar>
+    `;
+  }
 }
 
 customElements.define('user-form', UserForm);
@@ -189,13 +190,14 @@ import '@vaadin/grid';
 import './user-form.js';
 
 class MainView extends LitElement {
-    render() {
-        return html`
-            <div id="main-container">
-                <vaadin-grid id="users-grid"></vaadin-grid>
-                <user-form id="user-form"></user-form>
-            </div>`;
-    }
+  render() {
+    return html`
+      <div id="main-container">
+        <vaadin-grid id="users-grid"></vaadin-grid>
+        <user-form id="user-form"></user-form>
+      </div>
+    `;
+  }
 }
 
 customElements.define('main-view', MainView);

--- a/articles/create-ui/templates/basic.asciidoc
+++ b/articles/create-ui/templates/basic.asciidoc
@@ -25,15 +25,15 @@ import '@vaadin/text-field';
 import '@axa-ch/input-text';
 
 class HelloWorld extends LitElement {
-
-    render() {
-        return html`
-            <div>
-                <vaadin-text-field id="firstInput"></vaadin-text-field>
-                <axa-input-text id="secondInput"></axa-input-text>
-                <vaadin-button id="helloButton">Click me!</vaadin-button>
-            </div>`;
-    }
+  render() {
+    return html`
+      <div>
+        <vaadin-text-field id="firstInput"></vaadin-text-field>
+        <axa-input-text id="secondInput"></axa-input-text>
+        <vaadin-button id="helloButton">Click me!</vaadin-button>
+      </div>
+    `;
+  }
 }
 
 customElements.define('hello-world', HelloWorld);

--- a/articles/create-ui/templates/components-in-slot.asciidoc
+++ b/articles/create-ui/templates/components-in-slot.asciidoc
@@ -23,12 +23,13 @@ pass:[<!-- vale Vaadin.Headings = YES -->]
 import { html, LitElement } from 'lit';
 
 class ComponentContainer extends LitElement {
-    get render() {
-        return html`
-            <div>
-                <slot></slot>
-            </div>`;
-    }
+  render() {
+    return html`
+      <div>
+        <slot></slot>
+      </div>
+    `;
+  }
 }
 
 customElements.define('component-container', ComponentContainer);

--- a/articles/create-ui/templates/components.asciidoc
+++ b/articles/create-ui/templates/components.asciidoc
@@ -17,17 +17,17 @@ The same logic applies to Polymer templates.
 [source,javascript]
 ----
 class MainPage extends LitElement {
-
-    render() {
-        return html`
-            <div id="content"></div>
-            <button id="helloButton">Click me!</button>`;
-    }
+  render() {
+    return html`
+      <div id="content"></div>
+      <button id="helloButton">Click me!</button>
+    `;
+  }
 }
 
 customElements.define('main-page', MainPage);
 ----
-* The `html` returns a placeholder `div`  element with a `"content"` identifier and `button` element with a `helloButton` identifier.
+* The `html` returns a placeholder `div` element with a `"content"` identifier and `button` element with a `helloButton` identifier.
 * The `div` element is mapped to a `Div` component in the Java code (see below), allowing you to add a [classname]`Component` as a child to it.
 * The `button` element is mapped to a [classname]`NativeButton` component in the Java code (see below), allowing you to react to its click events.
 

--- a/articles/create-ui/templates/limitations.asciidoc
+++ b/articles/create-ui/templates/limitations.asciidoc
@@ -26,16 +26,16 @@ To keep children, instead wrap the text content in a separate child alongside `m
 [source,javascript]
 ----
 class MainPage extends LitElement {
-
-    render() {
-        return html`
-            <div id="header">Main page</div>
-            <div id="content"></div>
-            <hr>
-            <div id="footer">
-                <a href="mailto:someone@example.com?Subject=Hello" target="_top">Send Mail</a>
-            </div>`;
-    }
+  render() {
+    return html`
+      <div id="header">Main page</div>
+      <div id="content"></div>
+      <hr>
+      <div id="footer">
+        <a href="mailto:someone@example.com?Subject=Hello" target="_top">Send Mail</a>
+      </div>
+    `;
+  }
 }
 
 customElements.define("main-page", MainPage);
@@ -107,16 +107,16 @@ public class MainLayout extends LitTemplate {
 [source,javascript]
 ----
 class MainLayout extends LitElement {
-
-    render() {
-        return html`
-           <div>
-             <vaadin-vertical-layout id="layout">
-               <vaadin-text-field id="textfield"></vaadin-text-field>
-               <vaadin-button id="button"></vaadin-button>
-             </vaadin-vertical-layout>
-            </div>`;
-    }
+  render() {
+    return html`
+      <div>
+        <vaadin-vertical-layout id="layout">
+          <vaadin-text-field id="textfield"></vaadin-text-field>
+          <vaadin-button id="button"></vaadin-button>
+        </vaadin-vertical-layout>
+      </div>
+    `;
+  }
 }
 
 customElements.define("main-layout", MainLayout);
@@ -132,13 +132,13 @@ Id-mapped components should always be disabled from the server side using the [m
 [source,javascript]
 ----
 class MainLayout extends LitElement {
- render() {
-   return html`
-       <div>
-         <vaadin-button id="button" disabled></vaadin-button>
-       </div>
-     `;
- }
+  render() {
+    return html`
+      <div>
+        <vaadin-button id="button" disabled></vaadin-button>
+      </div>
+    `;
+  }
 }
 
 customElements.define("main-layout", MainLayout);

--- a/articles/create-ui/templates/polymer/bindings.asciidoc
+++ b/articles/create-ui/templates/polymer/bindings.asciidoc
@@ -54,12 +54,15 @@ Double square brackets ([[ ]]) indicate a one-way binding.
 [source,javascript]
 ----
 class MyTemplate extends PolymerElement {
-    static get template() {
-        return html`<div>[[hostProperty]]</div>`;
-    }
+  static get template() {
+    return html`<div>[[hostProperty]]</div>`;
+  }
 
-    static get is() {return 'my-template'}
+  static get is() {
+    return 'my-template';
+  }
 }
+
 customElements.define(MyTemplate.is, MyTemplate);
 ----
 
@@ -207,70 +210,72 @@ import '@polymer/paper-checkbox/paper-checkbox.js';
 
 class TwoWayBinding extends PolymerElement {
 
-    static get template() {
-        return html`
-            <table>
-                <tr>
-                    <td>Paper name:</td>
-                    <td>
-                        <paper-input value="{{name}}"></paper-input>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Input name:</td>
-                    <td>
-                        <input value="{{name::input}}">
-                    </td>
-                </tr>
-                <tr>
-                    <td>Change name:</td>
-                    <td>
-                        <input value="{{name::change}}">
-                    </td>
-                </tr>
-                <tr>
-                    <td>Input accepted:</td>
-                    <td>
-                        <input type="checkbox" checked="{{accepted::change}}">
-                    </td>
-                </tr>
-                <tr>
-                    <td>Polymer accepted:</td>
-                    <td>
-                        <paper-checkbox checked="{{accepted}}"></paper-checkbox>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Size:</td>
-                    <td>
-                        <paper-radio-group selected="{{size}}">
-                            <paper-radio-button name="small">Small</paper-radio-button>
-                            <paper-radio-button name="medium">Medium</paper-radio-button>
-                            <paper-radio-button name="large">Large</paper-radio-button>
-                        </paper-radio-group>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Size:</td>
-                    <td>
-                        <select value="{{size::change}}">
-                            <option value="small">Small</option>
-                            <option value="medium">Medium</option>
-                            <option value="large">Large</option>
-                        </select>
-                    </td>
-                </tr>
-            </table>
-            <div>
-                <button on-click="reset">Reset values</button>
-            </div>
-            <slot></slot>`;
-    }
+  static get template() {
+    return html`
+      <table>
+        <tr>
+          <td>Paper name:</td>
+          <td>
+            <paper-input value="{{name}}"></paper-input>
+          </td>
+        </tr>
+        <tr>
+          <td>Input name:</td>
+          <td>
+            <input value="{{name::input}}">
+          </td>
+        </tr>
+        <tr>
+          <td>Change name:</td>
+          <td>
+            <input value="{{name::change}}">
+          </td>
+        </tr>
+        <tr>
+          <td>Input accepted:</td>
+          <td>
+            <input type="checkbox" checked="{{accepted::change}}">
+          </td>
+        </tr>
+        <tr>
+          <td>Polymer accepted:</td>
+          <td>
+            <paper-checkbox checked="{{accepted}}"></paper-checkbox>
+          </td>
+        </tr>
+        <tr>
+          <td>Size:</td>
+          <td>
+            <paper-radio-group selected="{{size}}">
+              <paper-radio-button name="small">Small</paper-radio-button>
+              <paper-radio-button name="medium">Medium</paper-radio-button>
+              <paper-radio-button name="large">Large</paper-radio-button>
+            </paper-radio-group>
+          </td>
+        </tr>
+        <tr>
+          <td>Size:</td>
+          <td>
+            <select value="{{size::change}}">
+              <option value="small">Small</option>
+              <option value="medium">Medium</option>
+              <option value="large">Large</option>
+            </select>
+          </td>
+        </tr>
+      </table>
+      <div>
+        <button on-click="reset">Reset values</button>
+      </div>
+      <slot></slot>
+    `;
+  }
 
-    static get is() {
-        return 'two-way-template';
-    }
+  static get is() {
+    return 'two-way-template';
+  }
 }
+
 customElements.define(TwoWayBinding.is, TwoWayBinding);
 ----
 

--- a/articles/create-ui/templates/polymer/event-handlers.asciidoc
+++ b/articles/create-ui/templates/polymer/event-handlers.asciidoc
@@ -26,23 +26,26 @@ Note that the method name should not have any arguments or parentheses.
 
 pass:[<!-- vale Vale.Spelling = YES -->]
 
-*Example*: Defining an event handler in the [classname]`EventhandlerDemo` JavaScript Polymer template.
+*Example*: Defining an event handler in the [classname]`EventHandlerDemo` JavaScript Polymer template.
 
 [source,javascript]
 ----
-class EventhandlerDemo extends PolymerElement {
-    static get template() {
-        return html`<button on-click="handleClick">Say hello</button>`;
-    }
+class EventHandlerDemo extends PolymerElement {
+  static get template() {
+    return html`<button on-click="handleClick">Say hello</button>`;
+  }
 
-    static get is() {return 'eventhandler-demo'}
+  static get is() {
+    return 'event-handler-demo'
+  }
 
-    handleClick() {
-      console.log('Button was clicked.');
-      window.alert('Hello');
-    }
+  handleClick() {
+    console.log('Button was clicked.');
+    window.alert('Hello');
+  }
 }
-customElements.define(XCustom.is, XCustom);
+
+customElements.define(EventHandlerDemo.is, EventHandlerDemo);
 ----
 
 * This defines a `<button>` click that displays an alert in the browser.
@@ -63,11 +66,15 @@ You can use the `@EventHandler` annotation to handle DOM events defined in a Pol
 [source,javascript]
 ----
 class EventHandler extends PolymerElement {
-    static get template() {
-        return html`<button on-click="handleClick">Click me</button>`;
-    }
-    static get is() { return 'event-handler' }
+  static get template() {
+    return html`<button on-click="handleClick">Click me</button>`;
+  }
+
+  static get is() {
+    return 'event-handler';
+  }
 }
+
 customElements.define(EventHandler.is, EventHandler);
 ----
 
@@ -185,14 +192,21 @@ public class ModelItemHandlerPolymerTemplate
 [source,javascript]
 ----
 class ModelItemHandler extends PolymerElement {
-    static get template() {
-        return html`
-            <dom-repeat items="[[messages]]">
-                <template><div class='msg' on-click="handleClick">[[item.text]]</div></template>
-            </dom-repeat>`;
-    }
-    static get is() { return 'model-item-handler' }
+  static get template() {
+    return html`
+      <dom-repeat items="[[messages]]">
+        <template>
+          <div class='msg' on-click="handleClick">[[item.text]]</div>
+        </template>
+      </dom-repeat>
+    `;
+  }
+
+  static get is() {
+    return 'model-item-handler';
+  }
 }
+
 customElements.define(ModelItemHandler.is, ModelItemHandler);
 ----
 * When the item is clicked, the [methodname]`handleClick()` method is called on the server side and the data is identified by `event.model.item`.
@@ -242,22 +256,25 @@ To demonstrate the point clearly, the following example shows the incorrect way 
 [source,javascript]
 ----
 class ContactHandler extends PolymerElement {
+  static get template() {
+    return html`
+      <input id="name" type="text">
+      <button on-click="onClick">Send the contact</button>
+    `;
+  }
 
-    static get template() {
-        return html`
-            <input id="name" type="text">
-            <button on-click="onClick">Send the contact</button>`;
-    }
+  static get is() {
+    return 'contact-handler';
+  }
 
-    static get is() { return 'contact-handler' }
-
-    onClick(event) {
-        this.userInfo.name = this.$.name.value;
-        event.detail = {
-            userInfo: this.userInfo,
-        };
-    }
+  onClick(event) {
+    this.userInfo.name = this.$.name.value;
+    event.detail = {
+      userInfo: this.userInfo,
+    };
+  }
 }
+
 customElements.define(ContactHandler.is, ContactHandler);
 ----
 * This example results in the server-side model and the client being out of sync, because the client-side model is not updated correctly.
@@ -298,21 +315,21 @@ When this method is defined for the component, it is called each time the compon
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 
 class MyComponent extends PolymerElement {
+  static get template() {
+    return html`
+      <div>
+        <div>[[text]]</div>
+      </div>
+    `;
+  }
 
-    static get template() {
-        return html`
-            <div>
-                <div>[[text]]</div>
-            </div>`;
-    }
+  static get is() {
+    return 'my-component';
+  }
 
-    static get is() {
-          return 'my-component';
-    }
-
-    afterServerUpdate(){
-        console.log("The new 'text' value is: "+this.text);
-    }
+  afterServerUpdate(){
+    console.log("The new 'text' value is: " + this.text);
+  }
 }
 
 customElements.define(MyComponent.is, MyComponent);

--- a/articles/create-ui/templates/polymer/list-bindings.asciidoc
+++ b/articles/create-ui/templates/polymer/list-bindings.asciidoc
@@ -19,26 +19,30 @@ Polymer allows you to generate elements based on a list of items using a templat
 [source,javascript]
 ----
 class EmployeesList extends PolymerElement {
-    static get template() {
-        return html`
-            <table>
-                <tr on-click="processElement">
-                    <th>Name</th><th>Title</th><th>Email</th>
-                </tr>
-                <dom-repeat items="[[employees]]">
-                    <template>
-                        <tr on-click="handleClick" id="[[item.name]]">
-                            <td>{{item.name}}</td>
-                            <td>{{item.title}}</td>
-                            <td>{{item.email}}</td>
-                        </tr>
-                    </template>
-                </dom-repeat>
-            </table>`;
-    }
+  static get template() {
+    return html`
+      <table>
+        <tr on-click="processElement">
+          <th>Name</th><th>Title</th><th>Email</th>
+        </tr>
+        <dom-repeat items="[[employees]]">
+          <template>
+            <tr on-click="handleClick" id="[[item.name]]">
+              <td>[[item.name]]</td>
+              <td>[[item.title]]</td>
+              <td>[[item.email]]</td>
+            </tr>
+          </template>
+        </dom-repeat>
+      </table>
+    `;
+  }
 
-    static get is() {return 'employees-list'}
+  static get is() {
+    return 'employees-list';
+  }
 }
+
 customElements.define(EmployeesList.is, EmployeesList);
 ----
 * The `<dom-repeat>` element marks the content that is generated for each item in a list.
@@ -154,18 +158,19 @@ This means that client-side changes to the list property are not sent to the ser
 [source,javascript]
 ----
 class MyTemplate extends PolymerElement {
-    static get properties() {
-        return {
-            messages: {
-                type: Array,
-                value: [],
-                notify: true
-            }
-        };
-    }
-    addItem() {
-        this.push('messages', 'foo');
-    }
+  static get properties() {
+    return {
+      messages: {
+        type: Array,
+        value: () => [],
+        notify: true
+      }
+    };
+  }
+
+  addItem() {
+    this.push('messages', 'foo');
+  }
 }
 ----
 * An update to the [propertyname]`messages` property will NOT be sent to the server when the [methodname]`addItem()` method is called.

--- a/articles/create-ui/templates/polymer/model-bean.asciidoc
+++ b/articles/create-ui/templates/polymer/model-bean.asciidoc
@@ -26,30 +26,31 @@ A typical use case for using beans in a model is a form that allows the user to 
 [source,javascript]
 ----
 class MyForm extends PolymerElement {
-    static get template() {
-        return html`
-            <div>
-                <div>
-                    <span>First name</span>
-                    <input value="{{person.firstName}}" />
-                </div>
-                <div>
-                    <span>Last name</span>
-                    <input value="{{person.lastName}}" />
-                </div>
-                <div>
-                    <span>Age</span>
-                    <input value="{{person.age}}" />
-                </div>
-            </div>
-            <div>
-                <button on-click="setNameToJeff">Set Name To Jeff</button>
-            </div>`;
-    }
+  static get template() {
+    return html`
+      <div>
+        <div>
+          <span>First name</span>
+          <input value="{{person.firstName}}" />
+        </div>
+        <div>
+          <span>Last name</span>
+          <input value="{{person.lastName}}" />
+        </div>
+        <div>
+          <span>Age</span>
+          <input value="{{person.age}}" />
+        </div>
+      </div>
+      <div>
+        <button on-click="setNameToJeff">Set Name To Jeff</button>
+      </div>
+    `;
+  }
 
-    static get is() {
-        return 'my-form'
-    }
+  static get is() {
+    return 'my-form';
+  }
 }
 
 customElements.define(MyForm.is, MyForm);

--- a/articles/create-ui/templates/polymer/model-encoders.asciidoc
+++ b/articles/create-ui/templates/polymer/model-encoders.asciidoc
@@ -179,14 +179,15 @@ public class DateToDateBeanEncoder implements ModelEncoder<Date, DateBean> {
 [source,javascript]
 ----
 static get template() {
-    return html`
-        <div style="width: 200px;">
-            <label>Birth date:</label>
-            <label for="day">Enter your birthday:</label><paper-input id="day" value="{{birthDate.day}}"></paper-input>
-            <label for="month">Enter the month of your birthday:</label><paper-input id="month" value="{{birthDate.month}}"></paper-input>
-            <label for="year">Enter the year of your birthday:</label><paper-input id="year" value="{{birthDate.year}}"></paper-input>
-            <button on-click="commit" id="commit">Commit</button>
-        </div>`;
+  return html`
+    <div style="width: 200px;">
+      <label>Birth date:</label>
+      <label for="day">Enter your birthday:</label><paper-input id="day" value="{{birthDate.day}}"></paper-input>
+      <label for="month">Enter the month of your birthday:</label><paper-input id="month" value="{{birthDate.month}}"></paper-input>
+      <label for="year">Enter the year of your birthday:</label><paper-input id="year" value="{{birthDate.year}}"></paper-input>
+      <button on-click="commit" id="commit">Commit</button>
+    </div>
+  `;
 }
 ----
 

--- a/articles/create-ui/templates/polymer/parent-layout.asciidoc
+++ b/articles/create-ui/templates/polymer/parent-layout.asciidoc
@@ -19,19 +19,22 @@ A `PolymerTemplate` can be used as a parent layout by using the `<slot>` in the 
 [source,javascript]
 ----
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+
 class MainLayout extends PolymerElement {
-    static get template() {
-        return html`
-            <h1>Site title</h1>
-            <div class="menu">...</div>
-            <!-- child content comes here -->
-            <slot></slot>
-        `;
-    }
-    static get is() {
-        return 'main-layout'
-    }
+  static get template() {
+    return html`
+      <h1>Site title</h1>
+      <div class="menu">...</div>
+      <!-- child content comes here -->
+      <slot></slot>
+    `;
+  }
+
+  static get is() {
+    return 'main-layout';
+  }
 }
+
 customElements.define(MainLayout.is, MainLayout);
 ----
 

--- a/articles/create-ui/templates/polymer/polymer-template-and-binder.asciidoc
+++ b/articles/create-ui/templates/polymer/polymer-template-and-binder.asciidoc
@@ -25,25 +25,26 @@ import '@vaadin/checkbox';
 import '@vaadin/form-layout';
 import '@vaadin/text-area';
 import '@vaadin/text-field';
-import './form-buttons-bar.js'
+import './form-buttons-bar.js';
 
 class UserForm extends PolymerElement {
-    static get template() {
-        return html`
-            <style>
-            </style>
-            <vaadin-form-layout id="form">
-                <vaadin-text-field id="email" label="Email (login)" colspan="2"></vaadin-text-field>
-                <vaadin-text-field id="first-name" label="First Name"></vaadin-text-field>
-                <vaadin-text-field id="last-name" label="Last Name"></vaadin-text-field>
-                <vaadin-text-area id="comments" label="Comments"></vaadin-text-area>
-            </vaadin-form-layout>
-            <form-buttons-bar id="action-buttons"></form-buttons-bar>`;
-    }
+  static get template() {
+    return html`
+      <style>
+      </style>
+      <vaadin-form-layout id="form">
+        <vaadin-text-field id="email" label="Email (login)" colspan="2"></vaadin-text-field>
+        <vaadin-text-field id="first-name" label="First Name"></vaadin-text-field>
+        <vaadin-text-field id="last-name" label="Last Name"></vaadin-text-field>
+        <vaadin-text-area id="comments" label="Comments"></vaadin-text-area>
+      </vaadin-form-layout>
+      <form-buttons-bar id="action-buttons"></form-buttons-bar>
+    `;
+  }
 
-    static get is() {
-          return 'user-form';
-    }
+  static get is() {
+    return 'user-form';
+  }
 }
 
 customElements.define(UserForm.is, UserForm);
@@ -71,6 +72,7 @@ public class UserForm extends PolymerTemplate <UserForm.FormComponentModel> {
 
   @Id("action-buttons")
   private FormButtonsBar actionButtons;
+}
 ----
 
 == Creating and Linking the Binder
@@ -90,23 +92,24 @@ image:images/template-and-binder-first-result.png[MainView]
 [source,javascript]
 ----
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import '@vaadin/grid'
+import '@vaadin/grid';
 import './user-form.js';
 
 class MainView extends PolymerElement {
-    static get template() {
-        return html`
-            <style>
-            </style>
-            <div id="main-container">
-                <vaadin-grid id="users-grid"></vaadin-grid>
-                <user-form id="user-form"></user-form>
-            </div>`;
-    }
+  static get template() {
+    return html`
+      <style>
+      </style>
+      <div id="main-container">
+        <vaadin-grid id="users-grid"></vaadin-grid>
+        <user-form id="user-form"></user-form>
+      </div>
+    `;
+  }
 
-    static get is() {
-          return 'main-view';
-    }
+  static get is() {
+    return 'main-view';
+  }
 }
 
 customElements.define(MainView.is, MainView);

--- a/articles/create-ui/templates/polymer/polymer-template-basic.asciidoc
+++ b/articles/create-ui/templates/polymer/polymer-template-basic.asciidoc
@@ -27,19 +27,19 @@ import '@vaadin/button';
 import '@vaadin/text-field';
 
 class HelloWorld extends PolymerElement {
+  static get template() {
+    return html`
+      <div>
+        <vaadin-text-field id="firstInput"></vaadin-text-field>
+        <paper-input id="secondInput"></paper-input>
+        <vaadin-button id="helloButton">Click me!</vaadin-button>
+      </div>
+    `;
+  }
 
-    static get template() {
-        return html`
-            <div>
-                <vaadin-text-field id="firstInput"></vaadin-text-field>
-                <paper-input id="secondInput"></paper-input>
-                <vaadin-button id="helloButton">Click me!</vaadin-button>
-            </div>`;
-    }
-
-    static get is() {
-          return 'hello-world';
-    }
+  static get is() {
+    return 'hello-world';
+  }
 }
 
 customElements.define(HelloWorld.is, HelloWorld);

--- a/articles/create-ui/templates/polymer/polymer-template-components-in-slot.asciidoc
+++ b/articles/create-ui/templates/polymer/polymer-template-components-in-slot.asciidoc
@@ -25,16 +25,17 @@ pass:[<!-- vale Vaadin.Headings = YES -->]
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 
 class ComponentContainer extends PolymerElement {
-    static get template() {
-        return html`
-            <div>
-                <slot></slot>
-            </div>`;
-    }
+  static get template() {
+    return html`
+      <div>
+        <slot></slot>
+      </div>
+    `;
+  }
 
-    static get is() {
-        return 'component-container';
-    }
+  static get is() {
+    return 'component-container';
+  }
 }
 
 customElements.define(ComponentContainer.is, ComponentContainer);

--- a/articles/create-ui/templates/styling-templates.asciidoc
+++ b/articles/create-ui/templates/styling-templates.asciidoc
@@ -21,15 +21,15 @@ class MyView extends LitElement {
 
   static get styles() {
     return css`
-        :host {
-          /* Styles for the <my-view> host element */
-          display: block;
-        }
+      :host {
+        /* Styles for the <my-view> host element */
+        display: block;
+      }
 
-        .my-view-title {
-          font-weight: bold;
-          border-bottom: 1px solid gray;
-        }
+      .my-view-title {
+        font-weight: bold;
+        border-bottom: 1px solid gray;
+      }
     `;
   }
 

--- a/articles/create-ui/templates/subtemplate.asciidoc
+++ b/articles/create-ui/templates/subtemplate.asciidoc
@@ -23,12 +23,12 @@ import { html, LitElement } from 'lit';
 import 'child-template.js';
 
 class ParentTemplate extends LitElement {
-
-    render() {
-        return html`
-            <div>Parent Template</div>
-            <child-template id="childTemplate"></child-template>`;
-    }
+  render() {
+    return html`
+      <div>Parent Template</div>
+      <child-template id="childTemplate"></child-template>
+    `;
+  }
 }
 
 customElements.define('parent-template', ParentTemplate);
@@ -59,10 +59,9 @@ The `@Id` annotation mapping ensures that this instance is automatically created
 import { html, LitElement } from 'lit';
 
 class ChildTemplate extends LitElement {
-
-    render() {
-        return html`<button>Child Template</button>`;
-    }
+  render() {
+    return html`<button>Child Template</button>`;
+  }
 }
 
 customElements.define('child-template', ChildTemplate);

--- a/articles/integrations/cdi/instantiated-beans.asciidoc
+++ b/articles/integrations/cdi/instantiated-beans.asciidoc
@@ -81,13 +81,15 @@ public class DependentLabel extends Label {
 import { html, LitElement } from 'lit';
 
 class TestTemplate extends LitElement {
-    get render() {
-        return html`
-            <div>
-                <dependent-label id="label"/>
-            </div>`;
-    }
+  render() {
+    return html`
+      <div>
+        <dependent-label id="label"></dependent-label>
+      </div>
+    `;
+  }
 }
+
 customElements.define(TestTemplate.is, TestTemplate);
 ----
 

--- a/articles/tools/dspublisher/customization.asciidoc
+++ b/articles/tools/dspublisher/customization.asciidoc
@@ -116,11 +116,11 @@ If it exports a custom element class, Design System Publisher uses it to registe
 import { html, LitElement } from 'lit-element';
 
 export default class extends LitElement {
- render() {
-   return html`
-     <div>This is my custom header</div>
-   `;
- }
+  render() {
+    return html`
+      <div>This is my custom header</div>
+    `;
+  }
 }
 ----
 


### PR DESCRIPTION
## Description

- Changed the indentation of Polymer and Lit template to 2 spaces,
- Fixed a few things like self-closing tags, incorrect binding syntax,
- Also wrapped backticks, which seems to fix code highlighting:

### Before

![Screenshot 2022-09-28 at 16 06 31](https://user-images.githubusercontent.com/10589913/192786357-d73d91bf-53f8-4666-87c9-8daa40082777.png)

### After

![Screenshot 2022-09-28 at 16 06 18](https://user-images.githubusercontent.com/10589913/192786377-7fdd7d27-8d7b-4d4f-9d9a-f8e1f818355b.png)

## Note

Use "hide whitespace" checkmark when reviewing to make PR diff smaller.