### PR TITLE
chore: do not use ElementConstants for inline styles

### DIFF
--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionContent.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionContent.java
@@ -5,7 +5,6 @@ import com.vaadin.flow.component.accordion.AccordionPanel;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
@@ -51,7 +50,7 @@ public class AccordionContent extends Div {
 
     private Anchor createStyledAnchor(String href, String text) {
         Anchor anchor = new Anchor(href, text);
-        anchor.getStyle().set(ElementConstants.STYLE_COLOR, "var(--lumo-primary-text-color)");
+        anchor.getStyle().set("color", "var(--lumo-primary-text-color)");
         anchor.getStyle().set("text-decoration", "none");
 
         return anchor;

--- a/src/main/java/com/vaadin/demo/component/details/DetailsContent.java
+++ b/src/main/java/com/vaadin/demo/component/details/DetailsContent.java
@@ -4,7 +4,6 @@ import com.vaadin.flow.component.details.Details;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
@@ -49,8 +48,7 @@ public class DetailsContent extends Div {
 
     private Anchor createStyledAnchor(String href, String text) {
         Anchor anchor = new Anchor(href, text);
-        anchor.getStyle().set(ElementConstants.STYLE_COLOR,
-                "var(--lumo-primary-text-color)");
+        anchor.getStyle().set("color", "var(--lumo-primary-text-color)");
         anchor.getStyle().set("text-decoration", "none");
 
         return anchor;

--- a/src/main/java/com/vaadin/demo/component/details/DetailsSummary.java
+++ b/src/main/java/com/vaadin/demo/component/details/DetailsSummary.java
@@ -10,7 +10,6 @@ import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.textfield.TextField;
-import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.domain.Country;
 import com.vaadin.demo.domain.DataService;
@@ -25,16 +24,13 @@ public class DetailsSummary extends Div {
         summary.setSpacing(false);
 
         Icon icon = VaadinIcon.EXCLAMATION_CIRCLE.create();
-        icon.getStyle().set(ElementConstants.STYLE_WIDTH,
-                "var(--lumo-icon-size-s)");
-        icon.getStyle().set(ElementConstants.STYLE_HEIGHT,
-                "var(--lumo-icon-size-s)");
+        icon.getStyle().set("width", "var(--lumo-icon-size-s)");
+        icon.getStyle().set("height", "var(--lumo-icon-size-s)");
 
         HorizontalLayout errorBadge = new HorizontalLayout(icon,
                 new Span(" 2 errors"));
         errorBadge.setSpacing(false);
-        errorBadge.getStyle().set(ElementConstants.STYLE_COLOR,
-                "var(--lumo-error-text-color)");
+        errorBadge.getStyle().set("color", "var(--lumo-error-text-color)");
         errorBadge.getStyle().set("margin-left", "var(--lumo-space-s)");
 
         summary.add(new Text("Contact information"), errorBadge);


### PR DESCRIPTION
## Description

Removed usage of `ElementConstants` from several Java examples for consistency.

IMO it's ok to use `getStyle().set("color", "var(--lumo-primary-text-color)")`.
This also makes the code slightly more readable by not wrapping in 2 lines.