### PR TITLE
chore: fix DemoExporter hidden lines formatting

### DIFF
--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayout.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayout.java
@@ -22,6 +22,7 @@ public class BasicLayoutsVerticalLayout extends Div {
         this.add(layout);
     }
 
-    public static class Exporter extends DemoExporter<BasicLayoutsVerticalLayout> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<BasicLayoutsVerticalLayout> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxCustomPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxCustomPresentation.java
@@ -27,6 +27,7 @@ public class CheckboxCustomPresentation extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<CheckboxCustomPresentation> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<CheckboxCustomPresentation> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentBasic.java
+++ b/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentBasic.java
@@ -15,5 +15,6 @@ public class CookieConsentBasic extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<CookieConsentBasic> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<CookieConsentBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentLocalization.java
+++ b/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentLocalization.java
@@ -19,5 +19,7 @@ public class CookieConsentLocalization extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<CookieConsentLocalization> {} // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<CookieConsentLocalization> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentTheming.java
+++ b/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentTheming.java
@@ -18,5 +18,6 @@ public class CookieConsentTheming extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<CookieConsentTheming> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<CookieConsentTheming> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerCustomValidation.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerCustomValidation.java
@@ -28,6 +28,7 @@ public class DatePickerCustomValidation extends Div {
         add(datePicker);
     }
 
-    public static class Exporter extends DemoExporter<DatePickerCustomValidation> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DatePickerCustomValidation> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDateFormatIndicator.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDateFormatIndicator.java
@@ -21,6 +21,7 @@ public class DatePickerDateFormatIndicator extends Div {
         add(datePicker);
     }
 
-    public static class Exporter extends DemoExporter<DatePickerDateFormatIndicator> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DatePickerDateFormatIndicator> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerIndividualInputFields.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerIndividualInputFields.java
@@ -92,6 +92,7 @@ public class DatePickerIndividualInputFields extends Div {
     }
     // end::snippet[]
 
-    public static class Exporter extends DemoExporter<DatePickerIndividualInputFields> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DatePickerIndividualInputFields> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInitialPosition.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInitialPosition.java
@@ -24,6 +24,7 @@ public class DatePickerInitialPosition extends Div {
         add(datePicker);
     }
 
-    public static class Exporter extends DemoExporter<DatePickerInitialPosition> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DatePickerInitialPosition> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInternationalization.java
@@ -30,6 +30,7 @@ public class DatePickerInternationalization extends Div {
         add(datePicker);
     }
 
-    public static class Exporter extends DemoExporter<DatePickerInternationalization> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DatePickerInternationalization> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerCustomValidation.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerCustomValidation.java
@@ -37,6 +37,7 @@ public class DateTimePickerCustomValidation extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<DateTimePickerCustomValidation> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerCustomValidation> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInitialPosition.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInitialPosition.java
@@ -29,6 +29,8 @@ public class DateTimePickerInitialPosition extends Div {
         // end::snippet[]
         add(dateTimePicker);
     }
-    public static class Exporter extends DemoExporter<DateTimePickerInitialPosition> { // hidden-source-line
+
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerInitialPosition> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInputFormat.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInputFormat.java
@@ -20,6 +20,7 @@ public class DateTimePickerInputFormat extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<DateTimePickerInputFormat> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerInputFormat> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInternationalization.java
@@ -31,6 +31,7 @@ public class DateTimePickerInternationalization extends Div {
         add(dateTimePicker);
     }
 
-    public static class Exporter extends DemoExporter<DateTimePickerInternationalization> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerInternationalization> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinutesStep.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinutesStep.java
@@ -22,6 +22,7 @@ public class DateTimePickerMinutesStep extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<DateTimePickerMinutesStep> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerMinutesStep> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerSecondsStep.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerSecondsStep.java
@@ -22,6 +22,7 @@ public class DateTimePickerSecondsStep extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<DateTimePickerSecondsStep> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerSecondsStep> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerWeekNumbers.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerWeekNumbers.java
@@ -18,6 +18,8 @@ public class DateTimePickerWeekNumbers extends Div {
         // end::snippet[]
         add(dateTimePicker);
     }
-    public static class Exporter extends DemoExporter<DateTimePickerWeekNumbers> { // hidden-source-line
+
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerWeekNumbers> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogBasic.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogBasic.java
@@ -62,6 +62,6 @@ public class DialogBasic extends Div {
         return saveButton;
     }
 
-    public static class Exporter extends DemoExporter<DialogBasic> {
+    public static class Exporter extends DemoExporter<DialogBasic> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogClosing.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogClosing.java
@@ -48,7 +48,6 @@ public class DialogClosing extends Div {
         return dialogLayout;
     }
 
-    public static class Exporter // hidden-source-line
-            extends DemoExporter<DialogClosing> { // hidden-source-line
+    public static class Exporter extends DemoExporter<DialogClosing> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogDraggable.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogDraggable.java
@@ -70,7 +70,6 @@ public class DialogDraggable extends Div {
         dialog.getFooter().add(saveButton);
     }
 
-    public static class Exporter // hidden-source-line
-            extends DemoExporter<DialogDraggable> { // hidden-source-line
+    public static class Exporter extends DemoExporter<DialogDraggable> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogFooter.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogFooter.java
@@ -35,7 +35,6 @@ public class DialogFooter extends Div {
         add(dialog, button);
     }
 
-    public static class Exporter // hidden-source-line
-            extends DemoExporter<DialogFooter> { // hidden-source-line
+    public static class Exporter extends DemoExporter<DialogFooter> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogHeader.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogHeader.java
@@ -60,7 +60,6 @@ public class DialogHeader extends Div {
         return fieldLayout;
     }
 
-    public static class Exporter // hidden-source-line
-            extends DemoExporter<DialogHeader> { // hidden-source-line
+    public static class Exporter extends DemoExporter<DialogHeader> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogResizable.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogResizable.java
@@ -52,7 +52,6 @@ public class DialogResizable extends Div {
         return dialogLayout;
     }
 
-    public static class Exporter // hidden-source-line
-            extends DemoExporter<DialogResizable> { // hidden-source-line
+    public static class Exporter extends DemoExporter<DialogResizable> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightEditableCells.java
+++ b/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightEditableCells.java
@@ -33,6 +33,7 @@ public class GridProThemeHighlightEditableCells extends Div {
         add(grid);
     }
 
-    public static class Exporter extends DemoExporter<GridProThemeHighlightEditableCells> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<GridProThemeHighlightEditableCells> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightReadOnlyCells.java
+++ b/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightReadOnlyCells.java
@@ -33,6 +33,7 @@ public class GridProThemeHighlightReadOnlyCells extends Div {
         add(grid);
     }
 
-    public static class Exporter extends DemoExporter<GridProThemeHighlightReadOnlyCells> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<GridProThemeHighlightReadOnlyCells> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/listbox/ListBoxCustomItemPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/listbox/ListBoxCustomItemPresentation.java
@@ -51,6 +51,7 @@ public class ListBoxCustomItemPresentation extends Div {
         add(listBox);
     }
 
-    public static class Exporter extends DemoExporter<ListBoxCustomItemPresentation> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ListBoxCustomItemPresentation> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginAdditionalInformation.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginAdditionalInformation.java
@@ -22,5 +22,8 @@ public class LoginAdditionalInformation extends Div {
         // Prevent the example from stealing focus when browsing the documentation
         loginOverlay.getElement().setAttribute("no-autofocus", "");
     }
-    public static class Exporter extends DemoExporter<LoginAdditionalInformation> {} // hidden-source-line
+
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<LoginAdditionalInformation> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginBasic.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginBasic.java
@@ -24,5 +24,6 @@ public class LoginBasic extends Div {
         loginForm.getElement().setAttribute("no-autofocus", "");
     }
 
-    public static class Exporter extends DemoExporter<LoginBasic> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<LoginBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java
@@ -41,5 +41,7 @@ public class LoginInternationalization extends Div {
         loginForm.getElement().setAttribute("no-autofocus", "");
     }
 
-    public static class Exporter extends DemoExporter<LoginInternationalization> {} // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+                DemoExporter<LoginInternationalization> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginOverlayBasic.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginOverlayBasic.java
@@ -22,5 +22,6 @@ public class LoginOverlayBasic extends Div {
         add(login);
     }
 
-    public static class Exporter extends DemoExporter<LoginOverlayBasic> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<LoginOverlayBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginOverlayHeader.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginOverlayHeader.java
@@ -20,5 +20,6 @@ public class LoginOverlayHeader extends Div {
         loginOverlay.getElement().setAttribute("no-autofocus", "");
     }
 
-    public static class Exporter extends DemoExporter<LoginOverlayHeader> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<LoginOverlayHeader> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java
@@ -41,5 +41,7 @@ public class LoginOverlayInternationalization extends Div {
         loginOverlay.getElement().setAttribute("no-autofocus", "");
     }
 
-    public static class Exporter extends DemoExporter<LoginOverlayInternationalization> {} // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<LoginOverlayInternationalization> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginRichContent.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginRichContent.java
@@ -21,5 +21,6 @@ public class LoginRichContent extends Div {
         loginForm.getElement().setAttribute("no-autofocus", "");
     }
 
-    public static class Exporter extends DemoExporter<LoginRichContent> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<LoginRichContent> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginValidation.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginValidation.java
@@ -19,5 +19,6 @@ public class LoginValidation extends Div {
         loginOverlay.getElement().setAttribute("no-autofocus", "");
     }
 
-    public static class Exporter extends DemoExporter<LoginValidation> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<LoginValidation> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/map/MapBasic.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapBasic.java
@@ -16,5 +16,6 @@ public class MapBasic extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<MapBasic> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<MapBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/map/MapEvents.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapEvents.java
@@ -109,5 +109,6 @@ public class MapEvents extends VerticalLayout {
         }
     }
 
-    public static class Exporter extends DemoExporter<MapEvents> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<MapEvents> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/map/MapLayers.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapLayers.java
@@ -128,5 +128,6 @@ public class MapLayers extends Div {
         add(new HorizontalLayout(backgroundLayerGroup, overlayLayerGroup));
     }
 
-    public static class Exporter extends DemoExporter<MapLayers> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<MapLayers> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/map/MapMarkers.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapMarkers.java
@@ -57,5 +57,6 @@ public class MapMarkers extends Div {
         usOffice.setIcon(Icons.US_FLAG_ICON); // hidden-source-line
     }
 
-    public static class Exporter extends DemoExporter<MapMarkers> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<MapMarkers> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/map/MapSources.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapSources.java
@@ -100,5 +100,6 @@ public class MapSources extends VerticalLayout {
     }
     // end::snippet[]
 
-    public static class Exporter extends DemoExporter<MapSources> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<MapSources> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java
@@ -17,5 +17,6 @@ public class MapThemeBorderless extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<MapThemeBorderless> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<MapThemeBorderless> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/map/MapViewport.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapViewport.java
@@ -73,5 +73,6 @@ public class MapViewport extends VerticalLayout {
         setPadding(false);
     }
 
-    public static class Exporter extends DemoExporter<MapViewport> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<MapViewport> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/messages/MessageListWithThemeComponent.java
+++ b/src/main/java/com/vaadin/demo/component/messages/MessageListWithThemeComponent.java
@@ -37,6 +37,7 @@ public class MessageListWithThemeComponent extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<MessageListWithThemeComponent> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<MessageListWithThemeComponent> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStepperControls.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStepperControls.java
@@ -45,6 +45,7 @@ public class NumberFieldStepperControls extends FormLayout {
         addFormItem(infantsField, "Infants");
     }
 
-    public static class Exporter extends DemoExporter<NumberFieldStepperControls> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<NumberFieldStepperControls> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarCompletionTime.java
+++ b/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarCompletionTime.java
@@ -26,6 +26,7 @@ public class ProgressBarCompletionTime extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<ProgressBarCompletionTime> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ProgressBarCompletionTime> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarIndeterminate.java
+++ b/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarIndeterminate.java
@@ -22,6 +22,7 @@ public class ProgressBarIndeterminate extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<ProgressBarIndeterminate> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ProgressBarIndeterminate> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarThemeVariants.java
+++ b/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarThemeVariants.java
@@ -50,6 +50,7 @@ public class ProgressBarThemeVariants extends VerticalLayout {
         add(progressBarErrorWrapper);
     }
 
-    public static class Exporter extends DemoExporter<ProgressBarThemeVariants> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ProgressBarThemeVariants> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutInitialSplitterPosition.java
+++ b/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutInitialSplitterPosition.java
@@ -23,6 +23,7 @@ public class SplitLayoutInitialSplitterPosition extends Div {
         add(splitLayout);
     }
 
-    public static class Exporter extends DemoExporter<SplitLayoutInitialSplitterPosition> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<SplitLayoutInitialSplitterPosition> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutMinimalThemeVariants.java
+++ b/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutMinimalThemeVariants.java
@@ -22,6 +22,7 @@ public class SplitLayoutMinimalThemeVariants extends Div {
         add(splitLayout);
     }
 
-    public static class Exporter extends DemoExporter<SplitLayoutMinimalThemeVariants> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<SplitLayoutMinimalThemeVariants> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutThemeVariants.java
+++ b/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutThemeVariants.java
@@ -22,6 +22,7 @@ public class SplitLayoutThemeVariants extends Div {
         add(splitLayout);
     }
 
-    public static class Exporter extends DemoExporter<SplitLayoutThemeVariants> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<SplitLayoutThemeVariants> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/timepicker/TimePickerCustomValidation.java
+++ b/src/main/java/com/vaadin/demo/component/timepicker/TimePickerCustomValidation.java
@@ -33,6 +33,7 @@ public class TimePickerCustomValidation extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<TimePickerCustomValidation> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<TimePickerCustomValidation> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/tooltip/TooltipPositioning.java
+++ b/src/main/java/com/vaadin/demo/component/tooltip/TooltipPositioning.java
@@ -53,5 +53,6 @@ public class TooltipPositioning extends AppLayout {
         return tab;
     }
 
-    public static class Exporter extends DemoExporter<TooltipPositioning> {} // hidden-source-line
+    public static class Exporter extends DemoExporter<TooltipPositioning> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/treegrid/TreeGridBasic.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/TreeGridBasic.java
@@ -28,5 +28,7 @@ public class TreeGridBasic extends Div {
     public List<Person> getStaff(Person manager) {
         return DataService.getPeople(manager.getId());
     }
-    public static class Exporter extends DemoExporter<TreeGridBasic> {} // hidden-source-line
+
+    public static class Exporter extends DemoExporter<TreeGridBasic> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/treegrid/TreeGridColumn.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/TreeGridColumn.java
@@ -47,5 +47,7 @@ public class TreeGridColumn extends Div {
     public List<Person> getStaff(Person manager) {
         return DataService.getPeople(manager.getId());
     }
-    public static class Exporter extends DemoExporter<TreeGridColumn> {} // hidden-source-line
+
+    public static class Exporter extends DemoExporter<TreeGridColumn> { // hidden-source-line
+    } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java
@@ -96,5 +96,7 @@ public class TreeGridRichContent extends Div {
     public List<Person> getStaff(Person manager) {
         return DataService.getPeople(manager.getId());
     }
-    public static class Exporter extends DemoExporter<TreeGridRichContent> {} // hidden-source-line
+
+    public static class Exporter extends DemoExporter<TreeGridRichContent> { // hidden-source-line
+    } // hidden-source-line
 }


### PR DESCRIPTION
## Description

Fixed formatting for `DemoExporter` hidden source lines in Java examples after `mvn formatter:format`.