### PR TITLE
Update O11y Kit download link

### DIFF
--- a/articles/tools/observability/getting-started.asciidoc
+++ b/articles/tools/observability/getting-started.asciidoc
@@ -18,7 +18,7 @@ This guide covers the following topics:
 Observability Kit is packaged as a Java agent based on the OpenTelemetry standard.
 For more information, see <<{articles}/tools/observability/reference#,Reference>>.
 
-link:http://tools.vaadin.com/nexus/content/repositories/vaadin-prereleases/com/vaadin/observability/vaadin-opentelemetry-javaagent/[Download Observability Kit, role="button secondary water"]
+link:https://repo1.maven.org/maven2/com/vaadin/observability/vaadin-opentelemetry-javaagent/1.0.0/vaadin-opentelemetry-javaagent-1.0.0.jar[Download Observability Kit, role="button secondary water"]
 
 Next, Observability Kit needs to be configured to export traces to Jaeger, and metrics to Prometheus.
 For this, create an [filename]`agent.properties` file with the following contents:

--- a/articles/tools/observability/index.asciidoc
+++ b/articles/tools/observability/index.asciidoc
@@ -16,7 +16,7 @@ At its core, Observability Kit is a custom Java agent that runs together with a 
 
 Download the latest version from the following link:
 
-http://tools.vaadin.com/nexus/content/repositories/vaadin-prereleases/com/vaadin/observability/vaadin-opentelemetry-javaagent/[Download Observability Kit,role="button primary water"]
+https://repo1.maven.org/maven2/com/vaadin/observability/vaadin-opentelemetry-javaagent/1.0.0/vaadin-opentelemetry-javaagent-1.0.0.jar[Download Observability Kit,role="button primary water"]
 
 == Topics
 


### PR DESCRIPTION
Updates the O11y Kit agent pre-release download link with the Maven Central 1.0.0 artifact.