### PR TITLE
docs: update grid cell focus example to use global styles

### DIFF
--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -863,7 +863,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridCellFocus.java[
 
 [source,css]
 ----
-include::{root}/frontend/themes/docs/components/vaadin-grid-cell-focus.css[]
+include::{root}/frontend/themes/docs/grid-cell-focus.css[]
 ----
 
 --

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -44,7 +44,7 @@ export class Example extends LitElement {
   render() {
     return html`
       <vaadin-grid
-        theme="force-focus-outline"
+        class="force-focus-outline"
         .items="${this.items}"
         @cell-focus="${(e: GridCellFocusEvent<Person>) => {
           const eventContext = this.grid.getEventContext(e);

--- a/frontend/themes/docs/components/vaadin-grid.css
+++ b/frontend/themes/docs/components/vaadin-grid.css
@@ -1,2 +1,1 @@
 @import 'vaadin-grid-styling.css';
-@import 'vaadin-grid-cell-focus.css';

--- a/frontend/themes/docs/grid-cell-focus.css
+++ b/frontend/themes/docs/grid-cell-focus.css
@@ -1,6 +1,7 @@
-/* frontend/theme/[my-theme]/components/vaadin-grid.css */
+/* Add this to your global CSS, for example in: */
+/* frontend/theme/[my-theme]/styles.css */
 
-:host([theme~='force-focus-outline']) [part~='cell']:focus::before {
+vaadin-grid.force-focus-outline::part(cell):focus::before {
     content: '';
     position: absolute;
     top: 0;

--- a/frontend/themes/docs/grid-cell-focus.css
+++ b/frontend/themes/docs/grid-cell-focus.css
@@ -1,7 +1,7 @@
 /* Add this to your global CSS, for example in: */
 /* frontend/theme/[my-theme]/styles.css */
 
-vaadin-grid.force-focus-outline::part(cell):focus::before {
+vaadin-grid.force-focus-outline::part(focused-cell)::before {
     content: '';
     position: absolute;
     top: 0;

--- a/frontend/themes/docs/styles.css
+++ b/frontend/themes/docs/styles.css
@@ -5,6 +5,7 @@
 @import './login-rich-content.css';
 @import './notification-position-example.css';
 @import './board.css';
+@import './grid-cell-focus.css';
 
 html,
 :host {

--- a/src/main/java/com/vaadin/demo/component/grid/GridCellFocus.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridCellFocus.java
@@ -16,7 +16,7 @@ public class GridCellFocus extends Div {
 
     public GridCellFocus() {
         Grid<Person> grid = new Grid<>(Person.class, false);
-        grid.setThemeName("force-focus-outline");
+        grid.setClassName("force-focus-outline");
         grid.addColumn(Person::getFirstName).setKey("firstName")
                 .setHeader("First name");
         grid.addColumn(Person::getLastName).setKey("lastName")


### PR DESCRIPTION
Updates the grid cell focus example to use the new theming mechanism.