### PR TITLE
chore: update charts to set additionalOptions using JS

### DIFF
--- a/frontend/demo/component/charts/charts-overview.ts
+++ b/frontend/demo/component/charts/charts-overview.ts
@@ -60,6 +60,22 @@ export class Example extends LitElement {
   private columnOptions: Options = { yAxis: { title: { text: '' } } };
 
   @state()
+  private months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+
+  @state()
   private pieOptions: Options = {
     tooltip: {
       pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>',
@@ -114,37 +130,37 @@ export class Example extends LitElement {
     return html`
       <vaadin-chart
         type="column"
-        categories='["Jan", "Feb", "Mar"]'
+        .categories="${['Jan', 'Feb', 'Mar']}"
         .additionalOptions="${this.columnOptions}"
       >
-        <vaadin-chart-series title="Tokyo" values="[49.9, 71.5, 106.4]"></vaadin-chart-series>
-        <vaadin-chart-series title="New York" values="[83.6, 78.8, 98.5]"></vaadin-chart-series>
-        <vaadin-chart-series title="London" values="[48.9, 38.8, 39.3]"></vaadin-chart-series>
+        <vaadin-chart-series title="Tokyo" .values="${[49.9, 71.5, 106.4]}"></vaadin-chart-series>
+        <vaadin-chart-series title="New York" .values="${[83.6, 78.8, 98.5]}"></vaadin-chart-series>
+        <vaadin-chart-series title="London" .values="${[48.9, 38.8, 39.3]}"></vaadin-chart-series>
       </vaadin-chart>
 
       <vaadin-chart
         type="area"
         stacking="normal"
-        categories='["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]'
+        .categories="${this.months}"
+        .additionalOptions="${this.areaOptions}"
         tooltip
         no-legend
-        .additionalOptions="${this.areaOptions}"
       >
         <vaadin-chart-series
           title="United States dollar"
-          values="[135, 125, 89, 124, 105, 81, 111, 94, 95, 129, 98, 84]"
+          .values="${[135, 125, 89, 124, 105, 81, 111, 94, 95, 129, 98, 84]}"
         ></vaadin-chart-series>
         <vaadin-chart-series
           title="Euro"
-          values="[62, 72, 89, 68, 94, 92, 110, 100, 109, 89, 86, 105]"
+          .values="${[62, 72, 89, 68, 94, 92, 110, 100, 109, 89, 86, 105]}"
         ></vaadin-chart-series>
         <vaadin-chart-series
           title="Japanese yen"
-          values="[30, 25, 32, 26, 15, 31, 24, 32, 21, 8, 12, 32]"
+          .values="${[30, 25, 32, 26, 15, 31, 24, 32, 21, 8, 12, 32]}"
         ></vaadin-chart-series>
         <vaadin-chart-series
           title="Poud sterling"
-          values="[32, 21, 8, 12, 32, 21, 12, 30, 25, 19, 26, 15]"
+          .values="${[32, 21, 8, 12, 32, 21, 12, 30, 25, 19, 26, 15]}"
         ></vaadin-chart-series>
       </vaadin-chart>
 
@@ -156,12 +172,12 @@ export class Example extends LitElement {
         <vaadin-chart-series
           type="column"
           title="Column"
-          values="[8, 7, 6, 5, 4, 3, 2, 1]"
+          .values="${[8, 7, 6, 5, 4, 3, 2, 1]}"
           additional-options='{ "pointPlacement": "between" }'
         ></vaadin-chart-series>
-        <vaadin-chart-series type="line" title="Line" values="[1, 2, 3, 4, 5, 6, 7, 8]">
+        <vaadin-chart-series type="line" title="Line" .values="${[1, 2, 3, 4, 5, 6, 7, 8]}">
         </vaadin-chart-series>
-        <vaadin-chart-series type="area" title="Area" values="[1, 8, 2, 7, 3, 6, 4, 5]">
+        <vaadin-chart-series type="area" title="Area" .values="${[1, 8, 2, 7, 3, 6, 4, 5]}">
         </vaadin-chart-series>
       </vaadin-chart>
 

--- a/frontend/demo/component/charts/charts-overview.ts
+++ b/frontend/demo/component/charts/charts-overview.ts
@@ -1,8 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, css, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/charts';
+import type { Options, PointOptionsObject } from 'highcharts';
 
 @customElement('charts-overview')
 export class Example extends LitElement {
@@ -42,8 +43,68 @@ export class Example extends LitElement {
     }
   `;
 
+  @state()
+  private areaOptions: Options = {
+    yAxis: { title: { text: '' } },
+    xAxis: { visible: false },
+    plotOptions: {
+      series: {
+        marker: {
+          enabled: false,
+        },
+      },
+    },
+  };
+
+  @state()
+  private columnOptions: Options = { yAxis: { title: { text: '' } } };
+
+  @state()
+  private pieOptions: Options = {
+    tooltip: {
+      pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>',
+    },
+    plotOptions: {
+      pie: {
+        allowPointSelect: true,
+        cursor: 'pointer',
+        innerSize: '60%',
+      },
+    },
+  };
+
+  @state()
+  private pieValues: PointOptionsObject[] = [
+    { name: 'Chrome', y: 38 },
+    { name: 'Firefox', y: 24 },
+    { name: 'Edge', y: 15, sliced: true, selected: true },
+    { name: 'Internet Explorer', y: 8 },
+  ];
+
+  @state()
+  private polarOptions: Options = {
+    xAxis: {
+      tickInterval: 45,
+      min: 0,
+      max: 360,
+      labels: {},
+      visible: false,
+    },
+    yAxis: { min: 0 },
+    plotOptions: {
+      series: {
+        pointStart: 0,
+        pointInterval: 45,
+      },
+      column: {
+        pointPadding: 0,
+        groupPadding: 0,
+      },
+    },
+  };
+
   changeTheme(e: InputEvent) {
-    [...this.shadowRoot!.querySelectorAll('vaadin-chart')].forEach((chart) => {
+    [...this.renderRoot.querySelectorAll('vaadin-chart')].forEach((chart) => {
       chart.setAttribute('theme', (e.target as HTMLSelectElement).value);
     });
   }
@@ -52,10 +113,9 @@ export class Example extends LitElement {
   render() {
     return html`
       <vaadin-chart
-        id="vaadin-chart-1"
         type="column"
         categories='["Jan", "Feb", "Mar"]'
-        additional-options='{ "yAxis": { "title": { "text": "" } } }'
+        .additionalOptions="${this.columnOptions}"
       >
         <vaadin-chart-series title="Tokyo" values="[49.9, 71.5, 106.4]"></vaadin-chart-series>
         <vaadin-chart-series title="New York" values="[83.6, 78.8, 98.5]"></vaadin-chart-series>
@@ -68,23 +128,7 @@ export class Example extends LitElement {
         categories='["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]'
         tooltip
         no-legend
-        additional-options='{
-          "yAxis": {
-            "title": {
-              "text": ""
-            }
-          },
-           "xAxis": {
-            "visible":false
-          },
-          "plotOptions": {
-            "series": {
-              "marker": {
-                "enabled": false
-              }
-            }
-          }
-        }'
+        .additionalOptions="${this.areaOptions}"
       >
         <vaadin-chart-series
           title="United States dollar"
@@ -104,72 +148,11 @@ export class Example extends LitElement {
         ></vaadin-chart-series>
       </vaadin-chart>
 
-      <vaadin-chart
-        type="pie"
-        tooltip
-        additional-options='{
-          "tooltip": {
-            "pointFormat": "{series.name}: <b>{point.percentage:.1f}%</b>"
-          },
-          "plotOptions": {
-            "pie": {
-              "allowPointSelect":true,
-              "cursor": "pointer",
-              "innerSize": "60%"
-            }
-          }
-        }'
-      >
-        <vaadin-chart-series
-          title="Brands"
-          values='[
-            {
-              "name": "Chrome",
-              "y": 38
-            },
-            {
-              "name": "Firefox",
-              "y": 24
-            },
-            {
-              "name": "Edge",
-              "y": 15,
-              "sliced": true,
-              "selected": true
-            },
-            {
-              "name": "Internet Explorer",
-              "y": 8
-            }
-        ]'
-        ></vaadin-chart-series>
+      <vaadin-chart type="pie" tooltip .additionalOptions="${this.pieOptions}">
+        <vaadin-chart-series title="Brands" .values="${this.pieValues}"></vaadin-chart-series>
       </vaadin-chart>
 
-      <vaadin-chart
-        polar
-        additional-options='{
-          "xAxis": {
-            "tickInterval": 45,
-            "min": 0,
-            "max": 360,
-            "labels": {},
-            "visible":false
-          },
-          "yAxis": {
-            "min":0
-          },
-          "plotOptions": {
-            "series": {
-              "pointStart": 0,
-              "pointInterval":45
-            },
-            "column": {
-              "pointPadding": 0,
-              "groupPadding": 0
-            }
-          }
-        }'
-      >
+      <vaadin-chart polar .additionalOptions="${this.polarOptions}">
         <vaadin-chart-series
           type="column"
           title="Column"


### PR DESCRIPTION
## Description

This PR fixes the following warning from the `lit/attribute-value-entities` rule by `eslint-plugin-lit`:

```
/Users/serhii/vaadin/docs/frontend/demo/component/charts/charts-overview.ts
  110:9  error  Attribute values may not contain unencoded HTML entities, e.g. use `&gt;` instead of `>`
```
  
Also, we generally should  use TypeScript instead of JSON objects to HTML attributes 🙈 