### PR TITLE
Remove link to non-functioning application

### DIFF
--- a/articles/tutorial/overview.adoc
+++ b/articles/tutorial/overview.adoc
@@ -39,8 +39,6 @@ It features:
 * Cloud deployment.
 * Application installation on mobile and desktop.
 
-https://crm.demo.vaadin.com/[Try the completed application here.]
-
 image::images/overview/app-complete.png[A web application with a listing of contacts and an editor open.]
 
 == What You Need to Complete This Tutorial


### PR DESCRIPTION
The CRM tutorial live [demo](https://crm.demo.vaadin.com/) cannot be accessed with the provided username and password. Let's remove the link to demo until we figure out how to update it. 