### PR TITLE
chore: use type imports for demo entities

### DIFF
--- a/frontend/demo/component/accordion/accordion-summary.ts
+++ b/frontend/demo/component/accordion/accordion-summary.ts
@@ -11,7 +11,7 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import type { AccordionOpenedChangedEvent } from '@vaadin/accordion';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import { Binder, field } from '@hilla/form';
 import PersonModel from 'Frontend/generated/com/vaadin/demo/domain/PersonModel';

--- a/frontend/demo/component/app-layout/app-layout-height-auto.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-auto.ts
@@ -4,7 +4,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-height-auto')

--- a/frontend/demo/component/app-layout/app-layout-height-full.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-full.ts
@@ -4,7 +4,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-height-full')

--- a/frontend/demo/component/avatar/avatar-basic.ts
+++ b/frontend/demo/component/avatar/avatar-basic.ts
@@ -5,7 +5,7 @@ import '@vaadin/avatar';
 import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-group-basic.ts
+++ b/frontend/demo/component/avatar/avatar-group-basic.ts
@@ -4,7 +4,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar-group';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-group-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-group-bg-color.ts
+++ b/frontend/demo/component/avatar/avatar-group-bg-color.ts
@@ -4,7 +4,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar-group';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-group-bg-color')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-group-internationalisation.ts
+++ b/frontend/demo/component/avatar/avatar-group-internationalisation.ts
@@ -5,7 +5,7 @@ import '@vaadin/avatar-group';
 import type { AvatarGroupI18n } from '@vaadin/avatar-group';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-group-internationalistion')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-group-max-items.ts
+++ b/frontend/demo/component/avatar/avatar-group-max-items.ts
@@ -4,7 +4,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar-group';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-group-max-items')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -5,7 +5,7 @@ import '@vaadin/avatar';
 import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from '../../domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import * as companyLogo from '../../../../src/main/resources/images/company-logo.png';
 
 @customElement('avatar-image')

--- a/frontend/demo/component/avatar/avatar-menu-bar.ts
+++ b/frontend/demo/component/avatar/avatar-menu-bar.ts
@@ -7,7 +7,7 @@ import '@vaadin/menu-bar';
 import type { MenuBarItem } from '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-menu-bar')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-name.ts
+++ b/frontend/demo/component/avatar/avatar-name.ts
@@ -4,7 +4,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-name')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -5,7 +5,7 @@ import '@vaadin/avatar';
 import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-sizes')
 export class Example extends LitElement {

--- a/frontend/demo/component/badge/badge-highlight.ts
+++ b/frontend/demo/component/badge/badge-highlight.ts
@@ -1,6 +1,6 @@
 import { getReports, ReportStatus } from 'Frontend/demo/domain/DataService'; // hidden-source-line
 import 'Frontend/demo/init'; // hidden-source-line
-import Report from 'Frontend/generated/com/vaadin/demo/domain/Report'; // hidden-source-line
+import type Report from 'Frontend/generated/com/vaadin/demo/domain/Report'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';

--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -1,6 +1,6 @@
 import { getUserPermissions } from 'Frontend/demo/domain/DataService'; // hidden-source-line
 import 'Frontend/demo/init'; // hidden-source-line
-import UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermissions'; // hidden-source-line
+import type UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermissions'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';

--- a/frontend/demo/component/board/example-chart.ts
+++ b/frontend/demo/component/board/example-chart.ts
@@ -1,5 +1,5 @@
 import { getViewEvents } from 'Frontend/demo/domain/DataService'; // hidden-source-line
-import ViewEvent from 'Frontend/generated/com/vaadin/demo/domain/ViewEvent'; // hidden-source-line
+import type ViewEvent from 'Frontend/generated/com/vaadin/demo/domain/ViewEvent'; // hidden-source-line
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';

--- a/frontend/demo/component/board/example-statistics.ts
+++ b/frontend/demo/component/board/example-statistics.ts
@@ -1,5 +1,5 @@
 import { getServiceHealth } from 'Frontend/demo/domain/DataService';
-import ServiceHealth from 'Frontend/generated/com/vaadin/demo/domain/ServiceHealth';
+import type ServiceHealth from 'Frontend/generated/com/vaadin/demo/domain/ServiceHealth';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';

--- a/frontend/demo/component/button/button-grid.ts
+++ b/frontend/demo/component/button/button-grid.ts
@@ -11,7 +11,7 @@ import type { GridSelectedItemsChangedEvent } from '@vaadin/grid';
 import type { GridSelectionColumnSelectAllChangedEvent } from '@vaadin/grid/vaadin-grid-selection-column';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('button-grid')
 export class Example extends LitElement {

--- a/frontend/demo/component/checkbox/checkbox-custom-presentation.ts
+++ b/frontend/demo/component/checkbox/checkbox-custom-presentation.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/checkbox/checkbox-indeterminate.ts
+++ b/frontend/demo/component/checkbox/checkbox-indeterminate.ts
@@ -7,7 +7,7 @@ import '@vaadin/checkbox-group';
 import '@vaadin/vertical-layout';
 import type { CheckboxGroupValueChangedEvent } from '@vaadin/checkbox-group';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-indeterminate')

--- a/frontend/demo/component/combobox/combo-box-auto-open.ts
+++ b/frontend/demo/component/combobox/combo-box-auto-open.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-auto-open')

--- a/frontend/demo/component/combobox/combo-box-basic.ts
+++ b/frontend/demo/component/combobox/combo-box-basic.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-basic')

--- a/frontend/demo/component/combobox/combo-box-filtering-1.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-1.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-filtering-1')

--- a/frontend/demo/component/combobox/combo-box-filtering-2.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-2.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/combo-box';
 import type { ComboBoxFilterChangedEvent } from '@vaadin/combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/combobox/combo-box-placeholder.ts
+++ b/frontend/demo/component/combobox/combo-box-placeholder.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/combo-box';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-placeholder')

--- a/frontend/demo/component/combobox/combo-box-popup-width.ts
+++ b/frontend/demo/component/combobox/combo-box-popup-width.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/combo-box';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-popup-width')

--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -7,7 +7,7 @@ import { comboBoxRenderer } from '@vaadin/combo-box/lit.js';
 import type { ComboBoxLitRenderer } from '@vaadin/combo-box/lit.js';
 import type { ComboBoxFilterChangedEvent } from '@vaadin/combo-box';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-presentation')

--- a/frontend/demo/component/contextmenu/context-menu-basic.ts
+++ b/frontend/demo/component/contextmenu/context-menu-basic.ts
@@ -5,7 +5,7 @@ import '@vaadin/context-menu';
 import '@vaadin/grid';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('context-menu-basic')

--- a/frontend/demo/component/contextmenu/context-menu-dividers.ts
+++ b/frontend/demo/component/contextmenu/context-menu-dividers.ts
@@ -5,7 +5,7 @@ import '@vaadin/context-menu';
 import '@vaadin/grid';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('context-menu-dividers')

--- a/frontend/demo/component/contextmenu/context-menu-left-click.ts
+++ b/frontend/demo/component/contextmenu/context-menu-left-click.ts
@@ -6,7 +6,7 @@ import type { ContextMenuOpenedChangedEvent } from '@vaadin/context-menu';
 import '@vaadin/grid';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('context-menu-left-click')

--- a/frontend/demo/component/contextmenu/context-menu-presentation.ts
+++ b/frontend/demo/component/contextmenu/context-menu-presentation.ts
@@ -13,7 +13,7 @@ import '@vaadin/icons';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('context-menu-presentation')

--- a/frontend/demo/component/crud/crud-basic.ts
+++ b/frontend/demo/component/crud/crud-basic.ts
@@ -4,7 +4,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import '@vaadin/email-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-basic')

--- a/frontend/demo/component/crud/crud-columns.ts
+++ b/frontend/demo/component/crud/crud-columns.ts
@@ -5,7 +5,7 @@ import '@vaadin/crud';
 import '@vaadin/date-picker';
 import '@vaadin/email-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-columns')

--- a/frontend/demo/component/crud/crud-editor-aside.ts
+++ b/frontend/demo/component/crud/crud-editor-aside.ts
@@ -3,7 +3,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-editor-aside')

--- a/frontend/demo/component/crud/crud-editor-bottom.ts
+++ b/frontend/demo/component/crud/crud-editor-bottom.ts
@@ -3,7 +3,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-editor-bottom')

--- a/frontend/demo/component/crud/crud-editor-content.ts
+++ b/frontend/demo/component/crud/crud-editor-content.ts
@@ -8,7 +8,7 @@ import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import '@vaadin/email-field';
 import '@vaadin/text-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-editor-content')

--- a/frontend/demo/component/crud/crud-grid-replacement.ts
+++ b/frontend/demo/component/crud/crud-grid-replacement.ts
@@ -4,7 +4,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-grid-replacement')

--- a/frontend/demo/component/crud/crud-hidden-toolbar.ts
+++ b/frontend/demo/component/crud/crud-hidden-toolbar.ts
@@ -3,7 +3,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-hidden-toolbar')

--- a/frontend/demo/component/crud/crud-item-initialization.ts
+++ b/frontend/demo/component/crud/crud-item-initialization.ts
@@ -5,7 +5,7 @@ import '@vaadin/crud';
 import type { Crud, CrudNewEvent } from '@vaadin/crud';
 import '@vaadin/email-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-item-initialization')

--- a/frontend/demo/component/crud/crud-localization.ts
+++ b/frontend/demo/component/crud/crud-localization.ts
@@ -4,7 +4,7 @@ import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import type { Crud } from '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-localization')

--- a/frontend/demo/component/crud/crud-open-editor.ts
+++ b/frontend/demo/component/crud/crud-open-editor.ts
@@ -5,7 +5,7 @@ import '@vaadin/crud';
 import type { CrudEditedItemChangedEvent } from '@vaadin/crud';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-open-editor')

--- a/frontend/demo/component/crud/crud-sorting-filtering.ts
+++ b/frontend/demo/component/crud/crud-sorting-filtering.ts
@@ -3,7 +3,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-sorting-filtering')

--- a/frontend/demo/component/crud/crud-toolbar.ts
+++ b/frontend/demo/component/crud/crud-toolbar.ts
@@ -7,7 +7,7 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-toolbar')

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -13,7 +13,7 @@ import '@vaadin/text-field';
 import '@vaadin/vaadin-lumo-styles/sizing';
 import '@vaadin/vaadin-lumo-styles/color';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/dialog/dialog-footer.ts
+++ b/frontend/demo/component/dialog/dialog-footer.ts
@@ -9,7 +9,7 @@ import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('dialog-footer')
 export class Example extends LitElement {

--- a/frontend/demo/component/dialog/dialog-header.ts
+++ b/frontend/demo/component/dialog/dialog-header.ts
@@ -15,7 +15,7 @@ import { dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('dialog-header')
 export class Example extends LitElement {

--- a/frontend/demo/component/dialog/dialog-no-padding.ts
+++ b/frontend/demo/component/dialog/dialog-no-padding.ts
@@ -13,7 +13,7 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('dialog-no-padding')
 export class Example extends LitElement {

--- a/frontend/demo/component/dialog/dialog-resizable.ts
+++ b/frontend/demo/component/dialog/dialog-resizable.ts
@@ -10,7 +10,7 @@ import '@vaadin/vertical-layout';
 import { dialogRenderer } from '@vaadin/dialog/lit.js';
 
 import { applyTheme } from 'Frontend/generated/theme';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
 

--- a/frontend/demo/component/grid/grid-basic.ts
+++ b/frontend/demo/component/grid/grid-basic.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-basic')

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -6,7 +6,7 @@ import '@vaadin/grid';
 import type { Grid, GridCellFocusEvent } from '@vaadin/grid';
 import '@vaadin/text-area';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-cell-focus')

--- a/frontend/demo/component/grid/grid-column-alignment.ts
+++ b/frontend/demo/component/grid/grid-column-alignment.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 import { format } from 'date-fns';
 

--- a/frontend/demo/component/grid/grid-column-borders.ts
+++ b/frontend/demo/component/grid/grid-column-borders.ts
@@ -7,7 +7,7 @@ import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-column-borders')

--- a/frontend/demo/component/grid/grid-column-filtering.ts
+++ b/frontend/demo/component/grid/grid-column-filtering.ts
@@ -9,7 +9,7 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/horizontal-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 type PersonEnhanced = Person & { displayName: string };

--- a/frontend/demo/component/grid/grid-column-freezing.ts
+++ b/frontend/demo/component/grid/grid-column-freezing.ts
@@ -7,7 +7,7 @@ import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-column-freezing')

--- a/frontend/demo/component/grid/grid-column-grouping.ts
+++ b/frontend/demo/component/grid/grid-column-grouping.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-column-group.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/grid/grid-column-header-footer.ts
+++ b/frontend/demo/component/grid/grid-column-header-footer.ts
@@ -13,7 +13,7 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-column-header-footer')

--- a/frontend/demo/component/grid/grid-column-reordering-resizing.ts
+++ b/frontend/demo/component/grid/grid-column-reordering-resizing.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-column-group.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/grid/grid-column-visibility.ts
+++ b/frontend/demo/component/grid/grid-column-visibility.ts
@@ -8,7 +8,7 @@ import type { ContextMenuItem, ContextMenuItemSelectedEvent } from '@vaadin/cont
 import '@vaadin/grid';
 import '@vaadin/horizontal-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-column-visibility')

--- a/frontend/demo/component/grid/grid-column-width.ts
+++ b/frontend/demo/component/grid/grid-column-width.ts
@@ -9,7 +9,7 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/split-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/grid/grid-compact.ts
+++ b/frontend/demo/component/grid/grid-compact.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-compact')

--- a/frontend/demo/component/grid/grid-content.ts
+++ b/frontend/demo/component/grid/grid-content.ts
@@ -11,7 +11,7 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-content')

--- a/frontend/demo/component/grid/grid-context-menu.ts
+++ b/frontend/demo/component/grid/grid-context-menu.ts
@@ -10,7 +10,7 @@ import type { Grid } from '@vaadin/grid';
 import '@vaadin/item';
 import '@vaadin/list-box';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-context-menu')

--- a/frontend/demo/component/grid/grid-drag-drop-filters.ts
+++ b/frontend/demo/component/grid/grid-drag-drop-filters.ts
@@ -14,7 +14,7 @@ import type {
   GridItemModel,
 } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -7,7 +7,7 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import type { GridDragStartEvent } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-drag-rows-between-grids')

--- a/frontend/demo/component/grid/grid-dynamic-height.ts
+++ b/frontend/demo/component/grid/grid-dynamic-height.ts
@@ -12,7 +12,7 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-dynamic-height')

--- a/frontend/demo/component/grid/grid-external-filtering.ts
+++ b/frontend/demo/component/grid/grid-external-filtering.ts
@@ -13,7 +13,7 @@ import '@vaadin/icons';
 import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 type PersonEnhanced = Person & { displayName: string };

--- a/frontend/demo/component/grid/grid-item-details-toggle.ts
+++ b/frontend/demo/component/grid/grid-item-details-toggle.ts
@@ -7,7 +7,7 @@ import { columnBodyRenderer, gridRowDetailsRenderer } from '@vaadin/grid/lit.js'
 import '@vaadin/form-layout';
 import '@vaadin/text-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/grid/grid-item-details.ts
+++ b/frontend/demo/component/grid/grid-item-details.ts
@@ -8,7 +8,7 @@ import type { GridActiveItemChangedEvent } from '@vaadin/grid';
 import '@vaadin/form-layout';
 import '@vaadin/text-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/grid/grid-multi-select-mode.ts
+++ b/frontend/demo/component/grid/grid-multi-select-mode.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-selection-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/grid/grid-no-border.ts
+++ b/frontend/demo/component/grid/grid-no-border.ts
@@ -7,7 +7,7 @@ import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-no-border')

--- a/frontend/demo/component/grid/grid-no-row-border.ts
+++ b/frontend/demo/component/grid/grid-no-row-border.ts
@@ -7,7 +7,7 @@ import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-no-row-border')

--- a/frontend/demo/component/grid/grid-rich-content-sorting.ts
+++ b/frontend/demo/component/grid/grid-rich-content-sorting.ts
@@ -10,7 +10,7 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 import { differenceInYears, format, parseISO } from 'date-fns';
 

--- a/frontend/demo/component/grid/grid-row-reordering.ts
+++ b/frontend/demo/component/grid/grid-row-reordering.ts
@@ -8,7 +8,7 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import type { GridDragStartEvent, GridDropEvent } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/grid/grid-row-stripes.ts
+++ b/frontend/demo/component/grid/grid-row-stripes.ts
@@ -7,7 +7,7 @@ import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-row-stripes')

--- a/frontend/demo/component/grid/grid-single-selection-mode.ts
+++ b/frontend/demo/component/grid/grid-single-selection-mode.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import type { GridActiveItemChangedEvent } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-single-select-mode')

--- a/frontend/demo/component/grid/grid-sorting.ts
+++ b/frontend/demo/component/grid/grid-sorting.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-sorting')

--- a/frontend/demo/component/grid/grid-styling.ts
+++ b/frontend/demo/component/grid/grid-styling.ts
@@ -7,7 +7,7 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumn, GridItemModel } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/grid/grid-tooltip-generator.ts
+++ b/frontend/demo/component/grid/grid-tooltip-generator.ts
@@ -11,7 +11,7 @@ import '@vaadin/icons';
 import '@vaadin/tooltip';
 import { differenceInYears, parseISO } from 'date-fns';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-tooltip-generator')

--- a/frontend/demo/component/grid/grid-wrap-cell-content.ts
+++ b/frontend/demo/component/grid/grid-wrap-cell-content.ts
@@ -7,7 +7,7 @@ import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/gridpro/grid-pro-basic.ts
+++ b/frontend/demo/component/gridpro/grid-pro-basic.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-basic')

--- a/frontend/demo/component/gridpro/grid-pro-edit-column.ts
+++ b/frontend/demo/component/gridpro/grid-pro-edit-column.ts
@@ -8,7 +8,7 @@ import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-edit-column')

--- a/frontend/demo/component/gridpro/grid-pro-editors.ts
+++ b/frontend/demo/component/gridpro/grid-pro-editors.ts
@@ -8,7 +8,7 @@ import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { columnEditModeRenderer } from '@vaadin/grid-pro/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 import { format, parseISO } from 'date-fns';
 

--- a/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
+++ b/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-enter-next-row')

--- a/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
@@ -6,7 +6,7 @@ import '@vaadin/grid/vaadin-grid-column.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-highlight-editable-cells')

--- a/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
@@ -6,7 +6,7 @@ import '@vaadin/grid/vaadin-grid-column.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-highlight-read-only-cells')

--- a/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
+++ b/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
@@ -6,7 +6,7 @@ import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { Notification } from '@vaadin/notification';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-prevent-save')

--- a/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-single-cell-edit')

--- a/frontend/demo/component/gridpro/grid-pro-single-click.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-click.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-single-click')

--- a/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
+++ b/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
@@ -9,7 +9,7 @@ import '@vaadin/vaadin-lumo-styles/typography';
 import '@vaadin/vertical-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from '../../domain/DataService';
-import Person from '../../../generated/com/vaadin/demo/domain/Person';
+import type Person from '../../../generated/com/vaadin/demo/domain/Person';
 
 @customElement('list-box-custom-item-presentation')
 export class Example extends LitElement {

--- a/frontend/demo/component/listbox/list-box-multi-selection.ts
+++ b/frontend/demo/component/listbox/list-box-multi-selection.ts
@@ -5,7 +5,7 @@ import '@vaadin/item';
 import '@vaadin/list-box';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from '../../domain/DataService';
-import Person from '../../../generated/com/vaadin/demo/domain/Person';
+import type Person from '../../../generated/com/vaadin/demo/domain/Person';
 
 @customElement('list-box-multi-selection')
 export class Example extends LitElement {

--- a/frontend/demo/component/messages/message-list-component.ts
+++ b/frontend/demo/component/messages/message-list-component.ts
@@ -6,7 +6,7 @@ import '@vaadin/message-list';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import { format, subDays, subMinutes } from 'date-fns';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('message-list-component')
 export class Example extends LitElement {

--- a/frontend/demo/component/messages/message-list-with-theme-component.ts
+++ b/frontend/demo/component/messages/message-list-with-theme-component.ts
@@ -6,7 +6,7 @@ import '@vaadin/message-list';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import { format, subDays, subMinutes } from 'date-fns';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('message-list-component-with-theme')
 export class Example extends LitElement {

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-basic')

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/multi-select-combo-box';
 import type { MultiSelectComboBoxI18n } from '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-basic')

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-read-only')

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
@@ -7,7 +7,7 @@ import '@vaadin/multi-select-combo-box';
 import type { MultiSelectComboBoxSelectedItemsChangedEvent } from '@vaadin/multi-select-combo-box';
 import '@vaadin/text-area';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-selection-change')

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-selection')

--- a/frontend/demo/component/radiobutton/radio-button-custom-option.ts
+++ b/frontend/demo/component/radiobutton/radio-button-custom-option.ts
@@ -8,7 +8,7 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import { getCards } from 'Frontend/demo/domain/DataService';
-import Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
+import type Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-custom-option')

--- a/frontend/demo/component/radiobutton/radio-button-presentation.ts
+++ b/frontend/demo/component/radiobutton/radio-button-presentation.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/radio-group';
 import { getCards } from 'Frontend/demo/domain/DataService';
-import Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
+import type Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-presentation')

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -7,7 +7,7 @@ import '@vaadin/list-box';
 import '@vaadin/select';
 import { selectRenderer } from '@vaadin/select/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 
 const formatPersonFullName = (person: Person) => `${person.firstName} ${person.lastName}`;

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -7,7 +7,7 @@ import '@vaadin/list-box';
 import '@vaadin/select';
 import { selectRenderer } from '@vaadin/select/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-presentation')

--- a/frontend/demo/component/tree-grid/tree-grid-basic.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-basic.ts
@@ -6,7 +6,7 @@ import '@vaadin/grid';
 import type { GridDataProviderCallback, GridDataProviderParams } from '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-tree-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tree-grid-basic')

--- a/frontend/demo/component/tree-grid/tree-grid-column.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-column.ts
@@ -8,7 +8,7 @@ import type { GridDataProviderCallback, GridDataProviderParams } from '@vaadin/g
 import '@vaadin/grid/vaadin-grid-tree-column.js';
 import '@vaadin/horizontal-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tree-grid-column')

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -15,7 +15,7 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/vertical-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tree-grid-rich-content')

--- a/frontend/demo/component/virtuallist/virtual-list-basic.ts
+++ b/frontend/demo/component/virtuallist/virtual-list-basic.ts
@@ -12,7 +12,7 @@ import '@vaadin/virtual-list';
 import { virtualListRenderer } from '@vaadin/virtual-list/lit.js';
 import type { VirtualListLitRenderer } from '@vaadin/virtual-list/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('virtual-list-basic')

--- a/frontend/demo/domain/DataService.ts
+++ b/frontend/demo/domain/DataService.ts
@@ -1,10 +1,10 @@
-import Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
-import RawReport from 'Frontend/generated/com/vaadin/demo/domain/Report';
-import ServiceHealth from 'Frontend/generated/com/vaadin/demo/domain/ServiceHealth';
-import UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermissions';
-import ViewEvent from 'Frontend/generated/com/vaadin/demo/domain/ViewEvent';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import type Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
+import type RawReport from 'Frontend/generated/com/vaadin/demo/domain/Report';
+import type ServiceHealth from 'Frontend/generated/com/vaadin/demo/domain/ServiceHealth';
+import type UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermissions';
+import type ViewEvent from 'Frontend/generated/com/vaadin/demo/domain/ViewEvent';
 
 const datasetCache: { [key: string]: any[] } = {};
 async function getDataset<T>(fileName: string, count?: number): Promise<T[]> {


### PR DESCRIPTION
## Description

Changed TS components examples to use `import type` for generated entities like `Person`, `Country` etc.