### PR TITLE
docs: replace hasControls with stepButtonsVisible

### DIFF
--- a/articles/components/number-field/index.asciidoc
+++ b/articles/components/number-field/index.asciidoc
@@ -8,12 +8,12 @@ page-links:
 = Number Field
 
 // tag::description[]
-Number Field sports many of the same features as Text Field, but only accepts numeric input.
+Number Field has many of the same features as Text Field, but it accepts only numeric input.
 // end::description[]
 
-The input can be decimal, <<#integer-field,integer>> or <<#bigdecimal-field,big decimal>>.
+The input can be a decimal, an <<#integer-field,integer>> or a <<#bigdecimal-field,big decimal>>.
 
-You can specify a unit as a prefix or suffix for the field.
+You can specify a unit as a prefix, or a suffix for the field.
 
 [.example]
 --
@@ -35,7 +35,7 @@ include::{articles}/components/_shared.asciidoc[tag=field-features]
 
 == Step Buttons
 
-Step buttons allow the user to quickly make small adjustments.
+Step buttons allow the user to make small adjustments, quickly.
 
 [.example]
 --
@@ -53,7 +53,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldS
 
 == Minimum and Maximum Value
 
-The valid input range of a Number Field can be set by defining minimum and maximum values.
+The valid input range of a Number Field is set by defining the minimum and maximum values.
 
 You can set the <<../input-fields#helper,Helper>> text to give information about the range.
 
@@ -73,9 +73,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldM
 
 == Step
 
-The step value of a Number Field defines the allowed numeric intervals.
+The step value of a Number Field defines the numeric intervals that are allowed.
 
-It specifies the amount by which the value increases/decreases when using the Up/Down arrow keys or the step buttons.
+It specifies the amount by which the value increases or decreases when using the Up or Down arrow keys, or the step buttons.
 
 It also invalidates the field if the value entered doesn't align with the specified step.
 
@@ -97,7 +97,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldS
 
 === Integer Field
 
-To allow only integers to be entered, you can use the Integer Field:
+To allow only integers to be entered, you can use the Integer Field like so:
 
 [.example]
 --
@@ -132,12 +132,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldB
 
 == Best Practices
 
-Number Field should be used for actual number values, such as counts and measures.
-Don't use it for other digit-based values, such as telephone, credit card, and social security numbers.
-These values can have leading zeros and be greater than Number Field's maximum supported value.
+Number Field should be used for actual number values, such as counts and measures -- values that may be part of a calculation. Don't use it for other digit-based values, such as telephone, credit card, and social security numbers. These values can have leading zeros and be greater than Number Field's maximum supported value.
 
-When applicable, set the most common choice as the default value.
-For example, airline, bus, train and other travel companies typically default the number of passengers to 1.
+When applicable, set the most common choice as the default value. For example, airline, bus, train and other travel companies typically set the default number of passengers to 1.
 
 
 [discussion-id]`69FAE707-4778-4093-8FB9-8BAE22E9D7F6`

--- a/articles/components/number-field/index.asciidoc
+++ b/articles/components/number-field/index.asciidoc
@@ -33,21 +33,21 @@ include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldB
 :text-field-features: true
 include::{articles}/components/_shared.asciidoc[tag=field-features]
 
-== Stepper Controls
+== Step Buttons
 
-Stepper controls allow the user to quickly make small adjustments.
+Step buttons allow the user to quickly make small adjustments.
 
 [.example]
 --
 
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-stepper-controls.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-step-buttons.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStepperControls.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStepButtons.java[render,tags=snippet,indent=0,group=Java]
 ----
 --
 
@@ -75,7 +75,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldM
 
 The step value of a Number Field defines the allowed numeric intervals.
 
-It specifies the amount by which the value increases/decreases when using the Up/Down arrow keys or the stepper controls.
+It specifies the amount by which the value increases/decreases when using the Up/Down arrow keys or the step buttons.
 
 It also invalidates the field if the value entered doesn't align with the specified step.
 

--- a/frontend/demo/component/numberfield/number-field-min-max.ts
+++ b/frontend/demo/component/numberfield/number-field-min-max.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
         min="0"
         max="10"
         value="2"
-        has-controls
+        step-buttons-visible
       ></vaadin-integer-field>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/numberfield/number-field-step-buttons.ts
+++ b/frontend/demo/component/numberfield/number-field-step-buttons.ts
@@ -16,7 +16,7 @@ const layoutSteps: FormLayoutResponsiveStep[] = [
   },
 ];
 
-@customElement('number-field-stepper-controls')
+@customElement('number-field-step-buttons')
 export class Example extends LitElement {
   protected createRenderRoot() {
     const root = super.createRenderRoot();
@@ -31,7 +31,12 @@ export class Example extends LitElement {
         <vaadin-form-item>
           <label slot="label">Adults</label>
           <!-- tag::snippet[] -->
-          <vaadin-integer-field value="2" has-controls min="0" max="9"></vaadin-integer-field>
+          <vaadin-integer-field
+            value="2"
+            step-buttons-visible
+            min="0"
+            max="9"
+          ></vaadin-integer-field>
           <!-- end::snippet[] -->
         </vaadin-form-item>
 
@@ -40,12 +45,22 @@ export class Example extends LitElement {
             <div>Children</div>
             <div style="font-size: var(--lumo-font-size-xxs); position: absolute;">Age 2-12</div>
           </label>
-          <vaadin-integer-field value="2" has-controls min="0" max="9"></vaadin-integer-field>
+          <vaadin-integer-field
+            value="2"
+            step-buttons-visible
+            min="0"
+            max="9"
+          ></vaadin-integer-field>
         </vaadin-form-item>
 
         <vaadin-form-item>
           <label slot="label">Infants</label>
-          <vaadin-integer-field value="1" has-controls min="0" max="9"></vaadin-integer-field>
+          <vaadin-integer-field
+            value="1"
+            step-buttons-visible
+            min="0"
+            max="9"
+          ></vaadin-integer-field>
         </vaadin-form-item>
       </vaadin-form-layout>
     `;

--- a/frontend/demo/component/numberfield/number-field-step.ts
+++ b/frontend/demo/component/numberfield/number-field-step.ts
@@ -21,7 +21,7 @@ export class Example extends LitElement {
         label="Duration (hours)"
         step="0.5"
         value="12.5"
-        has-controls
+        step-buttons-visible
       ></vaadin-number-field>
       <!-- end::snippet[] -->
     `;

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldMinMax.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldMinMax.java
@@ -16,7 +16,7 @@ public class NumberFieldMinMax extends Div {
         integerField.setMin(0);
         integerField.setMax(10);
         integerField.setValue(2);
-        integerField.setHasControls(true);
+        integerField.setStepButtonsVisible(true);
         add(integerField);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStep.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStep.java
@@ -14,7 +14,7 @@ public class NumberFieldStep extends Div {
         numberField.setLabel("Duration (hours)");
         numberField.setStep(0.5);
         numberField.setValue(12.5);
-        numberField.setHasControls(true);
+        numberField.setStepButtonsVisible(true);
         add(numberField);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStepButtons.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStepButtons.java
@@ -7,16 +7,16 @@ import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
-@Route("number-field-stepper-controls")
-public class NumberFieldStepperControls extends FormLayout {
+@Route("number-field-step-buttons")
+public class NumberFieldStepButtons extends FormLayout {
 
-    public NumberFieldStepperControls() {
+    public NumberFieldStepButtons() {
         setResponsiveSteps(new ResponsiveStep("0", 1, LabelsPosition.ASIDE));
 
         // tag::snippet[]
         IntegerField adultsField = new IntegerField();
         adultsField.setValue(2);
-        adultsField.setHasControls(true);
+        adultsField.setStepButtonsVisible(true);
         adultsField.setMin(0);
         adultsField.setMax(9);
         // end::snippet[]
@@ -24,7 +24,7 @@ public class NumberFieldStepperControls extends FormLayout {
 
         IntegerField childrenField = new IntegerField();
         childrenField.setValue(2);
-        childrenField.setHasControls(true);
+        childrenField.setStepButtonsVisible(true);
         childrenField.setMin(0);
         childrenField.setMax(9);
 
@@ -40,13 +40,13 @@ public class NumberFieldStepperControls extends FormLayout {
 
         IntegerField infantsField = new IntegerField();
         infantsField.setValue(1);
-        infantsField.setHasControls(true);
+        infantsField.setStepButtonsVisible(true);
         infantsField.setMin(0);
         infantsField.setMax(9);
         addFormItem(infantsField, "Infants");
     }
 
     public static class Exporter extends // hidden-source-line
-            DemoExporter<NumberFieldStepperControls> { // hidden-source-line
+            DemoExporter<NumberFieldStepButtons> { // hidden-source-line
     } // hidden-source-line
 }


### PR DESCRIPTION
Replaces usages of the deprecated `hasControls` property with the `stepButtonsVisible` property, and updates references to the buttons in the asciidoc.

Needs to wait for the next 23.3 alpha release before being merged.

Part of https://github.com/vaadin/flow-components/issues/1106