### PR TITLE
Clean up key input formatting

### DIFF
--- a/articles/404.asciidoc
+++ b/articles/404.asciidoc
@@ -11,4 +11,4 @@ layout: index
 This page was not found.
 It might have moved, or it no longer exists.
 
-You can try searching for it (press kbd:[Ctrl/Cmd+K]), or you can go to the link:/[start page, role=skip-xref-check].
+You can try searching for it (press kbd:[Ctrl+K] / kbd:[Command+K]), or you can go to the link:/[start page, role=skip-xref-check].

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -811,7 +811,7 @@ The following keyboard shortcuts are available:
 [cols="1,5"]
 |====
 | kbd:[Tab] | Switches focus between sections of the grid (header, body, footer).
-| kbd:[←], kbd:[↑], kbd:[→], kbd:[↓] | Moves focus between cells within a section of the grid.
+| kbd:[Left], kbd:[Up], kbd:[Right], and kbd:[Down] arrow keys | Moves focus between cells within a section of the grid.
 | kbd:[Page Up] | Moves cell focus up by one page of visible rows.
 | kbd:[Page Down] | Moves cell focus down by one page of visible rows.
 | kbd:[Home] | Moves focus to the first cell in a row.

--- a/articles/components/menu-bar/index.asciidoc
+++ b/articles/components/menu-bar/index.asciidoc
@@ -321,13 +321,13 @@ See <<../tooltip#,Tooltips documentation>> for details on tooltip configuration.
 |Interaction |Keyboard Shortcut
 
 |Navigate between top-level items.
-|kbd:[left] and kbd:[right] arrow keys
+|kbd:[Left] and kbd:[Right] arrow keys
 
 |Open top-level menu.
-|kbd:[down] / kbd:[space] / kbd:[enter]
+|kbd:[Down] / kbd:[Space] / kbd:[Enter]
 
 |Trigger top-level item with a menu.
-|kbd:[space] / kbd:[enter]
+|kbd:[Space] / kbd:[Enter]
 |===
 
 === Menu-Items
@@ -336,19 +336,19 @@ See <<../tooltip#,Tooltips documentation>> for details on tooltip configuration.
 |Interaction |Keyboard Shortcut
 
 |Navigate between items in a drop-down menu.
-|kbd:[top] and kbd:[down] arrow keys
+|kbd:[Up] and kbd:[Down] arrow keys
 
 |Open sub-menu.
-|kbd:[right] / kbd:[space] / kbd:[enter]
+|kbd:[Right] / kbd:[Space] / kbd:[Enter]
 
 |Trigger menu item without a sub-menu.
-|kbd:[space] / kbd:[enter]
+|kbd:[Space] / kbd:[Enter]
 
 |Return to previous menu.
-|kbd:[left]
+|kbd:[Left]
 
 |Close the drop-down menu.
-|kbd:[esc]
+|kbd:[Esc]
 |===
 
 [[dropdown-buttons]]

--- a/articles/components/text-field/index.asciidoc
+++ b/articles/components/text-field/index.asciidoc
@@ -212,9 +212,9 @@ Use `autoselect` when the user might to want to replace the entire value rather 
 |`ON`|Pointing device or keyboard navigation|Contents selected
 |`OFF`|Pointing device|Cursor placed where clicked
 |`OFF`|Keyboard navigation +
-[guibutton]#Tab#|Cursor at the end of the input value
+kbd:[Tab]|Cursor at the end of the input value
 |`OFF`|Keyboard navigation +
-[guibutton]#⇧# [guibutton]#Tab#|Contents selectedfootnote:[Consequent keyboard navigation results in the contents being selected until the selection is changed, by either arrow navigation or mouse click.]
+kbd:[Shift+Tab]|Contents selectedfootnote:[Consequent keyboard navigation results in the contents being selected until the selection is changed, by either arrow navigation or mouse click.]
 |===
 
 

--- a/articles/contributing-docs/authoring/editing-tools.asciidoc
+++ b/articles/contributing-docs/authoring/editing-tools.asciidoc
@@ -128,7 +128,7 @@ image::../img/atom-editor.png[]
 
  experimental web
 
-. Now, when editing an AsciiDoc file, press *Ctrl+Shift+A* to preview the file.
+. Now, when editing an AsciiDoc file, press kbd:[Ctrl+Shift+A] to preview the file.
 
 === Limitations
 

--- a/articles/contributing-docs/style-guide/formatting-style.asciidoc
+++ b/articles/contributing-docs/style-guide/formatting-style.asciidoc
@@ -48,12 +48,12 @@ For non-ASCII characters, you should use HTML character entity markup.
 
 == Control-Key Combinations
 If your audience includes macOS users, provide the appropriate key-naming terminology.
-Spell out _Control_ and _Command_, rather than abbreviating them.
+Spell out _Command_, rather than abbreviating it.
 For example:
 
 [example]
 ====
-Press [guibutton]#Control+S# ([guibutton]#Command+S# on Macintosh) to save.
+Press kbd:[Ctrl+S] (kbd:[Command+S] on Macintosh) to save.
 ====
 
 == Capitalization
@@ -85,7 +85,7 @@ Use the emphasis styles, such as
 |GUI Labels | `+++[guilabel]#OK#+++` | [guilabel]#OK#
 |File Names | `+++[filename]`readme.txt`+++` | [filename]`readme.txt`
 |Other Monospace | `+++`appName`+++` | `appName`
-|Key Caps | `+++kbd:[Ctrl + C]+++` | kbd:[Ctrl + C]
+|Key Caps | `+++kbd:[Ctrl+Shift+C]+++` | kbd:[Ctrl+Shift+C]
 |Menu Choices | `+++"Help > Updates"+++` or
 `+++menu:Help[Updates]+++`| "Help > Updates"
 |====

--- a/articles/contributing/editor-settings-intellij-idea.asciidoc
+++ b/articles/contributing/editor-settings-intellij-idea.asciidoc
@@ -24,7 +24,7 @@ They can also be added after the original pull request but before a merge.
 == Code Conventions
 
 . Install the [guilabel]#Eclipse Code Formatter# plugin, then restart IDEA
-. Open Settings (kbd:[Ctrl + Alt + S] or kbd:[{commandkey} + ,])
+. Open Settings (kbd:[Ctrl + Alt + S] or kbd:[Command + ,])
 . On the menu:Other Settings[Eclipse Code Formatter] page
 .. Check [guilabel]#Use the Eclipse code formatter#
 .. In the [guilabel]#Supported file types# section, check [guilabel]#Enable Java#
@@ -33,7 +33,7 @@ They can also be added after the original pull request but before a merge.
 
 == Imports
 
-. Open Settings (kbd:[Ctrl + Alt + S] or kbd:[{commandkey} + ,])
+. Open Settings (kbd:[Ctrl + Alt + S] or kbd:[Command + ,])
 . Go to menu:Editor[General > Auto Import] and un-check [guilabel]#Optimize imports on the fly#
 . Go to menu:Editor[Code Style > Java] and on the [guilabel]#Imports# tab
 .. Make sure that [guilabel]#Use single class import# is checked
@@ -58,7 +58,7 @@ import static all other imports
 
 == Copyright
 
-. Open Settings (kbd:[Ctrl + Alt + S] or kbd:[{commandkey} + ,])
+. Open Settings (kbd:[Ctrl + Alt + S] or kbd:[Command + ,])
 . Go to menu:Editor[Copyright > Copyright Profiles] and create a new profile named *Vaadin*, with the copyright text as defined below:
 +
 ----

--- a/articles/create-ui/shortcut.asciidoc
+++ b/articles/create-ui/shortcut.asciidoc
@@ -11,7 +11,7 @@ Shortcuts allow you to assign keyboard shortcuts to your components to improve e
 
 You can add available shortcuts, create your own custom shortcuts, and configure the reaction when a shortcut is triggered.
 
-A shortcut key combination consists of one primary key and 0 to 4 key modifiers (`Alt`, `Ctrl`, `Meta`, `Shift`).
+A shortcut key combination consists of one primary key and 0 to 4 key modifiers (kbd:[Alt], kbd:[Ctrl], kbd:[Meta], kbd:[Shift]).
 
 == Adding Click Shortcuts
 
@@ -31,7 +31,7 @@ login.addClickListener(event -> this.login());
 login.addClickShortcut(Key.ENTER);
 ----
 
-* Instead of clicking the button, the user can use the `Enter` key to perform the action tied to the button click.
+* Instead of clicking the button, the user can use the kbd:[Enter] key to perform the action tied to the button click.
 
 
 == Adding Focus Shortcuts
@@ -48,7 +48,7 @@ TextField textField = new TextField("Label");
 textField.addFocusShortcut(Key.KEY_F, KeyModifier.ALT);
 ----
 
-* The user can focus on the `Label` text field using the `ALT+F` keyboard shortcut.
+* The user can focus on the `Label` text field using the kbd:[Alt+F] keyboard shortcut.
 
 == Adding Custom Shortcuts
 
@@ -65,7 +65,7 @@ UI.getCurrent().addShortcutListener(
         KeyModifier.CONTROL, KeyModifier.ALT);
 ----
 
-* When the user presses `Ctrl+Alt+N`, the form opens and the user can input the new customer information.
+* When the user presses kbd:[Ctrl+Alt+N], the form opens and the user can input the new customer information.
 
 You can configure a shortcut to run any code that complies with the [interfacename]`Command` functional interface.
 This interface has a single method called [methodname]`execute()`, which accepts zero arguments.
@@ -117,7 +117,7 @@ public class Scope extends Div {
 ----
 
 * The shortcut is tied to the parent component (`Scope`) of the input components.
-* If the user types input into either `TextField` and then presses `Escape`, both input fields are cleared and focus is returned to the first field.
+* If the user types input into either `TextField` and then presses kbd:[Esc], both input fields are cleared and focus is returned to the first field.
 * This is useful where the same action should be triggered by a shortcut configured on all fields contained inside the same scope, but not outside of the enveloping component.
 * The shortcut is created using the factory class [classname]`Shortcuts`, which offers the most generic method for creating shortcuts.
 
@@ -164,7 +164,7 @@ You can use the [methodname]`Shortcuts.addShortcutListener(...)` method to creat
 [source,java]
 ----
 Paragraph paragraph =
-        new Paragraph("When you see me, try ALT+G!");
+        new Paragraph("When you see me, try Alt+G!");
 
 Shortcuts.addShortcutListener(paragraph,
         () -> Notification.show("Well done!"),
@@ -174,7 +174,7 @@ add(paragraph);
 ----
 
 * The first parameter of the [methodname]`Shortcuts.addShortcutListener(Component, Command, Key, KeyModifier...)` method is the `lifecycleOwner` component.
-* This code binds the `ALT+G` shortcut to the life cycle of `paragraph` and is only active when the component is both attached and visible.
+* This code binds the kbd:[Alt+G] shortcut to the life cycle of `paragraph` and is only active when the component is both attached and visible.
 
 You can also use the [methodname]`bindLifecycleTo()` method to reconfigure the `lifecycleOwner` component of shortcuts.
 
@@ -213,7 +213,7 @@ UI.getCurrent().addShortcutListener(listener,
         Key.KEY_J, KeyModifier.ALT);
 ----
 
-* The `listener` handles events triggered by multiple shortcuts; both `ALT+G` and `ALT+J` invoke the listener.
+* The `listener` handles events triggered by multiple shortcuts; both kbd:[Alt+G] and kbd:[Alt+J] invoke the listener.
 * The [classname]`ShortcutEvent` provides the [methodname]`matches(Key, KeyModifier...)` method to determine which shortcut triggered the event.
 For additional comparisons, you can use [methodname]`getSource()` (which returns the `listenOn` component) and [methodname]`getLifecycleOwner()` (which returns the `lifecycleOwner` component).
 
@@ -230,7 +230,7 @@ Input input = new Input();
 input.addFocusShortcut(Key.KEY_F).withAlt().withShift();
 ----
 
-* The focus shortcut is triggered with `Alt+Shift+F`.
+* The focus shortcut is triggered with kbd:[Alt+Shift+F].
 
 [classname]`ShortcutRegistration` also has the [methodname]`withModifiers(KeyModifiers...modifiers)` method, which can be used to configure all modifiers simultaneously, or to remove all modifiers.
 Calling [methodname]`withModifiers(...)` without parameters removes all modifiers from the shortcut.

--- a/articles/tutorial/components-and-layouts.adoc
+++ b/articles/tutorial/components-and-layouts.adoc
@@ -165,7 +165,7 @@ public class ListView extends VerticalLayout { // <1>
 <8> Configure the search field to fire value-change events only when the user stops typing. This way you avoid unnecessary database calls.
 <9> The toolbar uses a `HorizontalLayout` to place the `TextField` and `Button` next to each other.
 
-If your application is still running from the previous step, you only need to perform a build, either with the `CMD/Ctrl-F9` keyboard shortcut, or by pressing the “hammer” icon in the toolbar.
+If your application is still running from the previous step, you only need to perform a build, either with the kbd:[Command+F9]/kbd:[Ctrl+F9] keyboard shortcut, or by pressing the “hammer” icon in the toolbar.
 Vaadin automatically reloads your browser to display the changes.
 
 image:images/components-and-layouts/build-project.png[The build project button is in the IntelliJ toolbar, width=300]


### PR DESCRIPTION
There is a lack of consistency with the presentation of key inputs. This standardizes the usage across the documentation.