### PR TITLE
chore: bump spring-boot-starter-parent to 2.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.4</version>
     </parent>
     <!-- end::spring-version[] -->
 


### PR DESCRIPTION
I forgot to bump `spring-boot-starter-parent` as part of #1914, so doing it here.