### PR TITLE
docs: ported and reworked Customizing System Messages documentation

### DIFF
--- a/articles/advanced/customize-system-messages.adoc
+++ b/articles/advanced/customize-system-messages.adoc
@@ -7,21 +7,21 @@ layout: page
 
 = Configuring Customizing System Messages
 
-System messages are notifications that indicates a major invalid state that may require restarting the application.
-The invalid states handled by system messages are session expiration, internal error and cookie disabled.
+System messages are notifications that indicate a major invalid state that may require restarting the application.
+The different types of invalid state handled by system messages are the session expired, internal error, and cookie disabled states.
 
-When the client falls into one of the invalid states, a notification is shown in the browser and, after the user clicks on it, the page is reloaded.
-For session expiration, the default is however to reload the page without showing the notification.
+When the client falls into invalid state, a notification appears in the browser that reloads the page and disappears after the user clicks on it.
+However, for the session expired state the default behavior is to reload the page without showing the notification.
 
-The messages and the behaviour are defined in the [classname]`SystemMessages` class.
+The message and behavior are defined in the [classname]`SystemMessages` class.
 
-Each invalid state has four properties: a short caption, the actual message, a URL to which to redirect after displaying the message, and a property indicating whether the notification is enabled.
+Each invalid state has four properties: A short caption, a message, a URL to where to redirect after displaying the message, and a property indicating whether the notification is enabled.
 If the URL is not specified, the current page is reloaded.
 When the notification is disabled, the reload or redirect happens without any notification to the user.
 Setting both caption and message to `null` has the same effect as disabling the notification.
 
 The default values of the properties are shown below.
-Default values for system messages are also documented on [classname]`SystemMessages` class javadocs.
+The default values for system messages are also documented in the [classname]`SystemMessages` class javadocs.
 
 // Allow "ESC" in the default message strings
 pass:[<!-- vale Vaadin.Abbr = NO -->]
@@ -41,13 +41,13 @@ pass:[<!-- vale Vaadin.Abbr = NO -->]
 
 pass:[<!-- vale Vaadin.Abbr = YES -->]
 
-As it can be noted, by default notification is disabled for session expiration, but enabled for internal error and cookie disabled.
+The notification is disabled by default for session expired, but enabled for internal error and cookie disabled.
 
 System messages can be overridden by setting the [classname]`SystemMessagesProvider` in the [classname]`VaadinService`.
-You need to implement the [methodname]`getSystemMessages(SystemMessagesInfo)` method, which should return a [classname]`SystemMessages` object.
-The easiest way to customize the messages is to use a [classname]`CustomizedSystemMessages` object, and use provided setter methods to configured the desired properties.
+You need to implement the [methodname]`getSystemMessages(SystemMessagesInfo)` method, which returns a [classname]`SystemMessages` object.
+The simplest way to customize the messages is to use a [classname]`CustomizedSystemMessages` object with the provided setter methods to configure the desired properties.
 
-The [classname]`SystemMessagesInfo` parameter provided to [methodname]`getSystemMessages()` allows to get access to the locale of UI, so that messages can be translated in the current user language.
+The [classname]`SystemMessagesInfo` parameter provided to [methodname]`getSystemMessages()` allows access to the UI locale, so that messages can be translated in the current user language.
 
 You can set the system message provider in the [methodname]`serviceInit()` method of a <<service-init-listener#, service init listener>>, for example as follows:
 

--- a/articles/advanced/customize-system-messages.adoc
+++ b/articles/advanced/customize-system-messages.adoc
@@ -18,6 +18,7 @@ The messages and the behaviour are defined in the [classname]`SystemMessages` cl
 Each invalid state has four properties: a short caption, the actual message, a URL to which to redirect after displaying the message, and a property indicating whether the notification is enabled.
 If the URL is not specified, the current page is reloaded.
 When the notification is disabled, the reload or redirect happens without any notification to the user.
+Setting both caption and message to `null` has the same effect as disabling the notification.
 
 Default values for system messages are documented on [classname]`SystemMessages` class javadocs.
 

--- a/articles/advanced/customize-system-messages.adoc
+++ b/articles/advanced/customize-system-messages.adoc
@@ -18,10 +18,10 @@ The message and behavior are defined in the [classname]`SystemMessages` class.
 Each invalid state has four properties: A short caption, a message, a URL to where to redirect after displaying the message, and a property indicating whether the notification is enabled.
 If the URL is not specified, the current page is reloaded.
 When the notification is disabled, the reload or redirect happens without any notification to the user.
-Setting both caption and message to `null` has the same effect as disabling the notification.
+Setting both the caption and message to `null` has the same effect as disabling the notification.
 
 The default values of the properties are shown below.
-The default values for system messages are also documented in the [classname]`SystemMessages` class javadocs.
+The default values for system messages are also documented in the [classname]`SystemMessages` class Javadocs.
 
 // Allow "ESC" in the default message strings
 pass:[<!-- vale Vaadin.Abbr = NO -->]

--- a/articles/advanced/customize-system-messages.adoc
+++ b/articles/advanced/customize-system-messages.adoc
@@ -20,7 +20,23 @@ If the URL is not specified, the current page is reloaded.
 When the notification is disabled, the reload or redirect happens without any notification to the user.
 Setting both caption and message to `null` has the same effect as disabling the notification.
 
-Default values for system messages are documented on [classname]`SystemMessages` class javadocs.
+The default values of the properties are shown below.
+Default values for system messages are also documented on [classname]`SystemMessages` class javadocs.
+
+* [propertyname]`sessionExpiredNotificationEnabled`: false
+* [propertyname]`sessionExpiredURL`: null
+* [propertyname]`sessionExpiredCaption`: Session Expired
+* [propertyname]`sessionExpiredMessage`: Take note of any unsaved data, and click here or press ESC key to continue.
+* [propertyname]`internalErrorNotificationEnabled`: true
+* [propertyname]`internalErrorURL`: null
+* [propertyname]`internalErrorCaption`: Internal error
+* [propertyname]`internalErrorMessage`: Please notify the administrator. Take note of any unsaved data, and click here or press ESC to continue.
+* [propertyname]`cookiesDisabledNotificationEnabled`: true
+* [propertyname]`cookiesDisabledURL`: null
+* [propertyname]`cookiesDisabledCaption`: Cookies disabled
+* [propertyname]`cookiesDisabledMessage`: This application requires cookies to function. Please enable cookies in your browser and click here or press ESC to try again.
+
+As it can be noted, by default notification is disabled for session expiration, but enabled for internal error and cookie disabled.
 
 System messages can be overridden by setting the [classname]`SystemMessagesProvider` in the [classname]`VaadinService`.
 You need to implement the [methodname]`getSystemMessages(SystemMessagesInfo)` method, which should return a [classname]`SystemMessages` object.

--- a/articles/advanced/customize-system-messages.adoc
+++ b/articles/advanced/customize-system-messages.adoc
@@ -1,0 +1,49 @@
+---
+title: Customizing System Messages
+description: Configuring messages for application invalid state
+order: 147
+layout: page
+---
+
+= Configuring Customizing System Messages
+
+System messages are notifications that indicates a major invalid state that may require restarting the application.
+The invalid states handled by system messages are session expiration, internal error and cookie disabled.
+
+When the client falls into one of the invalid states, a notification is shown in the browser and, after the user clicks on it, the page is reloaded.
+For session expiration, the default is however to reload the page without showing the notification.
+
+The messages and the behaviour are defined in the [classname]`SystemMessages` class.
+
+Each invalid state has four properties: a short caption, the actual message, a URL to which to redirect after displaying the message, and a property indicating whether the notification is enabled.
+If the URL is not specified, the current page is reloaded.
+When the notification is disabled, the reload or redirect happens without any notification to the user.
+
+Default values for system messages are documented on [classname]`SystemMessages` class javadocs.
+
+System messages can be overridden by setting the [classname]`SystemMessagesProvider` in the [classname]`VaadinService`.
+You need to implement the [methodname]`getSystemMessages()` method, which should return a [classname]`SystemMessages` object.
+The easiest way to customize the messages is to use a [classname]`CustomizedSystemMessages` object, and use provided setter methods to configured the desired properties.
+
+You can set the system message provider in the [methodname]`serviceInit()` method of a <<service-init-listener#, service init listener>>, for example as follows:
+
+
+[source,java]
+----
+public class CustomInitServiceListener implements VaadinServiceInitListener {
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        event.getSource().setSystemMessagesProvider(new SystemMessagesProvider() {
+            @Override
+            public SystemMessages getSystemMessages(SystemMessagesInfo systemMessagesInfo) {
+                CustomizedSystemMessages messages = new CustomizedSystemMessages();
+                messages.setSessionExpiredCaption("Session expired");
+                messages.setSessionExpiredMessage("Take note of any unsaved data, and click here or press ESC key to continue.");
+                messages.setSessionExpiredURL("session-expired.html");
+                messages.setSessionExpiredNotificationEnabled(true);
+                return messages;
+            }
+        });
+    };
+};
+----

--- a/articles/advanced/customize-system-messages.adoc
+++ b/articles/advanced/customize-system-messages.adoc
@@ -22,8 +22,10 @@ When the notification is disabled, the reload or redirect happens without any no
 Default values for system messages are documented on [classname]`SystemMessages` class javadocs.
 
 System messages can be overridden by setting the [classname]`SystemMessagesProvider` in the [classname]`VaadinService`.
-You need to implement the [methodname]`getSystemMessages()` method, which should return a [classname]`SystemMessages` object.
+You need to implement the [methodname]`getSystemMessages(SystemMessagesInfo)` method, which should return a [classname]`SystemMessages` object.
 The easiest way to customize the messages is to use a [classname]`CustomizedSystemMessages` object, and use provided setter methods to configured the desired properties.
+
+The [classname]`SystemMessagesInfo` parameter provided to [methodname]`getSystemMessages()` allows to get access to the locale of UI, so that messages can be translated in the current user language.
 
 You can set the system message provider in the [methodname]`serviceInit()` method of a <<service-init-listener#, service init listener>>, for example as follows:
 

--- a/articles/advanced/customize-system-messages.adoc
+++ b/articles/advanced/customize-system-messages.adoc
@@ -23,6 +23,9 @@ Setting both caption and message to `null` has the same effect as disabling the 
 The default values of the properties are shown below.
 Default values for system messages are also documented on [classname]`SystemMessages` class javadocs.
 
+// Allow "ESC" in the default message strings
+pass:[<!-- vale Vaadin.Abbr = NO -->]
+
 * [propertyname]`sessionExpiredNotificationEnabled`: false
 * [propertyname]`sessionExpiredURL`: null
 * [propertyname]`sessionExpiredCaption`: Session Expired
@@ -35,6 +38,8 @@ Default values for system messages are also documented on [classname]`SystemMess
 * [propertyname]`cookiesDisabledURL`: null
 * [propertyname]`cookiesDisabledCaption`: Cookies disabled
 * [propertyname]`cookiesDisabledMessage`: This application requires cookies to function. Please enable cookies in your browser and click here or press ESC to try again.
+
+pass:[<!-- vale Vaadin.Abbr = YES -->]
 
 As it can be noted, by default notification is disabled for session expiration, but enabled for internal error and cookie disabled.
 


### PR DESCRIPTION
Documentation for Customizing System Messages was present in Vaadin 8 but not ported to Flow.

Fixes #1699


