### PR TITLE
chore: bump Hilla to 1.3.0.alpha3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
         <!-- tag::vaadin-version[] -->
         <vaadin.version>23.3.0.alpha3</vaadin.version>
-        <hilla.version>1.3.0.alpha1</hilla.version>
+        <hilla.version>1.3.0.alpha3</hilla.version>
         <!-- end::vaadin-version[] -->
 
         <drivers.dir>${project.basedir}/drivers</drivers.dir>


### PR DESCRIPTION
I forgot to bump `Hilla` as part of #1914, so doing it here.