### PR TITLE
Indicate @PWA should be added rather than updated

### DIFF
--- a/articles/lit/start/in-depth/installing-and-offline-pwa.adoc
+++ b/articles/lit/start/in-depth/installing-and-offline-pwa.adoc
@@ -32,13 +32,20 @@ A browser considers an application a PWA if it meets the following three criteri
 2. It has a registered https://vaadin.com/pwa/learn/serviceworker[ServiceWorker] that handles `fetch` events and loads the application even when offline.
 3. The application is served over HTTPS or on localhost.
 
-Hilla automates the creation of the web application manifest and ServiceWorker with the `@PWA` annotation on [classname]`Application.java`.
-Update the `name` and `shortName` values as shown below:
+Hilla automates the creation of the web application manifest and ServiceWorker with the `@PWA` annotation.
+Add the @PWA annotation on [classname]`Application.java` as follows:
 
 .`Application.java`
 [source,java]
 ----
 @PWA(name = "Hilla CRM", shortName = "CRM", offlineResources = {"images/logo.png"})
+public class Application implements AppShellConfigurator {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}
 ----
 
 By default, Hilla caches all your frontend views for offline use.


### PR DESCRIPTION
start.vaadin.com no longer generates projects with the `@PWA` annotation. The annotation should, thus, be added rather than updated. 