### PR TITLE
docs: add TS example for configuring tooltip delays

### DIFF
--- a/articles/components/tooltip/index.asciidoc
+++ b/articles/components/tooltip/index.asciidoc
@@ -82,16 +82,37 @@ The delay before tooltips appear can be configured separately for hover and keyb
 The delay before tooltips disappear once the pointer leaves the target element can also be separately configured.
 On blur, the tooltip is closed immediately to avoid confusion when focusing another element.
 
+[.example.show-code]
+--
 [source,java]
 ----
+import com.vaadin.flow.component.shared.TooltipConfiguration;
+
 // Global delay configuration:
 TooltipConfiguration.setDefaultFocusDelay(2000);
 TooltipConfiguration.setDefaultHoverDelay(1000);
 TooltipConfiguration.setDefaultHideDelay(1000);
 
 // Overriding delays for a particular component’s tooltip:
-button.setTooltip("Home").withHoverDelay(500);
+button.setTooltipText("Home").withHoverDelay(500);
 ----
+
+[source,typescript]
+----
+import { Tooltip } from '@vaadin/tooltip';
+
+// Global delay configuration:
+Tooltip.setDefaultFocusDelay(2000);
+Tooltip.setDefaultHoverDelay(1000);
+Tooltip.setDefaultHideDelay(1000);
+
+// Overriding delays for a particular component’s tooltip:
+<vaadin-button>
+  Click me
+  <vaadin-tooltip .hoverDelay=${500} slot="tooltip" text="Home"></vaadin-tooltip>
+</vaadin-button>
+----
+--
 
 == Triggering Manually
 


### PR DESCRIPTION
## Description

Add TS example for configuring tooltip delays. Currently, there's an example for Java only.