### PR TITLE
Reorganized production build chapter

### DIFF
--- a/articles/lit/guides/production/production-build.asciidoc
+++ b/articles/lit/guides/production/production-build.asciidoc
@@ -6,7 +6,7 @@ order: 10
 
 // TODO partly outdated (mentions of webpack at least)
 
-= Creating a production build
+= Production build
 
 By default, Hilla applications are configured to run in development mode.
 This requires a bit more memory and CPU power, but enables easier debugging.
@@ -49,6 +49,8 @@ The actual content of the profile depends on what environment your application i
 . Set the property `vaadin.productionMode` to `true`
 . Call the Maven goal `vaadin:build-frontend`.
 The Maven goal `vaadin:prepare-frontend` is also required, but this is often already declared in the development build.
+
+== Creating a production build
 
 To create a production build, you can call `mvn clean package -Pproduction`.
 This builds a `JAR` or `WAR` file with all the dependencies and transpiled front-end resources, ready to be deployed.


### PR DESCRIPTION
Made it possible to link directly to the production build command and changed the title to match the navigation


