### PR TITLE
chore: replace ts-ignore comments with ts-expect-error

### DIFF
--- a/frontend/demo/example-resources.ts
+++ b/frontend/demo/example-resources.ts
@@ -1,10 +1,10 @@
 import './init-flow-namespace';
 import { applyTheme } from 'Frontend/generated/theme';
-// See webpack.config 'externals.Frontend/generated/theme'
-// This file ends up in the docs-app bundle
-// @ts-ignore
+// See Vite config 'apply-theme-fallback'
+// This file ends up in the DSP bundle
+// @ts-expect-error See vite.config.ts
 window.__applyTheme = { applyTheme };
-// @ts-ignore
+// @ts-expect-error See webpack.dspublisher.js
 import('all-flow-imports-or-empty').catch(() => {});
 
 // Verify if session is still active and reload the page otherwise

--- a/frontend/demo/init-flow-namespace.ts
+++ b/frontend/demo/init-flow-namespace.ts
@@ -1,5 +1,4 @@
 // The connectors require window.Vaadin.Flow namespace to exists
-// @ts-ignore
 window.Vaadin = window.Vaadin || {};
-// @ts-ignore
+// @ts-expect-error Used by the connectors
 window.Vaadin.Flow = window.Vaadin.Flow || {};

--- a/frontend/demo/init.ts
+++ b/frontend/demo/init.ts
@@ -4,17 +4,17 @@ import '@vaadin/polymer-legacy-adapter/style-modules.js';
 import './init-flow-namespace';
 import './init-flow-components';
 import '../generated/vaadin-featureflags';
-// @ts-ignore
+// @ts-expect-error See workaround below
 import Appointment from 'Frontend/generated/com/vaadin/demo/domain/Appointment';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
 import PersonModel from 'Frontend/generated/com/vaadin/demo/domain/PersonModel';
-// @ts-ignore
+// @ts-expect-error See workaround below
 import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import AddressModel from 'Frontend/generated/com/vaadin/demo/domain/AddressModel';
-// @ts-ignore
+// @ts-expect-error See workaround below
 import Address from 'Frontend/generated/com/vaadin/demo/domain/Address';
 import CardModel from 'Frontend/generated/com/vaadin/demo/domain/CardModel';
-// @ts-ignore
+// @ts-expect-error See workaround below
 import Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
 import client from 'Frontend/generated/connect-client.default';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -22,16 +22,16 @@ import { applyTheme } from 'Frontend/generated/theme';
 // Apply the theme, so that overlay elements styles and custom property overrides work as expected
 applyTheme(document);
 
-// @ts-ignore
-client.prefix = __VAADIN_CONNECT_PREFIX__;
+// @ts-expect-error Inserted by DS Publisher
+client.prefix = __VAADIN_CONNECT_PREFIX__; // eslint-disable-line no-undef
 
-// @ts-ignore Workaround a Vaadin issue
+// @ts-expect-error Workaround a Vaadin issue
 AppointmentModel.createEmptyValue = () => Appointment;
-// @ts-ignore Workaround a Vaadin issue
+// @ts-expect-error Workaround a Vaadin issue
 PersonModel.createEmptyValue = () => Person;
-// @ts-ignore Workaround a Vaadin issue
+// @ts-expect-error Workaround a Vaadin issue
 AddressModel.createEmptyValue = () => Address;
-// @ts-ignore Workaround a Vaadin issue
+// @ts-expect-error Workaround a Vaadin issue
 CardModel.createEmptyValue = () => Card;
 
 document.body.style.setProperty('--docs-example-render-font-family', 'var(--lumo-font-family)');

--- a/frontend/demo/session-verification.ts
+++ b/frontend/demo/session-verification.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error Suppress the error
 import { withPrefix } from 'gatsby';
 
 function testHeartbeat() {


### PR DESCRIPTION
## Description

Removed usage of `// @ts-ignore` to fix related warnings from `eslint-config-vaadin`.