### PR TITLE
In-Depth Course, Backend Page: Add missing import in the initial class snippet

### DIFF
--- a/articles/tutorials/in-depth-course/type-safe-server-access-with-endpoints.adoc
+++ b/articles/tutorials/in-depth-course/type-safe-server-access-with-endpoints.adoc
@@ -78,6 +78,7 @@ package com.example.application.data.endpoint;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import com.example.application.data.entity.Company;
 import com.example.application.data.entity.Contact;
 import com.example.application.data.entity.Status;


### PR DESCRIPTION
UUID import wasn't added when changed in the final fixes prior to launching Hilla: https://github.com/vaadin/docs/commit/3bc1fb572767d956bdacd3aaaf472f0e5d84a6bd

