### PR TITLE
docs: add documentation for spreadsheet charts

### DIFF
--- a/articles/components/spreadsheet/index.asciidoc
+++ b/articles/components/spreadsheet/index.asciidoc
@@ -259,6 +259,31 @@ include::{root}/src/main/java/com/vaadin/demo/component/spreadsheet/SpreadsheetR
 ----
 --
 
+== Charts Within Spreadsheets
+
+Vaadin Spreadsheet supports Vaadin Charts, making it possible to open Excel files with charts in them. Spreadsheet depends on Vaadin Charts so there is no need to add the Charts dependency in addition to the Spreadsheet dependency.
+
+The Vaadin Spreadsheet Charts integration package does not allow editing the chart. To change chart parameters such as type, categories, or legend inside the spreadsheet, you need to edit the original Excel file.
+
+Vaadin Charts integration allows changing the values of the data points in a chart. However, it does not allow changing the range of cells that are used for rendering the chart.
+
+Changing the position of charts within a spreadsheet is not supported.
+
+Vaadin charts are shown in the spreadsheet by default. You can disable showing them by using `spreadsheet.setChartsEnabled(false)`.
+
+[.example]
+--
+[source,typescript]
+----
+include::{root}/frontend/demo/component/spreadsheet/spreadsheet-imports.ts[preimport,hidden]
+----
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/spreadsheet/SpreadsheetCharts.java[render,tags=snippet,indent=0,group=Java]
+----
+--
+
 == Limitations
 * No provided toolbars, menus, or other controls for formatting cells.
 * Limited support for the older XSL format.
@@ -276,7 +301,6 @@ As a workaround, you can manually convert tables to ranges. Open the spreadsheet
 
 The following features are not yet implemented in the Flow version of Vaadin Spreadsheet:
 
-* Charts support.
 * Support for custom components.
 * Icons for custom context menu actions.
 

--- a/src/main/java/com/vaadin/demo/component/spreadsheet/SpreadsheetCharts.java
+++ b/src/main/java/com/vaadin/demo/component/spreadsheet/SpreadsheetCharts.java
@@ -1,0 +1,29 @@
+package com.vaadin.demo.component.spreadsheet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.spreadsheet.Spreadsheet;
+
+@Route("spreadsheet-charts")
+public class SpreadsheetCharts extends Div {
+
+    public SpreadsheetCharts() throws IOException, URISyntaxException {
+        // tag::snippet[]
+        InputStream stream = getClass()
+                .getResourceAsStream("/testsheets/simple-invoice.xlsx");
+
+        Spreadsheet spreadsheet = new Spreadsheet(stream);
+        // end::snippet[]
+        spreadsheet.setHeight("400px");
+        add(spreadsheet);
+
+    }
+
+    public static class Exporter extends DemoExporter<SpreadsheetCharts> { // hidden-source-line
+    } // hidden-source-line
+}


### PR DESCRIPTION
## Description

Add documentation for Spreadsheet Charts integration. The content is mainly derived from the [V8 Spreadsheet Charts documentation](https://vaadin.com/docs/v8/spreadsheet/spreadsheet-charts-integration).

Part of https://github.com/vaadin/platform/issues/3567

NOTE:
- Marked as a draft, because the live example included in the PR can only be finished once the target `docs` runs Vaadin 24