### PR TITLE
fix: remove duplicate header from input fields

### DIFF
--- a/articles/react/components/input-fields/index.adoc
+++ b/articles/react/components/input-fields/index.adoc
@@ -20,8 +20,6 @@ Use <<helper,helper texts>> to give more guidance, or tooltips in case a helper 
 In situations where enough context is provided, such as grid filters and search fields, visible labels can be omitted.
 In such cases, an `aria-label` attribute should be provided instead to identify the field, so that users of assistive technologies can interpret the input correctly.
 
-== Helpers
-
 == Helper
 
 Helpers provide information when needed so that end users can fill in a form or field without errors.


### PR DESCRIPTION
"Input fields" page contains a duplicate header which is removed in this PR