### PR TITLE
docs: remove Atom from commonly used IDEs

### DIFF
--- a/articles/guide/step-by-step/importing/index.asciidoc
+++ b/articles/guide/step-by-step/importing/index.asciidoc
@@ -19,7 +19,6 @@ The following table gives a rough evaluation of language support in the most com
 [%header, cols="3,1,1"]
 |====
 | IDE | Java  | TypeScript
-| Atom | 🌟 | 🌟🌟
 | Eclipse | 🌟🌟🌟 | 🌟🌟
 | IntelliJ IDEA Community Edition| 🌟🌟🌟 | –
 | IntelliJ IDEA Ultimate| 🌟🌟🌟 | 🌟🌟🌟


### PR DESCRIPTION
## Description

Microsoft stopped working on Atom and it will be officially sunset on December 15, 2022, see [the announcement](https://github.blog/2022-06-08-sunsetting-atom/).
Removed it from the table. We might want to also update [Editing Tools](https://vaadin.com/docs/latest/contributing-docs/authoring/editing-tools/#atom-editor) page to add VS Code instead.