### PR TITLE
chore: improved Vaadin session expiration docs

### DIFF
--- a/articles/advanced/application-lifecycle.asciidoc
+++ b/articles/advanced/application-lifecycle.asciidoc
@@ -69,7 +69,7 @@ This listener allows you, among other things, to add a [interfacename]`RequestHa
 A user session begins when a user first makes a request to a Vaadin servlet by opening the URL of a particular [classname]`UI`.
 All server requests belonging to a particular UI class are processed by the [classname]`VaadinServlet` class.
 When a new client connects, it creates a new user session, represented by an instance of [classname]`VaadinSession`.
-User sessions stored in the HTTP session and are tracked using cookies stored in the browser.
+User sessions are stored in the HTTP session and tracked using cookies stored in the browser.
 
 You can get the [classname]`VaadinSession` of a [classname]`UI` with [methodname]`getSession()`, or globally with [methodname]`VaadinSession.getCurrent()`.
 It also provides access to the lower-level session object [interfacename]`HttpSession`, through a [classname]`WrappedSession`.
@@ -145,7 +145,7 @@ You can make it happen more quickly by increasing the UI heartbeat frequency, or
 == User Session Expiration
 
 ((("session", "expiration")))
-An user session is kept alive by server requests caused by user interaction with the application, as well as by the heartbeat-monitoring mechanism of the UIs.
+A user session is kept alive by server requests caused by user interaction with the application, as well as by the heartbeat-monitoring mechanism of the UIs.
 When all UIs have expired, the user session still remains.
 It's cleaned up from the server when the HTTP session timeout configured in the web application elapses, and the whole HTTP session is invalidated.
 
@@ -161,6 +161,7 @@ If the [parameter]#closeIdleSessions# deployment configuration parameter of the 
 
 The user session and all its UIs are closed when the timeout specified by the [parameter]#session-timeout# parameter of the servlet elapses after the last non-heartbeat request.
 After the user session is gone, a `Session expired` notification is sent to the browser on the next server request, and the client-engine handles it based on to the [classname]`SystemMessages` settings.
+
 By default, it reloads the current page, effectively creating a new user session, but it can be configured to also shows a notification to the user before reloading the page.
 Furthermore, it is possible to customize the notification messages and set a URL to redirect the browser to, instead of reloading the current page.
 For example, setting a URL that points to a static page is useful to prevent the creation of a new user session.
@@ -209,7 +210,7 @@ public class MainLayout extends Div {
 ----
 
 When a user session is closed from one UI, any other UIs attached to it are left hanging.
-When the client-side engine notices that a UI and the user session are gone on the server side, it reloads the UI or displays a `Session Expired` message and reloads the UI when the message is clicked, accordingly to the System Messages configuration.
+When the client-side engine notices that a UI and the user session are gone on the server side, it reloads the UI or displays a `Session Expired` message and reloads the UI when the message is clicked, according to the System Messages configuration.
 
 
 [discussion-id]`9405AA6C-4F19-4CB6-AF79-C8DCBD0E0C3A`

--- a/articles/advanced/application-lifecycle.asciidoc
+++ b/articles/advanced/application-lifecycle.asciidoc
@@ -9,8 +9,8 @@ layout: page
 [[application.lifecycle]]
 = Application Lifecycle
 
-This section goes into more technical details of application deployment, user sessions, and the UI instance lifecycle.
-These details aren't needed for writing Vaadin applications, but may be useful for understanding how they actually work and in what circumstances their execution ends.
+This section dives into the technical details of application deployment, user sessions, and the UI instance lifecycle.
+These details aren't required for writing Vaadin applications but may be useful for understanding how they work and the circumstances where their execution ends.
 
 [[application.lifecycle.deployment]]
 == Deployment
@@ -23,7 +23,7 @@ Deployment doesn't usually run any code yet in the application, although static 
 A servlet class should extend the [classname]`VaadinServlet` class.
 However, there is no need to define your own servlet class if you are using the Servlet 3.1 specification.
 It's only necessary to have at least one class that carries the `@Route` annotation.
-A [classname]`VaadinServlet` instance is registered for you automatically and Vaadin registers all the required servlets automatically.
+A [classname]`VaadinServlet` instance is automatically registered for you and Vaadin registers all the required servlets.
 
 === Automatic Servlet Registration
 
@@ -33,7 +33,7 @@ This servlet is needed to serve the main application files.
 
 The servlet isn't registered if any [classname]`VaadinServlet` is already registered, or if there is no class annotated with the `@Route` annotation.
 
-Additionally, a servlet isn't registered if:
+A servlet isn't registered if:
 
 - there is a servlet that has already been mapped to the same path, or
 - if the system property `disable.automatic.servlet.registration` is set to `true`.
@@ -127,7 +127,7 @@ When the [classname]`UI` is detached from the session, [methodname]`detach()` is
 
 You can explicitly close a UI with [methodname]`close()`.
 The method marks the UI to be detached from the session after processing the current request.
-For that reason, the method doesn't invalidate the UI instance immediately and the response is sent as usual.
+For that reason, the method doesn't invalidate the UI instance and the response is sent as usual.
 
 Detaching a UI doesn't close the page or browser window in which the UI is running.
 Further server requests cause an error.
@@ -138,14 +138,14 @@ You can redirect the window to another URL via JavaScript.
 
 If you close UIs other than the one associated with the current request, they aren't detached at the end of the current request.
 This happens after the next request from the particular UI.
-You can make it happen more quickly by increasing the UI heartbeat frequency, or immediately by using server push.
+You can make it happen quicker by increasing the UI heartbeat frequency, or immediately by using server push.
 
 
 [[application.lifecycle.session-expiration]]
 == User Session Expiration
 
 ((("session", "expiration")))
-A user session is kept alive by server requests that are caused by user interacting with the application, as well as by the UIs heartbeat-monitoring mechanism.
+A user session is kept alive by server requests that are caused by a user interacting with the application, as well as by the UIs heartbeat-monitoring mechanism.
 When all UIs have expired, the user session still remains.
 It's removed from the server when the HTTP session timeout configured in the web application elapses, and the whole HTTP session is invalidated.
 
@@ -160,7 +160,7 @@ This is the original purpose of the session timeout setting.
 If the [parameter]#closeIdleSessions# deployment configuration parameter of the servlet is set to `true`, the closure mechanism works as follows.
 
 The user session and all its UIs are closed when the timeout specified by the [parameter]#session-timeout# parameter of the servlet elapses after the last non-heartbeat request.
-After the user session is gone, a `Session expired` notification is sent to the browser on the next server request and the client-engine handles it based on the [classname]`SystemMessages` settings.
+After the user session is gone, a `Session expired` notification is sent to the browser on the next server request and the client engine handles it based on the [classname]`SystemMessages` settings.
 
 By default, it reloads the current page creating a new user session, but it can also be configured to show a notification to the user before reloading the page.
 Furthermore, it is possible to customize the notification message and set a URL where to redirect the browser instead of reloading the current page.
@@ -172,7 +172,7 @@ You can handle user session expiration on the server side with a [interfacename]
 
 [NOTE]
 ====
-User sessions expiration does not imply the underlying HTTP session being invalidated.
+User session expiration does not imply the underlying HTTP session being invalidated.
 HTTP session invalidation can be performed by invoking [methodname]`invalidate` on the [classname]`WrappedSession` accessible through [classname]`VaadinSession`.
 ====
 

--- a/articles/advanced/application-lifecycle.asciidoc
+++ b/articles/advanced/application-lifecycle.asciidoc
@@ -69,15 +69,15 @@ This listener allows you, among other things, to add a [interfacename]`RequestHa
 A user session begins when a user first makes a request to a Vaadin servlet by opening the URL of a particular [classname]`UI`.
 All server requests belonging to a particular UI class are processed by the [classname]`VaadinServlet` class.
 When a new client connects, it creates a new user session, represented by an instance of [classname]`VaadinSession`.
-Sessions are tracked using cookies stored in the browser.
+User sessions stored in the HTTP session and are tracked using cookies stored in the browser.
 
 You can get the [classname]`VaadinSession` of a [classname]`UI` with [methodname]`getSession()`, or globally with [methodname]`VaadinSession.getCurrent()`.
 It also provides access to the lower-level session object [interfacename]`HttpSession`, through a [classname]`WrappedSession`.
 You can also access the deployment configuration through [classname]`VaadinSession`.
 
-A session ends after the last [classname]`UI` instance expires or is closed, as described later.
+A user session ends after the last [classname]`UI` instance expires or is closed, as described later.
 
-See <<{articles}/advanced/session-and-ui-init-listener#, Session and UI Listeners>> to learn how to listen for session initialization and destruction events.
+See <<{articles}/advanced/session-and-ui-init-listener#, Session and UI Listeners>> to learn how to listen for user session initialization and destruction events.
 
 [[application.lifecycle.ui]]
 == Loading a UI
@@ -96,7 +96,7 @@ The method gets the request as a [classname]`VaadinRequest`.
 
 The HTML content of the loader page is generated as an HTML `DOM` object, which can be customized by implementing an [interfacename]`IndexHtmlRequestListener` that modifies the `DOM` object.
 To do this, you need to extend the [classname]`VaadinServlet` and add a [interfacename]`SessionInitListener` to the service object, as outlined in <<application.lifecycle.session>>.
-You can then add the bootstrap listener to a session with
+You can then add the bootstrap listener to a user session with
 [methodname]`addIndexHtmlRequestListener()` when the session is initialized.
 
 Loading the widget set is handled in the loader page with functions defined in a separate [filename]`BootstrapHandler.js` script, whose content is included inline in the page.
@@ -142,36 +142,46 @@ You can make it happen more quickly by increasing the UI heartbeat frequency, or
 
 
 [[application.lifecycle.session-expiration]]
-== Session Expiration
+== User Session Expiration
 
 ((("session", "expiration")))
-A session is kept alive by server requests caused by user interaction with the application, as well as by the heartbeat-monitoring mechanism of the UIs.
-When all UIs have expired, the session still remains.
-It's cleaned up from the server when the session timeout configured in the web application elapses.
+An user session is kept alive by server requests caused by user interaction with the application, as well as by the heartbeat-monitoring mechanism of the UIs.
+When all UIs have expired, the user session still remains.
+It's cleaned up from the server when the HTTP session timeout configured in the web application elapses, and the whole HTTP session is invalidated.
 
 ((("closeIdleSessions")))
-If there are active UIs in an application, their heartbeat keeps the session alive indefinitely.
-You may want to have the sessions time out if the user is inactive for a certain time.
+If there are active UIs in an application, their heartbeat keeps the user session and underlying HTTP session alive indefinitely.
+However, you may want to have the user sessions time out if the user is inactive for a certain time.
 This is the original purpose of the session timeout setting.
 
 ((("session",
 "timeout")))
 ((("closeIdleSessions")))
 If the [parameter]#closeIdleSessions# deployment configuration parameter of the servlet is set to `true`, the closure mechanism works as follows.
-The session and all its UIs are closed when the timeout specified by the [parameter]#session-timeout# parameter of the servlet elapses after the last non-heartbeat request.
-After the session is gone, the browser shows an `Out of sync` error on the next server request.
 
-See <<{articles}/configuration/properties#,Configuration Properties>> for information on setting configuration parameters.
+The user session and all its UIs are closed when the timeout specified by the [parameter]#session-timeout# parameter of the servlet elapses after the last non-heartbeat request.
+After the user session is gone, a `Session expired` notification is sent to the browser on the next server request, and the client-engine handles it based on to the [classname]`SystemMessages` settings.
+By default, it reloads the current page, effectively creating a new user session, but it can be configured to also shows a notification to the user before reloading the page.
+Furthermore, it is possible to customize the notification messages and set a URL to redirect the browser to, instead of reloading the current page.
+For example, setting a URL that points to a static page is useful to prevent the creation of a new user session.
 
-You can handle session expiration on the server side with a [interfacename]`SessionDestroyListener`, as described in <<application.lifecycle.session>>.
+See <<customize-system-messages#,Customize System Messages>> to configure user session expiration, and <<{articles}/configuration/properties#,Configuration Properties>> for information on setting configuration parameters.
+
+You can handle user session expiration on the server side with a [interfacename]`SessionDestroyListener`, as described in <<application.lifecycle.session>>.
+
+[NOTE]
+====
+User sessions expiration does not imply the underlying HTTP session being invalidated.
+HTTP session invalidation can be performed by invoking [methodname]`invalidate` on the [classname]`WrappedSession` accessible through [classname]`VaadinSession`.
+====
 
 
 [[application.lifecycle.session-closing]]
-== Closing a Session
+== Closing a User Session
 
-You can close a session by calling [methodname]`close()` on the [classname]`VaadinSession`.
-This is typically used when logging a user out, as the session and all the UIs belonging to the session should be closed.
-The session is closed immediately and any objects related to it are unavailable after calling the method.
+You can close a user session by calling [methodname]`close()` on the [classname]`VaadinSession`.
+This is typically used when logging a user out, as the User session and all the UIs belonging to the User session should be closed.
+The user session is closed immediately and any objects related to it are unavailable after calling the method.
 
 ((("logout")))
 
@@ -198,8 +208,8 @@ public class MainLayout extends Div {
 }
 ----
 
-When a session is closed from one UI, any other UIs attached to it are left hanging.
-When the client-side engine notices that a UI and the session are gone on the server side, it displays a `Session Expired` message and, by default, reloads the UI when the message is clicked.
+When a user session is closed from one UI, any other UIs attached to it are left hanging.
+When the client-side engine notices that a UI and the user session are gone on the server side, it reloads the UI or displays a `Session Expired` message and reloads the UI when the message is clicked, accordingly to the System Messages configuration.
 
 
 [discussion-id]`9405AA6C-4F19-4CB6-AF79-C8DCBD0E0C3A`

--- a/articles/advanced/application-lifecycle.asciidoc
+++ b/articles/advanced/application-lifecycle.asciidoc
@@ -10,7 +10,7 @@ layout: page
 = Application Lifecycle
 
 This section goes into more technical details of application deployment, user sessions, and the UI instance lifecycle.
-These details aren't needed for writing Vaadin applications, but may be useful for understanding how they actually work and, especially, in what circumstances their execution ends.
+These details aren't needed for writing Vaadin applications, but may be useful for understanding how they actually work and in what circumstances their execution ends.
 
 [[application.lifecycle.deployment]]
 == Deployment
@@ -18,7 +18,7 @@ These details aren't needed for writing Vaadin applications, but may be useful f
 Before a Vaadin application can be used, it has to be deployed to a Java web server.
 The deployment process reads the servlet classes annotated with the `@WebServlet` annotation or the [filename]`web.xml` deployment descriptor in the application to register servlets for specific URL paths.
 It then loads the classes.
-Deployment doesn't yet usually run any code in the application, although static blocks in classes are executed when they are loaded.
+Deployment doesn't usually run any code yet in the application, although static blocks in classes are executed when they are loaded.
 
 A servlet class should extend the [classname]`VaadinServlet` class.
 However, there is no need to define your own servlet class if you are using the Servlet 3.1 specification.
@@ -69,7 +69,7 @@ This listener allows you, among other things, to add a [interfacename]`RequestHa
 A user session begins when a user first makes a request to a Vaadin servlet by opening the URL of a particular [classname]`UI`.
 All server requests belonging to a particular UI class are processed by the [classname]`VaadinServlet` class.
 When a new client connects, it creates a new user session, represented by an instance of [classname]`VaadinSession`.
-User sessions are stored in the HTTP session and tracked using cookies stored in the browser.
+User sessions are stored in the HTTP session and tracked using cookies that are stored in the browser.
 
 You can get the [classname]`VaadinSession` of a [classname]`UI` with [methodname]`getSession()`, or globally with [methodname]`VaadinSession.getCurrent()`.
 It also provides access to the lower-level session object [interfacename]`HttpSession`, through a [classname]`WrappedSession`.
@@ -96,8 +96,8 @@ The method gets the request as a [classname]`VaadinRequest`.
 
 The HTML content of the loader page is generated as an HTML `DOM` object, which can be customized by implementing an [interfacename]`IndexHtmlRequestListener` that modifies the `DOM` object.
 To do this, you need to extend the [classname]`VaadinServlet` and add a [interfacename]`SessionInitListener` to the service object, as outlined in <<application.lifecycle.session>>.
-You can then add the bootstrap listener to a user session with
-[methodname]`addIndexHtmlRequestListener()` when the session is initialized.
+You can then add the bootstrap listener to a user session with the 
+[methodname]`addIndexHtmlRequestListener()` method when the session is initialized.
 
 Loading the widget set is handled in the loader page with functions defined in a separate [filename]`BootstrapHandler.js` script, whose content is included inline in the page.
 
@@ -145,9 +145,9 @@ You can make it happen more quickly by increasing the UI heartbeat frequency, or
 == User Session Expiration
 
 ((("session", "expiration")))
-A user session is kept alive by server requests caused by user interaction with the application, as well as by the heartbeat-monitoring mechanism of the UIs.
+A user session is kept alive by server requests that are caused by user interacting with the application, as well as by the UIs heartbeat-monitoring mechanism.
 When all UIs have expired, the user session still remains.
-It's cleaned up from the server when the HTTP session timeout configured in the web application elapses, and the whole HTTP session is invalidated.
+It's removed from the server when the HTTP session timeout configured in the web application elapses, and the whole HTTP session is invalidated.
 
 ((("closeIdleSessions")))
 If there are active UIs in an application, their heartbeat keeps the user session and underlying HTTP session alive indefinitely.
@@ -160,10 +160,10 @@ This is the original purpose of the session timeout setting.
 If the [parameter]#closeIdleSessions# deployment configuration parameter of the servlet is set to `true`, the closure mechanism works as follows.
 
 The user session and all its UIs are closed when the timeout specified by the [parameter]#session-timeout# parameter of the servlet elapses after the last non-heartbeat request.
-After the user session is gone, a `Session expired` notification is sent to the browser on the next server request, and the client-engine handles it based on to the [classname]`SystemMessages` settings.
+After the user session is gone, a `Session expired` notification is sent to the browser on the next server request and the client-engine handles it based on the [classname]`SystemMessages` settings.
 
-By default, it reloads the current page, effectively creating a new user session, but it can be configured to also shows a notification to the user before reloading the page.
-Furthermore, it is possible to customize the notification messages and set a URL to redirect the browser to, instead of reloading the current page.
+By default, it reloads the current page creating a new user session, but it can also be configured to show a notification to the user before reloading the page.
+Furthermore, it is possible to customize the notification message and set a URL where to redirect the browser instead of reloading the current page.
 For example, setting a URL that points to a static page is useful to prevent the creation of a new user session.
 
 See <<customize-system-messages#,Customize System Messages>> to configure user session expiration, and <<{articles}/configuration/properties#,Configuration Properties>> for information on setting configuration parameters.
@@ -181,8 +181,8 @@ HTTP session invalidation can be performed by invoking [methodname]`invalidate` 
 == Closing a User Session
 
 You can close a user session by calling [methodname]`close()` on the [classname]`VaadinSession`.
-This is typically used when logging a user out, as the User session and all the UIs belonging to the User session should be closed.
-The user session is closed immediately and any objects related to it are unavailable after calling the method.
+This is typically used when logging a user out, as the user session and all the UIs belonging to the user session should be closed.
+Calling the method closes the user session and makes any related objects unavailable.
 
 ((("logout")))
 


### PR DESCRIPTION
Clarified that Vaadin session expiration does not imply HTTP session invalidation.
Documented the client side behavior on session expiration and customization options.

Closes #1954


