### PR TITLE
chore: update TS examples to use class field for styles

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,6 @@
     "vaadin/prettier"
   ],
   "rules": {
-    "@typescript-eslint/class-literal-property-style": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/member-ordering": "off",
     "@typescript-eslint/no-floating-promises": "off",

--- a/frontend/demo/component/accordion/accordion-content.ts
+++ b/frontend/demo/component/accordion/accordion-content.ts
@@ -9,14 +9,12 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-content')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      a {
-        text-decoration: none;
-        color: var(--lumo-primary-text-color);
-      }
-    `;
-  }
+  static styles = css`
+    a {
+      text-decoration: none;
+      color: var(--lumo-primary-text-color);
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/app-layout/app-layout-basic.ts
+++ b/frontend/demo/component/app-layout/app-layout-basic.ts
@@ -10,27 +10,25 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-basic')
 export class Example extends LitElement {
+  static styles = css`
+    h1 {
+      font-size: var(--lumo-font-size-l);
+      margin: 0;
+    }
+
+    vaadin-icon {
+      box-sizing: border-box;
+      margin-inline-end: var(--lumo-space-m);
+      margin-inline-start: var(--lumo-space-xs);
+      padding: var(--lumo-space-xs);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      h1 {
-        font-size: var(--lumo-font-size-l);
-        margin: 0;
-      }
-
-      vaadin-icon {
-        box-sizing: border-box;
-        margin-inline-end: var(--lumo-space-m);
-        margin-inline-start: var(--lumo-space-xs);
-        padding: var(--lumo-space-xs);
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
@@ -10,35 +10,33 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-bottom-navbar')
 export class Example extends LitElement {
+  static styles = css`
+    h1 {
+      font-size: var(--lumo-font-size-l);
+      margin: var(--lumo-space-m) var(--lumo-space-l);
+    }
+
+    vaadin-icon {
+      height: var(--lumo-icon-size-s);
+      margin: auto;
+      width: var(--lumo-icon-size-s);
+    }
+
+    vaadin-tabs {
+      width: 100%;
+    }
+
+    /* hidden-source-line: the bottom navbar is forced on in the example */
+    vaadin-app-layout[overlay] /* hidden-source-line */ {
+      --vaadin-app-layout-touch-optimized: true; /* hidden-source-line */
+    } /* hidden-source-line */
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      h1 {
-        font-size: var(--lumo-font-size-l);
-        margin: var(--lumo-space-m) var(--lumo-space-l);
-      }
-
-      vaadin-icon {
-        height: var(--lumo-icon-size-s);
-        margin: auto;
-        width: var(--lumo-icon-size-s);
-      }
-
-      vaadin-tabs {
-        width: 100%;
-      }
-
-      /* hidden-source-line: the bottom navbar is forced on in the example */
-      vaadin-app-layout[overlay] /* hidden-source-line */ {
-        --vaadin-app-layout-touch-optimized: true; /* hidden-source-line */
-      } /* hidden-source-line */
-    `;
   }
 
   render() {

--- a/frontend/demo/component/app-layout/app-layout-drawer.ts
+++ b/frontend/demo/component/app-layout/app-layout-drawer.ts
@@ -10,26 +10,24 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-drawer')
 export class Example extends LitElement {
+  static styles = css`
+    h1 {
+      font-size: var(--lumo-font-size-l);
+      margin: 0;
+    }
+
+    vaadin-icon {
+      box-sizing: border-box;
+      margin-inline-end: var(--lumo-space-m);
+      padding: var(--lumo-space-xs);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      h1 {
-        font-size: var(--lumo-font-size-l);
-        margin: 0;
-      }
-
-      vaadin-icon {
-        box-sizing: border-box;
-        margin-inline-end: var(--lumo-space-m);
-        padding: var(--lumo-space-xs);
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/app-layout/app-layout-height-auto.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-auto.ts
@@ -9,20 +9,18 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-height-auto')
 export class Example extends LitElement {
+  static styles = css`
+    h1 {
+      font-size: var(--lumo-font-size-l);
+      margin: var(--lumo-space-m);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      h1 {
-        font-size: var(--lumo-font-size-l);
-        margin: var(--lumo-space-m);
-      }
-    `;
   }
 
   @state()

--- a/frontend/demo/component/app-layout/app-layout-height-full.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-full.ts
@@ -9,24 +9,22 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-height-full')
 export class Example extends LitElement {
+  static styles = css`
+    :host {
+      height: 100vh;
+    }
+
+    h1 {
+      font-size: var(--lumo-font-size-l);
+      margin: var(--lumo-space-m);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      :host {
-        height: 100vh;
-      }
-
-      h1 {
-        font-size: var(--lumo-font-size-l);
-        margin: var(--lumo-space-m);
-      }
-    `;
   }
 
   @state()

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
@@ -10,26 +10,24 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-navbar-placement-side')
 export class Example extends LitElement {
+  static styles = css`
+    h1 {
+      font-size: var(--lumo-font-size-l);
+      margin: 0;
+    }
+
+    vaadin-icon {
+      box-sizing: border-box;
+      margin-inline-end: var(--lumo-space-m);
+      padding: var(--lumo-space-xs);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      h1 {
-        font-size: var(--lumo-font-size-l);
-        margin: 0;
-      }
-
-      vaadin-icon {
-        box-sizing: border-box;
-        margin-inline-end: var(--lumo-space-m);
-        padding: var(--lumo-space-xs);
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
@@ -10,27 +10,25 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-navbar-placement')
 export class Example extends LitElement {
+  static styles = css`
+    h1 {
+      font-size: var(--lumo-font-size-l);
+      margin: 0;
+    }
+
+    vaadin-icon {
+      box-sizing: border-box;
+      margin-inline-end: var(--lumo-space-m);
+      margin-inline-start: var(--lumo-space-xs);
+      padding: var(--lumo-space-xs);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      h1 {
-        font-size: var(--lumo-font-size-l);
-        margin: 0;
-      }
-
-      vaadin-icon {
-        box-sizing: border-box;
-        margin-inline-end: var(--lumo-space-m);
-        margin-inline-start: var(--lumo-space-xs);
-        padding: var(--lumo-space-xs);
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/app-layout/app-layout-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar.ts
@@ -10,26 +10,24 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-navbar')
 export class Example extends LitElement {
+  static styles = css`
+    h1 {
+      font-size: var(--lumo-font-size-l);
+      left: var(--lumo-space-l);
+      margin: 0;
+      position: absolute;
+    }
+
+    vaadin-tabs {
+      margin: auto;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      h1 {
-        font-size: var(--lumo-font-size-l);
-        left: var(--lumo-space-l);
-        margin: 0;
-        position: absolute;
-      }
-
-      vaadin-tabs {
-        margin: auto;
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
+++ b/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
@@ -12,32 +12,30 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-secondary-navigation')
 export class Example extends LitElement {
+  static styles = css`
+    h1 {
+      font-size: var(--lumo-font-size-l);
+      line-height: var(--lumo-size-l);
+      margin: 0 var(--lumo-space-m);
+    }
+
+    h2 {
+      font-size: var(--lumo-font-size-l);
+      margin: 0;
+    }
+
+    vaadin-icon {
+      box-sizing: border-box;
+      margin-inline-end: var(--lumo-space-m);
+      padding: var(--lumo-space-xs);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      h1 {
-        font-size: var(--lumo-font-size-l);
-        line-height: var(--lumo-size-l);
-        margin: 0 var(--lumo-space-m);
-      }
-
-      h2 {
-        font-size: var(--lumo-font-size-l);
-        margin: 0;
-      }
-
-      vaadin-icon {
-        box-sizing: border-box;
-        margin-inline-end: var(--lumo-space-m);
-        padding: var(--lumo-space-xs);
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/badge/badge-counter.ts
+++ b/frontend/demo/component/badge/badge-counter.ts
@@ -6,13 +6,11 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-counter')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      span[theme~='badge'] {
-        margin-inline-start: var(--lumo-space-s);
-      }
-    `;
-  }
+  static styles = css`
+    span[theme~='badge'] {
+      margin-inline-start: var(--lumo-space-s);
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/board/example-chart.ts
+++ b/frontend/demo/component/board/example-chart.ts
@@ -27,15 +27,13 @@ const chartOptions = {
 
 @customElement('example-chart')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      .title {
-        font-size: var(--lumo-font-size-l);
-        font-weight: 700;
-        margin-block-end: var(--lumo-space-m);
-      }
-    `;
-  }
+  static styles = css`
+    .title {
+      font-size: var(--lumo-font-size-l);
+      font-weight: 700;
+      margin-block-end: var(--lumo-space-m);
+    }
+  `;
 
   @state()
   private events: ViewEvent[] = [];

--- a/frontend/demo/component/board/example-indicator.ts
+++ b/frontend/demo/component/board/example-indicator.ts
@@ -7,49 +7,47 @@ import '@vaadin/vertical-layout';
 
 @customElement('example-indicator')
 export class ExampleIndicator extends LitElement {
-  static get styles() {
-    return css`
+  static styles = css`
+    .title {
+      margin: 0;
+      font-size: var(--lumo-font-size-xxs);
+      font-weight: 700;
+      color: var(--lumo-contrast-50pct);
+    }
+
+    .current {
+      font-size: var(--lumo-font-size-m);
+      font-weight: 700;
+    }
+
+    .icon {
+      font-size: var(--lumo-font-size-xxs);
+    }
+
+    .icon vaadin-icon {
+      --vaadin-icon-width: var(--lumo-font-size-xxs);
+      --vaadin-icon-height: var(--lumo-font-size-xxs);
+    }
+
+    @media (min-width: 1024px) {
       .title {
-        margin: 0;
         font-size: var(--lumo-font-size-xxs);
-        font-weight: 700;
-        color: var(--lumo-contrast-50pct);
       }
 
       .current {
-        font-size: var(--lumo-font-size-m);
-        font-weight: 700;
+        font-size: var(--lumo-font-size-xl);
       }
 
       .icon {
-        font-size: var(--lumo-font-size-xxs);
+        font-size: var(--lumo-font-size-m);
       }
 
       .icon vaadin-icon {
-        --vaadin-icon-width: var(--lumo-font-size-xxs);
-        --vaadin-icon-height: var(--lumo-font-size-xxs);
+        --vaadin-icon-width: var(--lumo-font-size-xs);
+        --vaadin-icon-height: var(--lumo-font-size-xs);
       }
-
-      @media (min-width: 1024px) {
-        .title {
-          font-size: var(--lumo-font-size-xxs);
-        }
-
-        .current {
-          font-size: var(--lumo-font-size-xl);
-        }
-
-        .icon {
-          font-size: var(--lumo-font-size-m);
-        }
-
-        .icon vaadin-icon {
-          --vaadin-icon-width: var(--lumo-font-size-xs);
-          --vaadin-icon-height: var(--lumo-font-size-xs);
-        }
-      }
-    `;
-  }
+    }
+  `;
 
   @property()
   title = 'Unknown';

--- a/frontend/demo/component/board/example-statistics.ts
+++ b/frontend/demo/component/board/example-statistics.ts
@@ -6,78 +6,76 @@ import { repeat } from 'lit/directives/repeat.js';
 
 @customElement('example-statistics')
 export class ExampleStatistics extends LitElement {
-  static get styles() {
-    return css`
-      :host {
-        display: flex;
-        flex-direction: column;
-        font-size: var(--lumo-font-size-s);
-      }
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      font-size: var(--lumo-font-size-s);
+    }
 
-      .level {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-      }
+    .level {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
 
-      .level::before {
-        content: '';
-        width: var(--lumo-font-size-xxs);
-        height: var(--lumo-font-size-xxs);
-        border-radius: 50%;
-      }
+    .level::before {
+      content: '';
+      width: var(--lumo-font-size-xxs);
+      height: var(--lumo-font-size-xxs);
+      border-radius: 50%;
+    }
 
-      .excellent::before {
-        background-color: var(--lumo-success-color);
-      }
+    .excellent::before {
+      background-color: var(--lumo-success-color);
+    }
 
-      .ok::before {
-        background-color: var(--lumo-primary-color);
-      }
+    .ok::before {
+      background-color: var(--lumo-primary-color);
+    }
 
-      .failing::before {
-        background-color: var(--lumo-error-color);
-      }
+    .failing::before {
+      background-color: var(--lumo-error-color);
+    }
 
-      .legend {
-        display: flex;
-      }
+    .legend {
+      display: flex;
+    }
 
-      .legend label {
-        display: flex;
-        align-items: center;
-        margin-inline-end: var(--lumo-space-m);
-      }
+    .legend label {
+      display: flex;
+      align-items: center;
+      margin-inline-end: var(--lumo-space-m);
+    }
 
-      .legend .level {
-        margin-inline-end: var(--lumo-space-s);
-      }
+    .legend .level {
+      margin-inline-end: var(--lumo-space-s);
+    }
 
-      .title {
-        font-size: var(--lumo-font-size-l);
-        font-weight: 700;
-      }
+    .title {
+      font-size: var(--lumo-font-size-l);
+      font-weight: 700;
+    }
 
-      .table {
-        overflow: auto;
-        flex-grow: 1;
-      }
+    .table {
+      overflow: auto;
+      flex-grow: 1;
+    }
 
-      .table table {
-        width: 100%;
-        margin-block-start: var(--lumo-space-s);
-      }
+    .table table {
+      width: 100%;
+      margin-block-start: var(--lumo-space-s);
+    }
 
-      .table .number {
-        text-align: end;
-      }
+    .table .number {
+      text-align: end;
+    }
 
-      .table th,
-      .table td {
-        white-space: nowrap;
-      }
-    `;
-  }
+    .table th,
+    .table td {
+      white-space: nowrap;
+    }
+  `;
 
   @state()
   private serviceHealth: ServiceHealth[] = [];

--- a/frontend/demo/component/button/button-labels.ts
+++ b/frontend/demo/component/button/button-labels.ts
@@ -11,19 +11,17 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-labels')
 export class Example extends LitElement {
+  static styles = css`
+    vaadin-horizontal-layout {
+      align-items: baseline;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      vaadin-horizontal-layout {
-        align-items: baseline;
-      }
-    `;
   }
 
   @state()

--- a/frontend/demo/component/button/fake-progress-bar.ts
+++ b/frontend/demo/component/button/fake-progress-bar.ts
@@ -4,13 +4,11 @@ import '@vaadin/progress-bar';
 
 @customElement('fake-progress-bar')
 export class FakeProgressBar extends LitElement {
-  static get styles() {
-    return css`
-      :host {
-        width: 100%;
-      }
-    `;
-  }
+  static styles = css`
+    :host {
+      width: 100%;
+    }
+  `;
 
   @property({ type: Number })
   progress = 0;

--- a/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
@@ -10,6 +10,20 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('confirm-dialog-basic')
 export class Example extends LitElement {
+  static styles = css`
+    /* Center the button within the example */
+    :host {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      display: flex !important;
+      align-items: center;
+      justify-content: center;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
@@ -65,20 +79,6 @@ export class Example extends LitElement {
       this.status = '';
     }
   }
-
-  static styles = css`
-    /* Center the button within the example */
-    :host {
-      position: fixed;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      display: flex !important;
-      align-items: center;
-      justify-content: center;
-    }
-  `;
 
   private open() {
     this.dialogOpened = true;

--- a/frontend/demo/component/crud/crud-editor-bottom.ts
+++ b/frontend/demo/component/crud/crud-editor-bottom.ts
@@ -8,19 +8,17 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-editor-bottom')
 export class Example extends LitElement {
+  static styles = css`
+    vaadin-crud {
+      --vaadin-crud-editor-max-height: 60%;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      vaadin-crud {
-        --vaadin-crud-editor-max-height: 60%;
-      }
-    `;
   }
 
   @state()

--- a/frontend/demo/component/details/details-content.ts
+++ b/frontend/demo/component/details/details-content.ts
@@ -9,20 +9,18 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('details-content')
 export class Example extends LitElement {
+  static styles = css`
+    a {
+      text-decoration: none;
+      color: var(--lumo-primary-text-color);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      a {
-        text-decoration: none;
-        color: var(--lumo-primary-text-color);
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/dialog/dialog-basic.ts
+++ b/frontend/demo/component/dialog/dialog-basic.ts
@@ -13,6 +13,20 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-basic')
 export class Example extends LitElement {
+  static styles = css`
+    /* Center the button within the example */
+    :host {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      display: flex !important;
+      align-items: center;
+      justify-content: center;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
@@ -62,18 +76,4 @@ export class Example extends LitElement {
   private close() {
     this.dialogOpened = false;
   }
-
-  static styles = css`
-    /* Center the button within the example */
-    :host {
-      position: fixed;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      display: flex !important;
-      align-items: center;
-      justify-content: center;
-    }
-  `;
 }

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -11,19 +11,17 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-cell-focus')
 export class Example extends LitElement {
+  static styles = css`
+    vaadin-text-area {
+      width: 100%;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      vaadin-text-area {
-        width: 100%;
-      }
-    `;
   }
 
   @query('vaadin-grid')

--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -11,29 +11,27 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-drag-rows-between-grids')
 export class Example extends LitElement {
+  static styles = css`
+    .grids-container {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+
+    vaadin-grid {
+      width: 300px;
+      height: 300px;
+      margin-left: 0.5rem;
+      margin-top: 0.5rem;
+      align-self: unset;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      .grids-container {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-      }
-
-      vaadin-grid {
-        width: 300px;
-        height: 300px;
-        margin-left: 0.5rem;
-        margin-top: 0.5rem;
-        align-self: unset;
-      }
-    `;
   }
 
   // tag::snippet[]

--- a/frontend/demo/component/login/login-basic.ts
+++ b/frontend/demo/component/login/login-basic.ts
@@ -6,22 +6,20 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-basic')
 export class Example extends LitElement {
+  static styles = css`
+    :host {
+      background-color: var(--lumo-contrast-5pct);
+      display: flex !important;
+      justify-content: center;
+      padding: var(--lumo-space-l);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      :host {
-        background-color: var(--lumo-contrast-5pct);
-        display: flex !important;
-        justify-content: center;
-        padding: var(--lumo-space-l);
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/login/login-internationalization.ts
+++ b/frontend/demo/component/login/login-internationalization.ts
@@ -7,22 +7,20 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-internationalization')
 export class Example extends LitElement {
+  static styles = css`
+    :host {
+      background-color: var(--lumo-contrast-5pct);
+      display: flex !important;
+      justify-content: center;
+      padding: var(--lumo-space-l);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      :host {
-        background-color: var(--lumo-contrast-5pct);
-        display: flex !important;
-        justify-content: center;
-        padding: var(--lumo-space-l);
-      }
-    `;
   }
 
   // tag::snippet[]

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -7,74 +7,72 @@ import img from '../../../../src/main/resources/images/starry-sky.png';
 
 @customElement('login-overlay-mockup')
 export class LoginOverlayMockupElement extends LitElement {
+  static styles = css`
+    [part='backdrop'] {
+      background: var(--lumo-base-color)
+        linear-gradient(var(--lumo-shade-5pct), var(--lumo-shade-5pct));
+      display: flex;
+      justify-content: center;
+      padding: var(--lumo-space-m);
+    }
+
+    [part='card'] {
+      background: var(--lumo-base-color)
+        linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct));
+      border-radius: var(--lumo-border-radius);
+      box-shadow: var(--lumo-box-shadow-s);
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      margin: var(--lumo-space-s);
+      max-width: 100%;
+      overflow: hidden;
+      height: max-content;
+      width: calc(var(--lumo-size-m) * 10);
+    }
+
+    [part='brand'] {
+      background-color: var(--lumo-primary-color);
+      box-sizing: border-box;
+      color: var(--lumo-primary-contrast-color);
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      flex-shrink: 0;
+      justify-content: flex-end;
+      min-height: calc(var(--lumo-size-m) * 5);
+      overflow: hidden;
+      padding: var(--lumo-space-l) var(--lumo-space-xl) var(--lumo-space-l) var(--lumo-space-l);
+    }
+
+    [part='brand'] h1 {
+      color: inherit;
+      font-family: var(--lumo-font-family);
+      font-size: var(--lumo-font-size-xxxl);
+      font-weight: 600;
+      line-height: var(--lumo-line-height-xs);
+      margin: 0;
+    }
+
+    [part='description'] {
+      color: var(--lumo-tint-70pct);
+      line-height: var(--lumo-line-height-s);
+      margin-bottom: 0;
+      margin-top: 0.5em;
+    }
+
+    :host([theme='header-customised']) [part='brand'] {
+      background-image: url(${unsafeCSS(img)});
+      background-position: center;
+      background-size: cover;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      [part='backdrop'] {
-        background: var(--lumo-base-color)
-          linear-gradient(var(--lumo-shade-5pct), var(--lumo-shade-5pct));
-        display: flex;
-        justify-content: center;
-        padding: var(--lumo-space-m);
-      }
-
-      [part='card'] {
-        background: var(--lumo-base-color)
-          linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct));
-        border-radius: var(--lumo-border-radius);
-        box-shadow: var(--lumo-box-shadow-s);
-        box-sizing: border-box;
-        display: flex;
-        flex-direction: column;
-        margin: var(--lumo-space-s);
-        max-width: 100%;
-        overflow: hidden;
-        height: max-content;
-        width: calc(var(--lumo-size-m) * 10);
-      }
-
-      [part='brand'] {
-        background-color: var(--lumo-primary-color);
-        box-sizing: border-box;
-        color: var(--lumo-primary-contrast-color);
-        display: flex;
-        flex-direction: column;
-        flex-grow: 1;
-        flex-shrink: 0;
-        justify-content: flex-end;
-        min-height: calc(var(--lumo-size-m) * 5);
-        overflow: hidden;
-        padding: var(--lumo-space-l) var(--lumo-space-xl) var(--lumo-space-l) var(--lumo-space-l);
-      }
-
-      [part='brand'] h1 {
-        color: inherit;
-        font-family: var(--lumo-font-family);
-        font-size: var(--lumo-font-size-xxxl);
-        font-weight: 600;
-        line-height: var(--lumo-line-height-xs);
-        margin: 0;
-      }
-
-      [part='description'] {
-        color: var(--lumo-tint-70pct);
-        line-height: var(--lumo-line-height-s);
-        margin-bottom: 0;
-        margin-top: 0.5em;
-      }
-
-      :host([theme='header-customised']) [part='brand'] {
-        background-image: url(${unsafeCSS(img)});
-        background-position: center;
-        background-size: cover;
-      }
-    `;
   }
 
   @property({ type: String })

--- a/frontend/demo/component/menubar/menu-bar-styles.ts
+++ b/frontend/demo/component/menubar/menu-bar-styles.ts
@@ -7,19 +7,17 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-styles')
 export class Example extends LitElement {
+  static styles = css`
+    vaadin-menu-bar {
+      display: inline-block;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      vaadin-menu-bar {
-        display: inline-block;
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
@@ -9,13 +9,11 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-basic')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      vaadin-multi-select-combo-box {
-        width: 300px;
-      }
-    `;
-  }
+  static styles = css`
+    vaadin-multi-select-combo-box {
+      width: 300px;
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
@@ -10,13 +10,11 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-basic')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      vaadin-multi-select-combo-box {
-        width: 300px;
-      }
-    `;
-  }
+  static styles = css`
+    vaadin-multi-select-combo-box {
+      width: 300px;
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
@@ -9,13 +9,11 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-read-only')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      vaadin-multi-select-combo-box {
-        width: 300px;
-      }
-    `;
-  }
+  static styles = css`
+    vaadin-multi-select-combo-box {
+      width: 300px;
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
@@ -9,13 +9,11 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-selection')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      vaadin-multi-select-combo-box {
-        width: 300px;
-      }
-    `;
-  }
+  static styles = css`
+    vaadin-multi-select-combo-box {
+      width: 300px;
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-popup.ts
+++ b/frontend/demo/component/notification/notification-popup.ts
@@ -12,28 +12,26 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-popup')
 export class Example2 extends LitElement {
+  static styles = [
+    badge,
+    css`
+      vaadin-context-menu {
+        /* Wrap the click target around the button */
+        display: inline-block;
+      }
+
+      span[theme~='badge'] {
+        position: absolute;
+        transform: translate(-40%, -30%);
+      }
+    `,
+  ];
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return [
-      badge,
-      css`
-        vaadin-context-menu {
-          /* Wrap the click target around the button */
-          display: inline-block;
-        }
-
-        span[theme~='badge'] {
-          position: absolute;
-          transform: translate(-40%, -30%);
-        }
-      `,
-    ];
   }
 
   // tag::snippet[]

--- a/frontend/demo/component/scroller/scroller-basic.ts
+++ b/frontend/demo/component/scroller/scroller-basic.ts
@@ -14,50 +14,48 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('scroller-basic')
 export class Example extends LitElement {
+  static styles = css`
+    #container {
+      align-items: stretch;
+      border: 1px solid var(--lumo-contrast-20pct);
+      max-width: 100%;
+      height: 400px;
+      width: 360px;
+    }
+
+    header {
+      align-items: center;
+      display: flex;
+      border-bottom: 1px solid var(--lumo-contrast-20pct);
+      padding: var(--lumo-space-m);
+    }
+
+    header h2 {
+      margin: 0;
+    }
+
+    header vaadin-icon {
+      box-sizing: border-box;
+      height: var(--lumo-icon-size-m);
+      margin-right: var(--lumo-space-m);
+      padding: calc(var(--lumo-space-xs) / 2);
+      width: var(--lumo-icon-size-m);
+    }
+
+    footer {
+      padding: var(--lumo-space-wide-m);
+    }
+
+    footer vaadin-button:first-child {
+      margin-right: var(--lumo-space-s);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      #container {
-        align-items: stretch;
-        border: 1px solid var(--lumo-contrast-20pct);
-        max-width: 100%;
-        height: 400px;
-        width: 360px;
-      }
-
-      header {
-        align-items: center;
-        display: flex;
-        border-bottom: 1px solid var(--lumo-contrast-20pct);
-        padding: var(--lumo-space-m);
-      }
-
-      header h2 {
-        margin: 0;
-      }
-
-      header vaadin-icon {
-        box-sizing: border-box;
-        height: var(--lumo-icon-size-m);
-        margin-right: var(--lumo-space-m);
-        padding: calc(var(--lumo-space-xs) / 2);
-        width: var(--lumo-icon-size-m);
-      }
-
-      footer {
-        padding: var(--lumo-space-wide-m);
-      }
-
-      footer vaadin-button:first-child {
-        margin-right: var(--lumo-space-s);
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/scroller/scroller-mobile.ts
+++ b/frontend/demo/component/scroller/scroller-mobile.ts
@@ -11,26 +11,24 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('scroller-mobile')
 export class Example extends LitElement {
+  static styles = css`
+    section {
+      border: 1px solid var(--lumo-contrast-20pct);
+      max-width: 100%;
+      width: 360px;
+    }
+
+    section h2 {
+      margin-left: var(--lumo-space-m);
+      margin-right: var(--lumo-space-m);
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      section {
-        border: 1px solid var(--lumo-contrast-20pct);
-        max-width: 100%;
-        width: 360px;
-      }
-
-      section h2 {
-        margin-left: var(--lumo-space-m);
-        margin-right: var(--lumo-space-m);
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/splitlayout/detail-content.ts
+++ b/frontend/demo/component/splitlayout/detail-content.ts
@@ -3,43 +3,41 @@ import { customElement } from 'lit/decorators.js';
 
 @customElement('detail-content')
 export class DetailContent extends LitElement {
-  static get styles() {
-    return css`
-      :host {
-        overflow: hidden !important;
-        color: var(--lumo-contrast-20pct);
-      }
+  static styles = css`
+    :host {
+      overflow: hidden !important;
+      color: var(--lumo-contrast-20pct);
+    }
 
-      .form {
-        display: flex;
-        flex-flow: row wrap;
-        align-content: flex-start;
-        box-sizing: border-box;
-      }
+    .form {
+      display: flex;
+      flex-flow: row wrap;
+      align-content: flex-start;
+      box-sizing: border-box;
+    }
 
-      .field {
-        display: flex;
-        flex-flow: column nowrap;
-        margin: var(--lumo-space-wide-l);
-        pointer-events: none;
-      }
+    .field {
+      display: flex;
+      flex-flow: column nowrap;
+      margin: var(--lumo-space-wide-l);
+      pointer-events: none;
+    }
 
-      label {
-        width: 6rem;
-        background: currentColor;
-        border-radius: calc(var(--lumo-size-m) / 2);
-        height: var(--lumo-font-size-xxs);
-      }
+    label {
+      width: 6rem;
+      background: currentColor;
+      border-radius: calc(var(--lumo-size-m) / 2);
+      height: var(--lumo-font-size-xxs);
+    }
 
-      input {
-        background: var(--lumo-contrast-10pct);
-        border-radius: var(--lumo-border-radius-s);
-        padding: var(--lumo-space-s) 0;
-        border: none;
-        margin-top: var(--lumo-space-s);
-      }
-    `;
-  }
+    input {
+      background: var(--lumo-contrast-10pct);
+      border-radius: var(--lumo-border-radius-s);
+      padding: var(--lumo-space-s) 0;
+      border: none;
+      margin-top: var(--lumo-space-s);
+    }
+  `;
 
   render() {
     return html`

--- a/frontend/demo/component/splitlayout/master-content.ts
+++ b/frontend/demo/component/splitlayout/master-content.ts
@@ -3,38 +3,36 @@ import { customElement } from 'lit/decorators.js';
 
 @customElement('master-content')
 export class MasterContent extends LitElement {
-  static get styles() {
-    return css`
-      :host {
-        overflow: hidden !important;
-        color: var(--lumo-contrast-20pct);
-      }
+  static styles = css`
+    :host {
+      overflow: hidden !important;
+      color: var(--lumo-contrast-20pct);
+    }
 
-      table {
-        border-collapse: collapse;
-      }
+    table {
+      border-collapse: collapse;
+    }
 
-      th,
-      td {
-        border-bottom: 1px solid currentColor;
-        padding: var(--lumo-space-wide-m);
-      }
+    th,
+    td {
+      border-bottom: 1px solid currentColor;
+      padding: var(--lumo-space-wide-m);
+    }
 
-      th::before,
-      td::before {
-        content: '\\00a0';
-        display: inline-block;
-        width: 8rem;
-        background: currentColor;
-        border-radius: calc(var(--lumo-size-m) / 2);
-        font-size: var(--lumo-font-size-xxs);
-      }
+    th::before,
+    td::before {
+      content: '\\00a0';
+      display: inline-block;
+      width: 8rem;
+      background: currentColor;
+      border-radius: calc(var(--lumo-size-m) / 2);
+      font-size: var(--lumo-font-size-xxs);
+    }
 
-      th {
-        background: var(--lumo-contrast-5pct);
-      }
-    `;
-  }
+    th {
+      background: var(--lumo-contrast-5pct);
+    }
+  `;
 
   render() {
     return html`

--- a/frontend/demo/component/tabs/tabs-badges.ts
+++ b/frontend/demo/component/tabs/tabs-badges.ts
@@ -7,16 +7,14 @@ import { badge } from '@vaadin/vaadin-lumo-styles/badge.js';
 
 @customElement('tabs-badges')
 export class Example extends LitElement {
-  static get styles() {
-    return [
-      badge,
-      css`
-        span[theme~='badge'] {
-          margin-inline-start: var(--lumo-space-xs);
-        }
-      `,
-    ];
-  }
+  static styles = [
+    badge,
+    css`
+      span[theme~='badge'] {
+        margin-inline-start: var(--lumo-space-xs);
+      }
+    `,
+  ];
 
   render() {
     return html`

--- a/frontend/demo/component/textarea/text-area-auto-height.ts
+++ b/frontend/demo/component/textarea/text-area-auto-height.ts
@@ -8,19 +8,17 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-auto-height')
 export class Example extends LitElement {
+  static styles = css`
+    vaadin-text-area {
+      width: 100%;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      vaadin-text-area {
-        width: 100%;
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/textarea/text-area-helper.ts
+++ b/frontend/demo/component/textarea/text-area-helper.ts
@@ -9,6 +9,12 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-helper-2')
 export class Example extends LitElement {
+  static styles = css`
+    vaadin-text-area {
+      width: 100%;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
@@ -21,14 +27,6 @@ export class Example extends LitElement {
 
   @state()
   private text = loremIpsum;
-
-  static get styles() {
-    return css`
-      vaadin-text-area {
-        width: 100%;
-      }
-    `;
-  }
 
   render() {
     return html`

--- a/frontend/demo/component/upload/upload-drag-and-drop.ts
+++ b/frontend/demo/component/upload/upload-drag-and-drop.ts
@@ -14,19 +14,17 @@ const layoutSteps: FormLayoutResponsiveStep[] = [
 
 @customElement('upload-drag-and-drop')
 export class Example extends LitElement {
+  static styles = css`
+    label {
+      font-weight: 600;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      label {
-        font-weight: 600;
-      }
-    `;
   }
 
   render() {

--- a/frontend/demo/component/upload/upload-file-count.ts
+++ b/frontend/demo/component/upload/upload-file-count.ts
@@ -9,17 +9,15 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-file-count')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      h4 {
-        margin-top: 0;
-      }
+  static styles = css`
+    h4 {
+      margin-top: 0;
+    }
 
-      p {
-        color: var(--lumo-secondary-text-color);
-      }
-    `;
-  }
+    p {
+      color: var(--lumo-secondary-text-color);
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/upload/upload-file-format.ts
+++ b/frontend/demo/component/upload/upload-file-format.ts
@@ -9,17 +9,15 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-file-format')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      h4 {
-        margin-top: 0;
-      }
+  static styles = css`
+    h4 {
+      margin-top: 0;
+    }
 
-      p {
-        color: var(--lumo-secondary-text-color);
-      }
-    `;
-  }
+    p {
+      color: var(--lumo-secondary-text-color);
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/upload/upload-file-size.ts
+++ b/frontend/demo/component/upload/upload-file-size.ts
@@ -9,17 +9,15 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-file-size')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      h4 {
-        margin-top: 0;
-      }
+  static styles = css`
+    h4 {
+      margin-top: 0;
+    }
 
-      p {
-        color: var(--lumo-secondary-text-color);
-      }
-    `;
-  }
+    p {
+      color: var(--lumo-secondary-text-color);
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/upload/upload-helper.ts
+++ b/frontend/demo/component/upload/upload-helper.ts
@@ -9,17 +9,15 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-helper')
 export class Example extends LitElement {
-  static get styles() {
-    return css`
-      h4 {
-        margin-top: 0;
-      }
+  static styles = css`
+    h4 {
+      margin-top: 0;
+    }
 
-      p {
-        color: var(--lumo-secondary-text-color);
-      }
-    `;
-  }
+    p {
+      color: var(--lumo-secondary-text-color);
+    }
+  `;
 
   protected createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/virtuallist/virtual-list-basic.ts
+++ b/frontend/demo/component/virtuallist/virtual-list-basic.ts
@@ -17,20 +17,18 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('virtual-list-basic')
 export class Example extends LitElement {
+  static styles = css`
+    vaadin-avatar {
+      height: 64px;
+      width: 64px;
+    }
+  `;
+
   protected createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
-  }
-
-  static get styles() {
-    return css`
-      vaadin-avatar {
-        height: 64px;
-        width: 64px;
-      }
-    `;
   }
 
   @state()

--- a/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
+++ b/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
@@ -14,14 +14,12 @@ import { Notification } from '@vaadin/notification';
 
 @customElement('new-relic-dashboard-generator')
 export class DashboardGenerator extends LitElement {
-  static get styles() {
-    return css`
-      .json-result {
-        width: 100%;
-        height: 200px;
-      }
-    `;
-  }
+  static styles = css`
+    .json-result {
+      width: 100%;
+      height: 200px;
+    }
+  `;
 
   @state()
   accountId = '';


### PR DESCRIPTION
## Description

Replaced `static get styles()` with `static styles` which is a bit less verbose and has 1 less indentation level.
Note, some examples were already using that. Also, [public class fields](https://caniuse.com/mdn-javascript_classes_public_class_fields) have good browser support (Safari 14.1+).