### PR TITLE
fix: fix link to API documentation

### DIFF
--- a/articles/api.adoc
+++ b/articles/api.adoc
@@ -9,7 +9,7 @@ layout: index
 
 The Application Programming Interface (API) documentation for all Java classes and interfaces.
 
-link:https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/[Javadoc, role="button primary water"]
+link:https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/index.html[Javadoc, role="button primary water"]
 
 == Shortcuts
 


### PR DESCRIPTION
The "Javadoc" button in https://vaadin.com/docs/latest/api links to https://vaadin.com/api/platform/23.3.6/ which redirects to https://vaadin.com/api/api/platform/23.3.6/index.html (404) instead of https://vaadin.com/api/platform/23.3.6/index.html