### PR TITLE
docs: mention to run cleanup task when downgrading

### DIFF
--- a/articles/upgrading/essential-steps/instructions/_common.adoc
+++ b/articles/upgrading/essential-steps/instructions/_common.adoc
@@ -5,6 +5,10 @@
 * Check the list of link:https://github.com/vaadin/platform/releases/tag/23.0.0[minimum requirements and supported technologies] for Vaadin 23 to ensure that it conforms with your own requirements.
 
 * Check the compatibility of the link:https://vaadin.com/directory/[add-ons] you are using to see if they work with Vaadin 23.
+
+* If for any reason you need to downgrade to an earlier Vaadin version, make sure to cleanup generated resources by using Maven or Gradle clean functionality (`mvn vaadin:clean-frontend` or `gradle vaadinClean`).
+Check the <<{articles}/production/production-build/#clean-frontend,documentation>> to see what gets removed by the command.
+
 ====
 
 == Preliminary Steps


### PR DESCRIPTION
Since Vaadin 23.3 some generated resources has been moved from target to fronted/generated directory.
When downgrading, running Vaadin clean tasks is necessary to avoid compilation errors building against the earlier version.

Closes vaadin/flow#15208


