### PR TITLE
chore: use TypeScript override keyword for LitElement methods

### DIFF
--- a/frontend/demo/component/accordion/accordion-basic.ts
+++ b/frontend/demo/component/accordion/accordion-basic.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>

--- a/frontend/demo/component/accordion/accordion-content.ts
+++ b/frontend/demo/component/accordion/accordion-content.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-content')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     a {
       text-decoration: none;
       color: var(--lumo-primary-text-color);

--- a/frontend/demo/component/accordion/accordion-content.ts
+++ b/frontend/demo/component/accordion/accordion-content.ts
@@ -16,14 +16,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>

--- a/frontend/demo/component/accordion/accordion-disabled-panels.ts
+++ b/frontend/demo/component/accordion/accordion-disabled-panels.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-disabled-panels')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>

--- a/frontend/demo/component/accordion/accordion-filled-panels.ts
+++ b/frontend/demo/component/accordion/accordion-filled-panels.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-filled-panels')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>

--- a/frontend/demo/component/accordion/accordion-reverse-panels.ts
+++ b/frontend/demo/component/accordion/accordion-reverse-panels.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-reverse-panels')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>

--- a/frontend/demo/component/accordion/accordion-small-panels.ts
+++ b/frontend/demo/component/accordion/accordion-small-panels.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-small-panels')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>

--- a/frontend/demo/component/accordion/accordion-summary.ts
+++ b/frontend/demo/component/accordion/accordion-summary.ts
@@ -37,18 +37,18 @@ export class Example extends LitElement {
   @state()
   private openedPanelIndex: number | null = 0;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.countries = await getCountries();
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion

--- a/frontend/demo/component/app-layout/app-layout-basic.ts
+++ b/frontend/demo/component/app-layout/app-layout-basic.ts
@@ -24,14 +24,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-app-layout>

--- a/frontend/demo/component/app-layout/app-layout-basic.ts
+++ b/frontend/demo/component/app-layout/app-layout-basic.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-basic')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h1 {
       font-size: var(--lumo-font-size-l);
       margin: 0;

--- a/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-bottom-navbar')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h1 {
       font-size: var(--lumo-font-size-l);
       margin: var(--lumo-space-m) var(--lumo-space-l);

--- a/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
@@ -32,14 +32,14 @@ export class Example extends LitElement {
     } /* hidden-source-line */
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-app-layout>

--- a/frontend/demo/component/app-layout/app-layout-drawer.ts
+++ b/frontend/demo/component/app-layout/app-layout-drawer.ts
@@ -23,14 +23,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-app-layout primary-section="drawer">

--- a/frontend/demo/component/app-layout/app-layout-drawer.ts
+++ b/frontend/demo/component/app-layout/app-layout-drawer.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-drawer')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h1 {
       font-size: var(--lumo-font-size-l);
       margin: 0;

--- a/frontend/demo/component/app-layout/app-layout-height-auto.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-auto.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,12 +26,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 20 });
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-app-layout>

--- a/frontend/demo/component/app-layout/app-layout-height-auto.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-auto.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-height-auto')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h1 {
       font-size: var(--lumo-font-size-l);
       margin: var(--lumo-space-m);

--- a/frontend/demo/component/app-layout/app-layout-height-full.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-full.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-height-full')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       height: 100vh;
     }

--- a/frontend/demo/component/app-layout/app-layout-height-full.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-full.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -30,12 +30,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-app-layout style="height: 100%;">

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
@@ -23,14 +23,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-app-layout primary-section="drawer">

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-navbar-placement-side')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h1 {
       font-size: var(--lumo-font-size-l);
       margin: 0;

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
@@ -24,14 +24,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-app-layout>

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-navbar-placement')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h1 {
       font-size: var(--lumo-font-size-l);
       margin: 0;

--- a/frontend/demo/component/app-layout/app-layout-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-navbar')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h1 {
       font-size: var(--lumo-font-size-l);
       left: var(--lumo-space-l);

--- a/frontend/demo/component/app-layout/app-layout-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar.ts
@@ -23,14 +23,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-app-layout>

--- a/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
+++ b/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
@@ -31,14 +31,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-app-layout primary-section="drawer">

--- a/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
+++ b/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-secondary-navigation')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h1 {
       font-size: var(--lumo-font-size-l);
       line-height: var(--lumo-size-l);

--- a/frontend/demo/component/avatar/avatar-abbreviation.ts
+++ b/frontend/demo/component/avatar/avatar-abbreviation.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-abbreviation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/avatar/avatar-basic.ts
+++ b/frontend/demo/component/avatar/avatar-basic.ts
@@ -9,7 +9,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,12 +19,12 @@ export class Example extends LitElement {
   @state()
   private person?: Person;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     this.person = people[0];
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/avatar/avatar-group-basic.ts
+++ b/frontend/demo/component/avatar/avatar-group-basic.ts
@@ -8,7 +8,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-group-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,12 +18,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 3 });
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-avatar-group

--- a/frontend/demo/component/avatar/avatar-group-bg-color.ts
+++ b/frontend/demo/component/avatar/avatar-group-bg-color.ts
@@ -8,7 +8,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-group-bg-color')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,12 +18,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 6 });
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-avatar-group

--- a/frontend/demo/component/avatar/avatar-group-internationalisation.ts
+++ b/frontend/demo/component/avatar/avatar-group-internationalisation.ts
@@ -9,7 +9,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-group-internationalistion')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 2 });
 
     // Add an anonymous user
@@ -60,7 +60,7 @@ export class Example extends LitElement {
     left: 'lähti',
   };
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-avatar-group
         .i18n="${this.i18n}"

--- a/frontend/demo/component/avatar/avatar-group-max-items.ts
+++ b/frontend/demo/component/avatar/avatar-group-max-items.ts
@@ -8,7 +8,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-group-max-items')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,12 +18,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 6 });
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-avatar-group

--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -10,7 +10,7 @@ import companyLogo from '../../../../src/main/resources/images/company-logo.png'
 
 @customElement('avatar-image')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,12 +20,12 @@ export class Example extends LitElement {
   @state()
   private person?: Person;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     this.person = people[0];
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/avatar/avatar-menu-bar.ts
+++ b/frontend/demo/component/avatar/avatar-menu-bar.ts
@@ -11,7 +11,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-menu-bar')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   @state()
   private person?: Person;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     this.person = people[0];
 
@@ -53,7 +53,7 @@ export class Example extends LitElement {
     ];
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-menu-bar .items="${this.menuBarItems}" theme="tertiary-inline"></vaadin-menu-bar>

--- a/frontend/demo/component/avatar/avatar-name.ts
+++ b/frontend/demo/component/avatar/avatar-name.ts
@@ -8,7 +8,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-name')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,12 +18,12 @@ export class Example extends LitElement {
   @state()
   private person?: Person;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     this.person = people[0];
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-avatar .name="${`${this.person?.firstName} ${this.person?.lastName}`}">

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -9,7 +9,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('avatar-sizes')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,12 +19,12 @@ export class Example extends LitElement {
   @state()
   private person?: Person;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     this.person = people[0];
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/badge/badge-basic.ts
+++ b/frontend/demo/component/badge/badge-basic.ts
@@ -6,14 +6,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/badge/badge-color.ts
+++ b/frontend/demo/component/badge/badge-color.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-color')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing">

--- a/frontend/demo/component/badge/badge-counter.ts
+++ b/frontend/demo/component/badge/badge-counter.ts
@@ -12,14 +12,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs>

--- a/frontend/demo/component/badge/badge-counter.ts
+++ b/frontend/demo/component/badge/badge-counter.ts
@@ -6,7 +6,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-counter')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     span[theme~='badge'] {
       margin-inline-start: var(--lumo-space-s);
     }

--- a/frontend/demo/component/badge/badge-highlight.ts
+++ b/frontend/demo/component/badge/badge-highlight.ts
@@ -20,18 +20,18 @@ export class Example extends LitElement {
   @state()
   private items: readonly Report[] = [];
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getReports();
   }
 
-  render() {
+  protected override render() {
     // tag::snippet[]
     return html`
       <vaadin-grid .items="${this.items}">

--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -15,18 +15,18 @@ export class Example extends LitElement {
   @state()
   private items: readonly UserPermissions[] = [];
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getUserPermissions();
   }
 
-  render() {
+  protected override render() {
     // tag::snippet[]
     const renderBoolean: GridColumnBodyLitRenderer<UserPermissions> = (item, _model, column) => {
       let icon: string;

--- a/frontend/demo/component/badge/badge-icons-only.ts
+++ b/frontend/demo/component/badge/badge-icons-only.ts
@@ -8,14 +8,14 @@ import '@vaadin/icons';
 
 @customElement('badge-icons-only')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/badge/badge-icons.ts
+++ b/frontend/demo/component/badge/badge-icons.ts
@@ -9,14 +9,14 @@ import '@vaadin/vertical-layout';
 
 @customElement('badge-icons')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing">

--- a/frontend/demo/component/badge/badge-interactive.ts
+++ b/frontend/demo/component/badge/badge-interactive.ts
@@ -24,19 +24,19 @@ export class Example extends LitElement {
   @state()
   private selectedProfessions: readonly Profession[] = [];
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = [...new Set(people.map(({ profession }) => profession))];
   }
 
-  render() {
+  protected override render() {
     // tag::snippet[]
     return html`
       <vaadin-vertical-layout theme="spacing">

--- a/frontend/demo/component/badge/badge-shape.ts
+++ b/frontend/demo/component/badge/badge-shape.ts
@@ -6,14 +6,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-shape')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/badge/badge-size.ts
+++ b/frontend/demo/component/badge/badge-size.ts
@@ -6,14 +6,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-size')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private size = '0';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="padding spacing">
         <vaadin-button style="flex-grow: ${this.size}">Button 1</vaadin-button>

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private justifyContent = 'flex-start';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout
         theme="spacing padding"

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -28,7 +28,7 @@ export class Example extends LitElement {
   @state()
   private alignFirstItem = 'auto';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout
         theme="spacing padding"

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private alignItems = 'stretch';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout
         theme="spacing padding"

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts
@@ -12,14 +12,14 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing padding">

--- a/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private theme = 'margin';
 
-  render() {
+  protected override render() {
     return html`
       <div class="container">
         <vaadin-vertical-layout theme="${this.theme} spacing padding" style="align-items: stretch">

--- a/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private theme = 'padding';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout
         theme="${this.theme} spacing"

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private themeVariant = 'spacing-xl';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout
         theme="${this.themeVariant} padding"

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private theme = 'spacing';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout
         theme="${this.theme} padding"

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private alignItems = 'flex-start';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout theme="spacing padding" style="align-items: ${this.alignItems}">
         <vaadin-button>Button 1</vaadin-button>

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -28,7 +28,7 @@ export class Example extends LitElement {
   @state()
   alignFirstItem = 'auto';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout theme="spacing padding" style="align-items: ${this.alignLayoutItems}">
         <vaadin-button style="align-self: ${this.alignFirstItem}" theme="primary">

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   justifyContent = 'flex-start';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout
         theme="spacing padding"

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts
@@ -12,14 +12,14 @@ export class Example extends LitElement {
     this.classList.add('basic-layouts-example');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing padding">

--- a/frontend/demo/component/board/board-basic.ts
+++ b/frontend/demo/component/board/board-basic.ts
@@ -13,14 +13,14 @@ export class Example extends LitElement {
     this.classList.add('basic-board');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-board>

--- a/frontend/demo/component/board/board-breakpoints.ts
+++ b/frontend/demo/component/board/board-breakpoints.ts
@@ -12,7 +12,7 @@ export class Example extends LitElement {
     this.classList.add('board-breakpoints');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     return html`
       <vaadin-split-layout>
         <vaadin-board style="width: 100%">

--- a/frontend/demo/component/board/board-column-span.ts
+++ b/frontend/demo/component/board/board-column-span.ts
@@ -11,14 +11,14 @@ export class Example extends LitElement {
     this.classList.add('board-column-span');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-board>

--- a/frontend/demo/component/board/board-column-wrapping.ts
+++ b/frontend/demo/component/board/board-column-wrapping.ts
@@ -12,14 +12,14 @@ export class Example extends LitElement {
     this.classList.add('board-column-wrapping');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-split-layout>

--- a/frontend/demo/component/board/board-nested.ts
+++ b/frontend/demo/component/board/board-nested.ts
@@ -13,14 +13,14 @@ export class Example extends LitElement {
     this.classList.add('board-nested');
   }
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-board>

--- a/frontend/demo/component/board/example-chart.ts
+++ b/frontend/demo/component/board/example-chart.ts
@@ -27,7 +27,7 @@ const chartOptions = {
 
 @customElement('example-chart')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     .title {
       font-size: var(--lumo-font-size-l);
       font-weight: 700;

--- a/frontend/demo/component/board/example-chart.ts
+++ b/frontend/demo/component/board/example-chart.ts
@@ -38,11 +38,11 @@ export class Example extends LitElement {
   @state()
   private events: ViewEvent[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.events = await getViewEvents();
   }
 
-  render() {
+  protected override render() {
     return html`
       <header class="title">View events</header>
       <vaadin-chart .additionalOptions="${chartOptions}" .categories="${monthNames}" type="area">

--- a/frontend/demo/component/board/example-indicator.ts
+++ b/frontend/demo/component/board/example-indicator.ts
@@ -58,14 +58,14 @@ export class ExampleIndicator extends LitElement {
   @property({ type: Number })
   change = 0;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     let theme;
     let icon;
     let sign;

--- a/frontend/demo/component/board/example-indicator.ts
+++ b/frontend/demo/component/board/example-indicator.ts
@@ -7,7 +7,7 @@ import '@vaadin/vertical-layout';
 
 @customElement('example-indicator')
 export class ExampleIndicator extends LitElement {
-  static styles = css`
+  static override styles = css`
     .title {
       margin: 0;
       font-size: var(--lumo-font-size-xxs);

--- a/frontend/demo/component/board/example-statistics.ts
+++ b/frontend/demo/component/board/example-statistics.ts
@@ -6,7 +6,7 @@ import { repeat } from 'lit/directives/repeat.js';
 
 @customElement('example-statistics')
 export class ExampleStatistics extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       display: flex;
       flex-direction: column;

--- a/frontend/demo/component/board/example-statistics.ts
+++ b/frontend/demo/component/board/example-statistics.ts
@@ -80,11 +80,11 @@ export class ExampleStatistics extends LitElement {
   @state()
   private serviceHealth: ServiceHealth[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.serviceHealth = await getServiceHealth();
   }
 
-  render() {
+  protected override render() {
     return html`
       <header class="title">Service health</header>
       <section class="legend">

--- a/frontend/demo/component/button/button-basic.ts
+++ b/frontend/demo/component/button/button-basic.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   @state()
   private counter = 0;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing" style="align-items: baseline">

--- a/frontend/demo/component/button/button-contrast.ts
+++ b/frontend/demo/component/button/button-contrast.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-contrast')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/button/button-dialog.ts
+++ b/frontend/demo/component/button/button-dialog.ts
@@ -12,14 +12,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-dialog')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing" style="align-items: stretch;">

--- a/frontend/demo/component/button/button-disable-long-action.ts
+++ b/frontend/demo/component/button/button-disable-long-action.ts
@@ -11,7 +11,7 @@ import type { FakeProgressBar } from './fake-progress-bar';
 
 @customElement('button-disable-long-action')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   @query('fake-progress-bar')
   private fakeProgressBar!: FakeProgressBar;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing" style="align-items: center;">

--- a/frontend/demo/component/button/button-disabled.ts
+++ b/frontend/demo/component/button/button-disabled.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-disabled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/button/button-error.ts
+++ b/frontend/demo/component/button/button-error.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-error')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/button/button-focus.ts
+++ b/frontend/demo/component/button/button-focus.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-focus')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-button focus-ring>Keyboard focus</vaadin-button>

--- a/frontend/demo/component/button/button-form.ts
+++ b/frontend/demo/component/button/button-form.ts
@@ -12,14 +12,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-form')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing">

--- a/frontend/demo/component/button/button-grid.ts
+++ b/frontend/demo/component/button/button-grid.ts
@@ -15,7 +15,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('button-grid')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -28,12 +28,12 @@ export class Example extends LitElement {
   @state()
   private selectedItems: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing" style="align-items: stretch;">

--- a/frontend/demo/component/button/button-icons.ts
+++ b/frontend/demo/component/button/button-icons.ts
@@ -10,14 +10,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-icons')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/button/button-images.ts
+++ b/frontend/demo/component/button/button-images.ts
@@ -8,14 +8,14 @@ import img from '../../../../src/main/resources/images/vaadin-logo-dark.png';
 
 @customElement('button-images')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-button theme="icon">

--- a/frontend/demo/component/button/button-labels.ts
+++ b/frontend/demo/component/button/button-labels.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-labels')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-horizontal-layout {
       align-items: baseline;
     }

--- a/frontend/demo/component/button/button-labels.ts
+++ b/frontend/demo/component/button/button-labels.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -30,7 +30,7 @@ export class Example extends LitElement {
   @state()
   private secondaryEmail = 'bar@example.com';
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout>

--- a/frontend/demo/component/button/button-sizes.ts
+++ b/frontend/demo/component/button/button-sizes.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-sizes')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/button/button-styles.ts
+++ b/frontend/demo/component/button/button-styles.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-styles')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/button/button-success.ts
+++ b/frontend/demo/component/button/button-success.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-success')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/button/button-tertiary-inline.ts
+++ b/frontend/demo/component/button/button-tertiary-inline.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-tertiary-inline')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-button theme="tertiary-inline">Tertiary inline</vaadin-button>

--- a/frontend/demo/component/button/fake-progress-bar.ts
+++ b/frontend/demo/component/button/fake-progress-bar.ts
@@ -25,7 +25,7 @@ export class FakeProgressBar extends LitElement {
     }, 25);
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-progress-bar .value="${this.progress}"></vaadin-progress-bar>`;
   }
 }

--- a/frontend/demo/component/button/fake-progress-bar.ts
+++ b/frontend/demo/component/button/fake-progress-bar.ts
@@ -4,7 +4,7 @@ import '@vaadin/progress-bar';
 
 @customElement('fake-progress-bar')
 export class FakeProgressBar extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       width: 100%;
     }

--- a/frontend/demo/component/charts/charts-overview.ts
+++ b/frontend/demo/component/charts/charts-overview.ts
@@ -7,7 +7,7 @@ import type { Options, PointOptionsObject } from 'highcharts';
 
 @customElement('charts-overview')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -126,7 +126,7 @@ export class Example extends LitElement {
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     return html`
       <vaadin-chart
         type="column"

--- a/frontend/demo/component/charts/charts-overview.ts
+++ b/frontend/demo/component/charts/charts-overview.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     return root;
   }
 
-  static styles = css`
+  static override styles = css`
     :host {
       display: grid !important;
       grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));

--- a/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts
+++ b/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-adjacent-groups')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout>

--- a/frontend/demo/component/checkbox/checkbox-basic.ts
+++ b/frontend/demo/component/checkbox/checkbox-basic.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-checkbox label="I accept the terms and conditions"></vaadin-checkbox>

--- a/frontend/demo/component/checkbox/checkbox-custom-presentation.ts
+++ b/frontend/demo/component/checkbox/checkbox-custom-presentation.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('checkbox-custom-presentation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,12 +21,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 4 });
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-checkbox-group label="Invitees" theme="vertical">
         ${this.items.map(

--- a/frontend/demo/component/checkbox/checkbox-disabled.ts
+++ b/frontend/demo/component/checkbox/checkbox-disabled.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-disabled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-checkbox-group label="Departments" theme="vertical" disabled>

--- a/frontend/demo/component/checkbox/checkbox-edit-multiple.ts
+++ b/frontend/demo/component/checkbox/checkbox-edit-multiple.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('checkbox-edit-multiple')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-checkbox label="Enabled"></vaadin-checkbox>`;
   }
 }

--- a/frontend/demo/component/checkbox/checkbox-group-basic.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-basic.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-group-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private value = ['0', '2'];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-checkbox-group

--- a/frontend/demo/component/checkbox/checkbox-horizontal.ts
+++ b/frontend/demo/component/checkbox/checkbox-horizontal.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-horizontal')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-checkbox-group label="Permissions">

--- a/frontend/demo/component/checkbox/checkbox-indeterminate.ts
+++ b/frontend/demo/component/checkbox/checkbox-indeterminate.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-indeterminate')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,13 +25,13 @@ export class Example extends LitElement {
   @state()
   private selectedIds: string[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 3 });
     this.items = people;
     this.selectedIds = [String(this.items[0].id), String(this.items[2].id)];
   }
 
-  render() {
+  protected override render() {
     const { items, selectedIds } = this;
 
     return html`

--- a/frontend/demo/component/checkbox/checkbox-labeling.ts
+++ b/frontend/demo/component/checkbox/checkbox-labeling.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('checkbox-labeling')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-checkbox label="Yes, I agree"></vaadin-checkbox>`;
   }
 }

--- a/frontend/demo/component/checkbox/checkbox-trigger.ts
+++ b/frontend/demo/component/checkbox/checkbox-trigger.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('checkbox-trigger')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-checkbox label="Enabled"></vaadin-checkbox>`;
   }
 }

--- a/frontend/demo/component/checkbox/checkbox-vertical.ts
+++ b/frontend/demo/component/checkbox/checkbox-vertical.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-vertical')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-checkbox-group label="Working days" theme="vertical">

--- a/frontend/demo/component/combobox/combo-box-auto-open.ts
+++ b/frontend/demo/component/combobox/combo-box-auto-open.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-auto-open')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,11 +19,11 @@ export class Example extends LitElement {
   @state()
   private items: Country[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCountries();
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-combo-box

--- a/frontend/demo/component/combobox/combo-box-basic.ts
+++ b/frontend/demo/component/combobox/combo-box-basic.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,11 +19,11 @@ export class Example extends LitElement {
   @state()
   private items: Country[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCountries();
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-combo-box

--- a/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-custom-entry-1')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   @state()
   private items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-combo-box

--- a/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-custom-entry-2')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   @state()
   private items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-combo-box

--- a/frontend/demo/component/combobox/combo-box-filtering-1.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-1.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-filtering-1')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,11 +19,11 @@ export class Example extends LitElement {
   @state()
   private items: Country[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCountries();
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-combo-box

--- a/frontend/demo/component/combobox/combo-box-filtering-2.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-2.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('combo-box-filtering-2')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,13 +24,13 @@ export class Example extends LitElement {
   @state()
   private filteredItems: Country[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const countries = await getCountries();
     this.allItems = countries;
     this.filteredItems = countries;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-combo-box
         label="Country"

--- a/frontend/demo/component/combobox/combo-box-placeholder.ts
+++ b/frontend/demo/component/combobox/combo-box-placeholder.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-placeholder')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -27,7 +27,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-combo-box

--- a/frontend/demo/component/combobox/combo-box-popup-width.ts
+++ b/frontend/demo/component/combobox/combo-box-popup-width.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-popup-width')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -27,7 +27,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-combo-box

--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-presentation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private filteredItems: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     const items = people.map((person) => ({
       ...person,
@@ -36,7 +36,7 @@ export class Example extends LitElement {
     this.filteredItems = items;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::combobox[] -->
       <vaadin-combo-box

--- a/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('confirm-dialog-basic')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     /* Center the button within the example */
     :host {
       position: fixed;

--- a/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -37,7 +37,7 @@ export class Example extends LitElement {
   @state()
   private status = '';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout
         style="align-items: center; justify-content: center;"

--- a/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('confirm-dialog-cancel-button')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   @state()
   private status = '';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout
         style="align-items: center; justify-content: center;"

--- a/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('confirm-dialog-confirm-button')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   @state()
   private status = '';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout
         style="align-items: center; justify-content: center;"

--- a/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('confirm-dialog-reject-button')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   @state()
   private status = '';
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout
         style="align-items: center; justify-content: center;"

--- a/frontend/demo/component/contextmenu/context-menu-basic.ts
+++ b/frontend/demo/component/contextmenu/context-menu-basic.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('context-menu-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,11 +25,11 @@ export class Example extends LitElement {
   @state()
   private gridItems: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.gridItems = (await getPeople({ count: 5 })).people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-context-menu .items=${this.items}>

--- a/frontend/demo/component/contextmenu/context-menu-best-practices.ts
+++ b/frontend/demo/component/contextmenu/context-menu-best-practices.ts
@@ -15,7 +15,7 @@ interface FileItem {
 
 @customElement('context-menu-best-practices')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,7 +33,7 @@ export class Example extends LitElement {
     { name: 'Financials.xlsx', size: '42 MB' },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-context-menu .items=${this.items}>

--- a/frontend/demo/component/contextmenu/context-menu-checkable.ts
+++ b/frontend/demo/component/contextmenu/context-menu-checkable.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('context-menu-checkable')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
     { text: 'Tamaki Ryushi' },
   ];
 
-  render() {
+  protected override render() {
     const selectedItem = this.items.find((item) => item.checked);
 
     return html`

--- a/frontend/demo/component/contextmenu/context-menu-disabled.ts
+++ b/frontend/demo/component/contextmenu/context-menu-disabled.ts
@@ -13,7 +13,7 @@ interface FileItem {
 
 @customElement('context-menu-disabled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -46,7 +46,7 @@ export class Example extends LitElement {
     { name: 'Financials.pdf', size: '42 MB' },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-context-menu .items=${this.items}>

--- a/frontend/demo/component/contextmenu/context-menu-dividers.ts
+++ b/frontend/demo/component/contextmenu/context-menu-dividers.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('context-menu-dividers')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,11 +20,11 @@ export class Example extends LitElement {
   @state()
   private gridItems: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.gridItems = (await getPeople({ count: 5 })).people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-context-menu

--- a/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
+++ b/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
@@ -13,7 +13,7 @@ interface FileItem {
 
 @customElement('context-menu-hierarchical')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -46,7 +46,7 @@ export class Example extends LitElement {
     { name: 'Financials.xlsx', size: '42 MB' },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-context-menu .items=${this.items}>

--- a/frontend/demo/component/contextmenu/context-menu-left-click.ts
+++ b/frontend/demo/component/contextmenu/context-menu-left-click.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('context-menu-left-click')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -36,11 +36,11 @@ export class Example extends LitElement {
     }
   };
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.gridItems = (await getPeople({ count: 5 })).people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-context-menu

--- a/frontend/demo/component/contextmenu/context-menu-presentation.ts
+++ b/frontend/demo/component/contextmenu/context-menu-presentation.ts
@@ -17,7 +17,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('context-menu-presentation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -31,7 +31,7 @@ export class Example extends LitElement {
   private items?: ContextMenuItem[];
 
   // tag::snippet[]
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 10 });
 
     this.gridItems = people.slice(0, 5);
@@ -55,7 +55,7 @@ export class Example extends LitElement {
   }
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-context-menu .items=${this.items}>

--- a/frontend/demo/component/cookieconsent/cookie-consent-basic.ts
+++ b/frontend/demo/component/cookieconsent/cookie-consent-basic.ts
@@ -6,7 +6,7 @@ import '@vaadin/cookie-consent';
 
 @customElement('cookie-consent-basic')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-cookie-consent></vaadin-cookie-consent>

--- a/frontend/demo/component/cookieconsent/cookie-consent-localization.ts
+++ b/frontend/demo/component/cookieconsent/cookie-consent-localization.ts
@@ -6,7 +6,7 @@ import '@vaadin/cookie-consent';
 
 @customElement('cookie-consent-localization')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-cookie-consent

--- a/frontend/demo/component/cookieconsent/cookie-consent-theming.ts
+++ b/frontend/demo/component/cookieconsent/cookie-consent-theming.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   // end::snippet[]
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     return html`<vaadin-cookie-consent></vaadin-cookie-consent>`;
   }
   // end::snippet[]

--- a/frontend/demo/component/crud/crud-basic.ts
+++ b/frontend/demo/component/crud/crud-basic.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,12 +19,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-crud

--- a/frontend/demo/component/crud/crud-columns.ts
+++ b/frontend/demo/component/crud/crud-columns.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-columns')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,12 +20,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <!-- Use 'include' or 'exclude' to select which fields to show -->

--- a/frontend/demo/component/crud/crud-editor-aside.ts
+++ b/frontend/demo/component/crud/crud-editor-aside.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-editor-aside')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,12 +18,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-crud

--- a/frontend/demo/component/crud/crud-editor-bottom.ts
+++ b/frontend/demo/component/crud/crud-editor-bottom.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,12 +24,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-crud

--- a/frontend/demo/component/crud/crud-editor-bottom.ts
+++ b/frontend/demo/component/crud/crud-editor-bottom.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-editor-bottom')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-crud {
       --vaadin-crud-editor-max-height: 60%;
     }

--- a/frontend/demo/component/crud/crud-editor-content.ts
+++ b/frontend/demo/component/crud/crud-editor-content.ts
@@ -13,7 +13,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-editor-content')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -29,7 +29,7 @@ export class Example extends LitElement {
   @state()
   private responsiveSteps: FormLayoutResponsiveStep[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
     this.professions = [...new Set(people.map((i) => i.profession))];
@@ -39,7 +39,7 @@ export class Example extends LitElement {
     ];
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-crud include="firstName, lastName, email, profession" .items=${this.items}>

--- a/frontend/demo/component/crud/crud-grid-replacement.ts
+++ b/frontend/demo/component/crud/crud-grid-replacement.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-grid-replacement')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,12 +19,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-crud include="firstName, lastName, email, profession" .items="${this.items}">

--- a/frontend/demo/component/crud/crud-hidden-toolbar.ts
+++ b/frontend/demo/component/crud/crud-hidden-toolbar.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-hidden-toolbar')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,12 +18,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <!-- Adding the no-toolbar attribute hides the toolbar -->

--- a/frontend/demo/component/crud/crud-item-initialization.ts
+++ b/frontend/demo/component/crud/crud-item-initialization.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-item-initialization')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -23,7 +23,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
@@ -38,7 +38,7 @@ export class Example extends LitElement {
     };
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-crud
         include="firstName, lastName, email, profession"

--- a/frontend/demo/component/crud/crud-localization.ts
+++ b/frontend/demo/component/crud/crud-localization.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-localization')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   @query('vaadin-crud')
   private crud!: Crud<Person>;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
     // tag::snippet[]
@@ -55,7 +55,7 @@ export class Example extends LitElement {
     // end::snippet[]
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
 

--- a/frontend/demo/component/crud/crud-open-editor.ts
+++ b/frontend/demo/component/crud/crud-open-editor.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-open-editor')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -23,12 +23,12 @@ export class Example extends LitElement {
   @state()
   private editedItem?: Person;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-crud

--- a/frontend/demo/component/crud/crud-sorting-filtering.ts
+++ b/frontend/demo/component/crud/crud-sorting-filtering.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-sorting-filtering')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,12 +18,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-crud

--- a/frontend/demo/component/crud/crud-toolbar.ts
+++ b/frontend/demo/component/crud/crud-toolbar.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('crud-toolbar')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,12 +22,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-crud

--- a/frontend/demo/component/custom-field/custom-field-basic.ts
+++ b/frontend/demo/component/custom-field/custom-field-basic.ts
@@ -10,7 +10,7 @@ import { differenceInDays, parseISO, isAfter } from 'date-fns';
 
 @customElement('custom-field-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
 
   private binder = new Binder(this, AppointmentModel);
 
-  firstUpdated() {
+  protected override firstUpdated() {
     // Set `aria-label` for screen readers
     this.start.setAttribute('aria-label', 'Start date');
     this.start.removeAttribute('aria-labelledby');
@@ -59,7 +59,7 @@ export class Example extends LitElement {
     });
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-custom-field

--- a/frontend/demo/component/custom-field/custom-field-native-input.ts
+++ b/frontend/demo/component/custom-field/custom-field-native-input.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('custom-field-native-input')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   @state()
   private customFieldValue = '';
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-custom-field

--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('custom-field-size-variants')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,7 +33,7 @@ export class Example extends LitElement {
     { label: 'USD', value: 'usd' },
   ];
 
-  firstUpdated() {
+  protected override firstUpdated() {
     // Set `aria-label` for screen readers
     this.amount.setAttribute('aria-label', 'Amount');
     this.amount.removeAttribute('aria-labelledby');
@@ -42,7 +42,7 @@ export class Example extends LitElement {
     this.currency.removeAttribute('aria-labelledby');
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-custom-field label="Price" theme="small">

--- a/frontend/demo/component/datepicker/date-picker-auto-open.ts
+++ b/frontend/demo/component/datepicker/date-picker-auto-open.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-auto-open')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-picker label="Start date" auto-open-disabled></vaadin-date-picker>

--- a/frontend/demo/component/datepicker/date-picker-basic.ts
+++ b/frontend/demo/component/datepicker/date-picker-basic.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-picker label="Start date"></vaadin-date-picker>

--- a/frontend/demo/component/datepicker/date-picker-custom-functions.ts
+++ b/frontend/demo/component/datepicker/date-picker-custom-functions.ts
@@ -10,7 +10,7 @@ import dateFnsParse from 'date-fns/parse';
 
 @customElement('date-picker-custom-functions')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   private selectedDateValue: string = dateFnsFormat(new Date(), 'yyyy-MM-dd');
 
   // tag::snippet[]
-  firstUpdated() {
+  protected override firstUpdated() {
     const formatDateIso8601 = (dateParts: DatePickerDate): string => {
       const { year, month, day } = dateParts;
       const date = new Date(year, month, day);
@@ -47,7 +47,7 @@ export class Example extends LitElement {
 
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-date-picker
         label="Select a date:"

--- a/frontend/demo/component/datepicker/date-picker-custom-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-custom-validation.ts
@@ -9,7 +9,7 @@ import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/Appointm
 
 @customElement('date-picker-custom-validation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   // tag::snippet[]
   private binder = new Binder(this, AppointmentModel);
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.binder.for(this.binder.model.startDate).addValidator({
       message: 'Select a weekday',
       validate: (startDate: string) => {
@@ -30,7 +30,7 @@ export class Example extends LitElement {
     });
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-date-picker
         label="Meeting date"

--- a/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-date-format-indicator')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-picker

--- a/frontend/demo/component/datepicker/date-picker-date-range.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-range.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-date-range')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   @state()
   private returnDate = '';
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing">

--- a/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
+++ b/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
@@ -10,7 +10,7 @@ import getDaysInMonth from 'date-fns/getDaysInMonth';
 
 @customElement('date-picker-individual-input-fields')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -73,7 +73,7 @@ export class Example extends LitElement {
     this.selectedDay = e.detail.value!;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <vaadin-combo-box

--- a/frontend/demo/component/datepicker/date-picker-initial-position.ts
+++ b/frontend/demo/component/datepicker/date-picker-initial-position.ts
@@ -8,7 +8,7 @@ import { formatISO, lastDayOfYear } from 'date-fns';
 
 @customElement('date-picker-initial-position')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   private lastDayOfTheYear = lastDayOfYear(Date.now());
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-picker

--- a/frontend/demo/component/datepicker/date-picker-internationalization.ts
+++ b/frontend/demo/component/datepicker/date-picker-internationalization.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-internationalization')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @query('vaadin-date-picker')
   private datePicker!: DatePicker;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.datePicker.i18n = {
       ...this.datePicker.i18n,
       monthNames: [
@@ -44,7 +44,7 @@ export class Example extends LitElement {
     };
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-date-picker label="Sitzungsdatum"></vaadin-date-picker>`;
   }
   // end::snippet[]

--- a/frontend/demo/component/datepicker/date-picker-min-max.ts
+++ b/frontend/demo/component/datepicker/date-picker-min-max.ts
@@ -8,7 +8,7 @@ import { addDays, formatISO } from 'date-fns';
 
 @customElement('date-picker-min-max')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,14 +21,14 @@ export class Example extends LitElement {
   @state()
   private upperLimit = '';
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.today = formatISO(Date.now(), { representation: 'date' });
 
     const upperLimit = addDays(Date.now(), 60);
     this.upperLimit = formatISO(upperLimit, { representation: 'date' });
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-picker

--- a/frontend/demo/component/datepicker/date-picker-week-numbers.ts
+++ b/frontend/demo/component/datepicker/date-picker-week-numbers.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-week-numbers')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,14 +19,14 @@ export class Example extends LitElement {
   private datePicker!: DatePicker;
 
   // tag::snippet[]
-  firstUpdated() {
+  protected override firstUpdated() {
     this.datePicker.i18n = {
       ...this.datePicker.i18n,
       firstDayOfWeek: 1,
     };
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-date-picker label="Vacation start date" show-week-numbers></vaadin-date-picker>
     `;

--- a/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-auto-open')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-time-picker

--- a/frontend/demo/component/datetimepicker/date-time-picker-basic.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-basic.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-time-picker label="Meeting date and time"></vaadin-date-time-picker>

--- a/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-custom-validation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   // tag::snippet[]
   private binder = new Binder(this, AppointmentModel);
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.binder.for(this.binder.model.startDateTime).addValidator({
       message: 'The selected day of week is not available',
       validate: (startDateTime: string) => {
@@ -39,7 +39,7 @@ export class Example extends LitElement {
     });
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-date-time-picker
         label="Appointment date and time"

--- a/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts
@@ -13,14 +13,14 @@ const startOfNextMonthISOString = formatISO(startOfNextMonth, { representation: 
 
 @customElement('date-time-picker-initial-position')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-time-picker

--- a/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-input-format')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-time-picker

--- a/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-internationalization')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @query('vaadin-date-time-picker')
   private dateTimePicker!: DateTimePicker;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.dateTimePicker.i18n = {
       ...this.dateTimePicker.i18n,
       monthNames: [
@@ -44,7 +44,7 @@ export class Example extends LitElement {
     };
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-date-time-picker label="Sitzungsdatum"></vaadin-date-time-picker>`;
   }
   // end::snippet[]

--- a/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts
@@ -13,14 +13,14 @@ const maxValue = format(addDays(new Date(), 60), dateTimeFormat);
 
 @customElement('date-time-picker-min-max')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-time-picker

--- a/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-minutes-step')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-time-picker

--- a/frontend/demo/component/datetimepicker/date-time-picker-range.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-range.ts
@@ -11,7 +11,7 @@ const initialEndValue = '2020-09-01T20:00';
 
 @customElement('date-time-picker-range')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   @state()
   private endDateTime = initialEndValue;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <div>

--- a/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-seconds-step')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-time-picker

--- a/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-week-numbers')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,14 +19,14 @@ export class Example extends LitElement {
   @query('vaadin-date-time-picker')
   private dateTimePicker!: DateTimePicker;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.dateTimePicker.i18n = {
       ...this.dateTimePicker.i18n,
       firstDayOfWeek: 1,
     };
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-date-time-picker
         label="Meeting date and time"

--- a/frontend/demo/component/details/details-basic.ts
+++ b/frontend/demo/component/details/details-basic.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('details-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-details opened>
         <div slot="summary">Contact information</div>

--- a/frontend/demo/component/details/details-content.ts
+++ b/frontend/demo/component/details/details-content.ts
@@ -16,14 +16,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-details opened>
         <div slot="summary">Analytics</div>

--- a/frontend/demo/component/details/details-content.ts
+++ b/frontend/demo/component/details/details-content.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('details-content')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     a {
       text-decoration: none;
       color: var(--lumo-primary-text-color);

--- a/frontend/demo/component/details/details-disabled.ts
+++ b/frontend/demo/component/details/details-disabled.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('details-disabled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-details disabled>
         <div slot="summary">Members (8)</div>

--- a/frontend/demo/component/details/details-filled.ts
+++ b/frontend/demo/component/details/details-filled.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('details-filled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-details opened theme="filled">
         <div slot="summary">Members (8)</div>

--- a/frontend/demo/component/details/details-reverse.ts
+++ b/frontend/demo/component/details/details-reverse.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('details-reverse')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-details opened theme="reverse">
         <div slot="summary">Members (8)</div>

--- a/frontend/demo/component/details/details-small.ts
+++ b/frontend/demo/component/details/details-small.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('details-small')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-details opened theme="small">
         <div slot="summary">Members (8)</div>

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -19,7 +19,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('details-summary')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -35,11 +35,11 @@ export class Example extends LitElement {
     { minWidth: '20em', columns: 2 },
   ];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCountries();
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-details opened>
         <vaadin-horizontal-layout

--- a/frontend/demo/component/dialog/dialog-basic.ts
+++ b/frontend/demo/component/dialog/dialog-basic.ts
@@ -13,7 +13,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-basic')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     /* Center the button within the example */
     :host {
       position: fixed;

--- a/frontend/demo/component/dialog/dialog-basic.ts
+++ b/frontend/demo/component/dialog/dialog-basic.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -37,7 +37,7 @@ export class Example extends LitElement {
   @state()
   private dialogOpened = true;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-dialog

--- a/frontend/demo/component/dialog/dialog-closing.ts
+++ b/frontend/demo/component/dialog/dialog-closing.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-closing')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   @state()
   private dialogOpened = false;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-dialog

--- a/frontend/demo/component/dialog/dialog-draggable.ts
+++ b/frontend/demo/component/dialog/dialog-draggable.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-draggable')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   @state()
   private dialogOpened = false;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-dialog

--- a/frontend/demo/component/dialog/dialog-footer.ts
+++ b/frontend/demo/component/dialog/dialog-footer.ts
@@ -13,7 +13,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('dialog-footer')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,12 +26,12 @@ export class Example extends LitElement {
   @state()
   private user?: Person;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     this.user = people[0];
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-dialog

--- a/frontend/demo/component/dialog/dialog-header.ts
+++ b/frontend/demo/component/dialog/dialog-header.ts
@@ -19,7 +19,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('dialog-header')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -32,12 +32,12 @@ export class Example extends LitElement {
   @state()
   private user?: Person;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     this.user = people[0];
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-dialog

--- a/frontend/demo/component/dialog/dialog-no-padding.ts
+++ b/frontend/demo/component/dialog/dialog-no-padding.ts
@@ -17,7 +17,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('dialog-no-padding')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -30,12 +30,12 @@ export class Example extends LitElement {
   @state()
   private people?: Person[];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 50 });
     this.people = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-dialog

--- a/frontend/demo/component/dialog/dialog-resizable.ts
+++ b/frontend/demo/component/dialog/dialog-resizable.ts
@@ -16,7 +16,7 @@ import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
 
 @customElement('dialog-resizable')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -29,12 +29,12 @@ export class Example extends LitElement {
   @state()
   private people?: Person[];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 50 });
     this.people = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-dialog

--- a/frontend/demo/component/emailfield/email-field-basic.ts
+++ b/frontend/demo/component/emailfield/email-field-basic.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('email-field-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/emailfield/email-field-pattern.ts
+++ b/frontend/demo/component/emailfield/email-field-pattern.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('email-field-pattern')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-email-field

--- a/frontend/demo/component/formlayout/form-layout-basic.ts
+++ b/frontend/demo/component/formlayout/form-layout-basic.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
     { minWidth: '500px', columns: 2 },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-form-layout .responsiveSteps="${this.responsiveSteps}">
         <vaadin-text-field label="First name"></vaadin-text-field>

--- a/frontend/demo/component/formlayout/form-layout-colspan.ts
+++ b/frontend/demo/component/formlayout/form-layout-colspan.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-custom-layout')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,7 +22,7 @@ export class Example extends LitElement {
     { minWidth: '20em', columns: 3 },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-form-layout .responsiveSteps="${this.responsiveSteps}">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/formlayout/form-layout-custom-layout.ts
+++ b/frontend/demo/component/formlayout/form-layout-custom-layout.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-custom-layout')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -28,7 +28,7 @@ export class Example extends LitElement {
     { minWidth: '500px', columns: 3 },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-split-layout>
         <vaadin-form-layout .responsiveSteps="${this.responsiveSteps}">

--- a/frontend/demo/component/formlayout/form-layout-native-input.ts
+++ b/frontend/demo/component/formlayout/form-layout-native-input.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-native-input')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-form-layout>

--- a/frontend/demo/component/formlayout/form-layout-side.ts
+++ b/frontend/demo/component/formlayout/form-layout-side.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-side')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-form-layout>

--- a/frontend/demo/component/grid/grid-basic.ts
+++ b/frontend/demo/component/grid/grid-basic.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,12 +20,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}">
         <vaadin-grid-column path="firstName"></vaadin-grid-column>

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-cell-focus')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-text-area {
       width: 100%;
     }

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,13 +33,13 @@ export class Example extends LitElement {
   @state()
   private eventSummary = '';
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid
         theme="force-focus-outline"

--- a/frontend/demo/component/grid/grid-column-alignment.ts
+++ b/frontend/demo/component/grid/grid-column-alignment.ts
@@ -11,7 +11,7 @@ import { format } from 'date-fns';
 
 @customElement('grid-column-alignment')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,7 +21,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -40,7 +40,7 @@ export class Example extends LitElement {
     );
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid .items="${this.items}">

--- a/frontend/demo/component/grid/grid-column-borders.ts
+++ b/frontend/demo/component/grid/grid-column-borders.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-column-borders')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,12 +22,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid .items="${this.items}" theme="column-borders">

--- a/frontend/demo/component/grid/grid-column-filtering.ts
+++ b/frontend/demo/component/grid/grid-column-filtering.ts
@@ -16,7 +16,7 @@ type PersonEnhanced = Person & { displayName: string };
 
 @customElement('grid-column-filtering')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   @state()
   private items: PersonEnhanced[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -34,7 +34,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid .items="${this.items}">

--- a/frontend/demo/component/grid/grid-column-freezing.ts
+++ b/frontend/demo/component/grid/grid-column-freezing.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-column-freezing')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,12 +21,12 @@ export class Example extends LitElement {
   @state()
   private items?: Person[];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}">
         <!-- tag::snippet1[] -->

--- a/frontend/demo/component/grid/grid-column-grouping.ts
+++ b/frontend/demo/component/grid/grid-column-grouping.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('grid-column-grouping')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,12 +21,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}">
         <vaadin-grid-column-group header="Name">

--- a/frontend/demo/component/grid/grid-column-header-footer.ts
+++ b/frontend/demo/component/grid/grid-column-header-footer.ts
@@ -18,7 +18,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-column-header-footer')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -29,7 +29,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -37,7 +37,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}">
         <vaadin-grid-column

--- a/frontend/demo/component/grid/grid-column-reordering-resizing.ts
+++ b/frontend/demo/component/grid/grid-column-reordering-resizing.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('grid-column-reordering-resizing')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,12 +21,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}" column-reordering-allowed>
         <vaadin-grid-column-group header="Name">

--- a/frontend/demo/component/grid/grid-column-visibility.ts
+++ b/frontend/demo/component/grid/grid-column-visibility.ts
@@ -13,7 +13,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-column-visibility')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,12 +33,12 @@ export class Example extends LitElement {
     { text: 'Profession', checked: true, key: 'profession' },
   ];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout style="align-items: baseline">
         <strong style="flex: 1;">Employees</strong>

--- a/frontend/demo/component/grid/grid-column-width.ts
+++ b/frontend/demo/component/grid/grid-column-width.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('grid-column-width')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -32,7 +32,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-split-layout>
         <vaadin-grid .items="${this.items}" style="width: 100%;">

--- a/frontend/demo/component/grid/grid-compact.ts
+++ b/frontend/demo/component/grid/grid-compact.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-compact')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,12 +19,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid .items="${this.items}" theme="compact">

--- a/frontend/demo/component/grid/grid-content.ts
+++ b/frontend/demo/component/grid/grid-content.ts
@@ -16,7 +16,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-content')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -27,12 +27,12 @@ export class Example extends LitElement {
   @state()
   private items?: Person[];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}">
         <vaadin-grid-selection-column></vaadin-grid-selection-column>

--- a/frontend/demo/component/grid/grid-context-menu.ts
+++ b/frontend/demo/component/grid/grid-context-menu.ts
@@ -15,7 +15,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-context-menu')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
@@ -53,7 +53,7 @@ export class Example extends LitElement {
     `;
   };
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-context-menu ${contextMenuRenderer(this.renderMenu, [])}>
         <vaadin-grid .items="${this.items}" @vaadin-contextmenu="${this.onContextMenu}">

--- a/frontend/demo/component/grid/grid-drag-drop-filters.ts
+++ b/frontend/demo/component/grid/grid-drag-drop-filters.ts
@@ -20,7 +20,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('grid-drag-drop-filters')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -42,7 +42,7 @@ export class Example extends LitElement {
   @state()
   private expandedItems: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
     this.managers = this.items.filter((item) => item.manager);
@@ -72,7 +72,7 @@ export class Example extends LitElement {
     callback(result, result.length);
   };
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid
         .dataProvider="${this.dataProvider}"

--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -44,7 +44,7 @@ export class Example extends LitElement {
   @state()
   private grid2Items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 10 });
     this.grid1Items = people.slice(0, 5);
     this.grid2Items = people.slice(5);
@@ -58,7 +58,7 @@ export class Example extends LitElement {
     delete this.draggedItem;
   };
 
-  render() {
+  protected override render() {
     return html`
       <div class="grids-container">
         <vaadin-grid

--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-drag-rows-between-grids')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     .grids-container {
       display: flex;
       flex-direction: row;

--- a/frontend/demo/component/grid/grid-dynamic-height.ts
+++ b/frontend/demo/component/grid/grid-dynamic-height.ts
@@ -17,7 +17,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-dynamic-height')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,7 +33,7 @@ export class Example extends LitElement {
   @state()
   private selectedValue = '';
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -41,7 +41,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <vaadin-combo-box

--- a/frontend/demo/component/grid/grid-external-filtering.ts
+++ b/frontend/demo/component/grid/grid-external-filtering.ts
@@ -20,7 +20,7 @@ type PersonEnhanced = Person & { displayName: string };
 
 @customElement('grid-external-filtering')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,7 +33,7 @@ export class Example extends LitElement {
 
   private items: PersonEnhanced[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     const items = people.map((person) => ({
       ...person,
@@ -43,7 +43,7 @@ export class Example extends LitElement {
     this.filteredItems = items;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout theme="spacing">
         <vaadin-text-field

--- a/frontend/demo/component/grid/grid-item-details-toggle.ts
+++ b/frontend/demo/component/grid/grid-item-details-toggle.ts
@@ -13,7 +13,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('grid-item-details-toggle')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   @state()
   private detailsOpenedItems: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -34,7 +34,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid
         theme="row-stripes"

--- a/frontend/demo/component/grid/grid-item-details.ts
+++ b/frontend/demo/component/grid/grid-item-details.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('grid-item-details')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   @state()
   private detailsOpenedItem: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -35,7 +35,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid
         theme="row-stripes"

--- a/frontend/demo/component/grid/grid-multi-select-mode.ts
+++ b/frontend/demo/component/grid/grid-multi-select-mode.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('grid-multi-select-mode')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,12 +21,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}">
         <vaadin-grid-selection-column></vaadin-grid-selection-column>

--- a/frontend/demo/component/grid/grid-multisort.ts
+++ b/frontend/demo/component/grid/grid-multisort.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-multisort')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -28,7 +28,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid .items="${this.items}" multi-sort multi-sort-priority="append">

--- a/frontend/demo/component/grid/grid-no-border.ts
+++ b/frontend/demo/component/grid/grid-no-border.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-no-border')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,12 +22,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid .items="${this.items}" theme="no-border">

--- a/frontend/demo/component/grid/grid-no-row-border.ts
+++ b/frontend/demo/component/grid/grid-no-row-border.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-no-row-border')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,12 +22,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid .items="${this.items}" theme="no-row-borders">

--- a/frontend/demo/component/grid/grid-rich-content-sorting.ts
+++ b/frontend/demo/component/grid/grid-rich-content-sorting.ts
@@ -16,7 +16,7 @@ import { differenceInYears, format, parseISO } from 'date-fns';
 
 @customElement('grid-rich-content-sorting')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -27,12 +27,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}">
         <vaadin-grid-sort-column

--- a/frontend/demo/component/grid/grid-row-reordering.ts
+++ b/frontend/demo/component/grid/grid-row-reordering.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('grid-row-reordering')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -27,12 +27,12 @@ export class Example extends LitElement {
   @state()
   private draggedItem?: Person;
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid

--- a/frontend/demo/component/grid/grid-row-stripes.ts
+++ b/frontend/demo/component/grid/grid-row-stripes.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-row-stripes')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,12 +22,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid .items="${this.items}" theme="row-stripes">

--- a/frontend/demo/component/grid/grid-single-selection-mode.ts
+++ b/frontend/demo/component/grid/grid-single-selection-mode.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-single-select-mode')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,12 +24,12 @@ export class Example extends LitElement {
   @state()
   private selectedItems: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid
         .items="${this.items}"

--- a/frontend/demo/component/grid/grid-sorting.ts
+++ b/frontend/demo/component/grid/grid-sorting.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-sorting')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({
       ...person,
@@ -28,7 +28,7 @@ export class Example extends LitElement {
     }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid .items="${this.items}">

--- a/frontend/demo/component/grid/grid-styling.ts
+++ b/frontend/demo/component/grid/grid-styling.ts
@@ -17,7 +17,7 @@ interface PersonWithRating extends Person {
 
 @customElement('grid-styling')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -32,12 +32,12 @@ export class Example extends LitElement {
     maximumFractionDigits: 2,
   });
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people.map((person) => ({ ...person, customerRating: Math.random() * 10 }));
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}" .cellClassNameGenerator="${this.cellClassNameGenerator}">
         <vaadin-grid-column path="firstName"></vaadin-grid-column>

--- a/frontend/demo/component/grid/grid-tooltip-generator.ts
+++ b/frontend/demo/component/grid/grid-tooltip-generator.ts
@@ -16,7 +16,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-tooltip-generator')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
@@ -53,7 +53,7 @@ export class Example extends LitElement {
   };
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}">
         <vaadin-grid-column path="firstName"></vaadin-grid-column>

--- a/frontend/demo/component/grid/grid-wrap-cell-content.ts
+++ b/frontend/demo/component/grid/grid-wrap-cell-content.ts
@@ -13,7 +13,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 // tag::snippet[]
 @customElement('grid-wrap-cell-content')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -23,12 +23,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .items="${this.items}" theme="wrap-cell-content">
         <vaadin-grid-column

--- a/frontend/demo/component/gridpro/grid-pro-basic.ts
+++ b/frontend/demo/component/gridpro/grid-pro-basic.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,12 +20,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro .items="${this.items}">

--- a/frontend/demo/component/gridpro/grid-pro-edit-column.ts
+++ b/frontend/demo/component/gridpro/grid-pro-edit-column.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-edit-column')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,12 +22,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro .items="${this.items}" enter-next-row>

--- a/frontend/demo/component/gridpro/grid-pro-editors.ts
+++ b/frontend/demo/component/gridpro/grid-pro-editors.ts
@@ -14,7 +14,7 @@ import { format, parseISO } from 'date-fns';
 
 @customElement('grid-pro-editors')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,12 +24,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro .items="${this.items}" enter-next-row>

--- a/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
+++ b/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-enter-next-row')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,12 +20,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro .items="${this.items}" enter-next-row>

--- a/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-highlight-editable-cells')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,12 +21,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro theme="highlight-editable-cells" .items="${this.items}">

--- a/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-highlight-read-only-cells')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,12 +21,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro theme="highlight-read-only-cells" .items="${this.items}">

--- a/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
+++ b/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-prevent-save')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,12 +26,12 @@ export class Example extends LitElement {
     notification.setAttribute('theme', 'error');
   }
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro .items="${this.items}" @item-property-changed="${this.itemPropertyListener}">

--- a/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-single-cell-edit')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,12 +20,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro .items="${this.items}" single-cell-edit>

--- a/frontend/demo/component/gridpro/grid-pro-single-click.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-click.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-pro-single-click')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,12 +20,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro .items="${this.items}" edit-on-click>

--- a/frontend/demo/component/icons/iconset-generator.ts
+++ b/frontend/demo/component/icons/iconset-generator.ts
@@ -180,7 +180,7 @@ export class IconsetGenerator extends LitElement {
   @query('.name')
   private nameInput!: HTMLInputElement;
 
-  render() {
+  protected override render() {
     return html`
       <label for="iconsetname">Icon set name</label><br />
       <small>Use CamelCase naming. Leave empty to use folder name(s) only.</small><br />

--- a/frontend/demo/component/icons/iconset-generator.ts
+++ b/frontend/demo/component/icons/iconset-generator.ts
@@ -7,7 +7,7 @@ const capitalize = (s: string) => s && s[0].toUpperCase() + s.slice(1);
 
 @customElement('iconset-generator')
 export class IconsetGenerator extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       margin: var(--docs-space-xl) 0;
       background-color: var(--docs-surface-color-2);

--- a/frontend/demo/component/inputfields/input-field-aria-label.ts
+++ b/frontend/demo/component/inputfields/input-field-aria-label.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-aria-label')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field aria-label="search" placeholder="Search" clear-button-visible>

--- a/frontend/demo/component/inputfields/input-field-disabled.ts
+++ b/frontend/demo/component/inputfields/input-field-disabled.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-disabled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field label="Disabled" value="Value" disabled></vaadin-text-field>

--- a/frontend/demo/component/inputfields/input-field-focus-styles.ts
+++ b/frontend/demo/component/inputfields/input-field-focus-styles.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-focus-styles')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/inputfields/input-field-focus.ts
+++ b/frontend/demo/component/inputfields/input-field-focus.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-focus')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,7 +21,7 @@ export class Example extends LitElement {
     { minWidth: '30em', columns: 2 },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-form-layout .responsiveSteps="${this.steps}">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/inputfields/input-field-helper-position.ts
+++ b/frontend/demo/component/inputfields/input-field-helper-position.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-helper-position')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field

--- a/frontend/demo/component/inputfields/input-field-helper.ts
+++ b/frontend/demo/component/inputfields/input-field-helper.ts
@@ -20,7 +20,7 @@ const StrengthColor: Record<PasswordStrength, string> = {
 
 @customElement('input-field-helper')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,7 +33,7 @@ export class Example extends LitElement {
   @state()
   private strengthColor = StrengthColor.weak;
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/inputfields/input-field-label.ts
+++ b/frontend/demo/component/inputfields/input-field-label.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-label')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-email-field label="Email address"></vaadin-email-field>

--- a/frontend/demo/component/inputfields/input-field-read-only.ts
+++ b/frontend/demo/component/inputfields/input-field-read-only.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-read-only')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field label="Read-only" value="Value" readonly></vaadin-text-field>

--- a/frontend/demo/component/inputfields/input-field-required.ts
+++ b/frontend/demo/component/inputfields/input-field-required.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-required')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/listbox/list-box-basic.ts
+++ b/frontend/demo/component/listbox/list-box-basic.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-list-box multiple .selectedValues="${[0, 2]}">

--- a/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
+++ b/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
@@ -13,7 +13,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('list-box-custom-item-presentation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -23,12 +23,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 5 });
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-list-box multiple .selectedValues="${[0, 2]}">

--- a/frontend/demo/component/listbox/list-box-disabled-items.ts
+++ b/frontend/demo/component/listbox/list-box-disabled-items.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-disabled-items')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-list-box selected="0">

--- a/frontend/demo/component/listbox/list-box-multi-selection.ts
+++ b/frontend/demo/component/listbox/list-box-multi-selection.ts
@@ -9,7 +9,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('list-box-multi-selection')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,12 +19,12 @@ export class Example extends LitElement {
   @state()
   private items: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 20 });
     this.items = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-list-box multiple .selectedValues="${[0, 3]}" style="height: 200px">

--- a/frontend/demo/component/listbox/list-box-separators.ts
+++ b/frontend/demo/component/listbox/list-box-separators.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-separators')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-list-box multiple .selectedValues="${[0, 2, 3]}">

--- a/frontend/demo/component/listbox/list-box-single-selection.ts
+++ b/frontend/demo/component/listbox/list-box-single-selection.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-single-selection')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-list-box selected="0">

--- a/frontend/demo/component/login/login-additional-information-preview.ts
+++ b/frontend/demo/component/login/login-additional-information-preview.ts
@@ -7,7 +7,7 @@ import type { LoginOverlayMockupElement } from './login-overlay-mockup';
 
 @customElement('login-additional-information')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -17,14 +17,14 @@ export class Example extends LitElement {
   @query('login-overlay-mockup')
   private login!: LoginOverlayMockupElement;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.login.i18n = {
       ...this.login.i18n,
       additionalInformation: `Contact admin@company.com if you're experiencing issues logging into your account`,
     };
   }
 
-  render() {
+  protected override render() {
     return html`<login-overlay-mockup></login-overlay-mockup>`;
   }
 }

--- a/frontend/demo/component/login/login-additional-information.ts
+++ b/frontend/demo/component/login/login-additional-information.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-additional-information')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -18,14 +18,14 @@ export class Example extends LitElement {
   @query('vaadin-login-overlay')
   private login!: LoginOverlay;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.login.i18n = {
       ...this.login.i18n,
       additionalInformation: `Contact admin@company.com if you're experiencing issues logging into your account`,
     };
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-login-overlay opened></vaadin-login-overlay>`;
   }
   // end::snippet[]

--- a/frontend/demo/component/login/login-basic.ts
+++ b/frontend/demo/component/login/login-basic.ts
@@ -15,14 +15,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <!-- no-autofocus is used to prevent the example from stealing focus when browsing the documentation -->

--- a/frontend/demo/component/login/login-basic.ts
+++ b/frontend/demo/component/login/login-basic.ts
@@ -6,7 +6,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-basic')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       background-color: var(--lumo-contrast-5pct);
       display: flex !important;

--- a/frontend/demo/component/login/login-internationalization.ts
+++ b/frontend/demo/component/login/login-internationalization.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-internationalization')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       background-color: var(--lumo-contrast-5pct);
       display: flex !important;

--- a/frontend/demo/component/login/login-internationalization.ts
+++ b/frontend/demo/component/login/login-internationalization.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -38,7 +38,7 @@ export class Example extends LitElement {
     },
   };
 
-  render() {
+  protected override render() {
     return html`
       <!-- no-autofocus is used to prevent the example from stealing focus when browsing the documentation -->
       <vaadin-login-form .i18n="${this.i18n}" no-autofocus></vaadin-login-form>

--- a/frontend/demo/component/login/login-overlay-basic.ts
+++ b/frontend/demo/component/login/login-overlay-basic.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-overlay-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   @state()
   private loginOpened = false;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-button

--- a/frontend/demo/component/login/login-overlay-header-preview.ts
+++ b/frontend/demo/component/login/login-overlay-header-preview.ts
@@ -6,14 +6,14 @@ import './login-overlay-mockup';
 
 @customElement('login-overlay-header')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <login-overlay-mockup
         headerTitle="TaskMob"

--- a/frontend/demo/component/login/login-overlay-header.ts
+++ b/frontend/demo/component/login/login-overlay-header.ts
@@ -6,14 +6,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-overlay-header')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <!-- no-autofocus is used to prevent the example from stealing focus when browsing the documentation -->

--- a/frontend/demo/component/login/login-overlay-internationalization-preview.ts
+++ b/frontend/demo/component/login/login-overlay-internationalization-preview.ts
@@ -7,7 +7,7 @@ import './login-overlay-mockup';
 
 @customElement('login-overlay-internationalization-preview')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,7 +33,7 @@ export class Example extends LitElement {
     additionalInformation: 'Jos tarvitset lisätietoja käyttäjälle.',
   };
 
-  render() {
+  protected override render() {
     return html`
       <login-overlay-mockup
         .i18n="${this.i18n}"

--- a/frontend/demo/component/login/login-overlay-internationalization.ts
+++ b/frontend/demo/component/login/login-overlay-internationalization.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-overlay-internationalization')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -34,7 +34,7 @@ export class Example extends LitElement {
     additionalInformation: 'Jos tarvitset lisätietoja käyttäjälle.',
   };
 
-  render() {
+  protected override render() {
     return html`
       <!-- no-autofocus is used to prevent the example from stealing focus when browsing the documentation -->
       <vaadin-login-overlay .i18n="${this.i18n}" opened no-autofocus></vaadin-login-overlay>

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -7,7 +7,7 @@ import img from '../../../../src/main/resources/images/starry-sky.png';
 
 @customElement('login-overlay-mockup')
 export class LoginOverlayMockupElement extends LitElement {
-  static styles = css`
+  static override styles = css`
     [part='backdrop'] {
       background: var(--lumo-base-color)
         linear-gradient(var(--lumo-shade-5pct), var(--lumo-shade-5pct));

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -68,7 +68,7 @@ export class LoginOverlayMockupElement extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -99,7 +99,7 @@ export class LoginOverlayMockupElement extends LitElement {
     },
   };
 
-  render() {
+  protected override render() {
     return html`
       <div part="backdrop">
         <section part="card">

--- a/frontend/demo/component/login/login-rich-content.ts
+++ b/frontend/demo/component/login/login-rich-content.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-rich-content')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <!-- See login-rich-content.css -->

--- a/frontend/demo/component/login/login-validation-preview.ts
+++ b/frontend/demo/component/login/login-validation-preview.ts
@@ -6,14 +6,14 @@ import './login-overlay-mockup';
 
 @customElement('login-validation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`<login-overlay-mockup error></login-overlay-mockup>`;
   }
 }

--- a/frontend/demo/component/login/login-validation.ts
+++ b/frontend/demo/component/login/login-validation.ts
@@ -6,14 +6,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-validation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <!-- no-autofocus is used to prevent the example from stealing focus when browsing the documentation -->

--- a/frontend/demo/component/menubar/menu-bar-basic.ts
+++ b/frontend/demo/component/menubar/menu-bar-basic.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -42,7 +42,7 @@ export class Example extends LitElement {
   private selectedItem?: MenuBarItem;
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar

--- a/frontend/demo/component/menubar/menu-bar-checkable.ts
+++ b/frontend/demo/component/menubar/menu-bar-checkable.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-checkable')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar

--- a/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
+++ b/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-combo-buttons')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar theme="icon primary" .items="${this.items}"></vaadin-menu-bar>

--- a/frontend/demo/component/menubar/menu-bar-custom-theme.ts
+++ b/frontend/demo/component/menubar/menu-bar-custom-theme.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-custom-theme')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
     },
   ];
 
-  render() {
+  protected override render() {
     return html`<vaadin-menu-bar .items="${this.items}"></vaadin-menu-bar>`;
   }
   // end::snippet[]

--- a/frontend/demo/component/menubar/menu-bar-disabled.ts
+++ b/frontend/demo/component/menubar/menu-bar-disabled.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-disabled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar .items="${this.items}"></vaadin-menu-bar>

--- a/frontend/demo/component/menubar/menu-bar-dividers.ts
+++ b/frontend/demo/component/menubar/menu-bar-dividers.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-dividers')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,7 +33,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar .items="${this.items}"></vaadin-menu-bar>

--- a/frontend/demo/component/menubar/menu-bar-drop-down.ts
+++ b/frontend/demo/component/menubar/menu-bar-drop-down.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-drop-down')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -30,7 +30,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar .items="${this.items}"></vaadin-menu-bar>

--- a/frontend/demo/component/menubar/menu-bar-icon-only.ts
+++ b/frontend/demo/component/menubar/menu-bar-icon-only.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-icon-only')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -40,7 +40,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar theme="tertiary-inline" .items="${this.items}"></vaadin-menu-bar>

--- a/frontend/demo/component/menubar/menu-bar-icons.ts
+++ b/frontend/demo/component/menubar/menu-bar-icons.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-icons')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -32,7 +32,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar theme="icon" .items="${this.items}"></vaadin-menu-bar>

--- a/frontend/demo/component/menubar/menu-bar-internationalization.ts
+++ b/frontend/demo/component/menubar/menu-bar-internationalization.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-internationalization')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -38,7 +38,7 @@ export class Example extends LitElement {
     { text: 'Duplicate' },
   ];
 
-  render() {
+  protected override render() {
     // tag::snippet[]
     const customI18n: MenuBarI18n = {
       // Provide accessible label for the overflow menu button

--- a/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
+++ b/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-open-on-hover')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -38,7 +38,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar .items="${this.items}" open-on-hover></vaadin-menu-bar>

--- a/frontend/demo/component/menubar/menu-bar-overflow.ts
+++ b/frontend/demo/component/menubar/menu-bar-overflow.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-overflow')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -39,7 +39,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-split-layout>

--- a/frontend/demo/component/menubar/menu-bar-right-aligned.ts
+++ b/frontend/demo/component/menubar/menu-bar-right-aligned.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-right-aligned')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
     },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-menu-bar theme="end-aligned" .items="${this.items}"></vaadin-menu-bar>

--- a/frontend/demo/component/menubar/menu-bar-styles.ts
+++ b/frontend/demo/component/menubar/menu-bar-styles.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-styles')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-menu-bar {
       display: inline-block;
     }

--- a/frontend/demo/component/menubar/menu-bar-styles.ts
+++ b/frontend/demo/component/menubar/menu-bar-styles.ts
@@ -13,14 +13,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-menu-bar

--- a/frontend/demo/component/menubar/menu-bar-tooltip.ts
+++ b/frontend/demo/component/menubar/menu-bar-tooltip.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-tooltip')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -44,7 +44,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippethtml[] -->
       <vaadin-menu-bar .items="${this.items}" theme="icon">

--- a/frontend/demo/component/messages/message-basic.ts
+++ b/frontend/demo/component/messages/message-basic.ts
@@ -11,7 +11,7 @@ import { getPeople } from 'Frontend/demo/domain/DataService';
 
 @customElement('message-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,7 +21,7 @@ export class Example extends LitElement {
   @state()
   private items: MessageListItem[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     const person = people[0];
     this.items = [
@@ -41,7 +41,7 @@ export class Example extends LitElement {
     ];
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-message-list .items="${this.items}"></vaadin-message-list>

--- a/frontend/demo/component/messages/message-input-component.ts
+++ b/frontend/demo/component/messages/message-input-component.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('message-input-component')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private message = '';
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-message-input @submit="${this._handleSubmit}"></vaadin-message-input>

--- a/frontend/demo/component/messages/message-list-component.ts
+++ b/frontend/demo/component/messages/message-list-component.ts
@@ -15,20 +15,20 @@ export class Example extends LitElement {
   private yesterday = format(subDays(new Date(), 1), this.isoMinutes);
   private fiftyMinutesAgo = format(subMinutes(new Date(), 50), this.isoMinutes);
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     this.person = people[0];
     this.requestUpdate();
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-message-list

--- a/frontend/demo/component/messages/message-list-with-theme-component.ts
+++ b/frontend/demo/component/messages/message-list-with-theme-component.ts
@@ -15,20 +15,20 @@ export class Example extends LitElement {
   private yesterday = format(subDays(new Date(), 1), this.isoMinutes);
   private fiftyMinutesAgo = format(subMinutes(new Date(), 50), this.isoMinutes);
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });
     this.person = people[0];
     this.requestUpdate();
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-message-list

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-basic')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-multi-select-combo-box {
       width: 300px;
     }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,11 +26,11 @@ export class Example extends LitElement {
   @state()
   private items: Country[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCountries();
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-multi-select-combo-box
         label="Countries"

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   @state()
   private items: Country[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCountries();
   }
 
@@ -39,7 +39,7 @@ export class Example extends LitElement {
     total: '{count} Einträge ausgewählt',
   };
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-multi-select-combo-box
         label="Länder"

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-basic')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-multi-select-combo-box {
       width: 300px;
     }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,11 +25,11 @@ export class Example extends LitElement {
   @state()
   private items: Country[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCountries();
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-multi-select-combo-box

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-read-only')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-multi-select-combo-box {
       width: 300px;
     }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-selection-change')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   @state()
   private items: Country[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCountries();
   }
 
@@ -34,7 +34,7 @@ export class Example extends LitElement {
     return this.selectedCountries.map((country) => country.name).join(', ');
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <vaadin-multi-select-combo-box

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-selection')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-multi-select-combo-box {
       width: 300px;
     }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,11 +25,11 @@ export class Example extends LitElement {
   @state()
   private items: Country[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCountries();
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-multi-select-combo-box

--- a/frontend/demo/component/notification/notification-basic-preview.ts
+++ b/frontend/demo/component/notification/notification-basic-preview.ts
@@ -4,14 +4,14 @@ import '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card slot="middle">
         Financial report generated

--- a/frontend/demo/component/notification/notification-basic.ts
+++ b/frontend/demo/component/notification/notification-basic.ts
@@ -11,7 +11,7 @@ export class Example extends LitElement {
   @state()
   private notificationOpened = false;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -34,7 +34,7 @@ export class Example extends LitElement {
     notification.addEventListener('opened-changed', handleOpenChanged);
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-button @click="${this.handleClick}" .disabled="${this.notificationOpened}">
         Try it

--- a/frontend/demo/component/notification/notification-content-length-do.ts
+++ b/frontend/demo/component/notification/notification-content-length-do.ts
@@ -7,14 +7,14 @@ import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card slot="middle">
         <div>

--- a/frontend/demo/component/notification/notification-content-length-dont.ts
+++ b/frontend/demo/component/notification/notification-content-length-dont.ts
@@ -7,14 +7,14 @@ import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card slot="middle">
         <div>

--- a/frontend/demo/component/notification/notification-contrast-preview.ts
+++ b/frontend/demo/component/notification/notification-contrast-preview.ts
@@ -4,14 +4,14 @@ import '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card theme="contrast" slot="middle">
         5 tasks deleted

--- a/frontend/demo/component/notification/notification-contrast.ts
+++ b/frontend/demo/component/notification/notification-contrast.ts
@@ -11,7 +11,7 @@ export class Example extends LitElement {
   @state()
   private notificationOpened = false;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -35,7 +35,7 @@ export class Example extends LitElement {
     notification.addEventListener('opened-changed', handleOpenChanged);
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-button @click="${this.handleClick}" .disabled="${this.notificationOpened}">
         Try it

--- a/frontend/demo/component/notification/notification-error-preview.ts
+++ b/frontend/demo/component/notification/notification-error-preview.ts
@@ -8,14 +8,14 @@ import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card theme="error" slot="middle">
         <vaadin-horizontal-layout theme="spacing" style="align-items: center;">

--- a/frontend/demo/component/notification/notification-error.ts
+++ b/frontend/demo/component/notification/notification-error.ts
@@ -16,14 +16,14 @@ export class Example extends LitElement {
   @state()
   private notificationOpened = false;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-button .disabled="${this.notificationOpened}" @click="${this.open}">
         Try it

--- a/frontend/demo/component/notification/notification-keyboard-a11y-preview.ts
+++ b/frontend/demo/component/notification/notification-keyboard-a11y-preview.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 const isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(window.navigator.platform);
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card theme="contrast" slot="middle">
         <vaadin-horizontal-layout style="align-items: center;">

--- a/frontend/demo/component/notification/notification-keyboard-a11y.ts
+++ b/frontend/demo/component/notification/notification-keyboard-a11y.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   @state()
   private isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(window.navigator.platform);
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     return html`
       <!-- end::snippet[] -->
       <vaadin-button .disabled="${this.notificationOpened}" @click="${this.open}">

--- a/frontend/demo/component/notification/notification-link-preview.ts
+++ b/frontend/demo/component/notification/notification-link-preview.ts
@@ -8,14 +8,14 @@ import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card slot="middle">
         <vaadin-horizontal-layout theme="spacing" style="align-items: center;">

--- a/frontend/demo/component/notification/notification-link.ts
+++ b/frontend/demo/component/notification/notification-link.ts
@@ -16,14 +16,14 @@ export class Example extends LitElement {
   @state()
   private notificationOpened = false;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-button .disabled="${this.notificationOpened}" @click="${this.open}">
         Try it

--- a/frontend/demo/component/notification/notification-popup.ts
+++ b/frontend/demo/component/notification/notification-popup.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-popup')
 export class Example2 extends LitElement {
-  static styles = [
+  static override styles = [
     badge,
     css`
       vaadin-context-menu {

--- a/frontend/demo/component/notification/notification-popup.ts
+++ b/frontend/demo/component/notification/notification-popup.ts
@@ -27,7 +27,7 @@ export class Example2 extends LitElement {
     `,
   ];
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -35,7 +35,7 @@ export class Example2 extends LitElement {
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     return html`
       <vaadin-context-menu
         open-on="click"

--- a/frontend/demo/component/notification/notification-position.ts
+++ b/frontend/demo/component/notification/notification-position.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-position')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,7 +21,7 @@ export class Example extends LitElement {
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     return html`
       <vaadin-button @click="${this.show}">top-stretch</vaadin-button>
       <vaadin-button @click="${this.show}">top-start</vaadin-button>

--- a/frontend/demo/component/notification/notification-primary-preview.ts
+++ b/frontend/demo/component/notification/notification-primary-preview.ts
@@ -4,14 +4,14 @@ import '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card theme="primary" slot="middle">
         New project plan available

--- a/frontend/demo/component/notification/notification-primary.ts
+++ b/frontend/demo/component/notification/notification-primary.ts
@@ -11,7 +11,7 @@ export class Example extends LitElement {
   @state()
   private notificationOpened = false;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -35,7 +35,7 @@ export class Example extends LitElement {
     notification.addEventListener('opened-changed', handleOpenChanged);
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-button @click="${this.handleClick}" .disabled="${this.notificationOpened}">
         Try it

--- a/frontend/demo/component/notification/notification-retry-preview.ts
+++ b/frontend/demo/component/notification/notification-retry-preview.ts
@@ -8,14 +8,14 @@ import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card theme="error" slot="middle">
         <vaadin-horizontal-layout theme="spacing" style="align-items: center;">

--- a/frontend/demo/component/notification/notification-retry.ts
+++ b/frontend/demo/component/notification/notification-retry.ts
@@ -16,14 +16,14 @@ export class Example extends LitElement {
   @state()
   private notificationOpened = false;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-button .disabled="${this.notificationOpened}" @click="${this.open}">
         Try it

--- a/frontend/demo/component/notification/notification-rich-preview.ts
+++ b/frontend/demo/component/notification/notification-rich-preview.ts
@@ -11,14 +11,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-rich-preview')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card theme="success" slot="middle">
         <vaadin-horizontal-layout theme="spacing" style="align-items: center">

--- a/frontend/demo/component/notification/notification-rich.ts
+++ b/frontend/demo/component/notification/notification-rich.ts
@@ -14,14 +14,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-rich')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-notification

--- a/frontend/demo/component/notification/notification-static-helper.ts
+++ b/frontend/demo/component/notification/notification-static-helper.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-static-helper')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -42,7 +42,7 @@ export class Example extends LitElement {
     // end::snippet[]
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-button @click="${this.handleTextNotification}">
         Show text notification

--- a/frontend/demo/component/notification/notification-success-preview.ts
+++ b/frontend/demo/component/notification/notification-success-preview.ts
@@ -4,14 +4,14 @@ import '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card theme="success" slot="middle">
         Application submitted!

--- a/frontend/demo/component/notification/notification-success.ts
+++ b/frontend/demo/component/notification/notification-success.ts
@@ -11,7 +11,7 @@ export class Example extends LitElement {
   @state()
   private notificationOpened = false;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -35,7 +35,7 @@ export class Example extends LitElement {
     notification.addEventListener('opened-changed', handleOpenChanged);
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-button @click="${this.handleClick}" .disabled="${this.notificationOpened}">
         Try it

--- a/frontend/demo/component/notification/notification-undo-preview.ts
+++ b/frontend/demo/component/notification/notification-undo-preview.ts
@@ -8,14 +8,14 @@ import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-notification-card theme="contrast" slot="middle">
         <vaadin-horizontal-layout theme="spacing" style="align-items: center;">

--- a/frontend/demo/component/notification/notification-undo.ts
+++ b/frontend/demo/component/notification/notification-undo.ts
@@ -16,14 +16,14 @@ export class Example extends LitElement {
   @state()
   private notificationOpened = false;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-button .disabled="${this.notificationOpened}" @click="${this.open}">
         Try it

--- a/frontend/demo/component/numberfield/number-field-basic.ts
+++ b/frontend/demo/component/numberfield/number-field-basic.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/numberfield/number-field-integer.ts
+++ b/frontend/demo/component/numberfield/number-field-integer.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-integer')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/numberfield/number-field-min-max.ts
+++ b/frontend/demo/component/numberfield/number-field-min-max.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-stepper-min-max')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-integer-field

--- a/frontend/demo/component/numberfield/number-field-step-buttons.ts
+++ b/frontend/demo/component/numberfield/number-field-step-buttons.ts
@@ -18,14 +18,14 @@ const layoutSteps: FormLayoutResponsiveStep[] = [
 
 @customElement('number-field-step-buttons')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-form-layout .responsiveSteps="${layoutSteps}">
         <vaadin-form-item>

--- a/frontend/demo/component/numberfield/number-field-step.ts
+++ b/frontend/demo/component/numberfield/number-field-step.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-step')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-number-field

--- a/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
+++ b/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
@@ -18,7 +18,7 @@ const StrengthColor: Record<PasswordStrength, string> = {
 
 @customElement('password-field-advanced-helper')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -33,7 +33,7 @@ export class Example extends LitElement {
 
   private pattern = '^(?=.*[0-9])(?=.*[a-zA-Z]).{8}.*$';
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-password-field

--- a/frontend/demo/component/passwordfield/password-field-basic.ts
+++ b/frontend/demo/component/passwordfield/password-field-basic.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('password-field-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-password-field label="Password" value="Ex@mplePassw0rd"></vaadin-password-field>

--- a/frontend/demo/component/passwordfield/password-field-helper.ts
+++ b/frontend/demo/component/passwordfield/password-field-helper.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-helper')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-password-field

--- a/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts
+++ b/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('password-field-reveal-button-hidden')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-password-field

--- a/frontend/demo/component/progressbar/progress-bar-basic.ts
+++ b/frontend/demo/component/progressbar/progress-bar-basic.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-progress-bar value="0.5"></vaadin-progress-bar>

--- a/frontend/demo/component/progressbar/progress-bar-completion-time.ts
+++ b/frontend/demo/component/progressbar/progress-bar-completion-time.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-completion-time')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <div style="color: var(--lumo-secondary-text-color);">

--- a/frontend/demo/component/progressbar/progress-bar-custom-range.ts
+++ b/frontend/demo/component/progressbar/progress-bar-custom-range.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-custom-range')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <div style="color: var(--lumo-secondary-text-color);">

--- a/frontend/demo/component/progressbar/progress-bar-determinate.ts
+++ b/frontend/demo/component/progressbar/progress-bar-determinate.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-determinate')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <div style="color: var(--lumo-secondary-text-color);">

--- a/frontend/demo/component/progressbar/progress-bar-indeterminate.ts
+++ b/frontend/demo/component/progressbar/progress-bar-indeterminate.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-indeterminate')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <div style="color: var(--lumo-secondary-text-color);">

--- a/frontend/demo/component/progressbar/progress-bar-label.ts
+++ b/frontend/demo/component/progressbar/progress-bar-label.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-label')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <div style="color: var(--lumo-secondary-text-color);">

--- a/frontend/demo/component/progressbar/progress-bar-theme-variants.ts
+++ b/frontend/demo/component/progressbar/progress-bar-theme-variants.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-theme-variants')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout theme="spacing" style="color: var(--lumo-secondary-text-color);">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/radiobutton/radio-button-basic.ts
+++ b/frontend/demo/component/radiobutton/radio-button-basic.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-radio-group label="Travel class" theme="vertical">

--- a/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts
+++ b/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-checkbox-alternative')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout>
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/radiobutton/radio-button-custom-option.ts
+++ b/frontend/demo/component/radiobutton/radio-button-custom-option.ts
@@ -13,7 +13,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-custom-option')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -26,12 +26,12 @@ export class Example extends LitElement {
   @state()
   private items: Card[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCards();
     this.value = String(this.items[0].id);
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout>

--- a/frontend/demo/component/radiobutton/radio-button-default-value.ts
+++ b/frontend/demo/component/radiobutton/radio-button-default-value.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-default-value')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-radio-group label="Repeat" theme="vertical">

--- a/frontend/demo/component/radiobutton/radio-button-disabled.ts
+++ b/frontend/demo/component/radiobutton/radio-button-disabled.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-disabled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-radio-group label="Status" disabled>

--- a/frontend/demo/component/radiobutton/radio-button-group-labels.ts
+++ b/frontend/demo/component/radiobutton/radio-button-group-labels.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-group-labels')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout>
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/radiobutton/radio-button-horizontal.ts
+++ b/frontend/demo/component/radiobutton/radio-button-horizontal.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-horizontal')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-radio-group label="Status" theme="horizontal">

--- a/frontend/demo/component/radiobutton/radio-button-presentation.ts
+++ b/frontend/demo/component/radiobutton/radio-button-presentation.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-presentation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -23,12 +23,12 @@ export class Example extends LitElement {
   @state()
   private items: Card[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.items = await getCards();
     this.value = String(this.items[0].id);
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-radio-group label="Payment method" theme="vertical" .value="${this.value}">

--- a/frontend/demo/component/radiobutton/radio-button-readonly.ts
+++ b/frontend/demo/component/radiobutton/radio-button-readonly.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-readonly')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-radio-group label="Status" readonly>

--- a/frontend/demo/component/radiobutton/radio-button-vertical.ts
+++ b/frontend/demo/component/radiobutton/radio-button-vertical.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-vertical')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-radio-group label="Status" theme="vertical">

--- a/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('rich-text-editor-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private richText = templates.richTextDelta;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-rich-text-editor

--- a/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('rich-text-editor-min-max-height')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private richText = templates.richTextDelta;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-rich-text-editor

--- a/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('rich-text-editor-readonly')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private richText = templates.richTextDelta;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-rich-text-editor

--- a/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
@@ -10,7 +10,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('rich-text-editor-set-get-value')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -23,7 +23,7 @@ export class Example extends LitElement {
   @query('vaadin-rich-text-editor')
   private richTextEditor!: RichTextEditor;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::htmlsnippet[] -->
       <vaadin-rich-text-editor

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('rich-text-editor-theme-compact')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private richText = templates.richTextDelta;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-rich-text-editor

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('rich-text-editor-no-border')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private richText = templates.richTextDelta;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-rich-text-editor

--- a/frontend/demo/component/scroller/scroller-basic.ts
+++ b/frontend/demo/component/scroller/scroller-basic.ts
@@ -51,14 +51,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout id="container">
         <header>

--- a/frontend/demo/component/scroller/scroller-basic.ts
+++ b/frontend/demo/component/scroller/scroller-basic.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('scroller-basic')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     #container {
       align-items: stretch;
       border: 1px solid var(--lumo-contrast-20pct);

--- a/frontend/demo/component/scroller/scroller-both.ts
+++ b/frontend/demo/component/scroller/scroller-both.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('scroller-both')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-scroller style="height: 300px; width: 100%;">

--- a/frontend/demo/component/scroller/scroller-mobile.ts
+++ b/frontend/demo/component/scroller/scroller-mobile.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('scroller-mobile')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     section {
       border: 1px solid var(--lumo-contrast-20pct);
       max-width: 100%;

--- a/frontend/demo/component/scroller/scroller-mobile.ts
+++ b/frontend/demo/component/scroller/scroller-mobile.ts
@@ -24,14 +24,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <section id="container">
         <h2>Create new...</h2>

--- a/frontend/demo/component/select/select-basic.ts
+++ b/frontend/demo/component/select/select-basic.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -38,7 +38,7 @@ export class Example extends LitElement {
     },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-select

--- a/frontend/demo/component/select/select-complex-value-label.ts
+++ b/frontend/demo/component/select/select-complex-value-label.ts
@@ -9,7 +9,7 @@ import { getPeople } from 'Frontend/demo/domain/DataService';
 
 @customElement('select-complex-value-label')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   @state()
   private items: SelectItem[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const people = (await getPeople({ count: 5 })).people;
     // tag::snippet[]
     this.items = people.map((person) => ({
@@ -29,7 +29,7 @@ export class Example extends LitElement {
     // end::snippet[]
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-select label="Assignee" .items="${this.items}"></vaadin-select>`;
   }
 }

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -14,7 +14,7 @@ const formatPersonFullName = (person: Person) => `${person.firstName} ${person.l
 
 @customElement('select-custom-renderer-label')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,11 +24,11 @@ export class Example extends LitElement {
   @state()
   private people: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     this.people = (await getPeople({ count: 5 })).people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-select
         label="Assignee"

--- a/frontend/demo/component/select/select-disabled.ts
+++ b/frontend/demo/component/select/select-disabled.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-disabled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -41,7 +41,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-select
         label="Size"

--- a/frontend/demo/component/select/select-dividers.ts
+++ b/frontend/demo/component/select/select-dividers.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-dividers')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -46,7 +46,7 @@ export class Example extends LitElement {
   ];
   // end::snippet[]
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-select
         label="Sort by"

--- a/frontend/demo/component/select/select-placeholder.ts
+++ b/frontend/demo/component/select/select-placeholder.ts
@@ -7,7 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-placeholder')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -38,7 +38,7 @@ export class Example extends LitElement {
     },
   ];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-select label="Size" placeholder="Select size" .items="${this.items}"></vaadin-select>

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -12,7 +12,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-presentation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,12 +22,12 @@ export class Example extends LitElement {
   @state()
   private people: Person[] = [];
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople({ count: 4 });
     this.people = people;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-select

--- a/frontend/demo/component/splitlayout/detail-content.ts
+++ b/frontend/demo/component/splitlayout/detail-content.ts
@@ -39,7 +39,7 @@ export class DetailContent extends LitElement {
     }
   `;
 
-  render() {
+  protected override render() {
     return html`
       <div class="form">
         <div class="field"><label></label><input type="text" /></div>

--- a/frontend/demo/component/splitlayout/detail-content.ts
+++ b/frontend/demo/component/splitlayout/detail-content.ts
@@ -3,7 +3,7 @@ import { customElement } from 'lit/decorators.js';
 
 @customElement('detail-content')
 export class DetailContent extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       overflow: hidden !important;
       color: var(--lumo-contrast-20pct);

--- a/frontend/demo/component/splitlayout/master-content.ts
+++ b/frontend/demo/component/splitlayout/master-content.ts
@@ -3,7 +3,7 @@ import { customElement } from 'lit/decorators.js';
 
 @customElement('master-content')
 export class MasterContent extends LitElement {
-  static styles = css`
+  static override styles = css`
     :host {
       overflow: hidden !important;
       color: var(--lumo-contrast-20pct);

--- a/frontend/demo/component/splitlayout/master-content.ts
+++ b/frontend/demo/component/splitlayout/master-content.ts
@@ -34,7 +34,7 @@ export class MasterContent extends LitElement {
     }
   `;
 
-  render() {
+  protected override render() {
     return html`
       <table>
         <thead>

--- a/frontend/demo/component/splitlayout/split-layout-basic.ts
+++ b/frontend/demo/component/splitlayout/split-layout-basic.ts
@@ -8,14 +8,14 @@ import './detail-content';
 
 @customElement('split-layout-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-split-layout style="max-height: 280px;">

--- a/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts
+++ b/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts
@@ -8,14 +8,14 @@ import './detail-content';
 
 @customElement('split-layout-initial-splitter-position')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-split-layout style="max-height: 280px;">

--- a/frontend/demo/component/splitlayout/split-layout-min-max-size.ts
+++ b/frontend/demo/component/splitlayout/split-layout-min-max-size.ts
@@ -6,14 +6,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('split-layout-min-max-size')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-split-layout style="max-height: 280px;">

--- a/frontend/demo/component/splitlayout/split-layout-orientation.ts
+++ b/frontend/demo/component/splitlayout/split-layout-orientation.ts
@@ -8,14 +8,14 @@ import './detail-content';
 
 @customElement('split-layout-orientation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-split-layout style="max-height: 350px;" orientation="vertical">

--- a/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts
+++ b/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts
@@ -8,14 +8,14 @@ import './detail-content';
 
 @customElement('split-layout-theme-minimal')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-split-layout style="max-height: 280px;" theme="minimal">

--- a/frontend/demo/component/splitlayout/split-layout-theme-small.ts
+++ b/frontend/demo/component/splitlayout/split-layout-theme-small.ts
@@ -8,14 +8,14 @@ import './detail-content';
 
 @customElement('split-layout-theme-small')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-split-layout style="max-height: 280px;" theme="small">

--- a/frontend/demo/component/splitlayout/split-layout-toggle.ts
+++ b/frontend/demo/component/splitlayout/split-layout-toggle.ts
@@ -11,7 +11,7 @@ import './detail-content';
 
 @customElement('split-layout-toggle')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   @state()
   private sidebarCollapsed = false;
 
-  render() {
+  protected override render() {
     const sidebarWidthPercentage = this.sidebarCollapsed ? 13 : 40;
 
     return html`

--- a/frontend/demo/component/tabs/tabs-badges.ts
+++ b/frontend/demo/component/tabs/tabs-badges.ts
@@ -7,7 +7,7 @@ import { badge } from '@vaadin/vaadin-lumo-styles/badge.js';
 
 @customElement('tabs-badges')
 export class Example extends LitElement {
-  static styles = [
+  static override styles = [
     badge,
     css`
       span[theme~='badge'] {

--- a/frontend/demo/component/tabs/tabs-badges.ts
+++ b/frontend/demo/component/tabs/tabs-badges.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
     `,
   ];
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <!--

--- a/frontend/demo/component/tabs/tabs-basic.ts
+++ b/frontend/demo/component/tabs/tabs-basic.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-basic')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs>

--- a/frontend/demo/component/tabs/tabs-content.ts
+++ b/frontend/demo/component/tabs/tabs-content.ts
@@ -14,14 +14,14 @@ export class Example extends LitElement {
   @state()
   private pages = ['Dashboard', 'Payment', 'Shipping'];
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs @selected-changed="${this.selectedChanged}">

--- a/frontend/demo/component/tabs/tabs-focus-ring.ts
+++ b/frontend/demo/component/tabs/tabs-focus-ring.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-focus-ring')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs>

--- a/frontend/demo/component/tabs/tabs-hide-scroll-buttons.ts
+++ b/frontend/demo/component/tabs/tabs-hide-scroll-buttons.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-hide-scroll-buttons')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs theme="hide-scroll-buttons">

--- a/frontend/demo/component/tabs/tabs-horizontal.ts
+++ b/frontend/demo/component/tabs/tabs-horizontal.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-horizontal')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs style="max-width: 100%; width: 400px;">

--- a/frontend/demo/component/tabs/tabs-icons-horizontal.ts
+++ b/frontend/demo/component/tabs/tabs-icons-horizontal.ts
@@ -8,7 +8,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-icons-horizontal')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs>

--- a/frontend/demo/component/tabs/tabs-icons-vertical.ts
+++ b/frontend/demo/component/tabs/tabs-icons-vertical.ts
@@ -8,7 +8,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-icons-vertical')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs orientation="vertical">

--- a/frontend/demo/component/tabs/tabs-states.ts
+++ b/frontend/demo/component/tabs/tabs-states.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-states')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs>

--- a/frontend/demo/component/tabs/tabs-theme-centered.ts
+++ b/frontend/demo/component/tabs/tabs-theme-centered.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-theme-centered')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs theme="centered">

--- a/frontend/demo/component/tabs/tabs-theme-equal-width.ts
+++ b/frontend/demo/component/tabs/tabs-theme-equal-width.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-theme-equal-width')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs theme="equal-width-tabs">

--- a/frontend/demo/component/tabs/tabs-theme-minimal.ts
+++ b/frontend/demo/component/tabs/tabs-theme-minimal.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-theme-minimal')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs theme="minimal">

--- a/frontend/demo/component/tabs/tabs-theme-small.ts
+++ b/frontend/demo/component/tabs/tabs-theme-small.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-theme-small')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs theme="small">

--- a/frontend/demo/component/tabs/tabs-vertical.ts
+++ b/frontend/demo/component/tabs/tabs-vertical.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('tabs-vertical')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabs orientation="vertical" style="height: 240px; width: 240px;">

--- a/frontend/demo/component/tabs/tabsheet-basic.ts
+++ b/frontend/demo/component/tabs/tabsheet-basic.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tabsheet-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabsheet>

--- a/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
+++ b/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tabsheet-lazy-initialization')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -24,7 +24,7 @@ export class Example extends LitElement {
     this.visitedTabs = new Set([...this.visitedTabs, event.detail.value]);
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-tabsheet @selected-changed=${this.selectedTabChanged}>
         <vaadin-tabs slot="tabs">

--- a/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts
+++ b/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts
@@ -11,14 +11,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tabsheet-prefix-suffix')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-tabsheet>
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/tabs/tabsheet-theme-bordered.ts
+++ b/frontend/demo/component/tabs/tabsheet-theme-bordered.ts
@@ -7,7 +7,7 @@ import '@vaadin/tabsheet';
 
 @customElement('tabsheet-theme-bordered')
 export class Example extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-tabsheet theme="bordered">

--- a/frontend/demo/component/textarea/text-area-auto-height.ts
+++ b/frontend/demo/component/textarea/text-area-auto-height.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-auto-height')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-text-area {
       width: 100%;
     }

--- a/frontend/demo/component/textarea/text-area-auto-height.ts
+++ b/frontend/demo/component/textarea/text-area-auto-height.ts
@@ -14,14 +14,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-area label="Description" value="${loremIpsum}"></vaadin-text-area>

--- a/frontend/demo/component/textarea/text-area-basic.ts
+++ b/frontend/demo/component/textarea/text-area-basic.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   @state()
   private text = 'Great job. This is excellent!';
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-area

--- a/frontend/demo/component/textarea/text-area-height.ts
+++ b/frontend/demo/component/textarea/text-area-height.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-height')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <style>

--- a/frontend/demo/component/textarea/text-area-helper.ts
+++ b/frontend/demo/component/textarea/text-area-helper.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -28,7 +28,7 @@ export class Example extends LitElement {
   @state()
   private text = loremIpsum;
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-text-area
         label="Description"

--- a/frontend/demo/component/textarea/text-area-helper.ts
+++ b/frontend/demo/component/textarea/text-area-helper.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-helper-2')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-text-area {
       width: 100%;
     }

--- a/frontend/demo/component/textfield/text-field-allowed-char-pattern.ts
+++ b/frontend/demo/component/textfield/text-field-allowed-char-pattern.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-allowed-char-pattern')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field

--- a/frontend/demo/component/textfield/text-field-basic.ts
+++ b/frontend/demo/component/textfield/text-field-basic.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field label="Street Address" value="Ruukinkatu 2" clear-button-visible>

--- a/frontend/demo/component/textfield/text-field-clear-button.ts
+++ b/frontend/demo/component/textfield/text-field-clear-button.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field value="Value" clear-button-visible></vaadin-text-field>

--- a/frontend/demo/component/textfield/text-field-min-max-input-length.ts
+++ b/frontend/demo/component/textfield/text-field-min-max-input-length.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-min-max-input-length')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/textfield/text-field-pattern.ts
+++ b/frontend/demo/component/textfield/text-field-pattern.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-pattern')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field

--- a/frontend/demo/component/textfield/text-field-placeholder.ts
+++ b/frontend/demo/component/textfield/text-field-placeholder.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-placeholder')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field placeholder="Search">

--- a/frontend/demo/component/textfield/text-field-prefix-suffix.ts
+++ b/frontend/demo/component/textfield/text-field-prefix-suffix.ts
@@ -10,14 +10,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-prefix-suffix')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <!-- tag::snippet[] -->

--- a/frontend/demo/component/textfield/text-field-small-variant.ts
+++ b/frontend/demo/component/textfield/text-field-small-variant.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-small-variant')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing">
         <vaadin-text-field label="Default size" value="Value"></vaadin-text-field>

--- a/frontend/demo/component/textfield/text-field-text-alignment.ts
+++ b/frontend/demo/component/textfield/text-field-text-alignment.ts
@@ -18,14 +18,14 @@ const layoutSteps: FormLayoutResponsiveStep[] = [
 
 @customElement('text-field-text-alignment')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-form-layout .responsiveSteps="${layoutSteps}">
         <vaadin-form-item>

--- a/frontend/demo/component/timepicker/time-picker-auto-open.ts
+++ b/frontend/demo/component/timepicker/time-picker-auto-open.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-auto-open')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-time-picker

--- a/frontend/demo/component/timepicker/time-picker-basic.ts
+++ b/frontend/demo/component/timepicker/time-picker-basic.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-time-picker label="Alarm" value="07:00"></vaadin-time-picker>

--- a/frontend/demo/component/timepicker/time-picker-custom-parser.ts
+++ b/frontend/demo/component/timepicker/time-picker-custom-parser.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-custom-parser')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-time-picker label="Alarm"></vaadin-time-picker>

--- a/frontend/demo/component/timepicker/time-picker-custom-validation.ts
+++ b/frontend/demo/component/timepicker/time-picker-custom-validation.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-custom-validation')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   // tag::snippet[]
   private binder = new Binder(this, AppointmentModel);
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.binder.for(this.binder.model.startTime).addValidator({
       message: 'The selected time is not available',
       validate: (startTime: string) =>
@@ -28,7 +28,7 @@ export class Example extends LitElement {
     });
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-time-picker
         label="Appointment time"

--- a/frontend/demo/component/timepicker/time-picker-min-max.ts
+++ b/frontend/demo/component/timepicker/time-picker-min-max.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-min-max')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-time-picker

--- a/frontend/demo/component/timepicker/time-picker-minutes-step.ts
+++ b/frontend/demo/component/timepicker/time-picker-minutes-step.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-minutes-step')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-time-picker

--- a/frontend/demo/component/timepicker/time-picker-parsing.ts
+++ b/frontend/demo/component/timepicker/time-picker-parsing.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-parsing')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-select label="Locale"></vaadin-select>

--- a/frontend/demo/component/timepicker/time-picker-seconds-step.ts
+++ b/frontend/demo/component/timepicker/time-picker-seconds-step.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-seconds-step')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-time-picker label="Message received" value="15:45:08" step="1"></vaadin-time-picker>

--- a/frontend/demo/component/tooltip/tooltip-basic.ts
+++ b/frontend/demo/component/tooltip/tooltip-basic.ts
@@ -10,14 +10,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tooltip-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-text-field placeholder="Search">

--- a/frontend/demo/component/tooltip/tooltip-html-element.ts
+++ b/frontend/demo/component/tooltip/tooltip-html-element.ts
@@ -7,14 +7,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tooltip-html-element')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <h2 id="heading">Heading with tooltip</h2>

--- a/frontend/demo/component/tooltip/tooltip-manual.ts
+++ b/frontend/demo/component/tooltip/tooltip-manual.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tooltip-manual')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,7 +21,7 @@ export class Example extends LitElement {
   @state()
   private tooltipOpened = false;
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-text-field placeholder="Search">
         <vaadin-icon slot="prefix" icon="lumo:search"></vaadin-icon>

--- a/frontend/demo/component/tooltip/tooltip-positioning.ts
+++ b/frontend/demo/component/tooltip/tooltip-positioning.ts
@@ -11,14 +11,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tooltip-positioning')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-app-layout theme="narrow-drawer">
         <vaadin-drawer-toggle slot="navbar">

--- a/frontend/demo/component/tree-grid/tree-grid-basic.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-basic.ts
@@ -11,7 +11,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tree-grid-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -34,7 +34,7 @@ export class Example extends LitElement {
     callback(people, hierarchyLevelSize);
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .dataProvider="${this.dataProvider}">
         <vaadin-grid-tree-column

--- a/frontend/demo/component/tree-grid/tree-grid-column.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-column.ts
@@ -13,7 +13,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tree-grid-column')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -43,7 +43,7 @@ export class Example extends LitElement {
   @state()
   private expandedItems: unknown[] = [];
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-horizontal-layout
         style="align-items: center; height: var(--lumo-size-xl);"

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -20,7 +20,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tree-grid-rich-content')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -95,7 +95,7 @@ export class Example extends LitElement {
     </vaadin-vertical-layout>
   `;
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-grid .dataProvider="${this.dataProvider}" .expandedItems="${this.expandedItems}">
         <vaadin-grid-column

--- a/frontend/demo/component/upload/upload-all-files.ts
+++ b/frontend/demo/component/upload/upload-all-files.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-all-files')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -21,13 +21,13 @@ export class Example extends LitElement {
   private upload!: Upload;
 
   // end::snippet[]
-  firstUpdated() {
+  protected override firstUpdated() {
     this.upload.i18n.addFiles.many = 'Select Files...';
     this.upload.i18n = { ...this.upload.i18n };
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     return html`
       <vaadin-upload
         no-auto

--- a/frontend/demo/component/upload/upload-auto-upload-disabled.ts
+++ b/frontend/demo/component/upload/upload-auto-upload-disabled.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-auto-upload-disabled')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,12 +20,12 @@ export class Example extends LitElement {
   @query('vaadin-upload')
   private upload!: Upload;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.upload.i18n.addFiles.many = 'Select Files...';
     this.upload.i18n = { ...this.upload.i18n };
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-upload
         no-auto

--- a/frontend/demo/component/upload/upload-basic.ts
+++ b/frontend/demo/component/upload/upload-basic.ts
@@ -8,14 +8,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-basic')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <!-- Use the target attribute to specify the URL

--- a/frontend/demo/component/upload/upload-button-theme-variant.ts
+++ b/frontend/demo/component/upload/upload-button-theme-variant.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-button-theme-variant')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -27,12 +27,12 @@ export class Example extends LitElement {
   @state()
   private maxFilesReached = false;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.upload.i18n.dropFiles.one = 'Drop PDF here';
     this.upload.i18n = { ...this.upload.i18n };
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-upload

--- a/frontend/demo/component/upload/upload-clear-button.ts
+++ b/frontend/demo/component/upload/upload-clear-button.ts
@@ -18,14 +18,14 @@ function createFakeFiles() {
 
 @customElement('upload-clear-button')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-upload .files="${createFakeFiles()}"></vaadin-upload>`;
   }
 }

--- a/frontend/demo/component/upload/upload-drag-and-drop.ts
+++ b/frontend/demo/component/upload/upload-drag-and-drop.ts
@@ -14,7 +14,7 @@ const layoutSteps: FormLayoutResponsiveStep[] = [
 
 @customElement('upload-drag-and-drop')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     label {
       font-weight: 600;
     }

--- a/frontend/demo/component/upload/upload-drag-and-drop.ts
+++ b/frontend/demo/component/upload/upload-drag-and-drop.ts
@@ -20,14 +20,14 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-form-layout .responsiveSteps="${layoutSteps}">
         <div>

--- a/frontend/demo/component/upload/upload-drop-label.ts
+++ b/frontend/demo/component/upload/upload-drop-label.ts
@@ -9,14 +9,14 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-drop-label')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-upload>

--- a/frontend/demo/component/upload/upload-error-messages.ts
+++ b/frontend/demo/component/upload/upload-error-messages.ts
@@ -15,7 +15,7 @@ const layoutSteps: FormLayoutResponsiveStep[] = [
 
 @customElement('upload-error-messages')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -29,7 +29,7 @@ export class Example extends LitElement {
   private uploadRecommended!: Upload;
 
   // tag::snippet[]
-  firstUpdated() {
+  protected override firstUpdated() {
     // end::snippet[]
     this.uploadCaution.setupMockErrorResponse(); // hidden-source-line
     this.uploadRecommended.setupMockErrorResponse(); // hidden-source-line
@@ -41,7 +41,7 @@ export class Example extends LitElement {
     this.uploadRecommended.i18n = { ...this.uploadRecommended.i18n };
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- end::snippet[] -->
       <vaadin-form-layout .responsiveSteps="${layoutSteps}">

--- a/frontend/demo/component/upload/upload-file-count.ts
+++ b/frontend/demo/component/upload/upload-file-count.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-file-count')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h4 {
       margin-top: 0;
     }

--- a/frontend/demo/component/upload/upload-file-count.ts
+++ b/frontend/demo/component/upload/upload-file-count.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -29,13 +29,13 @@ export class Example extends LitElement {
   @query('vaadin-upload')
   private upload!: Upload;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.upload.i18n.error.tooManyFiles = 'You may only upload a maximum of three files at once.';
     this.upload.i18n = { ...this.upload.i18n };
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     const maxFiles = 3;
     return html`
       <h4>Upload files</h4>

--- a/frontend/demo/component/upload/upload-file-format.ts
+++ b/frontend/demo/component/upload/upload-file-format.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-file-format')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h4 {
       margin-top: 0;
     }

--- a/frontend/demo/component/upload/upload-file-format.ts
+++ b/frontend/demo/component/upload/upload-file-format.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -29,7 +29,7 @@ export class Example extends LitElement {
   @query('vaadin-upload')
   private upload!: Upload;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.upload.i18n.addFiles.one = 'Upload Report...';
     this.upload.i18n.dropFiles.one = 'Drop report here';
     this.upload.i18n.error.incorrectFileType =
@@ -37,7 +37,7 @@ export class Example extends LitElement {
     this.upload.i18n = { ...this.upload.i18n };
   }
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <h4>Upload report</h4>

--- a/frontend/demo/component/upload/upload-file-size.ts
+++ b/frontend/demo/component/upload/upload-file-size.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-file-size')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h4 {
       margin-top: 0;
     }

--- a/frontend/demo/component/upload/upload-file-size.ts
+++ b/frontend/demo/component/upload/upload-file-size.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -29,13 +29,13 @@ export class Example extends LitElement {
   @query('vaadin-upload')
   private upload!: Upload;
 
-  firstUpdated() {
+  protected override firstUpdated() {
     this.upload.i18n.error.fileIsTooBig = 'The file exceeds the maximum allowed size of 10MB.';
     this.upload.i18n = { ...this.upload.i18n };
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     const maxFileSizeInMB = 10;
     const maxFileSizeInBytes = maxFileSizeInMB * 1024 * 1024;
     return html`

--- a/frontend/demo/component/upload/upload-helper.ts
+++ b/frontend/demo/component/upload/upload-helper.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -30,7 +30,7 @@ export class Example extends LitElement {
   private upload!: Upload;
 
   // tag::snippet[]
-  firstUpdated() {
+  protected override firstUpdated() {
     this.upload.i18n.addFiles.one = 'Upload Spreadsheet...';
     this.upload.i18n.dropFiles.one = 'Drop spreadsheet here';
     this.upload.i18n.error.incorrectFileType =
@@ -38,7 +38,7 @@ export class Example extends LitElement {
     this.upload.i18n = { ...this.upload.i18n };
   }
 
-  render() {
+  protected override render() {
     // end::snippet[]
     const maxFileSizeInMB = 1;
     const maxFileSizeInBytes = maxFileSizeInMB * 1024 * 1024;

--- a/frontend/demo/component/upload/upload-helper.ts
+++ b/frontend/demo/component/upload/upload-helper.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-helper')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     h4 {
       margin-top: 0;
     }

--- a/frontend/demo/component/upload/upload-internationalization.ts
+++ b/frontend/demo/component/upload/upload-internationalization.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-internationalization')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   // tag::snippet[]
-  render() {
+  protected override render() {
     const i18n: UploadI18n = {
       dropFiles: {
         one: 'Raahaa tiedosto tähän',

--- a/frontend/demo/component/upload/upload-labelling.ts
+++ b/frontend/demo/component/upload/upload-labelling.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-labelling')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   private upload!: Upload;
 
   // tag::snippet[]
-  firstUpdated() {
+  protected override firstUpdated() {
     this.upload.i18n.addFiles.one = 'Upload PDF...';
     this.upload.i18n.dropFiles.one = 'Drop PDF here';
     this.upload.i18n.error.incorrectFileType =
@@ -28,7 +28,7 @@ export class Example extends LitElement {
     this.upload.i18n = { ...this.upload.i18n };
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-upload
         max-files="1"

--- a/frontend/demo/component/upload/upload-retry-button.ts
+++ b/frontend/demo/component/upload/upload-retry-button.ts
@@ -13,14 +13,14 @@ function createFakeFiles() {
 
 @customElement('upload-retry-button')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-upload .files="${createFakeFiles()}"></vaadin-upload>`;
   }
 }

--- a/frontend/demo/component/upload/upload-start-button.ts
+++ b/frontend/demo/component/upload/upload-start-button.ts
@@ -17,14 +17,14 @@ function createFakeFiles() {
 
 @customElement('upload-start-button')
 export class Example extends LitElement {
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
 
-  render() {
+  protected override render() {
     return html`<vaadin-upload .files="${createFakeFiles()}"></vaadin-upload>`;
   }
 }

--- a/frontend/demo/component/virtuallist/virtual-list-basic.ts
+++ b/frontend/demo/component/virtuallist/virtual-list-basic.ts
@@ -17,7 +17,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('virtual-list-basic')
 export class Example extends LitElement {
-  static styles = css`
+  static override styles = css`
     vaadin-avatar {
       height: 64px;
       width: 64px;

--- a/frontend/demo/component/virtuallist/virtual-list-basic.ts
+++ b/frontend/demo/component/virtuallist/virtual-list-basic.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
     }
   `;
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -36,7 +36,7 @@ export class Example extends LitElement {
 
   private expandedPeople = new Set<Person>();
 
-  async firstUpdated() {
+  protected override async firstUpdated() {
     const { people } = await getPeople();
     this.people = people;
   }
@@ -74,7 +74,7 @@ export class Example extends LitElement {
     </vaadin-horizontal-layout>
   `;
 
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-virtual-list

--- a/frontend/demo/flow/application/events/events-basic.ts
+++ b/frontend/demo/flow/application/events/events-basic.ts
@@ -12,7 +12,7 @@ export class EventsBasic extends LitElement {
   @state()
   private count = 0;
 
-  render() {
+  protected override render() {
     return html`<vaadin-button @click="${this.onClick}">${this.caption}</vaadin-button>`;
   }
 

--- a/frontend/demo/flow/application/images/icons-basic.ts
+++ b/frontend/demo/flow/application/images/icons-basic.ts
@@ -8,7 +8,7 @@ import '@vaadin/vertical-layout';
 
 @customElement('fusion-application-icons-basic')
 export class IconsBasic extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout>

--- a/frontend/demo/flow/application/images/images-basic.ts
+++ b/frontend/demo/flow/application/images/images-basic.ts
@@ -6,7 +6,7 @@ import { customElement } from 'lit/decorators.js';
 
 @customElement('fusion-application-images-basic')
 export class ImagesBasic extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <img src="foobar.png" alt="Alt Text"></img>

--- a/frontend/demo/flow/application/routing/routing-basic.ts
+++ b/frontend/demo/flow/application/routing/routing-basic.ts
@@ -8,7 +8,7 @@ import '@vaadin/vertical-layout';
 
 @customElement('routing-login')
 export class LoginView extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <vaadin-vertical-layout style="width: 15em">
         <vaadin-form-layout>

--- a/frontend/demo/flow/application/routing/routing-registration.ts
+++ b/frontend/demo/flow/application/routing/routing-registration.ts
@@ -4,7 +4,7 @@ import '@vaadin/button';
 
 @customElement('routing-registration')
 export class RegistrationView extends LitElement {
-  render() {
+  protected override render() {
     return html`<vaadin-button @click="${this.onClick}">Read More</vaadin-button>`;
   }
 

--- a/frontend/demo/flow/application/ui/ui-menu-basic.ts
+++ b/frontend/demo/flow/application/ui/ui-menu-basic.ts
@@ -6,7 +6,7 @@ import '@vaadin/tabs';
 
 @customElement('fusion-application-ui-menu')
 export class UiMenu extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout>

--- a/frontend/demo/flow/binding/binding-overview.ts
+++ b/frontend/demo/flow/binding/binding-overview.ts
@@ -13,7 +13,7 @@ import '@vaadin/vertical-layout';
 
 @customElement('binding-overview')
 export class DataBindingExample extends LitElement {
-  render() {
+  protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout>

--- a/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
+++ b/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
@@ -14,7 +14,7 @@ import { Notification } from '@vaadin/notification';
 
 @customElement('new-relic-dashboard-generator')
 export class DashboardGenerator extends LitElement {
-  static styles = css`
+  static override styles = css`
     .json-result {
       width: 100%;
       height: 200px;

--- a/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
+++ b/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
@@ -27,7 +27,7 @@ export class DashboardGenerator extends LitElement {
   @state()
   json = '';
 
-  protected createRenderRoot() {
+  protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
@@ -52,7 +52,7 @@ export class DashboardGenerator extends LitElement {
     });
   }
 
-  render() {
+  protected override render() {
     return html`
       <vaadin-text-field
         label="Account ID"

--- a/frontend/demo/upgrade-tool/upgrade-tool.ts
+++ b/frontend/demo/upgrade-tool/upgrade-tool.ts
@@ -58,7 +58,7 @@ export default class UpgradeTool extends LitElement {
   private isInstructionsDisplayed = false;
   private isFirstUpdated = false;
 
-  render() {
+  protected override render() {
     return html`
       <div>
         <h2>Select your Vaadin versions:</h2>
@@ -428,7 +428,7 @@ export default class UpgradeTool extends LitElement {
     });
   }
 
-  firstUpdated() {
+  protected override firstUpdated() {
     const urlParams = new URLSearchParams(window.location.search);
     const fromParam = urlParams.get('from');
     const toParam = urlParams.get('to');


### PR DESCRIPTION
## Description

Updated TS examples and other code (upgrade tool etc) to use `protected override` for the following methods:

- [`createRenderRoot()`](https://github.com/lit/lit/blob/7c93499ccdfc493df9397163e552356e64bfd2c3/packages/lit-element/src/lit-element.ts#L138) - already overridden in `LitElement`
- [`render()`](https://github.com/lit/lit/blob/7c93499ccdfc493df9397163e552356e64bfd2c3/packages/lit-element/src/lit-element.ts#L224) - defined in `LitElement`
- [`firstUpdated()`](https://github.com/lit/lit/blob/7c93499ccdfc493df9397163e552356e64bfd2c3/packages/reactive-element/src/reactive-element.ts#L1512) - defined in `ReactiveElement`

This is how e.g. [Material Web Components](https://github.com/material-components/material-web/blob/aef3ee3d3fcd7887cd3169eb80cddd42e89df8b3/fab/lib/fab-shared.ts#L44) use these methods. Also, it makes code more self-explanatory.
Finally, this gets us a bit closer to enabling `@typescript-eslint/member-ordering` rule in the future.

See also related section in the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-3.html#override-and-the---noimplicitoverride-flag).