### PR TITLE
chore: simplify custom-field size variants demo

### DIFF
--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/custom-field';
 import '@vaadin/horizontal-layout';
 import '@vaadin/select';
 import '@vaadin/text-field';
-import { selectRenderer } from '@vaadin/select/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('custom-field-size-variants')
@@ -17,15 +16,30 @@ export class Example extends LitElement {
     return root;
   }
 
+  @query('#amount > input')
+  private amount!: HTMLInputElement;
+
+  @query('#currency > [slot="value"]')
+  private currency!: HTMLElement;
+
+  @state()
+  private currencies = [
+    { label: 'AUD', value: 'aud' },
+    { label: 'CAD', value: 'cad' },
+    { label: 'CHF', value: 'chf' },
+    { label: 'EUR', value: 'eur' },
+    { label: 'GBP', value: 'gbp' },
+    { label: 'JPY', value: 'jpy' },
+    { label: 'USD', value: 'usd' },
+  ];
+
   firstUpdated() {
     // Set `aria-label` for screen readers
-    const amount = this.renderRoot.querySelector('#amount > input') as HTMLInputElement;
-    amount.setAttribute('aria-label', 'Amount');
-    amount.removeAttribute('aria-labelledby');
+    this.amount.setAttribute('aria-label', 'Amount');
+    this.amount.removeAttribute('aria-labelledby');
 
-    const currency = this.renderRoot.querySelector('#currency > [slot="value"]') as HTMLElement;
-    currency.setAttribute('aria-label', 'Currency');
-    currency.removeAttribute('aria-labelledby');
+    this.currency.setAttribute('aria-label', 'Currency');
+    this.currency.removeAttribute('aria-labelledby');
   }
 
   render() {
@@ -36,23 +50,9 @@ export class Example extends LitElement {
           <vaadin-text-field id="amount" theme="small"></vaadin-text-field>
           <vaadin-select
             id="currency"
+            .items="${this.currencies}"
             theme="small"
             style="width: 6em;"
-            ${selectRenderer(
-              () =>
-                html`
-                  <vaadin-list-box>
-                    <vaadin-item value="eur">AUD</vaadin-item>
-                    <vaadin-item value="eur">CAD</vaadin-item>
-                    <vaadin-item value="eur">CHF</vaadin-item>
-                    <vaadin-item value="eur">EUR</vaadin-item>
-                    <vaadin-item value="gbp">GBP</vaadin-item>
-                    <vaadin-item value="gbp">JPY</vaadin-item>
-                    <vaadin-item value="usd">USD</vaadin-item>
-                  </vaadin-list-box>
-                `,
-              []
-            )}
           ></vaadin-select>
         </vaadin-horizontal-layout>
       </vaadin-custom-field>


### PR DESCRIPTION
## Description

1. Updated the demo to use `items` property for `vaadin-select`,
2. Changed to use `@query()` decorator for setting `aria-label`.