### PR TITLE
chore: add missing horizontal-layout import to demo

### DIFF
--- a/frontend/demo/component/notification/notification-rich.ts
+++ b/frontend/demo/component/notification/notification-rich.ts
@@ -3,6 +3,7 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/button';
+import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/notification';


### PR DESCRIPTION
## Description

The Notification [rich content](https://vaadin.com/docs/latest/components/notification/#icons-and-other-rich-formatting) example is currently broken when [opening in a new tab](https://vaadin.com/docs/latest/example?path=component/notification/notification-rich.ts).
Added a missing import for `vaadin-horizontal-layout` web component to fix that.