### PR TITLE
docs: update menu bar styling menu items example

### DIFF
--- a/articles/components/menu-bar/index.asciidoc
+++ b/articles/components/menu-bar/index.asciidoc
@@ -91,13 +91,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarRightAlig
 
 === Styling Menu Items
 
-An individual menu item can be styled using a <<{articles}/styling/custom-theme/custom-component-variants#, custom variant>>.
+An individual menu item can be styled using custom theme variants.
+A custom variant can be created by adding a custom theme name, such as `custom-theme`, to an item, and then adding respective CSS for styling all items using that theme name.
 
-To style a root-level item, create a custom variant for the `vaadin-menu-bar-button` component.
-
-To style a sub-menu item, create a custom variant for the `vaadin-context-menu-item` component.
-
-See <<{articles}/styling/custom-theme/creating-custom-theme#vaadin-component-styles, Vaadin Component Variants>> for details of how to add style sheets for these components.
+The following example shows how to add a custom theme variant named `custom-theme` to individual menu bar buttons and items, and how to style that variant through CSS:
 
 [.example]
 --
@@ -114,12 +111,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarCustomThe
 
 [source,css]
 ----
-include::{root}/frontend/themes/docs/components/vaadin-context-menu-item.css[]
-----
-
-[source,css]
-----
-include::{root}/frontend/themes/docs/components/vaadin-menu-bar-button.css[]
+include::{root}/frontend/themes/docs/menu-bar-custom-theme.css[]
 ----
 
 --

--- a/frontend/themes/docs/components/vaadin-context-menu-item.css
+++ b/frontend/themes/docs/components/vaadin-context-menu-item.css
@@ -1,3 +1,0 @@
-:host([theme~='custom-theme']) {
-    text-transform: uppercase;
-}

--- a/frontend/themes/docs/components/vaadin-menu-bar-button.css
+++ b/frontend/themes/docs/components/vaadin-menu-bar-button.css
@@ -1,3 +1,0 @@
-:host([theme~='custom-theme']) {
-    text-transform: uppercase;
-}

--- a/frontend/themes/docs/menu-bar-custom-theme.css
+++ b/frontend/themes/docs/menu-bar-custom-theme.css
@@ -1,0 +1,9 @@
+/* Add this to your global CSS, for example in: */
+/* frontend/theme/[my-theme]/styles.css */
+
+/* Use vaadin-menu-bar-button to style root menu items */
+/* Use vaadin-menu-bar-item to style sub-menu items */
+vaadin-menu-bar-button[theme~="custom-theme"],
+vaadin-menu-bar-item[theme~="custom-theme"] {
+    text-transform: uppercase;
+}

--- a/frontend/themes/docs/styles.css
+++ b/frontend/themes/docs/styles.css
@@ -6,6 +6,7 @@
 @import './notification-position-example.css';
 @import './board.css';
 @import './grid-cell-focus.css';
+@import './menu-bar-custom-theme.css';
 
 html,
 :host {


### PR DESCRIPTION
Updates the menubar custom item styling example to use global CSS. The text is also rewritten as the referenced theme variant sections have been removed in favor of using class names. However as menu bar items do not support class names as of now, we need to provide some additional explanation around theme variants.