### PR TITLE
fix: fix webpack config for Vaadin 24

### DIFF
--- a/dspublisher/application-theme-plugin/application-theme-plugin.js
+++ b/dspublisher/application-theme-plugin/application-theme-plugin.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { processThemeResources, extractThemeName, findParentThemes } from './theme-handle.js';
+
+/**
+ * The application theme plugin is for generating, collecting and copying of theme files for the application theme.
+ *
+ * The plugin should be supplied with the paths for
+ *
+ *  themeResourceFolder             - theme folder where flow copies local and jar resource frontend files
+ *  themeProjectFolders             - array of possible locations for theme folders inside the project
+ *  projectStaticAssetsOutputFolder - path to where static assets should be put
+ *  frontendGeneratedFolder         - the path to where frontend auto-generated files are put
+ *
+ *  @throws Error in constructor if required option is not received
+ */
+class ApplicationThemePlugin {
+  constructor(options) {
+    this.options = options;
+
+    if (!this.options.themeResourceFolder) {
+      throw new Error('Missing themeResourceFolder path');
+    }
+    if (!this.options.projectStaticAssetsOutputFolder) {
+      throw new Error('Missing projectStaticAssetsOutputFolder path');
+    }
+    if (!this.options.themeProjectFolders) {
+      throw new Error('Missing themeProjectFolders path array');
+    }
+    if (!this.options.frontendGeneratedFolder) {
+      throw new Error('Missing frontendGeneratedFolder path');
+    }
+  }
+
+  apply(compiler) {
+    const logger = compiler.getInfrastructureLogger('ApplicationThemePlugin');
+
+    compiler.hooks.afterEnvironment.tap('ApplicationThemePlugin', () => processThemeResources(this.options, logger));
+  }
+}
+
+export { ApplicationThemePlugin, processThemeResources, extractThemeName, findParentThemes };

--- a/dspublisher/application-theme-plugin/package.json
+++ b/dspublisher/application-theme-plugin/package.json
@@ -1,0 +1,27 @@
+{
+  "description": "application-theme-plugin",
+  "keywords": [
+    "plugin",
+    "application theme"
+  ],
+  "repository": "vaadin/flow",
+  "name": "@vaadin/application-theme-plugin",
+  "version": "0.4.2",
+  "main": "application-theme-plugin.js",
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/vaadin/flow/issues"
+  },
+  "type": "module",
+  "dependencies": {
+    "mkdirp": "0.5.6",
+    "glob": "7.2.3"
+  },
+  "files": [
+    "application-theme-plugin.js",
+    "theme-generator.js",
+    "theme-copy.js",
+    "theme-handle.js"
+  ]
+}

--- a/dspublisher/application-theme-plugin/theme-copy.js
+++ b/dspublisher/application-theme-plugin/theme-copy.js
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * This contains functions and features used to copy theme files.
+ */
+
+import { readdirSync, statSync, mkdirSync, existsSync, copyFileSync } from 'fs';
+import { resolve, basename, relative, extname } from 'path';
+import glob from 'glob';
+import mkdirp from 'mkdirp';
+
+const { sync } = glob;
+const { sync: mkdirpSync } = mkdirp;
+
+const ignoredFileExtensions = ['.css', '.js', '.json'];
+
+/**
+ * Copy theme static resources to static assets folder. All files in the theme
+ * folder will be copied excluding css, js and json files that will be
+ * handled by webpack and not be shared as static files.
+ *
+ * @param {string} themeFolder Folder with theme file
+ * @param {string} projectStaticAssetsOutputFolder resources output folder
+ * @param {object} logger plugin logger
+ */
+function copyThemeResources(themeFolder, projectStaticAssetsOutputFolder, logger) {
+  const staticAssetsThemeFolder = resolve(projectStaticAssetsOutputFolder, 'themes', basename(themeFolder));
+  const collection = collectFolders(themeFolder, logger);
+
+  // Only create assets folder if there are files to copy.
+  if (collection.files.length > 0) {
+    mkdirpSync(staticAssetsThemeFolder);
+    // create folders with
+    collection.directories.forEach((directory) => {
+      const relativeDirectory = relative(themeFolder, directory);
+      const targetDirectory = resolve(staticAssetsThemeFolder, relativeDirectory);
+
+      mkdirpSync(targetDirectory);
+    });
+
+    collection.files.forEach((file) => {
+      const relativeFile = relative(themeFolder, file);
+      const targetFile = resolve(staticAssetsThemeFolder, relativeFile);
+      copyFileIfAbsentOrNewer(file, targetFile, logger);
+    });
+  }
+}
+
+/**
+ * Collect all folders with copyable files and all files to be copied.
+ * Foled will not be added if no files in folder or subfolders.
+ *
+ * Files will not contain files with ignored extensions and folders only containing ignored files will not be added.
+ *
+ * @param folderToCopy folder we will copy files from
+ * @param logger plugin logger
+ * @return {{directories: [], files: []}} object containing directories to create and files to copy
+ */
+function collectFolders(folderToCopy, logger) {
+  const collection = { directories: [], files: [] };
+  logger.trace('files in directory', readdirSync(folderToCopy));
+  readdirSync(folderToCopy).forEach((file) => {
+    const fileToCopy = resolve(folderToCopy, file);
+    if (statSync(fileToCopy).isDirectory()) {
+      logger.debug('Going through directory', fileToCopy);
+      const result = collectFolders(fileToCopy, logger);
+      if (result.files.length > 0) {
+        collection.directories.push(fileToCopy);
+        logger.debug('Adding directory', fileToCopy);
+        collection.directories.push.apply(collection.directories, result.directories);
+        collection.files.push.apply(collection.files, result.files);
+      }
+    } else if (!ignoredFileExtensions.includes(extname(fileToCopy))) {
+      logger.debug('Adding file', fileToCopy);
+      collection.files.push(fileToCopy);
+    }
+  });
+  return collection;
+}
+
+/**
+ * Copy any static node_modules assets marked in theme.json to
+ * project static assets folder.
+ *
+ * The theme.json content for assets is set up as:
+ * {
+ *   assets: {
+ *     "node_module identifier": {
+ *       "copy-rule": "target/folder",
+ *     }
+ *   }
+ * }
+ *
+ * This would mean that an asset would be built as:
+ * "@fortawesome/fontawesome-free": {
+ *   "svgs/regular/**": "fortawesome/icons"
+ * }
+ * Where '@fortawesome/fontawesome-free' is the npm package, 'svgs/regular/**' is what should be copied
+ * and 'fortawesome/icons' is the target directory under projectStaticAssetsOutputFolder where things
+ * will get copied to.
+ *
+ * Note! there can be multiple copy-rules with target folders for one npm package asset.
+ *
+ * @param {string} themeName name of the theme we are copying assets for
+ * @param {json} themeProperties theme properties json with data on assets
+ * @param {string} projectStaticAssetsOutputFolder project output folder where we copy assets to under theme/[themeName]
+ * @param {object} logger plugin logger
+ */
+function copyStaticAssets(themeName, themeProperties, projectStaticAssetsOutputFolder, logger) {
+  const assets = themeProperties['assets'];
+  if (!assets) {
+    logger.debug('no assets to handle no static assets were copied');
+    return;
+  }
+
+  mkdirSync(projectStaticAssetsOutputFolder, {
+    recursive: true
+  });
+  const missingModules = checkModules(Object.keys(assets));
+  if (missingModules.length > 0) {
+    throw Error(
+      "Missing npm modules '" +
+        missingModules.join("', '") +
+        "' for assets marked in 'theme.json'.\n" +
+        "Install package(s) by adding a @NpmPackage annotation or install it using 'npm/pnpm i'"
+    );
+  }
+  Object.keys(assets).forEach((module) => {
+    const copyRules = assets[module];
+    Object.keys(copyRules).forEach((copyRule) => {
+      const nodeSources = resolve('node_modules/', module, copyRule);
+      const files = sync(nodeSources, { nodir: true });
+      const targetFolder = resolve(projectStaticAssetsOutputFolder, 'themes', themeName, copyRules[copyRule]);
+
+      mkdirSync(targetFolder, {
+        recursive: true
+      });
+      files.forEach((file) => {
+        const copyTarget = resolve(targetFolder, basename(file));
+        copyFileIfAbsentOrNewer(file, copyTarget, logger);
+      });
+    });
+  });
+}
+
+function checkModules(modules) {
+  const missing = [];
+
+  modules.forEach((module) => {
+    if (!existsSync(resolve('node_modules/', module))) {
+      missing.push(module);
+    }
+  });
+
+  return missing;
+}
+
+/**
+ * Copies given file to a given target path, if target file doesn't exist or if
+ * file to copy is newer.
+ * @param {string} fileToCopy path of the file to copy
+ * @param {string} copyTarget path of the target file
+ * @param {object} logger plugin logger
+ */
+function copyFileIfAbsentOrNewer(fileToCopy, copyTarget, logger) {
+  if (!existsSync(copyTarget) || statSync(copyTarget).mtime < statSync(fileToCopy).mtime) {
+    logger.trace('Copying: ', fileToCopy, '=>', copyTarget);
+    copyFileSync(fileToCopy, copyTarget);
+  }
+}
+
+export { checkModules, copyStaticAssets, copyThemeResources };

--- a/dspublisher/application-theme-plugin/theme-generator.js
+++ b/dspublisher/application-theme-plugin/theme-generator.js
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * This file handles the generation of the '[theme-name].js' to
+ * the themes/[theme-name] folder according to properties from 'theme.json'.
+ */
+import glob from 'glob';
+import { resolve, basename } from 'path';
+import { existsSync, writeFileSync } from 'fs';
+import { checkModules } from './theme-copy.js';
+
+const { sync } = glob;
+
+// Special folder inside a theme for component themes that go inside the component shadow root
+const themeComponentsFolder = 'components';
+// The contents of a global CSS file with this name in a theme is always added to
+// the document. E.g. @font-face must be in this
+const documentCssFile = 'document.css';
+// styles.css is the only entrypoint css file with document.css. Everything else should be imported using css @import
+const stylesCssFile = 'styles.css';
+
+const headerImport = `import 'construct-style-sheets-polyfill';
+`;
+
+const createLinkReferences = `
+const createLinkReferences = (css, target) => {
+  // Unresolved urls are written as '@import url(text);' or '@import "text";' to the css
+  // media query can be present on @media tag or on @import directive after url
+  // Note that with Vite production build there is no space between @import and "text"
+  // [0] is the full match
+  // [1] matches the media query
+  // [2] matches the url
+  // [3] matches the quote char surrounding in '@import "..."'
+  // [4] matches the url in '@import "..."'
+  // [5] matches media query on @import statement
+  const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import\\s*(?:url\\(\\s*['"]?(.+?)['"]?\\s*\\)|(["'])((?:\\\\.|[^\\\\])*?)\\3)([^;]*);(?:})?/g
+  
+  // Only cleanup if comment exist
+  if(/\\/\\*(.|[\\r\\n])*?\\*\\//gm.exec(css) != null) {
+    // clean up comments
+    css = stripCssComments(css);
+  }
+  
+  var match;
+  var styleCss = css;
+  
+  // For each external url import add a link reference
+  while((match = importMatcher.exec(css)) !== null) {
+    styleCss = styleCss.replace(match[0], "");
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = match[2] || match[4];
+    const media = match[1] || match[5];
+    if (media) {
+      link.media = media;
+    }
+    // For target document append to head else append to target
+    if (target === document) {
+      document.head.appendChild(link);
+    } else {
+      target.appendChild(link);
+    }
+  };
+  return styleCss;
+};
+`;
+
+const injectGlobalCssMethod = `
+// target: Document | ShadowRoot
+export const injectGlobalCss = (css, target, first) => {
+  if(target === document) {
+    const hash = getHash(css);
+    if (window.Vaadin.theme.injectedGlobalCss.indexOf(hash) !== -1) {
+      return;
+    }
+    window.Vaadin.theme.injectedGlobalCss.push(hash);
+  }
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(createLinkReferences(css,target));
+  if (first) {
+    target.adoptedStyleSheets = [sheet, ...target.adoptedStyleSheets];
+  } else {
+    target.adoptedStyleSheets = [...target.adoptedStyleSheets, sheet];
+  }
+};
+`;
+
+/**
+ * Generate the [themeName].js file for themeFolder which collects all required information from the folder.
+ *
+ * @param {string} themeFolder folder of the theme
+ * @param {string} themeName name of the handled theme
+ * @param {JSON} themeProperties content of theme.json
+ * @param {Object} options build options (e.g. prod or dev mode)
+ * @returns {string} theme file content
+ */
+function generateThemeFile(themeFolder, themeName, themeProperties, options) {
+  const productionMode = !options.devMode;
+  const useDevServer = !options.useDevBundle;
+  const styles = resolve(themeFolder, stylesCssFile);
+  const document = resolve(themeFolder, documentCssFile);
+  const autoInjectComponents = themeProperties.autoInjectComponents ?? true;
+  let themeFile = headerImport;
+  var componentsFiles;
+
+  if (autoInjectComponents) {
+    componentsFiles = sync('*.css', {
+      cwd: resolve(themeFolder, themeComponentsFolder),
+      nodir: true
+    });
+
+    if (componentsFiles.length > 0) {
+      themeFile += "import { unsafeCSS, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';\n";
+    }
+  }
+
+  if (themeProperties.parent) {
+    themeFile += `import {applyTheme as applyBaseTheme} from './theme-${themeProperties.parent}.generated.js';\n`;
+  }
+  themeFile += `import stripCssComments from 'strip-css-comments';\n`;
+
+  themeFile += createLinkReferences;
+  themeFile += injectGlobalCssMethod;
+
+  const imports = [];
+  const globalCssCode = [];
+  const lumoCssCode = [];
+  const componentCssCode = [];
+  const parentTheme = themeProperties.parent ? 'applyBaseTheme(target);\n' : '';
+
+  const themeIdentifier = '_vaadintheme_' + themeName + '_';
+  const lumoCssFlag = '_vaadinthemelumoimports_';
+  const globalCssFlag = themeIdentifier + 'globalCss';
+  const componentCssFlag = themeIdentifier + 'componentCss';
+
+  if (!existsSync(styles)) {
+    if (productionMode) {
+      throw new Error(`styles.css file is missing and is needed for '${themeName}' in folder '${themeFolder}'`);
+    }
+    writeFileSync(
+      styles,
+      '/* Import your application global css files here or add the styles directly to this file */',
+      'utf8'
+    );
+  }
+
+  // styles.css will always be available as we write one if it doesn't exist.
+  let filename = basename(styles);
+  let variable = camelCase(filename);
+  if (useDevServer) {
+    imports.push(`import ${variable} from 'themes/${themeName}/${filename}?inline';\n`);
+  }
+  /* Lumo must be first so that custom styles override Lumo styles */
+  const lumoImports = themeProperties.lumoImports || ['color', 'typography'];
+  if (lumoImports && lumoImports.length > 0) {
+    lumoImports.forEach((lumoImport) => {
+      imports.push(`import { ${lumoImport} } from '@vaadin/vaadin-lumo-styles/${lumoImport}.js';\n`);
+    });
+
+    lumoImports.forEach((lumoImport) => {
+      lumoCssCode.push(`injectGlobalCss(${lumoImport}.cssText, target, true);\n`);
+    });
+  }
+
+  if (useDevServer) {
+    globalCssCode.push(`injectGlobalCss(${variable}.toString(), target);\n    `);
+  }
+  if (existsSync(document)) {
+    filename = basename(document);
+    variable = camelCase(filename);
+    imports.push(`import ${variable} from 'themes/${themeName}/${filename}?inline';\n`);
+    globalCssCode.push(`injectGlobalCss(${variable}.toString(), document);\n    `);
+  }
+
+  let i = 0;
+  if (themeProperties.documentCss) {
+    const missingModules = checkModules(themeProperties.documentCss);
+    if (missingModules.length > 0) {
+      throw Error(
+        "Missing npm modules or files '" +
+          missingModules.join("', '") +
+          "' for documentCss marked in 'theme.json'.\n" +
+          "Install or update package(s) by adding a @NpmPackage annotation or install it using 'npm/pnpm i'"
+      );
+    }
+    themeProperties.documentCss.forEach((cssImport) => {
+      const variable = 'module' + i++;
+      imports.push(`import ${variable} from '${cssImport}?inline';\n`);
+      // Due to chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=336876 font-face will not work
+      // inside shadowRoot so we need to inject it there also.
+      globalCssCode.push(`if(target !== document) {
+      injectGlobalCss(${variable}.toString(), target);
+    }\n    `);
+      globalCssCode.push(`injectGlobalCss(${variable}.toString(), document);\n    `);
+    });
+  }
+  if (themeProperties.importCss) {
+    const missingModules = checkModules(themeProperties.importCss);
+    if (missingModules.length > 0) {
+      throw Error(
+        "Missing npm modules or files '" +
+          missingModules.join("', '") +
+          "' for importCss marked in 'theme.json'.\n" +
+          "Install or update package(s) by adding a @NpmPackage annotation or install it using 'npm/pnpm i'"
+      );
+    }
+    themeProperties.importCss.forEach((cssPath) => {
+      const variable = 'module' + i++;
+      imports.push(`import ${variable} from '${cssPath}';\n`);
+      globalCssCode.push(`injectGlobalCss(${variable}.toString(), target);\n`);
+    });
+  }
+
+  if (autoInjectComponents) {
+    componentsFiles.forEach((componentCss) => {
+      const filename = basename(componentCss);
+      const tag = filename.replace('.css', '');
+      const variable = camelCase(filename);
+      imports.push(`import ${variable} from 'themes/${themeName}/${themeComponentsFolder}/${filename}?inline';\n`);
+      // Don't format as the generated file formatting will get wonky!
+      const componentString = `registerStyles(
+        '${tag}',
+        unsafeCSS(${variable}.toString())
+      );
+      `;
+      componentCssCode.push(componentString);
+    });
+  }
+
+  themeFile += imports.join('');
+  themeFile += `
+window.Vaadin = window.Vaadin || {};
+window.Vaadin.theme = window.Vaadin.theme || {};
+window.Vaadin.theme.injectedGlobalCss = [];
+
+/**
+ * Calculate a 32 bit FNV-1a hash
+ * Found here: https://gist.github.com/vaiorabbit/5657561
+ * Ref.: http://isthe.com/chongo/tech/comp/fnv/
+ *
+ * @param {string} str the input value
+ * @returns {string} 32 bit (as 8 byte hex string)
+ */
+function hashFnv32a(str) {
+  /*jshint bitwise:false */
+  let i, l, hval = 0x811c9dc5;
+
+  for (i = 0, l = str.length; i < l; i++) {
+    hval ^= str.charCodeAt(i);
+    hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
+  }
+
+  // Convert to 8 digit hex string
+  return ("0000000" + (hval >>> 0).toString(16)).substr(-8);
+}
+
+/**
+ * Calculate a 64 bit hash for the given input.
+ * Double hash is used to significantly lower the collision probability.
+ *
+ * @param {string} input value to get hash for
+ * @returns {string} 64 bit (as 16 byte hex string)
+ */
+function getHash(input) {
+  let h1 = hashFnv32a(input); // returns 32 bit (as 8 byte hex string)
+  return h1 + hashFnv32a(h1 + input); 
+}
+`;
+
+  // Don't format as the generated file formatting will get wonky!
+  // If targets check that we only register the style parts once, checks exist for global css and component css
+  const themeFileApply = `export const applyTheme = (target) => {
+  ${parentTheme}
+  ${globalCssCode.join('')}
+  
+  if (!document['${componentCssFlag}']) {
+    ${componentCssCode.join('')}
+    document['${componentCssFlag}'] = true;
+  }
+  ${lumoCssCode.join('')}
+}
+`;
+
+  themeFile += themeFileApply;
+
+  return themeFile;
+}
+
+/**
+ * Make given string into camelCase.
+ *
+ * @param {string} str string to make into cameCase
+ * @returns {string} camelCased version
+ */
+function camelCase(str) {
+  return str
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, function (word, index) {
+      return index === 0 ? word.toLowerCase() : word.toUpperCase();
+    })
+    .replace(/\s+/g, '')
+    .replace(/\.|\-/g, '');
+}
+
+export { generateThemeFile };

--- a/dspublisher/application-theme-plugin/theme-handle.js
+++ b/dspublisher/application-theme-plugin/theme-handle.js
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * This file contains functions for look up and handle the theme resources
+ * for application theme plugin.
+ */
+import { existsSync, writeFileSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import { generateThemeFile } from './theme-generator.js';
+import { copyStaticAssets, copyThemeResources } from './theme-copy.js';
+
+// matches theme name in './theme-my-theme.generated.js'
+const nameRegex = /theme-(.*)\.generated\.js/;
+
+let prevThemeName = undefined;
+let firstThemeName = undefined;
+
+/**
+ * Looks up for a theme resources in a current project and in jar dependencies,
+ * copies the found resources and generates/updates meta data for webpack
+ * compilation.
+ *
+ * @param {object} options application theme plugin mandatory options,
+ * @see {@link ApplicationThemePlugin}
+ *
+ * @param logger application theme plugin logger
+ */
+function processThemeResources(options, logger) {
+  const themeName = extractThemeName(options.frontendGeneratedFolder);
+  if (themeName) {
+    if (!prevThemeName && !firstThemeName) {
+      firstThemeName = themeName;
+    } else if (
+      (prevThemeName && prevThemeName !== themeName && firstThemeName !== themeName) ||
+      (!prevThemeName && firstThemeName !== themeName)
+    ) {
+      // Warning message is shown to the developer when:
+      // 1. He is switching to any theme, which is differ from one being set up
+      // on application startup, by changing theme name in `@Theme()`
+      // 2. He removes or comments out `@Theme()` to see how the app
+      // looks like without theming, and then again brings `@Theme()` back
+      // with a themeName which is differ from one being set up on application
+      // startup.
+      const warning = `Attention: Active theme is switched to '${themeName}'.`;
+      const description = `
+      Note that adding new style sheet files to '/themes/${themeName}/components', 
+      may not be taken into effect until the next application restart.
+      Changes to already existing style sheet files are being reloaded as before.`;
+      logger.warn('*******************************************************************');
+      logger.warn(warning);
+      logger.warn(description);
+      logger.warn('*******************************************************************');
+    }
+    prevThemeName = themeName;
+
+    findThemeFolderAndHandleTheme(themeName, options, logger);
+  } else {
+    // This is needed in the situation that the user decides to comment or
+    // remove the @Theme(...) completely to see how the application looks
+    // without any theme. Then when the user brings back one of the themes,
+    // the previous theme should be undefined to enable us to detect the change.
+    prevThemeName = undefined;
+    logger.debug('Skipping Vaadin application theme handling.');
+    logger.trace('Most likely no @Theme annotation for application or only themeClass used.');
+  }
+}
+
+/**
+ * Search for the given theme in the project and resource folders.
+ *
+ * @param {string} themeName name of theme to find
+ * @param {object} options application theme plugin mandatory options,
+ * @see {@link ApplicationThemePlugin}
+ * @param logger application theme plugin logger
+ * @return true or false for if theme was found
+ */
+function findThemeFolderAndHandleTheme(themeName, options, logger) {
+  let themeFound = false;
+  for (let i = 0; i < options.themeProjectFolders.length; i++) {
+    const themeProjectFolder = options.themeProjectFolders[i];
+    if (existsSync(themeProjectFolder)) {
+      logger.debug("Searching themes folder '" + themeProjectFolder + "' for theme '" + themeName + "'");
+      const handled = handleThemes(themeName, themeProjectFolder, options, logger);
+      if (handled) {
+        if (themeFound) {
+          throw new Error(
+            "Found theme files in '" +
+              themeProjectFolder +
+              "' and '" +
+              themeFound +
+              "'. Theme should only be available in one folder"
+          );
+        }
+        logger.debug("Found theme files from '" + themeProjectFolder + "'");
+        themeFound = themeProjectFolder;
+      }
+    }
+  }
+
+  if (existsSync(options.themeResourceFolder)) {
+    if (themeFound && existsSync(resolve(options.themeResourceFolder, themeName))) {
+      throw new Error(
+        "Theme '" +
+          themeName +
+          "'should not exist inside a jar and in the project at the same time\n" +
+          'Extending another theme is possible by adding { "parent": "my-parent-theme" } entry to the theme.json file inside your theme folder.'
+      );
+    }
+    logger.debug(
+      "Searching theme jar resource folder '" + options.themeResourceFolder + "' for theme '" + themeName + "'"
+    );
+    handleThemes(themeName, options.themeResourceFolder, options, logger);
+    themeFound = true;
+  }
+  return themeFound;
+}
+
+/**
+ * Copies static resources for theme and generates/writes the
+ * [theme-name].generated.js for webpack to handle.
+ *
+ * Note! If a parent theme is defined it will also be handled here so that the parent theme generated file is
+ * generated in advance of the theme generated file.
+ *
+ * @param {string} themeName name of theme to handle
+ * @param {string} themesFolder folder containing application theme folders
+ * @param {object} options application theme plugin mandatory options,
+ * @see {@link ApplicationThemePlugin}
+ * @param {object} logger plugin logger instance
+ *
+ * @throws Error if parent theme defined, but can't locate parent theme
+ *
+ * @returns true if theme was found else false.
+ */
+function handleThemes(themeName, themesFolder, options, logger) {
+  const themeFolder = resolve(themesFolder, themeName);
+  if (existsSync(themeFolder)) {
+    logger.debug('Found theme ', themeName, ' in folder ', themeFolder);
+
+    const themeProperties = getThemeProperties(themeFolder);
+
+    // If theme has parent handle parent theme immediately.
+    if (themeProperties.parent) {
+      const found = findThemeFolderAndHandleTheme(themeProperties.parent, options, logger);
+      if (!found) {
+        throw new Error(
+          "Could not locate files for defined parent theme '" +
+            themeProperties.parent +
+            "'.\n" +
+            'Please verify that dependency is added or theme folder exists.'
+        );
+      }
+    }
+    copyStaticAssets(themeName, themeProperties, options.projectStaticAssetsOutputFolder, logger);
+    copyThemeResources(themeFolder, options.projectStaticAssetsOutputFolder, logger);
+    const themeFile = generateThemeFile(themeFolder, themeName, themeProperties, options);
+
+    writeFileSync(resolve(options.frontendGeneratedFolder, 'theme-' + themeName + '.generated.js'), themeFile);
+    return true;
+  }
+  return false;
+}
+
+function getThemeProperties(themeFolder) {
+  const themePropertyFile = resolve(themeFolder, 'theme.json');
+  if (!existsSync(themePropertyFile)) {
+    return {};
+  }
+  const themePropertyFileAsString = readFileSync(themePropertyFile);
+  if (themePropertyFileAsString.length === 0) {
+    return {};
+  }
+  return JSON.parse(themePropertyFileAsString);
+}
+
+/**
+ * Extracts current theme name from auto-generated 'theme.js' file located on a
+ * given folder.
+ * @param frontendGeneratedFolder folder in project containing 'theme.js' file
+ * @returns {string} current theme name
+ */
+function extractThemeName(frontendGeneratedFolder) {
+  if (!frontendGeneratedFolder) {
+    throw new Error(
+      "Couldn't extract theme name from 'theme.js'," +
+        ' because the path to folder containing this file is empty. Please set' +
+        ' the a correct folder path in ApplicationThemePlugin constructor' +
+        ' parameters.'
+    );
+  }
+  const generatedThemeFile = resolve(frontendGeneratedFolder, 'theme.js');
+  if (existsSync(generatedThemeFile)) {
+    // read theme name from the 'generated/theme.js' as there we always
+    // mark the used theme for webpack to handle.
+    const themeName = nameRegex.exec(readFileSync(generatedThemeFile, { encoding: 'utf8' }))[1];
+    if (!themeName) {
+      throw new Error("Couldn't parse theme name from '" + generatedThemeFile + "'.");
+    }
+    return themeName;
+  } else {
+    return '';
+  }
+}
+
+/**
+ * Finds all the parent themes located in the project themes folders and in
+ * the JAR dependencies with respect to the given custom theme with
+ * {@code themeName}.
+ * @param {string} themeName given custom theme name to look parents for
+ * @param {object} options application theme plugin mandatory options,
+ * @see {@link ApplicationThemePlugin}
+ * @returns {string[]} array of paths to found parent themes with respect to the
+ * given custom theme
+ */
+function findParentThemes(themeName, options) {
+  const existingThemeFolders = [options.themeResourceFolder, ...options.themeProjectFolders].filter((folder) =>
+    existsSync(folder)
+  );
+  return collectParentThemes(themeName, existingThemeFolders, false);
+}
+
+function collectParentThemes(themeName, themeFolders, isParent) {
+  let foundParentThemes = [];
+  themeFolders.forEach((folder) => {
+    const themeFolder = resolve(folder, themeName);
+    if (existsSync(themeFolder)) {
+      const themeProperties = getThemeProperties(themeFolder);
+
+      if (themeProperties.parent) {
+        foundParentThemes.push(...collectParentThemes(themeProperties.parent, themeFolders, true));
+        if (!foundParentThemes.length) {
+          throw new Error(
+            "Could not locate files for defined parent theme '" +
+              themeProperties.parent +
+              "'.\n" +
+              'Please verify that dependency is added or theme folder exists.'
+          );
+        }
+      }
+      // Add a theme path to result collection only if a given themeName
+      // is supposed to be a parent theme
+      if (isParent) {
+        foundParentThemes.push(themeFolder);
+      }
+    }
+  });
+  return foundParentThemes;
+}
+
+export { processThemeResources, extractThemeName, findParentThemes };

--- a/dspublisher/dspublisher-scripts.js
+++ b/dspublisher/dspublisher-scripts.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const http = require('http');
 
-const DSP_VERSION = '2.1.0-alpha.4';
+const DSP_VERSION = '2.1.0-alpha.5';
 
 async function checkPreConditions() {
   try {

--- a/frontend/demo/init-flow-components.ts
+++ b/frontend/demo/init-flow-components.ts
@@ -12,11 +12,7 @@ import '@vaadin/flow-frontend/dndConnector-es6.js';
 import '@vaadin/flow-frontend/flow-component-renderer.js';
 
 // Flow component specific modules
-import '@vaadin/flow-frontend/confirmDialogConnector.js';
-import '@vaadin/flow-frontend/dialogConnector.js';
 import '@vaadin/flow-frontend/cookieConsentConnector.js';
-import '@vaadin/flow-frontend/loginOverlayConnector.js';
-import '@vaadin/flow-frontend/notificationConnector.js';
 import '@vaadin/flow-frontend/comboBoxConnector.js';
 import '@vaadin/flow-frontend/contextMenuConnector.js';
 import '@vaadin/flow-frontend/contextMenuTargetConnector.js';

--- a/webpack.dspublisher.js
+++ b/webpack.dspublisher.js
@@ -62,8 +62,13 @@ const themesPath = usesProjectTheme ? projectThemePath : reusableThemesPath;
 const applyThemePath = path.resolve(frontendGeneratedFolder, 'theme.js');
 
 module.exports = async function (config) {
+  // const { ApplicationThemePlugin, extractThemeName, findParentThemes } = await import(
+  //   buildDirectory + '/plugins/application-theme-plugin/application-theme-plugin.js'
+  // );
+
+  // TODO: Remove this temporary workaround (and the referenced files) once the above import works (Vaadin 24.0.0.beta2)
   const { ApplicationThemePlugin, extractThemeName, findParentThemes } = await import(
-    buildDirectory + '/plugins/application-theme-plugin/application-theme-plugin.js'
+    __dirname + '/dspublisher/application-theme-plugin/application-theme-plugin.js'
   );
 
   const allFlowImportsPath = path.resolve(__dirname, 'target/frontend/generated-flow-imports.js');

--- a/webpack.dspublisher.js
+++ b/webpack.dspublisher.js
@@ -3,11 +3,6 @@ const fs = require('fs');
 const settings = require('./target/vaadin-dev-server-settings.json');
 
 const buildDirectory = path.resolve(__dirname, 'target');
-const {
-  ApplicationThemePlugin,
-  extractThemeName,
-  findParentThemes,
-} = require(buildDirectory + '/plugins/application-theme-plugin');
 
 const frontendFolder = path.resolve(__dirname, settings.frontendFolder);
 
@@ -66,7 +61,11 @@ const usesProjectTheme = projectThemeNames.some((themeName) =>
 const themesPath = usesProjectTheme ? projectThemePath : reusableThemesPath;
 const applyThemePath = path.resolve(frontendGeneratedFolder, 'theme.js');
 
-module.exports = function (config) {
+module.exports = async function (config) {
+  const { ApplicationThemePlugin, extractThemeName, findParentThemes } = await import(
+    buildDirectory + '/plugins/application-theme-plugin/application-theme-plugin.js'
+  );
+
   const allFlowImportsPath = path.resolve(__dirname, 'target/frontend/generated-flow-imports.js');
   config.resolve.alias['all-flow-imports-or-empty'] =
     process.env.DOCS_IMPORT_EXAMPLE_RESOURCES === 'true'


### PR DESCRIPTION
- Update webpack config to use dynamic `import()` for `application-theme-plugin`
- Remove the no longer existing connector imports
- Bump DSP version
- Temporarily copy application-theme-plugin to the project