### PR TITLE
Add direct download links as alternate ways to start a Hilla project

### DIFF
--- a/articles/lit/start/basics/index.adoc
+++ b/articles/lit/start/basics/index.adoc
@@ -40,12 +40,16 @@ ifdef::lit[]
 ----
 npx @hilla/cli init --preset hilla-tutorial hilla-todo
 ----
+
+Alternatively, you can https://start.vaadin.com/dl?preset=hilla-tutorial&projectName=hilla-todo[download the starter as a zip-file] and extract it.
 endif::[]
 ifdef::react[]
 [source,terminal]
 ----
 npx @hilla/cli init --preset react-tutorial hilla-todo
 ----
+
+Alternatively, you can https://start.vaadin.com/dl?preset=react-tutorial&projectName=hilla-todo[download the starter as a zip-file] and extract it.
 endif::[]
 
 Unpack the downloaded zip into a folder on your computer, and import the project in the IDE of your choice.

--- a/articles/lit/start/in-depth/project-setup.adoc
+++ b/articles/lit/start/in-depth/project-setup.adoc
@@ -35,6 +35,9 @@ Create an application using the Hilla CLI:
 npx @hilla/cli init --preset hilla-crm-tutorial hilla-crm
 ----
 
+Alternatively, you can https://start.vaadin.com/dl?preset=hilla-crm-tutorial&projectName=hilla-crm[download the starter as a zip-file] and extract it.
+
+
 == Importing a Hilla project in VS Code
 
 Open the created `hilla-crm` folder in VS Code.

--- a/articles/lit/start/quick.adoc
+++ b/articles/lit/start/quick.adoc
@@ -21,18 +21,23 @@ order: 10
 
 You can create a new Hilla project using the Hilla CLI:
 
-.terminal
 ifdef::lit[]
+.terminal
 [source,terminal]
 ----
 npx @hilla/cli init my-hilla-app
 ----
+
+Alternatively, you can https://start.vaadin.com/dl?preset=hilla&projectName=my-hilla-app[download the starter as a zip-file] and extract it.
 endif::[]
 ifdef::react[]
+.terminal
 [source,terminal]
 ----
 npx @hilla/cli init --react my-hilla-app
 ----
+
+Alternatively, you can https://start.vaadin.com/dl?preset=react&projectName=my-hilla-app[download the starter as a zip-file] and extract it.
 endif::[]
 
 ifdef::lit[]


### PR DESCRIPTION
A community member reached out and said that they were not able to start a Hilla project with the CLI because of corporate policy blocking the CLI. This PR provides direct download links to the same projects as ZIP files. 

Please verify this locally before merging, I was not able to get the docs app running locally.