### PR TITLE
Update GridContextMenuExample.java

### DIFF
--- a/src/main/java/com/vaadin/demo/component/grid/GridContextMenuExample.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridContextMenuExample.java
@@ -25,7 +25,7 @@ public class GridContextMenuExample extends Div {
 
         PersonContextMenu contextMenu = new PersonContextMenu(grid);
 
-        add(grid, contextMenu);
+        add(grid);
         // end::snippet1[]
 
         List<Person> people = DataService.getPeople();


### PR DESCRIPTION
Removed obsolete parameter to add method. Context menu don't need to be added separately to the DOM when bound to Grid.


