### PR TITLE
Extended essential steps

### DIFF
--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -33,6 +33,7 @@ Vaadin 24 doesn't fundamentally change how applications are developed and behave
 * Upgrade third-party dependencies used in your project (such as, Maven/Gradle plugins, libraries, frameworks) to the Jakarta and Spring-compatible versions.
 * Check if your application is not using deprecated code fragments.
 * Make sure your application runs well on Java 17 runtime.
+* If you have used Webpack, it is recommended to check, if your application also build, runs and appears the same with Vite.
 
 == Limitations
 


### PR DESCRIPTION
A major issue switching to V23 can be, that Webpack was used beforehand. Switching to Vite can lead to a lot of compiling issues with Typescript or different appearance of the application due to its handling of css imports in Javascript.


