### PR TITLE
chore: update components TS definitions article

### DIFF
--- a/articles/advanced/components-definitions.asciidoc
+++ b/articles/advanced/components-definitions.asciidoc
@@ -1,13 +1,13 @@
 ---
 title: TypeScript Definitions of Components
-description: Understanding how to use Vaadin components' TypeScript definitions with web components in TypeScript views. 
+description: Understanding how to use Vaadin components' TypeScript definitions with web components in TypeScript views.
 order: 170
 layout: page
 ---
 
 = TypeScript Definitions of Components
 
-[since:com.vaadin:vaadin@V17]#Vaadin components come with TypeScript definitions#, facilitating the use of web components in TypeScript views.
+Vaadin components come with TypeScript definitions, facilitating the use of web components in TypeScript views.
 The type definitions are [filename]#d.ts# files generated every time a new release is published to `npm`.
 
 In most cases, TypeScript support does not require any changes to the code.
@@ -75,7 +75,6 @@ The `as` keyword is a https://www.typescriptlang.org/docs/handbook/basic-types.h
 It is a hint for the TypeScript compiler, forcing it to use the type provided explicitly.
 In this particular case, it is safe, as the component that dispatches the event is known in advance.
 
-[role="since:com.vaadin:vaadin@V19"]
 == Custom Events [[custom-events]]
 
 Vaadin components offer the set of type definitions for custom events, making it easier to use them in TypeScript.
@@ -127,7 +126,6 @@ The `GridColumn` declaration is the type of the `<vaadin-grid-column>` component
 
 See also the https://vaadin.com/docs/ds/components/grid#content[Grid content] example, which demonstrates how to define `renderer` functions on the `Grid` columns to provide rich content based on the column.
 
-[role="since:com.vaadin:vaadin@V21"]
 == Generic Types [[generic-types]]
 
 Certain Vaadin components, namely `Grid`, `Combo Box`, `CRUD`, and `Virtual List`, support setting the `items` property as an array of objects.

--- a/articles/advanced/components-definitions.asciidoc
+++ b/articles/advanced/components-definitions.asciidoc
@@ -7,11 +7,9 @@ layout: page
 
 = TypeScript Definitions of Components
 
-Vaadin components come with TypeScript definitions, facilitating the use of web components in TypeScript views.
-The type definitions are [filename]#d.ts# files generated every time a new release is published to `npm`.
+Vaadin components come with TypeScript definitions located in [filename]#d.ts# files published to `npm` together with source code.
 
-In most cases, TypeScript support does not require any changes to the code.
-At the same time, using proper types for the web components helps to make the client-side views more reliable.
+Using proper types for the web components helps to make the client-side logic more reliable.
 Depending on the IDE you use, TypeScript definitions can also enable better code completion and auto-import.
 
 When using Visual Studio Code, it is recommended to install the https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin[lit-plugin], which provides syntax highlighting and type-checking support for Lit templates.


### PR DESCRIPTION
## Description

Removed `since` badges which are no longer relevant for Hilla. Also fixed the introduction: the `.d.ts` files are no longer generated, and "TypeScript support" / "client-side views" were only relevant for Flow (not Hilla).