### PR TITLE
chore: hide DemoExporter from Java examples

### DIFF
--- a/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogRejectButton.java
+++ b/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogRejectButton.java
@@ -54,7 +54,7 @@ public class ConfirmDialogRejectButton extends Div {
         status.setVisible(true);
     }
 
-    public static class Exporter
-            extends DemoExporter<ConfirmDialogRejectButton> {
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ConfirmDialogRejectButton> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectionChange.java
+++ b/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectionChange.java
@@ -40,6 +40,6 @@ public class MultiSelectComboBoxSelectionChange extends Div {
     }
 
     public static class Exporter extends // hidden-source-line
-                DemoExporter<MultiSelectComboBoxSelectionChange> { // hidden-source-line
+            DemoExporter<MultiSelectComboBoxSelectionChange> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java
@@ -71,7 +71,7 @@ public class NotificationKeyboardA11y extends Div {
     }
     // end::setupUndoShortcut[]
 
-    public static class Exporter
-            extends DemoExporter<NotificationKeyboardA11y> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<NotificationKeyboardA11y> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/tabs/TabSheetLazyInitialization.java
+++ b/src/main/java/com/vaadin/demo/component/tabs/TabSheetLazyInitialization.java
@@ -38,7 +38,7 @@ public class TabSheetLazyInitialization extends Div {
     }
     // end::snippet[]
 
-    public static class Exporter
-            extends DemoExporter<TabSheetLazyInitialization> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<TabSheetLazyInitialization> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/tooltip/TooltipHtmlElement.java
+++ b/src/main/java/com/vaadin/demo/component/tooltip/TooltipHtmlElement.java
@@ -17,7 +17,7 @@ public class TooltipHtmlElement extends Div {
                 .withPosition(Tooltip.TooltipPosition.TOP_START);
         add(heading);
         // end::snippet[]
-  }
+    }
 
     public static class Exporter extends DemoExporter<TooltipHtmlElement> { // hidden-source-line
     } // hidden-source-line


### PR DESCRIPTION
## Description

Follow-up to #1791. Added some missing `// hidden-source-line` comments, fixed formatting.