### PR TITLE
chore: simplify Lit renderers by removing extra return

### DIFF
--- a/frontend/demo/component/checkbox/checkbox-custom-presentation.ts
+++ b/frontend/demo/component/checkbox/checkbox-custom-presentation.ts
@@ -29,8 +29,8 @@ export class Example extends LitElement {
   render() {
     return html`
       <vaadin-checkbox-group label="Invitees" theme="vertical">
-        ${this.items.map((person) => {
-          return html`
+        ${this.items.map(
+          (person) => html`
             <vaadin-checkbox .value="${String(person.id)}">
               <label slot="label">
                 <div style="display: flex;">
@@ -42,8 +42,8 @@ export class Example extends LitElement {
                 </div>
               </label>
             </vaadin-checkbox>
-          `;
-        })}
+          `
+        )}
       </vaadin-checkbox-group>
     `;
   }

--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -64,22 +64,20 @@ export class Example extends LitElement {
   // We recommend placing CSS in a separate style sheet and
   // encapsulating the styling in a new component.
 
-  private renderer: ComboBoxLitRenderer<Person> = (person) => {
-    return html`
-      <div style="display: flex;">
-        <img
-          style="height: var(--lumo-size-m); margin-right: var(--lumo-space-s);"
-          src="${person.pictureUrl}"
-          alt="Portrait of ${person.firstName} ${person.lastName}"
-        />
-        <div>
-          ${person.firstName} ${person.lastName}
-          <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);">
-            ${person.profession}
-          </div>
+  private renderer: ComboBoxLitRenderer<Person> = (person) => html`
+    <div style="display: flex;">
+      <img
+        style="height: var(--lumo-size-m); margin-right: var(--lumo-space-s);"
+        src="${person.pictureUrl}"
+        alt="Portrait of ${person.firstName} ${person.lastName}"
+      />
+      <div>
+        ${person.firstName} ${person.lastName}
+        <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);">
+          ${person.profession}
         </div>
       </div>
-    `;
-  };
+    </div>
+  `;
   // end::renderer[]
 }

--- a/frontend/demo/component/contextmenu/context-menu-best-practices.ts
+++ b/frontend/demo/component/contextmenu/context-menu-best-practices.ts
@@ -33,11 +33,6 @@ export class Example extends LitElement {
     { name: 'Financials.xlsx', size: '42 MB' },
   ];
 
-  private menuBarRenderer = () => {
-    const items = [{ component: this.makeIcon(), children: this.items }];
-    return html`<vaadin-menu-bar .items=${items} theme="tertiary"></vaadin-menu-bar>`;
-  };
-
   render() {
     return html`
       <!-- tag::snippethtml[] -->
@@ -52,7 +47,15 @@ export class Example extends LitElement {
           <vaadin-grid-column
             width="70px"
             flex-grow="0"
-            ${columnBodyRenderer(this.menuBarRenderer, [])}
+            ${columnBodyRenderer(
+              () => html`
+                <vaadin-menu-bar
+                  .items=${[{ component: this.makeIcon(), children: this.items }]}
+                  theme="tertiary"
+                ></vaadin-menu-bar>
+              `,
+              []
+            )}
           ></vaadin-grid-column>
         </vaadin-grid>
       </vaadin-context-menu>

--- a/frontend/demo/component/contextmenu/context-menu-presentation.ts
+++ b/frontend/demo/component/contextmenu/context-menu-presentation.ts
@@ -6,7 +6,6 @@ import '@vaadin/context-menu';
 import type { ContextMenuItem } from '@vaadin/context-menu';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import type { Grid } from '@vaadin/grid';
 import '@vaadin/icon';
 import '@vaadin/icons';
@@ -67,7 +66,10 @@ export class Example extends LitElement {
         >
           <vaadin-grid-column
             header="Applicant"
-            ${columnBodyRenderer(this.nameRenderer, [])}
+            ${columnBodyRenderer<Person>(
+              (person) => html`<span>${person.firstName} ${person.lastName}</span>`,
+              []
+            )}
           ></vaadin-grid-column>
           <vaadin-grid-column path="email"></vaadin-grid-column>
           <vaadin-grid-column header="Phone number" path="address.phone"></vaadin-grid-column>
@@ -132,8 +134,4 @@ export class Example extends LitElement {
       e.stopPropagation();
     }
   }
-
-  private nameRenderer: GridColumnBodyLitRenderer<Person> = (person) => {
-    return html`<span>${person.firstName} ${person.lastName}</span>`;
-  };
 }

--- a/frontend/demo/component/grid/grid-column-width.ts
+++ b/frontend/demo/component/grid/grid-column-width.ts
@@ -6,7 +6,6 @@ import '@vaadin/button';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-selection-column.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/split-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
@@ -45,16 +44,12 @@ export class Example extends LitElement {
             width="6em"
             flex-grow="0"
             header="Has Sub"
-            ${columnBodyRenderer(this.subscriptionRenderer, [])}
+            ${columnBodyRenderer<Person>((item) => html`${item.subscriber ? 'Yes' : 'No'}`, [])}
           ></vaadin-grid-column>
         </vaadin-grid>
         <div></div>
       </vaadin-split-layout>
     `;
   }
-
-  private subscriptionRenderer: GridColumnBodyLitRenderer<Person> = (item) => {
-    return html`${item.subscriber ? 'Yes' : 'No'}`;
-  };
 }
 // end::snippet[]

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -44,60 +44,56 @@ export class Example extends LitElement {
   }
 
   // tag::snippet[]
-  private employeeRenderer: GridColumnBodyLitRenderer<Person> = (person, model) => {
-    return html`
-      <vaadin-grid-tree-toggle
-        .leaf="${!person.manager}"
-        .level="${model.level || 0}"
-        @expanded-changed="${(e: GridTreeToggleExpandedChangedEvent) => {
-          if (e.detail.value) {
-            this.expandedItems = [...this.expandedItems, person];
-          } else {
-            this.expandedItems = this.expandedItems.filter((p) => p.id !== person.id);
-          }
-        }}"
-        .expanded="${!!model.expanded}"
-      >
-        <vaadin-horizontal-layout style="align-items: center;" theme="spacing">
-          <vaadin-avatar
-            img="${person.pictureUrl}"
-            name="${`${person.firstName} ${person.lastName}`}"
-          ></vaadin-avatar>
-          <vaadin-vertical-layout style="line-height: var(--lumo-line-height-m);">
-            <span>${person.firstName} ${person.lastName}</span>
-            <span
-              style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);"
-            >
-              ${person.profession}
-            </span>
-          </vaadin-vertical-layout>
-        </vaadin-horizontal-layout>
-      </vaadin-grid-tree-toggle>
-    `;
-  };
+  private employeeRenderer: GridColumnBodyLitRenderer<Person> = (person, model) => html`
+    <vaadin-grid-tree-toggle
+      .leaf="${!person.manager}"
+      .level="${model.level ?? 0}"
+      @expanded-changed="${(e: GridTreeToggleExpandedChangedEvent) => {
+        if (e.detail.value) {
+          this.expandedItems = [...this.expandedItems, person];
+        } else {
+          this.expandedItems = this.expandedItems.filter((p) => p.id !== person.id);
+        }
+      }}"
+      .expanded="${!!model.expanded}"
+    >
+      <vaadin-horizontal-layout style="align-items: center;" theme="spacing">
+        <vaadin-avatar
+          img="${person.pictureUrl}"
+          name="${`${person.firstName} ${person.lastName}`}"
+        ></vaadin-avatar>
+        <vaadin-vertical-layout style="line-height: var(--lumo-line-height-m);">
+          <span>${person.firstName} ${person.lastName}</span>
+          <span
+            style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);"
+          >
+            ${person.profession}
+          </span>
+        </vaadin-vertical-layout>
+      </vaadin-horizontal-layout>
+    </vaadin-grid-tree-toggle>
+  `;
 
-  private contactRenderer: GridColumnBodyLitRenderer<Person> = (person) => {
-    return html`
-      <vaadin-vertical-layout
-        style="font-size: var(--lumo-font-size-s); line-height: var(--lumo-line-height-m);"
-      >
-        <a href="mailto:${person.email}" style="align-items: center; display: flex;">
-          <vaadin-icon
-            icon="vaadin:envelope"
-            style="height: var(--lumo-icon-size-s); margin-inline-end: var(--lumo-space-s); width: var(--lumo-icon-size-s);"
-          ></vaadin-icon>
-          <span>${person.email}</span>
-        </a>
-        <a href="tel:${person.address.phone}" style="align-items: center; display: flex;">
-          <vaadin-icon
-            icon="vaadin:phone"
-            style="height: var(--lumo-icon-size-s); margin-inline-end: var(--lumo-space-s); width: var(--lumo-icon-size-s);"
-          ></vaadin-icon>
-          <span>${person.address.phone}</span>
-        </a>
-      </vaadin-vertical-layout>
-    `;
-  };
+  private contactRenderer: GridColumnBodyLitRenderer<Person> = (person) => html`
+    <vaadin-vertical-layout
+      style="font-size: var(--lumo-font-size-s); line-height: var(--lumo-line-height-m);"
+    >
+      <a href="mailto:${person.email}" style="align-items: center; display: flex;">
+        <vaadin-icon
+          icon="vaadin:envelope"
+          style="height: var(--lumo-icon-size-s); margin-inline-end: var(--lumo-space-s); width: var(--lumo-icon-size-s);"
+        ></vaadin-icon>
+        <span>${person.email}</span>
+      </a>
+      <a href="tel:${person.address.phone}" style="align-items: center; display: flex;">
+        <vaadin-icon
+          icon="vaadin:phone"
+          style="height: var(--lumo-icon-size-s); margin-inline-end: var(--lumo-space-s); width: var(--lumo-icon-size-s);"
+        ></vaadin-icon>
+        <span>${person.address.phone}</span>
+      </a>
+    </vaadin-vertical-layout>
+  `;
 
   render() {
     return html`


### PR DESCRIPTION
## Description

Fixed some more `eslint-config-vaadin` errors by removing extra `return` from Lit renderers.