### PR TITLE
docs: fix typo in reference date example

### DIFF
--- a/articles/components/date-picker/index.asciidoc
+++ b/articles/components/date-picker/index.asciidoc
@@ -142,7 +142,7 @@ When parsing a 2-digit year, the component must decide which century to parse th
 pass:[<!-- vale Vaadin.RangeFormat = NO -->]
 
 [since:com.vaadin:vaadin@V23.3]#Two-digit years are interpreted as being within a 100-year range whose midpoint is called the _reference date_#.
-For example, a reference date of 2000-01-01 means that the date entered is interpreted as being within the range 1950-01-01 – 2049-12-31, and the year `50` is parsed to 1950 while `39` is parsed to 2049.
+For example, a reference date of 2000-01-01 means that the date entered is interpreted as being within the range 1950-01-01 – 2049-12-31, and the year `50` is parsed to 1950 while `49` is parsed to 2049.
 
 pass:[<!-- vale Vaadin.RangeFormat = YES -->]
 


### PR DESCRIPTION
Fix typo in reference date documentation. The 2-digit year for the example date should be '49', but is '39'.