### PR TITLE
docs: fix DX findings for TabSheet and Tooltip

### DIFF
--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -517,7 +517,11 @@ Tooltips on cells can be used for many different use cases:
 --
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-tooltip-generator.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-tooltip-generator.ts[render,tag=snippet,indent=0,group=TypeScript]
+
+...
+
+include::{root}/frontend/demo/component/grid/grid-tooltip-generator.ts[render,tag=snippethtml,indent=0,group=TypeScript]
 ----
 
 [source,java]

--- a/articles/components/menu-bar/index.asciidoc
+++ b/articles/components/menu-bar/index.asciidoc
@@ -294,7 +294,11 @@ When a top-level item is disabled, the corresponding tooltip is not shown.
 
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-tooltip.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-tooltip.ts[render,tag=snippet,indent=0,group=TypeScript]
+
+...
+
+include::{root}/frontend/demo/component/menubar/menu-bar-tooltip.ts[render,tag=snippethtml,indent=0,group=TypeScript]
 ----
 
 [source,java]

--- a/articles/components/tabs/index.asciidoc
+++ b/articles/components/tabs/index.asciidoc
@@ -29,7 +29,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsBasic.java[rend
 
 Use Tabs when you want to allow in-place navigation within a certain part of the UI, instead of showing everything at once or forcing the user to navigate between different views.
 
-Tabs are most conveniently used as part of a [since:com.vaadin:vaadin@V23.3]#Tab Sheet# that includes automatically switched content areas for each tab.
+[role="since:com.vaadin:vaadin@V23.3"]
+== Tab Sheet
+
+Tabs are most conveniently used as part of a Tab Sheet that includes automatically switched content areas for each tab.
 
 [.example]
 --

--- a/articles/components/tooltip/index.asciidoc
+++ b/articles/components/tooltip/index.asciidoc
@@ -1,7 +1,7 @@
 ---
 title: Tooltip
 page-links:
-  - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:tooltip}/#/elements/tooltip[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/shared/HasTooltip.html[Java]'
+  - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:tooltip}/#/elements/vaadin-tooltip[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/shared/HasTooltip.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:vaadin-tooltip}/packages/tooltip[TypeScript] / https://github.com/vaadin/flow-components/blob/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java[Java]'
 ---
 = Tooltip

--- a/frontend/demo/component/tooltip/tooltip-positioning.ts
+++ b/frontend/demo/component/tooltip/tooltip-positioning.ts
@@ -20,19 +20,19 @@ export class Example extends LitElement {
 
   render() {
     return html`
-      <!-- tag::snippet[] -->
       <vaadin-app-layout theme="narrow-drawer">
         <vaadin-drawer-toggle slot="navbar">
           <vaadin-tooltip slot="tooltip" text="Expand menu" position="end"></vaadin-tooltip>
         </vaadin-drawer-toggle>
-
         <vaadin-tabs slot="drawer" orientation="vertical">
+          <!-- tag::snippet[] -->
           <vaadin-tab>
             <a tabindex="-1">
               <vaadin-icon icon="vaadin:home"></vaadin-icon>
             </a>
             <vaadin-tooltip slot="tooltip" text="Home" position="end"></vaadin-tooltip>
           </vaadin-tab>
+          <!-- end::snippet[] -->
           <vaadin-tab>
             <a tabindex="-1">
               <vaadin-icon icon="vaadin:calendar"></vaadin-icon>
@@ -47,7 +47,6 @@ export class Example extends LitElement {
           </vaadin-tab>
         </vaadin-tabs>
       </vaadin-app-layout>
-      <!-- end::snippet[] -->
     `;
   }
 }


### PR DESCRIPTION
## Description

Fixed some DX test findings:

- Added heading for `TabSheet` to the `Tabs` page to emphasize it
- Fixed broken API docs link for `vaadin-tooltip` web component
- Changed some tooltip TS examples to have better separation
- Changed the snippet in the TS example for tooltip positioning
