### PR TITLE
docs: update RTE value docs to reflect default format change (v24)

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -32,6 +32,7 @@ DeltaSpike
 [dD]estructuring
 [dD]ialogs
 Dockerfile
+[dD]ompurify
 # Vale spelling doesn't recognize "dos and don'ts"
 don'ts
 [dD]raggable

--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -116,6 +116,7 @@ reactively
 [rR]enderers?
 Roboto
 [rR]esizable
+[sS]anitization
 [sS]cannability
 [sS]crollable
 [sS]crollbars?

--- a/articles/components/rich-text-editor/index.asciidoc
+++ b/articles/components/rich-text-editor/index.asciidoc
@@ -119,7 +119,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextE
 
 Rich Text Editor supports the HTML format and the https://github.com/quilljs/delta[Quill Delta format] for reading and setting its value.
 
-For the Flow component, the default is the HTML format, which will also be used automatically when binding the component with `Binder`.
+For the Flow component, the default is the HTML format, which is also used automatically when binding the component with `Binder`.
 
 To read, write, or bind the component's value using the Delta format, use the https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/richtexteditor/RichTextEditor.html#asDelta()[`RichTextEditor.asDelta()`] wrapper.
 

--- a/articles/components/rich-text-editor/index.asciidoc
+++ b/articles/components/rich-text-editor/index.asciidoc
@@ -117,14 +117,28 @@ include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextE
 
 == Value Format
 
-Rich Text Editor natively uses the JSON-based https://github.com/quilljs/delta[Delta format] for reading and setting its value, but HTML values can also be used, with some limitations.
+Rich Text Editor supports the HTML format and the https://github.com/quilljs/delta[Quill Delta format] for reading and setting its value.
+
+For the Flow component, the default is the HTML format, which will also automatically be used when binding the component using `Binder`.
+To read, write, or bind the component's value using the Delta format, use the https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/richtexteditor/RichTextEditor.html#asDelta()[`RichTextEditor.asDelta()`] wrapper.
+
+For the web component, to read or write the value in the Delta format, use the `value` property.
+To read or write the value in the HTML format, use the `htmlValue` property and the `dangerouslySetHtmlValue` method.
+
+.HTML sanitization
+[NOTE]
+Please make sure to sanitize HTML strings, for example using a library such as https://www.npmjs.com/package/dompurify[dompurify], before passing them to the web component using `dangerouslySetHtmlValue` in order to prevent injecting malicious content.
 
 [.example]
 --
 
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=htmlsnippet;snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=htmlsnippet,indent=0,group=TypeScript]
+
+...
+
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,java]

--- a/articles/components/rich-text-editor/index.asciidoc
+++ b/articles/components/rich-text-editor/index.asciidoc
@@ -98,7 +98,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextE
 
 === No Border
 
-Apply the `no-border` theme variant to remove Rich Text Editor’s border, for example when the component is wrapped in a container with its own borders.
+Apply the `no-border` theme variant to remove Rich Text Editor’s border. An example of this is when the component is wrapped in a container with its own borders.
 
 [.example]
 --
@@ -119,15 +119,17 @@ include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextE
 
 Rich Text Editor supports the HTML format and the https://github.com/quilljs/delta[Quill Delta format] for reading and setting its value.
 
-For the Flow component, the default is the HTML format, which will also automatically be used when binding the component using `Binder`.
+For the Flow component, the default is the HTML format, which will also be used automatically when binding the component with `Binder`.
+
 To read, write, or bind the component's value using the Delta format, use the https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/richtexteditor/RichTextEditor.html#asDelta()[`RichTextEditor.asDelta()`] wrapper.
 
 For the web component, to read or write the value in the Delta format, use the `value` property.
+
 To read or write the value in the HTML format, use the `htmlValue` property and the `dangerouslySetHtmlValue` method.
 
 .HTML sanitization
 [NOTE]
-Please make sure to sanitize HTML strings, for example using a library such as https://www.npmjs.com/package/dompurify[dompurify], before passing them to the web component using `dangerouslySetHtmlValue` in order to prevent injecting malicious content.
+To prevent injecting malicious content, be sure to sanitize HTML strings before passing them to the web component using `dangerouslySetHtmlValue`. An example of this would be using a library such as https://www.npmjs.com/package/dompurify[dompurify].
 
 [.example]
 --
@@ -158,11 +160,11 @@ include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextE
 
 |image::icons/undo.svg[opts=inline, 20, 20, role=icon]
 |Undo
-|Reverses the previous action
+|Reverses the previous action.
 
 |image::icons/redo.svg[opts=inline, 20, 20, role=icon]
 |Redo
-|Restores actions undone by `Undo`
+|Restores actions undone by `Undo`.
 
 |===
 
@@ -174,26 +176,26 @@ include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextE
 
 |[.bold.rte-button]#B#
 |Bold
-s|Boldens text
+s|Boldens text.
 
 |[.italic.rte-button]#I#
 |Italic
-e|Italicizes text
+e|Italicizes text.
 
 |[.underline.rte-button]#U#
 |Underline
-|[.underline]#Underlines text#
+|[.underline]#Underlines text.#
 
 |[.strikethrough.rte-button]#T#
 |Strikethrough
-|[.strikethrough]#Strikes through text#
+|[.strikethrough]#Strikes through text.#
 
 |===
 
 === Headings
 
-Three different headings are available in Rich Text Editor: H1, H2 ,and H3.
-Use them to signify structure (and importance).
+Three different headings are available in Rich Text Editor: H1, H2, and H3.
+Use them to signify structure, as well as importance.
 
 [cols="^.^1,4,8"]
 |===
@@ -201,15 +203,15 @@ Use them to signify structure (and importance).
 
 |[.h1.heading.rte-button]#H1#
 |H1
-|[.h1]#Heading level 1#
+|[.h1]#Heading level 1.#
 
 |[.h2.heading.rte-button]#H2#
 |H2
-|[.h2]#Heading level 2#
+|[.h2]#Heading level 2.#
 
 |[.h3.heading.rte-button]#H3#
 |H3
-|[.h3]#Heading level 3#
+|[.h3]#Heading level 3.#
 
 |===
 
@@ -221,11 +223,11 @@ Use them to signify structure (and importance).
 
 |[.subscript.rte-button]#X#
 |Subscript
-|Subscript text is positioned ~below~ the normal baseline and with smaller font size
+|Subscript text is positioned ~below~ the normal baseline and with a smaller font size.
 
 |[.superscript.rte-button]#X#
 |Superscript
-|Superscript text is positioned ^above^ the normal baseline and with smaller font size
+|Superscript text is positioned ^above^ the normal baseline and a with smaller font size.
 
 |===
 
@@ -237,11 +239,11 @@ Use them to signify structure (and importance).
 
 |image::icons/list-ordered.svg[opts=inline, 20, 20, role=icon]
 |Ordered list
-|. Creates a numbered list
+|. Creates a numbered list.
 
 |image::icons/list-bullet.svg[opts=inline, 20, 20, role=icon]
 |Unordered list
-|* Creates a bulleted list
+|* Creates a bulleted list.
 
 |===
 
@@ -253,15 +255,15 @@ Use them to signify structure (and importance).
 
 |image::icons/align-left.svg[opts=inline, 20, 20, role=icon]
 |Left align
-<|Left-aligns text (default)
+<|Left-aligns text (default).
 
 |image::icons/align-center.svg[opts=inline, 20, 20, role=icon]
 |Center align
-^|Center-aligns text
+^|Center-aligns text.
 
 |image::icons/align-right.svg[opts=inline, 20, 20, role=icon]
 |Right align
->|Right-aligns text
+>|Right-aligns text.
 
 |===
 
@@ -273,11 +275,11 @@ Use them to signify structure (and importance).
 
 |image::icons/image.svg[opts=inline, 20, 20, role=icon]
 |Image
-|Uploads and inserts an image from your device
+|Uploads and inserts an image from your device.
 
 |image::icons/link.svg[opts=inline, 20, 20, role=icon]
 |Link
-a|https://vaadin.com/[Creates a hyperlink]
+a|https://vaadin.com/[Creates a hyperlink].
 
 |===
 
@@ -289,11 +291,11 @@ a|https://vaadin.com/[Creates a hyperlink]
 
 |[.block-quote.rte-button]#”#
 |Block quote
-|Creates a section quoted from another source
+|Creates a section quoted from another source.
 
 |[.code-block.rte-button]#<>#
 |Code block
-|Creates a block formatted as code
+|Creates a block formatted as code.
 
 |===
 
@@ -305,7 +307,7 @@ a|https://vaadin.com/[Creates a hyperlink]
 
 |image::icons/clean.svg[opts=inline, 20, 20, role=icon]
 |Clear formatting
-|Removes all formatting of the selected text
+|Removes all formatting of the selected text.
 
 |===
 

--- a/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
@@ -3,7 +3,11 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/rich-text-editor';
-import type { RichTextEditor, RichTextEditorChangeEvent } from '@vaadin/rich-text-editor';
+import type {
+  RichTextEditor,
+  RichTextEditorHtmlValueChangedEvent,
+  RichTextEditorValueChangedEvent,
+} from '@vaadin/rich-text-editor';
 import '@vaadin/text-area';
 import type { TextAreaChangeEvent } from '@vaadin/text-area';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -19,6 +23,7 @@ export class Example extends LitElement {
 
   @state()
   private htmlValue = '';
+
   @state()
   private deltaValue = '';
 
@@ -31,9 +36,11 @@ export class Example extends LitElement {
       <vaadin-rich-text-editor
         style="height: 400px;"
         .value="${this.deltaValue}"
-        @change="${(event: RichTextEditorChangeEvent) => {
-          this.htmlValue = event.target.htmlValue ?? '';
-          this.deltaValue = event.target.value ?? '';
+        @value-changed="${(event: RichTextEditorValueChangedEvent) => {
+          this.deltaValue = event.detail.value;
+        }}"
+        @html-value-changed="${(event: RichTextEditorHtmlValueChangedEvent) => {
+          this.htmlValue = event.detail.value;
         }}"
       ></vaadin-rich-text-editor>
 

--- a/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
@@ -19,6 +19,8 @@ export class Example extends LitElement {
 
   @state()
   private htmlValue = '';
+  @state()
+  private deltaValue = '';
 
   @query('vaadin-rich-text-editor')
   private richTextEditor!: RichTextEditor;
@@ -28,17 +30,29 @@ export class Example extends LitElement {
       <!-- tag::htmlsnippet[] -->
       <vaadin-rich-text-editor
         style="height: 400px;"
+        .value="${this.deltaValue}"
         @change="${(event: RichTextEditorChangeEvent) => {
           this.htmlValue = event.target.htmlValue ?? '';
+          this.deltaValue = event.target.value ?? '';
         }}"
       ></vaadin-rich-text-editor>
 
       <vaadin-text-area
-        label="Html Value"
-        @change="${(e: TextAreaChangeEvent) => this.setHtmlValue(e.target.value)}"
-        placeholder="Type html string here to set it as value to the Rich Text Editor above..."
+        label="HTML Value"
+        placeholder="Enter something in the Rich Text Editor to see its HTML value here."
         style="width: 100%;"
         .value="${this.htmlValue}"
+        @change="${(e: TextAreaChangeEvent) => this.setHtmlValue(e.target.value)}"
+      ></vaadin-text-area>
+
+      <vaadin-text-area
+        label="Delta Value"
+        placeholder="Enter something in the Rich Text Editor to see its Delta value here."
+        style="width: 100%;"
+        .value="${this.deltaValue}"
+        @change="${(e: TextAreaChangeEvent) => {
+          this.deltaValue = e.target.value;
+        }}"
       ></vaadin-text-area>
       <!-- end::htmlsnippet[] -->
     `;
@@ -46,7 +60,9 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   setHtmlValue(htmlValue: string) {
+    this.htmlValue = htmlValue;
     this.richTextEditor.dangerouslySetHtmlValue(htmlValue);
   }
+
   // end::snippet[]
 }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java
@@ -11,21 +11,32 @@ public class RichTextEditorSetGetValue extends Div {
 
     public RichTextEditorSetGetValue() {
         // tag::snippet[]
-        TextArea textArea = new TextArea("Html Value",
-                "Type html string here to set it as value to the Rich Text Editor above...");
-        textArea.setWidthFull();
-
         RichTextEditor rte = new RichTextEditor();
         rte.getStyle().set("max-height", "400px");
 
-        rte.asHtml()
-                .addValueChangeListener(e -> textArea.setValue(e.getValue()));
-        textArea.addValueChangeListener(e -> {
-            if (!rte.asHtml().getValue().equals(e.getValue())) {
-                rte.asHtml().setValue(e.getValue());
+        // HTML value
+        TextArea htmlTextArea = new TextArea("HTML Value",
+                "Enter something in the Rich Text Editor to see its HTML value here.");
+        htmlTextArea.setWidthFull();
+        rte.addValueChangeListener(e -> htmlTextArea.setValue(e.getValue()));
+        htmlTextArea.addValueChangeListener(e -> {
+            if (!rte.getValue().equals(e.getValue())) {
+                rte.setValue(e.getValue());
             }
         });
-        add(rte, textArea);
+
+        // Delta value
+        TextArea deltaTextArea = new TextArea("Delta Value",
+                "Enter something in the Rich Text Editor to see its Delta value here.");
+        deltaTextArea.setWidthFull();
+        rte.asDelta().addValueChangeListener(e -> deltaTextArea.setValue(e.getValue()));
+        deltaTextArea.addValueChangeListener(e -> {
+            if (!rte.asDelta().getValue().equals(e.getValue())) {
+                rte.asDelta().setValue(e.getValue());
+            }
+        });
+
+        add(rte, htmlTextArea);
         // end::snippet[]
     }
 

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java
@@ -3,6 +3,7 @@ package com.vaadin.demo.component.richtexteditor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.richtexteditor.RichTextEditor;
 import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
@@ -13,6 +14,7 @@ public class RichTextEditorSetGetValue extends Div {
         // tag::snippet[]
         RichTextEditor rte = new RichTextEditor();
         rte.getStyle().set("max-height", "400px");
+        rte.setValueChangeMode(ValueChangeMode.TIMEOUT);
 
         // HTML value
         TextArea htmlTextArea = new TextArea("HTML Value",
@@ -36,7 +38,7 @@ public class RichTextEditorSetGetValue extends Div {
             }
         });
 
-        add(rte, htmlTextArea);
+        add(rte, htmlTextArea, deltaTextArea);
         // end::snippet[]
     }
 


### PR DESCRIPTION
Updates the RichTextEditor "Value Format" section to reflect changes in v24 where the HTML format becomes the default for the Flow component.

Also updates the code examples to demonstrate usage of both formats.

This should only be merged after v24 has been released and docs have been upgraded.