### PR TITLE
fix: use default import syntax for images

### DIFF
--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -6,7 +6,7 @@ import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import * as companyLogo from '../../../../src/main/resources/images/company-logo.png';
+import companyLogo from '../../../../src/main/resources/images/company-logo.png';
 
 @customElement('avatar-image')
 export class Example extends LitElement {

--- a/frontend/demo/component/button/button-images.ts
+++ b/frontend/demo/component/button/button-images.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import { applyTheme } from 'Frontend/generated/theme';
-import * as img from '../../../../src/main/resources/images/vaadin-logo-dark.png';
+import img from '../../../../src/main/resources/images/vaadin-logo-dark.png';
 
 @customElement('button-images')
 export class Example extends LitElement {

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -3,7 +3,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/login/vaadin-login-form.js';
 import type { LoginI18n } from '@vaadin/login';
-import * as img from '../../../../src/main/resources/images/starry-sky.png';
+import img from '../../../../src/main/resources/images/starry-sky.png';
 
 @customElement('login-overlay-mockup')
 export class LoginOverlayMockupElement extends LitElement {

--- a/frontend/demo/component/scroller/scroller-both.ts
+++ b/frontend/demo/component/scroller/scroller-both.ts
@@ -3,7 +3,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import '@vaadin/scroller';
-import * as img from '../../../../src/main/resources/images/reindeer.jpg';
+import img from '../../../../src/main/resources/images/reindeer.jpg';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('scroller-both')


### PR DESCRIPTION
Vite exports images via the default export. Updated the imports accordingly to fix the images not showing up in certain examples.

```diff
- import * as img from '../../../../src/main/resources/images/starry-sky.png';
+ import img from '../../../../src/main/resources/images/starry-sky.png';
```
