### PR TITLE
docs: explain Custom Field value type and format

### DIFF
--- a/articles/components/custom-field/index.asciidoc
+++ b/articles/components/custom-field/index.asciidoc
@@ -12,7 +12,7 @@ page-links:
 // tag::description[]
 Custom Field is a component for wrapping multiple components as a single field.
 // end::description[]
-It has the same features as <<{components-path-prefix}input-fields#,Input Fields>>, such as its own label, helper, validation, and data binding.
+It has the same features as <<{components-path-prefix}input-fields#,Input Fields>>, such as its label, helper, validation, and data binding.
 Use it to create custom input components.
 
 [.example]
@@ -57,17 +57,17 @@ Custom Field is optimized for wrapping the following components:
 * <<../date-picker#,Date Picker>>
 * <<../time-picker#,Time Picker>>
 
-It can also be used to provide a label, helper, and the other field features, for components that don't have them built-in, such as <<../list-box#,List Box>>.
+It can also be used to give a label, helper, and other field features for components that don't have them built-in, such as <<../list-box#,List Box>>.
 
 == Value Type and Format
 
-Custom Field handles the value type and format differently in Java and TypeScript.
+Custom Field handles the value types and formats differently in Java and TypeScript.
 
 === Java
 
-Custom Field is a generic class that requires a value type. The value type can be anything: String, List, a bean, etc.
+Custom Field is a generic class that requires a value type. The value type can be anything: String, List, a bean, and so forth.
 
-In addition to that, you must implement the `generateModelValue` and `setPresentationValue` methods which define how to build the Custom Field value from the child component values and how to propagate the Custom Field value to the child components respectively.
+Implement the `generateModelValue` and `setPresentationValue` methods to define how to build the Custom Field value from the child component values and how to propagate the Custom Field value to the child components respectively.
 
 The following example shows how to set up value propagation, using a bean as the value type:
 
@@ -155,7 +155,7 @@ render() {
 
 Custom Field works with native HTML elements.
 
-The `whitespace` variant can be used when components without an outer margin are used within Custom Field, to compensate for the missing space between the label and the component itself.
+The `whitespace` variant can be used when components without an outer margin are used within Custom Field to compensate for the missing space between the label and the component itself.
 
 [.example]
 --

--- a/articles/components/custom-field/index.asciidoc
+++ b/articles/components/custom-field/index.asciidoc
@@ -123,7 +123,7 @@ class PhoneField extends CustomField<Phone> {
 
 Custom Field only supports string values. The default value format is a string concatenation of the child component values, separated by the `\t` character.
 
-You can customize the value format by providing your own value formatter and parser, as shown in the following example:
+You can customize the value format by defining your own value formatter and parser, as shown in the following example:
 
 [.example]
 --

--- a/articles/components/custom-field/index.asciidoc
+++ b/articles/components/custom-field/index.asciidoc
@@ -67,7 +67,7 @@ Custom Field handles the value type and format differently in Java and TypeScrip
 
 Custom Field is a generic class that requires a value type. The value type can be anything: String, List, a bean, etc.
 
-In addition to that, you must provide the `generateModelValue` and `setPresentationValue` methods which specify how to build the Custom Field value from the child component values and how to propagate the Custom Field value to the child components respectively.
+In addition to that, you must implement the `generateModelValue` and `setPresentationValue` methods which define how to build the Custom Field value from the child component values and how to propagate the Custom Field value to the child components respectively.
 
 The following example shows how to set up value propagation, using a bean as the value type:
 

--- a/articles/components/custom-field/index.asciidoc
+++ b/articles/components/custom-field/index.asciidoc
@@ -59,6 +59,84 @@ Custom Field is optimized for wrapping the following components:
 
 It can also be used to provide a label, helper, and the other field features, for components that don't have them built-in, such as <<../list-box#,List Box>>.
 
+== Value Type and Format
+
+Custom Field handles the value type and format differently in Java and TypeScript.
+
+=== Java
+
+Custom Field is a generic class that requires a value type. The value type can be anything: String, a bean, etc.
+
+In addition to that, you must provide the `generateModelValue` and `setPresentationValue` methods which specify how to build Custom Field's value from the child component values and how to propagate Custom Field's value to the child components respectively.
+
+The following example shows how to set up the value propagation:
+
+[.example]
+--
+
+[source,java]
+----
+class ExpirationField extends CustomField<String> {
+  private final Select month = new Select();
+  private final Select year = new Select();
+
+  public ExpirationField() {
+    add(month, year);
+  }
+
+  ...
+
+  @Override
+  protected String generateModelValue() {
+    if (month.getValue() == month.getEmptyValue() ||
+        year.getValue() == year.getEmptyValue()) {
+      return null;
+    }
+
+    return String.join(
+        month.getValue().getString(),
+        year.getValue().getString());
+  }
+
+  @Override
+  protected void setPresentationValue(String value) {
+    String[] valueParts = value.split("/");
+    month.setValue(valueParts[0]);
+    year.setValue(valueParts[1]);
+  }
+}
+----
+--
+
+=== TypeScript
+
+Custom Field only supports string values. The default value format is a string concatenation of the child component values, separated by the `\t` character.
+
+You can customize the value format by providing a custom value formatter and parser, as shown in the following example:
+
+[.example]
+--
+
+[source,typescript]
+----
+render() {
+  return html`
+    <vaadin-custom-field
+      .parseValue="${(value: string) => {
+        return value ? value.split('/') : ['', ''];
+      }}"
+      .formatValue="${(values: unknown[]) => {
+        return values[0] && values[1] ? values.join('/') : '';
+      }}"
+    >
+      <vaadin-select title="Month">...</vaadin-select>
+      <vaadin-select title="Year">...</vaadin-select>
+    </vaadin-custom-field>
+  `
+}
+----
+--
+
 == Native Input Fields
 
 Custom Field works with native HTML elements.

--- a/articles/components/custom-field/index.asciidoc
+++ b/articles/components/custom-field/index.asciidoc
@@ -118,7 +118,6 @@ class PhoneField extends CustomField<Phone> {
 ----
 --
 
-
 === TypeScript
 
 Custom Field only supports string values. The default value format is a string concatenation of the child component values, separated by the `\t` character.
@@ -132,20 +131,20 @@ You can customize the value format by defining your own value formatter and pars
 ----
 render() {
   return html`
+    <!-- Phone Custom Field -->
     <vaadin-custom-field
-      .parseValue="${(value: string) => {
-        return value ? value.split('/') : ['', ''];
+      .formatValue="${([code, number]: unknown[]) => {
+        return code && number ? [code, number].join('|') : '';
       }}"
-      .formatValue="${(values: unknown[]) => {
-        return values[0] && values[1] ? values.join('/') : '';
+      .parseValue="${(value: string) => {
+        return value ? value.split('|') : ['', ''];
       }}"
     >
-      <vaadin-select title="Month">
-        ...
-      </vaadin-select>
-      <vaadin-select title="Year">
-        ...
-      </vaadin-select>
+      <!-- Country code -->
+      <vaadin-select></vaadin-select>
+
+      <!-- Phone number -->
+      <vaadin-text-field></vaadin-text-field>
     </vaadin-custom-field>
   `
 }

--- a/articles/components/custom-field/index.asciidoc
+++ b/articles/components/custom-field/index.asciidoc
@@ -65,54 +65,65 @@ Custom Field handles the value type and format differently in Java and TypeScrip
 
 === Java
 
-Custom Field is a generic class that requires a value type. The value type can be anything: String, a bean, etc.
+Custom Field is a generic class that requires a value type. The value type can be anything: String, List, a bean, etc.
 
-In addition to that, you must provide the `generateModelValue` and `setPresentationValue` methods which specify how to build Custom Field's value from the child component values and how to propagate Custom Field's value to the child components respectively.
+In addition to that, you must provide the `generateModelValue` and `setPresentationValue` methods which specify how to build the Custom Field value from the child component values and how to propagate the Custom Field value to the child components respectively.
 
-The following example shows how to set up the value propagation:
+The following example shows how to set up value propagation, using a bean as the value type:
 
 [.example]
 --
 
-[source,java]
+[source, java]
 ----
-class ExpirationField extends CustomField<String> {
-  private final Select month = new Select();
-  private final Select year = new Select();
+class Phone {
+    private final String code;
+    private final String number;
 
-  public ExpirationField() {
-    add(month, year);
-  }
-
-  ...
-
-  @Override
-  protected String generateModelValue() {
-    if (month.getValue() == month.getEmptyValue() ||
-        year.getValue() == year.getEmptyValue()) {
-      return null;
+    public Phone(String code, String number) {
+        this.code = code;
+        this.number = number;
     }
 
-    return String.join(
-        month.getValue().getString(),
-        year.getValue().getString());
-  }
+    public String getCode() {
+        return code;
+    }
 
-  @Override
-  protected void setPresentationValue(String value) {
-    String[] valueParts = value.split("/");
-    month.setValue(valueParts[0]);
-    year.setValue(valueParts[1]);
-  }
+    public String getNumber() {
+        return number;
+    }
+}
+
+class PhoneField extends CustomField<Phone> {
+    private final Select code = new Select();
+    private final TextField number = new TextField();
+
+    public PhoneField() {
+        ...
+
+        add(code, number);
+    }
+
+    @Override
+    protected String generateModelValue() {
+        return new Phone(code.getValue(), number.getValue());
+    }
+
+    @Override
+    protected void setPresentationValue(Phone value) {
+        code.setValue(value.getCode());
+        number.setValue(value.getNumber());
+    }
 }
 ----
 --
+
 
 === TypeScript
 
 Custom Field only supports string values. The default value format is a string concatenation of the child component values, separated by the `\t` character.
 
-You can customize the value format by providing a custom value formatter and parser, as shown in the following example:
+You can customize the value format by providing your own value formatter and parser, as shown in the following example:
 
 [.example]
 --
@@ -129,8 +140,12 @@ render() {
         return values[0] && values[1] ? values.join('/') : '';
       }}"
     >
-      <vaadin-select title="Month">...</vaadin-select>
-      <vaadin-select title="Year">...</vaadin-select>
+      <vaadin-select title="Month">
+        ...
+      </vaadin-select>
+      <vaadin-select title="Year">
+        ...
+      </vaadin-select>
     </vaadin-custom-field>
   `
 }


### PR DESCRIPTION
Added a section explaining the difference between how Custom Field handles the value type and format in Java and TypeScript.

Fixes #1941 