### PR TITLE
docs: add missing upgrade instructions for date picker

### DIFF
--- a/articles/upgrading/V23-V24-steps/_styling.adoc
+++ b/articles/upgrading/V23-V24-steps/_styling.adoc
@@ -166,16 +166,33 @@ The buttons in the Date Picker's overlay have been moved from shadow DOM to slot
 The date cells in the calendar can have multiple part names to reflect their states, so the part attribute selector must use the `~=` operator to match individual words:
 
 [source,css,role="before"]
-.`vaadin-date-picker-overlay-content.css`
+.`vaadin-month-calendar.css`
 ----
 [part="date"] {...}
 ----
 [source,css,role="after"]
-.`vaadin-date-picker-overlay-content.css`
+.`vaadin-month-calendar.css`
 ----
 [part~="date"] {...}
 ----
 
+The state attributes for date cells have been replaced with part names:
+[source,css,role="before"]
+.`vaadin-month-calendar.css`
+----
+[part="date"][disabled] {...}
+[part="date"][focused] {...}
+[part="date"][selected] {...}
+[part="date"][today] {...}
+----
+[source,css,role="after"]
+.`vaadin-month-calendar.css`
+----
+[part~="date"][part~="disabled"] {...}
+[part~="date"][part~="focused"] {...}
+[part~="date"][part~="selected"] {...}
+[part~="date"][part~="today"] {...}
+----
 
 [discrete]
 === Details


### PR DESCRIPTION
Adds missing instructions for migrating date picker theme. Also fixes existing instructions to refer to month calendar CSS file.