### PR TITLE
chore: fix TS compilation errors in grid examples

### DIFF
--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -4,7 +4,6 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import type { GridDragStartEvent } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
@@ -85,7 +84,10 @@ export class Example extends LitElement {
         >
           <vaadin-grid-column
             header="Full name"
-            ${columnBodyRenderer(this.fullNameRenderer, [])}
+            ${columnBodyRenderer<Person>(
+              (person) => html`${person.firstName} ${person.lastName}`,
+              []
+            )}
           ></vaadin-grid-column>
           <vaadin-grid-column path="profession"></vaadin-grid-column>
         </vaadin-grid>

--- a/frontend/demo/component/gridpro/grid-pro-edit-column.ts
+++ b/frontend/demo/component/gridpro/grid-pro-edit-column.ts
@@ -6,7 +6,6 @@ import '@vaadin/grid/vaadin-grid-column.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';


### PR DESCRIPTION
## Description

Fixed the following TS compilation errors that I introduced by accident 😞 

```
13:54:55  [ERROR] frontend/demo/component/grid/grid-drag-rows-between-grids.ts(7,1): error TS6133: 'GridColumnBodyLitRenderer' is declared but its value is never read.
13:54:55  [ERROR] frontend/demo/component/grid/grid-drag-rows-between-grids.ts(88,39): error TS2339: Property 'fullNameRenderer' does not exist on type 'Example'.
13:54:55  [ERROR] frontend/demo/component/gridpro/grid-pro-edit-column.ts(9,1): error TS6133: 'GridColumnBodyLitRenderer' is declared but its value is never read.
```