### PR TITLE
chore: reindent Java examples using 4 spaces (part 6)

### DIFF
--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java
@@ -16,53 +16,51 @@ import com.vaadin.flow.router.RouterLink;
 // tag::snippet[]
 public class AppLayoutBasic extends AppLayout {
 
-  public AppLayoutBasic() {
-    DrawerToggle toggle = new DrawerToggle();
+    public AppLayoutBasic() {
+        DrawerToggle toggle = new DrawerToggle();
 
-    H1 title = new H1("MyApp");
-    title.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("margin", "0");
+        H1 title = new H1("MyApp");
+        title.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("margin", "0");
 
-    Tabs tabs = getTabs();
+        Tabs tabs = getTabs();
 
-    addToDrawer(tabs);
-    addToNavbar(toggle, title);
-  }
-  // end::snippet[]
+        addToDrawer(tabs);
+        addToNavbar(toggle, title);
+    }
+    // end::snippet[]
 
-  private Tabs getTabs() {
-    Tabs tabs = new Tabs();
-    tabs.add(
-      createTab(VaadinIcon.DASHBOARD, "Dashboard"),
-      createTab(VaadinIcon.CART, "Orders"),
-      createTab(VaadinIcon.USER_HEART, "Customers"),
-      createTab(VaadinIcon.PACKAGE, "Products"),
-      createTab(VaadinIcon.RECORDS, "Documents"),
-      createTab(VaadinIcon.LIST, "Tasks"),
-      createTab(VaadinIcon.CHART, "Analytics")
-    );
-    tabs.setOrientation(Tabs.Orientation.VERTICAL);
-    return tabs;
-  }
+    private Tabs getTabs() {
+        Tabs tabs = new Tabs();
+        tabs.add(createTab(VaadinIcon.DASHBOARD, "Dashboard"),
+                createTab(VaadinIcon.CART, "Orders"),
+                createTab(VaadinIcon.USER_HEART, "Customers"),
+                createTab(VaadinIcon.PACKAGE, "Products"),
+                createTab(VaadinIcon.RECORDS, "Documents"),
+                createTab(VaadinIcon.LIST, "Tasks"),
+                createTab(VaadinIcon.CHART, "Analytics"));
+        tabs.setOrientation(Tabs.Orientation.VERTICAL);
+        return tabs;
+    }
 
-  private Tab createTab(VaadinIcon viewIcon, String viewName) {
-    Icon icon = viewIcon.create();
-    icon.getStyle()
-            .set("box-sizing", "border-box")
-            .set("margin-inline-end", "var(--lumo-space-m)")
-            .set("margin-inline-start", "var(--lumo-space-xs)")
-            .set("padding", "var(--lumo-space-xs)");
+    private Tab createTab(VaadinIcon viewIcon, String viewName) {
+        Icon icon = viewIcon.create();
+        icon.getStyle().set("box-sizing", "border-box")
+                .set("margin-inline-end", "var(--lumo-space-m)")
+                .set("margin-inline-start", "var(--lumo-space-xs)")
+                .set("padding", "var(--lumo-space-xs)");
 
-    RouterLink link = new RouterLink();
-    link.add(icon, new Span(viewName));
-    // Demo has no routes
-    // link.setRoute(viewClass.java);
-    link.setTabIndex(-1);
+        RouterLink link = new RouterLink();
+        link.add(icon, new Span(viewName));
+        // Demo has no routes
+        // link.setRoute(viewClass.java);
+        link.setTabIndex(-1);
 
-    return new Tab(link);
-  }
-  public static class Exporter extends DemoExporter<AppLayoutBasic> {} // hidden-source-line
-  // tag::snippet[]
+        return new Tab(link);
+    }
+
+    public static class Exporter extends DemoExporter<AppLayoutBasic> { // hidden-source-line
+    } // hidden-source-line
+      // tag::snippet[]
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBottomNavbar.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBottomNavbar.java
@@ -18,54 +18,55 @@ import com.vaadin.flow.router.RouterLink;
 // tag::snippet[]
 public class AppLayoutBottomNavbar extends AppLayout {
 
-  public AppLayoutBottomNavbar() {
-    getElement().getStyle().set("--vaadin-app-layout-touch-optimized", "true"); // hidden-source-line
-    H1 title = new H1("MyApp");
-    title.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("margin", "var(--lumo-space-m) var(--lumo-space-l)");
+    public AppLayoutBottomNavbar() {
+        getElement().getStyle().set("--vaadin-app-layout-touch-optimized", // hidden-source-line
+                "true"); // hidden-source-line
+        H1 title = new H1("MyApp");
+        title.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("margin", "var(--lumo-space-m) var(--lumo-space-l)");
 
-    Tabs tabs = getTabs();
+        Tabs tabs = getTabs();
 
-    H2 viewTitle = new H2("View title");
-    Paragraph viewContent = new Paragraph("View content");
+        H2 viewTitle = new H2("View title");
+        Paragraph viewContent = new Paragraph("View content");
 
-    Div content = new Div();
-    content.add(viewTitle, viewContent);
+        Div content = new Div();
+        content.add(viewTitle, viewContent);
 
-    addToNavbar(title);
-    addToNavbar(true, tabs);
+        addToNavbar(title);
+        addToNavbar(true, tabs);
 
-    setContent(content);
-  }
-  // end::snippet[]
+        setContent(content);
+    }
+    // end::snippet[]
 
-  private Tabs getTabs() {
-    Tabs tabs = new Tabs();
-    tabs.add(
-      createTab(VaadinIcon.DASHBOARD, "Dashboard"),
-      createTab(VaadinIcon.CART, "Orders"),
-      createTab(VaadinIcon.USER_HEART, "Customers"),
-      createTab(VaadinIcon.PACKAGE, "Products")
-    );
-    tabs.addThemeVariants(TabsVariant.LUMO_MINIMAL, TabsVariant.LUMO_EQUAL_WIDTH_TABS);
-    return tabs;
-  }
+    private Tabs getTabs() {
+        Tabs tabs = new Tabs();
+        tabs.add(createTab(VaadinIcon.DASHBOARD, "Dashboard"),
+                createTab(VaadinIcon.CART, "Orders"),
+                createTab(VaadinIcon.USER_HEART, "Customers"),
+                createTab(VaadinIcon.PACKAGE, "Products"));
+        tabs.addThemeVariants(TabsVariant.LUMO_MINIMAL,
+                TabsVariant.LUMO_EQUAL_WIDTH_TABS);
+        return tabs;
+    }
 
-  private Tab createTab(VaadinIcon viewIcon, String viewName) {
-    Icon icon = viewIcon.create();
-    icon.setSize("var(--lumo-icon-size-s)");
-    icon.getStyle().set("margin", "auto");
+    private Tab createTab(VaadinIcon viewIcon, String viewName) {
+        Icon icon = viewIcon.create();
+        icon.setSize("var(--lumo-icon-size-s)");
+        icon.getStyle().set("margin", "auto");
 
-    RouterLink link = new RouterLink();
-    link.add(icon);
-    // Demo has no routes
-    // link.setRoute(viewClass.java);
-    link.setTabIndex(-1);
+        RouterLink link = new RouterLink();
+        link.add(icon);
+        // Demo has no routes
+        // link.setRoute(viewClass.java);
+        link.setTabIndex(-1);
 
-    return new Tab(link);
-  }
-  public static class Exporter extends DemoExporter<AppLayoutBottomNavbar> {} // hidden-source-line
-  // tag::snippet[]
+        return new Tab(link);
+    }
+
+    public static class Exporter extends DemoExporter<AppLayoutBottomNavbar> { // hidden-source-line
+    } // hidden-source-line
+      // tag::snippet[]
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java
@@ -16,54 +16,52 @@ import com.vaadin.flow.router.RouterLink;
 // tag::snippet[]
 public class AppLayoutDrawer extends AppLayout {
 
-  public AppLayoutDrawer() {
-    DrawerToggle toggle = new DrawerToggle();
+    public AppLayoutDrawer() {
+        DrawerToggle toggle = new DrawerToggle();
 
-    H1 title = new H1("Dashboard");
-    title.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("margin", "0");
+        H1 title = new H1("Dashboard");
+        title.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("margin", "0");
 
-    Tabs tabs = getTabs();
+        Tabs tabs = getTabs();
 
-    addToDrawer(tabs);
-    addToNavbar(toggle, title);
+        addToDrawer(tabs);
+        addToNavbar(toggle, title);
 
-    setPrimarySection(Section.DRAWER);
-  }
-  // end::snippet[]
+        setPrimarySection(Section.DRAWER);
+    }
+    // end::snippet[]
 
-  private Tabs getTabs() {
-    Tabs tabs = new Tabs();
-    tabs.add(
-      createTab(VaadinIcon.DASHBOARD, "Dashboard"),
-      createTab(VaadinIcon.CART, "Orders"),
-      createTab(VaadinIcon.USER_HEART, "Customers"),
-      createTab(VaadinIcon.PACKAGE, "Products"),
-      createTab(VaadinIcon.RECORDS, "Documents"),
-      createTab(VaadinIcon.LIST, "Tasks"),
-      createTab(VaadinIcon.CHART, "Analytics")
-    );
-    tabs.setOrientation(Tabs.Orientation.VERTICAL);
-    return tabs;
-  }
+    private Tabs getTabs() {
+        Tabs tabs = new Tabs();
+        tabs.add(createTab(VaadinIcon.DASHBOARD, "Dashboard"),
+                createTab(VaadinIcon.CART, "Orders"),
+                createTab(VaadinIcon.USER_HEART, "Customers"),
+                createTab(VaadinIcon.PACKAGE, "Products"),
+                createTab(VaadinIcon.RECORDS, "Documents"),
+                createTab(VaadinIcon.LIST, "Tasks"),
+                createTab(VaadinIcon.CHART, "Analytics"));
+        tabs.setOrientation(Tabs.Orientation.VERTICAL);
+        return tabs;
+    }
 
-  private Tab createTab(VaadinIcon viewIcon, String viewName) {
-    Icon icon = viewIcon.create();
-    icon.getStyle()
-      .set("box-sizing", "border-box")
-      .set("margin-inline-end", "var(--lumo-space-m)")
-      .set("padding", "var(--lumo-space-xs)");
+    private Tab createTab(VaadinIcon viewIcon, String viewName) {
+        Icon icon = viewIcon.create();
+        icon.getStyle().set("box-sizing", "border-box")
+                .set("margin-inline-end", "var(--lumo-space-m)")
+                .set("padding", "var(--lumo-space-xs)");
 
-    RouterLink link = new RouterLink();
-    link.add(icon, new Span(viewName));
-    // Demo has no routes
-    // link.setRoute(viewClass.java);
-    link.setTabIndex(-1);
+        RouterLink link = new RouterLink();
+        link.add(icon, new Span(viewName));
+        // Demo has no routes
+        // link.setRoute(viewClass.java);
+        link.setTabIndex(-1);
 
-    return new Tab(link);
-  }
-  public static class Exporter extends DemoExporter<AppLayoutDrawer> {} // hidden-source-line
-  // tag::snippet[]
+        return new Tab(link);
+    }
+
+    public static class Exporter extends DemoExporter<AppLayoutDrawer> { // hidden-source-line
+    } // hidden-source-line
+      // tag::snippet[]
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightAuto.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightAuto.java
@@ -14,27 +14,27 @@ import com.vaadin.demo.domain.DataService;
 // tag::snippet[]
 public class AppLayoutHeightAuto extends AppLayout {
 
-  public AppLayoutHeightAuto() {
-    H1 title = new H1("MyApp");
-    title.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("margin", "var(--lumo-space-m)");
-    addToNavbar(title);
+    public AppLayoutHeightAuto() {
+        H1 title = new H1("MyApp");
+        title.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("margin", "var(--lumo-space-m)");
+        addToNavbar(title);
 
-    Grid<Person> grid = new Grid<>(Person.class, false);
-    grid.addColumn(Person::getFirstName).setHeader("First name");
-    grid.addColumn(Person::getLastName).setHeader("Last name");
-    grid.addColumn(Person::getEmail).setHeader("Email");
-    grid.addColumn(Person::getProfession).setHeader("Profession");
+        Grid<Person> grid = new Grid<>(Person.class, false);
+        grid.addColumn(Person::getFirstName).setHeader("First name");
+        grid.addColumn(Person::getLastName).setHeader("Last name");
+        grid.addColumn(Person::getEmail).setHeader("Email");
+        grid.addColumn(Person::getProfession).setHeader("Profession");
 
-    List<Person> people = DataService.getPeople(20);
-    grid.setItems(people);
-    grid.setAllRowsVisible(true);
-    setContent(grid);
-  }
-  // end::snippet[]
+        List<Person> people = DataService.getPeople(20);
+        grid.setItems(people);
+        grid.setAllRowsVisible(true);
+        setContent(grid);
+    }
+    // end::snippet[]
 
-  public static class Exporter extends DemoExporter<AppLayoutHeightAuto> {} // hidden-source-line
-  // tag::snippet[]
+    public static class Exporter extends DemoExporter<AppLayoutHeightAuto> { // hidden-source-line
+    } // hidden-source-line
+      // tag::snippet[]
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightFull.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightFull.java
@@ -36,11 +36,10 @@ public class AppLayoutHeightFull extends AppLayout {
         grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
         // hidden-source-line - TODO: workaround to get the exported WC
         // hidden-source-line - height to take all the space within DSP
-        getElement().executeJavaScript( // hidden-source-line
-                "this.getRootNode().host.style.height='100vh'"); // hidden-source-line
+        getElement().executeJs("this.getRootNode().host.style.height='100vh'"); // hidden-source-line
         // hidden-source-line - TODO: workaround to remove the padding from
         // hidden-source-line - parent container (coming from DSP)
-        getElement().executeJavaScript( // hidden-source-line
+        getElement().executeJs( // hidden-source-line
                 "this.getRootNode().host.parentElement.style.padding='0'"); // hidden-source-line
     }
     // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightFull.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightFull.java
@@ -15,33 +15,38 @@ import com.vaadin.demo.domain.DataService;
 // tag::snippet[]
 public class AppLayoutHeightFull extends AppLayout {
 
-  public AppLayoutHeightFull() {
-    H1 title = new H1("MyApp");
-    title.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("margin", "var(--lumo-space-m)");
-    addToNavbar(title);
+    public AppLayoutHeightFull() {
+        H1 title = new H1("MyApp");
+        title.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("margin", "var(--lumo-space-m)");
+        addToNavbar(title);
 
-    Grid<Person> grid = new Grid<>(Person.class, false);
-    grid.addColumn(Person::getFirstName).setHeader("First name");
-    grid.addColumn(Person::getLastName).setHeader("Last name");
-    grid.addColumn(Person::getEmail).setHeader("Email");
-    grid.addColumn(Person::getProfession).setHeader("Profession");
+        Grid<Person> grid = new Grid<>(Person.class, false);
+        grid.addColumn(Person::getFirstName).setHeader("First name");
+        grid.addColumn(Person::getLastName).setHeader("Last name");
+        grid.addColumn(Person::getEmail).setHeader("Email");
+        grid.addColumn(Person::getProfession).setHeader("Profession");
 
-    List<Person> people = DataService.getPeople();
-    grid.setItems(people);
-    setContent(grid);
+        List<Person> people = DataService.getPeople();
+        grid.setItems(people);
+        setContent(grid);
 
-    getElement().getStyle().set("height", "100%");
-    grid.setHeight("100%");
-    grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+        getElement().getStyle().set("height", "100%");
+        grid.setHeight("100%");
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+        // hidden-source-line - TODO: workaround to get the exported WC
+        // hidden-source-line - height to take all the space within DSP
+        getElement().executeJavaScript( // hidden-source-line
+                "this.getRootNode().host.style.height='100vh'"); // hidden-source-line
+        // hidden-source-line - TODO: workaround to remove the padding from
+        // hidden-source-line - parent container (coming from DSP)
+        getElement().executeJavaScript( // hidden-source-line
+                "this.getRootNode().host.parentElement.style.padding='0'"); // hidden-source-line
+    }
+    // end::snippet[]
 
-    getElement().executeJavaScript("this.getRootNode().host.style.height='100vh'"); // hidden-source-line - TODO: workaround to get the exported web component height to take all the space within Design System Publisher
-    getElement().executeJavaScript("this.getRootNode().host.parentElement.style.padding='0'"); // hidden-source-line - TODO: workaround to remove the padding from parent container (coming from Design System Publisher)
-  }
-  // end::snippet[]
-
-  public static class Exporter extends DemoExporter<AppLayoutHeightFull> {} // hidden-source-line
-  // tag::snippet[]
+    public static class Exporter extends DemoExporter<AppLayoutHeightFull> { // hidden-source-line
+    } // hidden-source-line
+      // tag::snippet[]
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbar.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbar.java
@@ -12,42 +12,38 @@ import com.vaadin.flow.router.RouterLink;
 // tag::snippet[]
 public class AppLayoutNavbar extends AppLayout {
 
-  public AppLayoutNavbar() {
-    H1 title = new H1("MyApp");
-    title.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("left", "var(--lumo-space-l)")
-      .set("margin", "0")
-      .set("position", "absolute");
+    public AppLayoutNavbar() {
+        H1 title = new H1("MyApp");
+        title.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("left", "var(--lumo-space-l)").set("margin", "0")
+                .set("position", "absolute");
 
-    Tabs tabs = getTabs();
+        Tabs tabs = getTabs();
 
-    addToNavbar(title, tabs);
-  }
-  // end::snippet[]
+        addToNavbar(title, tabs);
+    }
+    // end::snippet[]
 
-  private Tabs getTabs() {
-    Tabs tabs = new Tabs();
-    tabs.getStyle().set("margin", "auto");
-    tabs.add(
-      createTab("Dashboard"),
-      createTab("Orders"),
-      createTab("Customers"),
-      createTab("Products")
-    );
-    return tabs;
-  }
+    private Tabs getTabs() {
+        Tabs tabs = new Tabs();
+        tabs.getStyle().set("margin", "auto");
+        tabs.add(createTab("Dashboard"), createTab("Orders"),
+                createTab("Customers"), createTab("Products"));
+        return tabs;
+    }
 
-  private Tab createTab(String viewName) {
-    RouterLink link = new RouterLink();
-    link.add(viewName);
-    // Demo has no routes
-    // link.setRoute(viewClass.java);
-    link.setTabIndex(-1);
+    private Tab createTab(String viewName) {
+        RouterLink link = new RouterLink();
+        link.add(viewName);
+        // Demo has no routes
+        // link.setRoute(viewClass.java);
+        link.setTabIndex(-1);
 
-    return new Tab(link);
-  }
-  public static class Exporter extends DemoExporter<AppLayoutNavbar> {} // hidden-source-line
-  // tag::snippet[]
+        return new Tab(link);
+    }
+
+    public static class Exporter extends DemoExporter<AppLayoutNavbar> { // hidden-source-line
+    } // hidden-source-line
+      // tag::snippet[]
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
@@ -16,53 +16,52 @@ import com.vaadin.flow.router.RouterLink;
 // tag::snippet[]
 public class AppLayoutNavbarPlacement extends AppLayout {
 
-  public AppLayoutNavbarPlacement() {
-    DrawerToggle toggle = new DrawerToggle();
+    public AppLayoutNavbarPlacement() {
+        DrawerToggle toggle = new DrawerToggle();
 
-    H1 title = new H1("MyApp");
-    title.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("margin", "0");
+        H1 title = new H1("MyApp");
+        title.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("margin", "0");
 
-    Tabs tabs = getTabs();
+        Tabs tabs = getTabs();
 
-    addToDrawer(tabs);
-    addToNavbar(toggle, title);
-  }
-  // end::snippet[]
+        addToDrawer(tabs);
+        addToNavbar(toggle, title);
+    }
+    // end::snippet[]
 
-  private Tabs getTabs() {
-    Tabs tabs = new Tabs();
-    tabs.add(
-      createTab(VaadinIcon.DASHBOARD, "Dashboard"),
-      createTab(VaadinIcon.CART, "Orders"),
-      createTab(VaadinIcon.USER_HEART, "Customers"),
-      createTab(VaadinIcon.PACKAGE, "Products"),
-      createTab(VaadinIcon.RECORDS, "Documents"),
-      createTab(VaadinIcon.LIST, "Tasks"),
-      createTab(VaadinIcon.CHART, "Analytics")
-    );
-    tabs.setOrientation(Tabs.Orientation.VERTICAL);
-    return tabs;
-  }
+    private Tabs getTabs() {
+        Tabs tabs = new Tabs();
+        tabs.add(createTab(VaadinIcon.DASHBOARD, "Dashboard"),
+                createTab(VaadinIcon.CART, "Orders"),
+                createTab(VaadinIcon.USER_HEART, "Customers"),
+                createTab(VaadinIcon.PACKAGE, "Products"),
+                createTab(VaadinIcon.RECORDS, "Documents"),
+                createTab(VaadinIcon.LIST, "Tasks"),
+                createTab(VaadinIcon.CHART, "Analytics"));
+        tabs.setOrientation(Tabs.Orientation.VERTICAL);
+        return tabs;
+    }
 
-  private Tab createTab(VaadinIcon viewIcon, String viewName) {
-    Icon icon = viewIcon.create();
-    icon.getStyle()
-      .set("box-sizing", "border-box")
-      .set("margin-inline-end", "var(--lumo-space-m)")
-      .set("margin-inline-start", "var(--lumo-space-xs)")
-      .set("padding", "var(--lumo-space-xs)");
+    private Tab createTab(VaadinIcon viewIcon, String viewName) {
+        Icon icon = viewIcon.create();
+        icon.getStyle().set("box-sizing", "border-box")
+                .set("margin-inline-end", "var(--lumo-space-m)")
+                .set("margin-inline-start", "var(--lumo-space-xs)")
+                .set("padding", "var(--lumo-space-xs)");
 
-    RouterLink link = new RouterLink();
-    link.add(icon, new Span(viewName));
-    // Demo has no routes
-    // link.setRoute(viewClass.java);
-    link.setTabIndex(-1);
+        RouterLink link = new RouterLink();
+        link.add(icon, new Span(viewName));
+        // Demo has no routes
+        // link.setRoute(viewClass.java);
+        link.setTabIndex(-1);
 
-    return new Tab(link);
-  }
-  public static class Exporter extends DemoExporter<AppLayoutNavbarPlacement> {} // hidden-source-line
-  // tag::snippet[]
+        return new Tab(link);
+    }
+
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<AppLayoutNavbarPlacement> { // hidden-source-line
+    } // hidden-source-line
+      // tag::snippet[]
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java
@@ -16,54 +16,53 @@ import com.vaadin.flow.router.RouterLink;
 // tag::snippet[]
 public class AppLayoutNavbarPlacementSide extends AppLayout {
 
-  public AppLayoutNavbarPlacementSide() {
-    DrawerToggle toggle = new DrawerToggle();
+    public AppLayoutNavbarPlacementSide() {
+        DrawerToggle toggle = new DrawerToggle();
 
-    H1 title = new H1("Dashboard");
-    title.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("margin", "0");
+        H1 title = new H1("Dashboard");
+        title.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("margin", "0");
 
-    Tabs tabs = getTabs();
+        Tabs tabs = getTabs();
 
-    addToDrawer(tabs);
-    addToNavbar(toggle, title);
+        addToDrawer(tabs);
+        addToNavbar(toggle, title);
 
-    setPrimarySection(Section.DRAWER);
-  }
-  // end::snippet[]
+        setPrimarySection(Section.DRAWER);
+    }
+    // end::snippet[]
 
-  private Tabs getTabs() {
-    Tabs tabs = new Tabs();
-    tabs.add(
-      createTab(VaadinIcon.DASHBOARD, "Dashboard"),
-      createTab(VaadinIcon.CART, "Orders"),
-      createTab(VaadinIcon.USER_HEART, "Customers"),
-      createTab(VaadinIcon.PACKAGE, "Products"),
-      createTab(VaadinIcon.RECORDS, "Documents"),
-      createTab(VaadinIcon.LIST, "Tasks"),
-      createTab(VaadinIcon.CHART, "Analytics")
-    );
-    tabs.setOrientation(Tabs.Orientation.VERTICAL);
-    return tabs;
-  }
+    private Tabs getTabs() {
+        Tabs tabs = new Tabs();
+        tabs.add(createTab(VaadinIcon.DASHBOARD, "Dashboard"),
+                createTab(VaadinIcon.CART, "Orders"),
+                createTab(VaadinIcon.USER_HEART, "Customers"),
+                createTab(VaadinIcon.PACKAGE, "Products"),
+                createTab(VaadinIcon.RECORDS, "Documents"),
+                createTab(VaadinIcon.LIST, "Tasks"),
+                createTab(VaadinIcon.CHART, "Analytics"));
+        tabs.setOrientation(Tabs.Orientation.VERTICAL);
+        return tabs;
+    }
 
-  private Tab createTab(VaadinIcon viewIcon, String viewName) {
-    Icon icon = viewIcon.create();
-    icon.getStyle()
-      .set("box-sizing", "border-box")
-      .set("margin-inline-end", "var(--lumo-space-m)")
-      .set("padding", "var(--lumo-space-xs)");
+    private Tab createTab(VaadinIcon viewIcon, String viewName) {
+        Icon icon = viewIcon.create();
+        icon.getStyle().set("box-sizing", "border-box")
+                .set("margin-inline-end", "var(--lumo-space-m)")
+                .set("padding", "var(--lumo-space-xs)");
 
-    RouterLink link = new RouterLink();
-    link.add(icon, new Span(viewName));
-    // Demo has no routes
-    // link.setRoute(viewClass.java);
-    link.setTabIndex(-1);
+        RouterLink link = new RouterLink();
+        link.add(icon, new Span(viewName));
+        // Demo has no routes
+        // link.setRoute(viewClass.java);
+        link.setTabIndex(-1);
 
-    return new Tab(link);
-  }
-  public static class Exporter extends DemoExporter<AppLayoutNavbarPlacementSide> {} // hidden-source-line
-  // tag::snippet[]
+        return new Tab(link);
+    }
+
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<AppLayoutNavbarPlacementSide> { // hidden-source-line
+    } // hidden-source-line
+      // tag::snippet[]
 }
 // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
@@ -20,82 +20,76 @@ import com.vaadin.flow.router.RouterLink;
 // tag::snippet[]
 public class AppLayoutSecondaryNavigation extends AppLayout {
 
-  public AppLayoutSecondaryNavigation() {
-    H1 appTitle = new H1("MyApp");
-    appTitle.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("line-height", "var(--lumo-size-l)")
-      .set("margin", "0 var(--lumo-space-m)");
+    public AppLayoutSecondaryNavigation() {
+        H1 appTitle = new H1("MyApp");
+        appTitle.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("line-height", "var(--lumo-size-l)")
+                .set("margin", "0 var(--lumo-space-m)");
 
-    Tabs views = getPrimaryNavigation();
+        Tabs views = getPrimaryNavigation();
 
-    DrawerToggle toggle = new DrawerToggle();
+        DrawerToggle toggle = new DrawerToggle();
 
-    H2 viewTitle = new H2("Orders");
-    viewTitle.getStyle()
-      .set("font-size", "var(--lumo-font-size-l)")
-      .set("margin", "0");
+        H2 viewTitle = new H2("Orders");
+        viewTitle.getStyle().set("font-size", "var(--lumo-font-size-l)")
+                .set("margin", "0");
 
-    Tabs subViews = getSecondaryNavigation();
+        Tabs subViews = getSecondaryNavigation();
 
-    HorizontalLayout wrapper = new HorizontalLayout(toggle, viewTitle);
-    wrapper.setAlignItems(FlexComponent.Alignment.CENTER);
-    wrapper.setSpacing(false);
+        HorizontalLayout wrapper = new HorizontalLayout(toggle, viewTitle);
+        wrapper.setAlignItems(FlexComponent.Alignment.CENTER);
+        wrapper.setSpacing(false);
 
-    VerticalLayout viewHeader = new VerticalLayout(wrapper, subViews);
-    viewHeader.setPadding(false);
-    viewHeader.setSpacing(false);
+        VerticalLayout viewHeader = new VerticalLayout(wrapper, subViews);
+        viewHeader.setPadding(false);
+        viewHeader.setSpacing(false);
 
-    addToDrawer(appTitle, views);
-    addToNavbar(viewHeader);
+        addToDrawer(appTitle, views);
+        addToNavbar(viewHeader);
 
-    setPrimarySection(Section.DRAWER);
-  }
-  // end::snippet[]
+        setPrimarySection(Section.DRAWER);
+    }
+    // end::snippet[]
 
-  private Tabs getPrimaryNavigation() {
-    Tabs tabs = new Tabs();
-    tabs.add(
-      createTab(VaadinIcon.DASHBOARD, "Dashboard"),
-      createTab(VaadinIcon.CART, "Orders"),
-      createTab(VaadinIcon.USER_HEART, "Customers"),
-      createTab(VaadinIcon.PACKAGE, "Products"),
-      createTab(VaadinIcon.RECORDS, "Documents"),
-      createTab(VaadinIcon.LIST, "Tasks"),
-      createTab(VaadinIcon.CHART, "Analytics")
-    );
-    tabs.setOrientation(Tabs.Orientation.VERTICAL);
-    tabs.setSelectedIndex(1);
-    return tabs;
-  }
+    private Tabs getPrimaryNavigation() {
+        Tabs tabs = new Tabs();
+        tabs.add(createTab(VaadinIcon.DASHBOARD, "Dashboard"),
+                createTab(VaadinIcon.CART, "Orders"),
+                createTab(VaadinIcon.USER_HEART, "Customers"),
+                createTab(VaadinIcon.PACKAGE, "Products"),
+                createTab(VaadinIcon.RECORDS, "Documents"),
+                createTab(VaadinIcon.LIST, "Tasks"),
+                createTab(VaadinIcon.CHART, "Analytics"));
+        tabs.setOrientation(Tabs.Orientation.VERTICAL);
+        tabs.setSelectedIndex(1);
+        return tabs;
+    }
 
-  private Tab createTab(VaadinIcon viewIcon, String viewName) {
-    Icon icon = viewIcon.create();
-    icon.getStyle()
-            .set("box-sizing", "border-box")
-            .set("margin-inline-end", "var(--lumo-space-m)")
-            .set("padding", "var(--lumo-space-xs)");
+    private Tab createTab(VaadinIcon viewIcon, String viewName) {
+        Icon icon = viewIcon.create();
+        icon.getStyle().set("box-sizing", "border-box")
+                .set("margin-inline-end", "var(--lumo-space-m)")
+                .set("padding", "var(--lumo-space-xs)");
 
-    RouterLink link = new RouterLink();
-    link.add(icon, new Span(viewName));
-    // Demo has no routes
-    // link.setRoute(viewClass.java);
-    link.setTabIndex(-1);
+        RouterLink link = new RouterLink();
+        link.add(icon, new Span(viewName));
+        // Demo has no routes
+        // link.setRoute(viewClass.java);
+        link.setTabIndex(-1);
 
-    return new Tab(link);
-  }
+        return new Tab(link);
+    }
 
-  private Tabs getSecondaryNavigation() {
-    Tabs tabs = new Tabs();
-    tabs.add(
-            new Tab("All"),
-            new Tab("Open"),
-            new Tab("Completed"),
-            new Tab("Cancelled")
-    );
-    return tabs;
-  }
-  public static class Exporter extends DemoExporter<AppLayoutSecondaryNavigation> {} // hidden-source-line
-  // tag::snippet[]
+    private Tabs getSecondaryNavigation() {
+        Tabs tabs = new Tabs();
+        tabs.add(new Tab("All"), new Tab("Open"), new Tab("Completed"),
+                new Tab("Cancelled"));
+        return tabs;
+    }
+
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<AppLayoutSecondaryNavigation> { // hidden-source-line
+    } // hidden-source-line
+      // tag::snippet[]
 }
 // end::snippet[]


### PR DESCRIPTION
## Description

Fixes #1735

Fixed indentation from 2 spaces to 4 spaces for the following components examples:

- `AppLayout`

## Note

Use "hide whitespace" checkmark when reviewing to make PR diff smaller.