### PR TITLE
fix: adjust details and accordion TS examples to V24 API

### DIFF
--- a/frontend/demo/component/accordion/accordion-basic.ts
+++ b/frontend/demo/component/accordion/accordion-basic.ts
@@ -20,9 +20,7 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>
-        <vaadin-accordion-panel>
-          <div slot="summary">Personal information</div>
-
+        <vaadin-accordion-panel summary="Personal information">
           <vaadin-vertical-layout>
             <span>Sophia Williams</span>
             <span>sophia.williams@company.com</span>
@@ -31,9 +29,7 @@ export class Example extends LitElement {
         </vaadin-accordion-panel>
         <!-- end::snippet[] -->
 
-        <vaadin-accordion-panel>
-          <div slot="summary">Billing address</div>
-
+        <vaadin-accordion-panel summary="Billing address">
           <vaadin-vertical-layout>
             <span>4027 Amber Lake Canyon</span>
             <span>72333-5884 Cozy Nook</span>
@@ -41,9 +37,7 @@ export class Example extends LitElement {
           </vaadin-vertical-layout>
         </vaadin-accordion-panel>
 
-        <vaadin-accordion-panel>
-          <div slot="summary">Payment</div>
-
+        <vaadin-accordion-panel summary="Payment">
           <vaadin-vertical-layout>
             <span>MasterCard</span>
             <span>1234 5678 9012 3456</span>

--- a/frontend/demo/component/accordion/accordion-content.ts
+++ b/frontend/demo/component/accordion/accordion-content.ts
@@ -27,9 +27,7 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>
-        <vaadin-accordion-panel>
-          <div slot="summary">Analytics</div>
-
+        <vaadin-accordion-panel summary="Analytics">
           <vaadin-vertical-layout>
             <a href="#">Dashboard</a>
             <a href="#">Reports</a>
@@ -38,18 +36,14 @@ export class Example extends LitElement {
         </vaadin-accordion-panel>
         <!-- end::snippet[] -->
 
-        <vaadin-accordion-panel>
-          <div slot="summary">Customers</div>
-
+        <vaadin-accordion-panel summary="Customers">
           <vaadin-vertical-layout>
             <a href="#">Accounts</a>
             <a href="#">Contacts</a>
           </vaadin-vertical-layout>
         </vaadin-accordion-panel>
 
-        <vaadin-accordion-panel>
-          <div slot="summary">Finances</div>
-
+        <vaadin-accordion-panel summary="Finances">
           <vaadin-vertical-layout>
             <a href="#">Invoices</a>
             <a href="#">Transactions</a>

--- a/frontend/demo/component/accordion/accordion-disabled-panels.ts
+++ b/frontend/demo/component/accordion/accordion-disabled-panels.ts
@@ -21,9 +21,7 @@ export class Example extends LitElement {
       <!-- tag::snippet[] -->
       <vaadin-accordion>
         <!-- end::snippet[] -->
-        <vaadin-accordion-panel>
-          <div slot="summary">Personal information</div>
-
+        <vaadin-accordion-panel summary="Personal information">
           <vaadin-vertical-layout>
             <span>Sophia Williams</span>
             <span>sophia.williams@company.com</span>
@@ -31,9 +29,7 @@ export class Example extends LitElement {
           </vaadin-vertical-layout>
         </vaadin-accordion-panel>
 
-        <vaadin-accordion-panel disabled>
-          <div slot="summary">Billing address</div>
-
+        <vaadin-accordion-panel summary="Billing address" disabled>
           <vaadin-vertical-layout>
             <span>4027 Amber Lake Canyon</span>
             <span>72333-5884 Cozy Nook</span>
@@ -41,10 +37,7 @@ export class Example extends LitElement {
           </vaadin-vertical-layout>
         </vaadin-accordion-panel>
 
-        <!-- tag::snippet[] -->
-        <vaadin-accordion-panel disabled>
-          <div slot="summary">Payment</div>
-
+        <vaadin-accordion-panel summary="Payment" disabled>
           <vaadin-vertical-layout>
             <span>MasterCard</span>
             <span>1234 5678 9012 3456</span>

--- a/frontend/demo/component/accordion/accordion-filled-panels.ts
+++ b/frontend/demo/component/accordion/accordion-filled-panels.ts
@@ -20,9 +20,7 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>
-        <vaadin-accordion-panel theme="filled">
-          <div slot="summary">Personal information</div>
-
+        <vaadin-accordion-panel summary="Personal information" theme="filled">
           <vaadin-vertical-layout>
             <span>Sophia Williams</span>
             <span>sophia.williams@company.com</span>
@@ -31,9 +29,7 @@ export class Example extends LitElement {
         </vaadin-accordion-panel>
         <!-- end::snippet[] -->
 
-        <vaadin-accordion-panel theme="filled">
-          <div slot="summary">Billing address</div>
-
+        <vaadin-accordion-panel summary="Billing address" theme="filled">
           <vaadin-vertical-layout>
             <span>4027 Amber Lake Canyon</span>
             <span>72333-5884 Cozy Nook</span>
@@ -41,9 +37,7 @@ export class Example extends LitElement {
           </vaadin-vertical-layout>
         </vaadin-accordion-panel>
 
-        <vaadin-accordion-panel theme="filled">
-          <div slot="summary">Payment</div>
-
+        <vaadin-accordion-panel summary="Payment" theme="filled">
           <vaadin-vertical-layout>
             <span>MasterCard</span>
             <span>1234 5678 9012 3456</span>

--- a/frontend/demo/component/accordion/accordion-reverse-panels.ts
+++ b/frontend/demo/component/accordion/accordion-reverse-panels.ts
@@ -20,9 +20,7 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>
-        <vaadin-accordion-panel theme="reverse">
-          <div slot="summary">Personal information</div>
-
+        <vaadin-accordion-panel summary="Personal information" theme="reverse">
           <vaadin-vertical-layout>
             <span>Sophia Williams</span>
             <span>sophia.williams@company.com</span>
@@ -31,9 +29,7 @@ export class Example extends LitElement {
         </vaadin-accordion-panel>
         <!-- end::snippet[] -->
 
-        <vaadin-accordion-panel theme="reverse">
-          <div slot="summary">Billing address</div>
-
+        <vaadin-accordion-panel summary="Billing address" theme="reverse">
           <vaadin-vertical-layout>
             <span>4027 Amber Lake Canyon</span>
             <span>72333-5884 Cozy Nook</span>
@@ -41,9 +37,7 @@ export class Example extends LitElement {
           </vaadin-vertical-layout>
         </vaadin-accordion-panel>
 
-        <vaadin-accordion-panel theme="reverse">
-          <div slot="summary">Payment</div>
-
+        <vaadin-accordion-panel summary="Payment" theme="reverse">
           <vaadin-vertical-layout>
             <span>MasterCard</span>
             <span>1234 5678 9012 3456</span>

--- a/frontend/demo/component/accordion/accordion-small-panels.ts
+++ b/frontend/demo/component/accordion/accordion-small-panels.ts
@@ -20,9 +20,7 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-accordion>
-        <vaadin-accordion-panel theme="small">
-          <div slot="summary">Personal information</div>
-
+        <vaadin-accordion-panel summary="Personal information" theme="small">
           <vaadin-vertical-layout>
             <span>Sophia Williams</span>
             <span>sophia.williams@company.com</span>
@@ -31,9 +29,7 @@ export class Example extends LitElement {
         </vaadin-accordion-panel>
         <!-- end::snippet[] -->
 
-        <vaadin-accordion-panel theme="small">
-          <div slot="summary">Billing address</div>
-
+        <vaadin-accordion-panel summary="Billing address" theme="small">
           <vaadin-vertical-layout>
             <span>4027 Amber Lake Canyon</span>
             <span>72333-5884 Cozy Nook</span>
@@ -41,9 +37,7 @@ export class Example extends LitElement {
           </vaadin-vertical-layout>
         </vaadin-accordion-panel>
 
-        <vaadin-accordion-panel theme="small">
-          <div slot="summary">Payment</div>
-
+        <vaadin-accordion-panel summary="Payment" theme="small">
           <vaadin-vertical-layout>
             <span>MasterCard</span>
             <span>1234 5678 9012 3456</span>

--- a/frontend/demo/component/accordion/accordion-summary.ts
+++ b/frontend/demo/component/accordion/accordion-summary.ts
@@ -7,6 +7,7 @@ import '@vaadin/button';
 import '@vaadin/combo-box';
 import '@vaadin/email-field';
 import '@vaadin/form-layout';
+import '@vaadin/horizontal-layout';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import type { AccordionOpenedChangedEvent } from '@vaadin/accordion';
@@ -59,15 +60,19 @@ export class Example extends LitElement {
       >
         <vaadin-accordion-panel>
           <vaadin-accordion-heading slot="summary">
-            Customer details
-            <vaadin-vertical-layout
-              .hidden="${this.openedPanelIndex === 0}"
-              style="font-size: var(--lumo-font-size-s)"
-            >
-              <span>${this.personBinder.value.firstName} ${this.personBinder.value.lastName}</span>
-              <span>${this.personBinder.value.email}</span>
-              <span>${this.personBinder.value.address?.phone}</span>
-            </vaadin-vertical-layout>
+            <vaadin-horizontal-layout style="width: 100%; align-items: center">
+              Customer details
+              <vaadin-vertical-layout
+                .hidden="${this.openedPanelIndex === 0}"
+                style="font-size: var(--lumo-font-size-s); margin-left: auto"
+              >
+                <span>
+                  ${this.personBinder.value.firstName} ${this.personBinder.value.lastName}
+                </span>
+                <span>${this.personBinder.value.email}</span>
+                <span>${this.personBinder.value.address?.phone}</span>
+              </vaadin-vertical-layout>
+            </vaadin-horizontal-layout>
           </vaadin-accordion-heading>
           <!-- end::snippet[] -->
 
@@ -103,23 +108,25 @@ export class Example extends LitElement {
 
         <vaadin-accordion-panel>
           <vaadin-accordion-heading slot="summary">
-            Billing address
-            <vaadin-vertical-layout
-              .hidden="${this.openedPanelIndex === 1}"
-              style="font-size: var(--lumo-font-size-s)"
-            >
-              <span>${this.personBinder.value.address?.street}</span>
-              <span>
-                ${this.personBinder.value.address?.zip} ${this.personBinder.value.address?.city}
-              </span>
+            <vaadin-horizontal-layout style="width: 100%; align-items: center">
+              Billing address
+              <vaadin-vertical-layout
+                .hidden="${this.openedPanelIndex === 1}"
+                style="font-size: var(--lumo-font-size-s); margin-left: auto"
+              >
+                <span>${this.personBinder.value.address?.street}</span>
+                <span>
+                  ${this.personBinder.value.address?.zip} ${this.personBinder.value.address?.city}
+                </span>
 
-              <span>
-                ${
-                  // @ts-expect-error Workaround a Binder issue
-                  this.personBinder.value.address?.country?.name
-                }
-              </span>
-            </vaadin-vertical-layout>
+                <span>
+                  ${
+                    // @ts-expect-error Workaround a Binder issue
+                    this.personBinder.value.address?.country?.name
+                  }
+                </span>
+              </vaadin-vertical-layout>
+            </vaadin-horizontal-layout>
           </vaadin-accordion-heading>
 
           <vaadin-form-layout .responsiveSteps="${responsiveSteps}">
@@ -156,14 +163,16 @@ export class Example extends LitElement {
 
         <vaadin-accordion-panel>
           <vaadin-accordion-heading slot="summary">
-            Payment
-            <vaadin-vertical-layout
-              .hidden="${this.openedPanelIndex === 2}"
-              style="font-size: var(--lumo-font-size-s)"
-            >
-              <span>${this.cardBinder.value.accountNumber}</span>
-              <span>${this.cardBinder.value.expiryDate}</span>
-            </vaadin-vertical-layout>
+            <vaadin-horizontal-layout style="width: 100%; align-items: center">
+              Payment
+              <vaadin-vertical-layout
+                .hidden="${this.openedPanelIndex === 2}"
+                style="font-size: var(--lumo-font-size-s); margin-left: auto"
+              >
+                <span>${this.cardBinder.value.accountNumber}</span>
+                <span>${this.cardBinder.value.expiryDate}</span>
+              </vaadin-vertical-layout>
+            </vaadin-horizontal-layout>
           </vaadin-accordion-heading>
 
           <vaadin-form-layout .responsiveSteps="${responsiveSteps}">

--- a/frontend/demo/component/accordion/accordion-summary.ts
+++ b/frontend/demo/component/accordion/accordion-summary.ts
@@ -58,7 +58,7 @@ export class Example extends LitElement {
         }}"
       >
         <vaadin-accordion-panel>
-          <div slot="summary">
+          <vaadin-accordion-heading slot="summary">
             Customer details
             <vaadin-vertical-layout
               .hidden="${this.openedPanelIndex === 0}"
@@ -68,7 +68,7 @@ export class Example extends LitElement {
               <span>${this.personBinder.value.email}</span>
               <span>${this.personBinder.value.address?.phone}</span>
             </vaadin-vertical-layout>
-          </div>
+          </vaadin-accordion-heading>
           <!-- end::snippet[] -->
 
           <vaadin-form-layout .responsiveSteps="${responsiveSteps}">
@@ -102,7 +102,7 @@ export class Example extends LitElement {
         </vaadin-accordion-panel>
 
         <vaadin-accordion-panel>
-          <div slot="summary">
+          <vaadin-accordion-heading slot="summary">
             Billing address
             <vaadin-vertical-layout
               .hidden="${this.openedPanelIndex === 1}"
@@ -120,7 +120,7 @@ export class Example extends LitElement {
                 }
               </span>
             </vaadin-vertical-layout>
-          </div>
+          </vaadin-accordion-heading>
 
           <vaadin-form-layout .responsiveSteps="${responsiveSteps}">
             <vaadin-text-field
@@ -155,7 +155,7 @@ export class Example extends LitElement {
         </vaadin-accordion-panel>
 
         <vaadin-accordion-panel>
-          <div slot="summary">
+          <vaadin-accordion-heading slot="summary">
             Payment
             <vaadin-vertical-layout
               .hidden="${this.openedPanelIndex === 2}"
@@ -164,7 +164,7 @@ export class Example extends LitElement {
               <span>${this.cardBinder.value.accountNumber}</span>
               <span>${this.cardBinder.value.expiryDate}</span>
             </vaadin-vertical-layout>
-          </div>
+          </vaadin-accordion-heading>
 
           <vaadin-form-layout .responsiveSteps="${responsiveSteps}">
             <vaadin-text-field

--- a/frontend/demo/component/details/details-basic.ts
+++ b/frontend/demo/component/details/details-basic.ts
@@ -18,9 +18,7 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-details opened>
-        <div slot="summary">Contact information</div>
-
+      <vaadin-details summary="Contact information" opened>
         <vaadin-vertical-layout>
           <span>Sophia Williams</span>
           <span>sophia.williams@company.com</span>

--- a/frontend/demo/component/details/details-content.ts
+++ b/frontend/demo/component/details/details-content.ts
@@ -25,9 +25,7 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-details opened>
-        <div slot="summary">Analytics</div>
-
+      <vaadin-details summary="Analytics" opened>
         <vaadin-vertical-layout>
           <a href="#">Dashboard</a>
           <a href="#">Reports</a>
@@ -35,18 +33,14 @@ export class Example extends LitElement {
         </vaadin-vertical-layout>
       </vaadin-details>
 
-      <vaadin-details opened>
-        <div slot="summary">Customers</div>
-
+      <vaadin-details summary="Customers" opened>
         <vaadin-vertical-layout>
           <a href="#">Accounts</a>
           <a href="#">Contacts</a>
         </vaadin-vertical-layout>
       </vaadin-details>
 
-      <vaadin-details opened>
-        <div slot="summary">Finances</div>
-
+      <vaadin-details summary="Finances" opened>
         <vaadin-vertical-layout>
           <a href="#">Invoices</a>
           <a href="#">Transactions</a>

--- a/frontend/demo/component/details/details-disabled.ts
+++ b/frontend/demo/component/details/details-disabled.ts
@@ -17,9 +17,7 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-details disabled>
-        <div slot="summary">Members (8)</div>
-
+      <vaadin-details summary="Members (8)" disabled>
         <ul>
           <li>Blake Martin</li>
           <li>Caroline Clark</li>

--- a/frontend/demo/component/details/details-filled.ts
+++ b/frontend/demo/component/details/details-filled.ts
@@ -17,9 +17,7 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-details opened theme="filled">
-        <div slot="summary">Members (8)</div>
-
+      <vaadin-details summary="Members (8)" opened theme="filled">
         <ul>
           <li>Blake Martin</li>
           <li>Caroline Clark</li>

--- a/frontend/demo/component/details/details-reverse.ts
+++ b/frontend/demo/component/details/details-reverse.ts
@@ -17,9 +17,7 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-details opened theme="reverse">
-        <div slot="summary">Members (8)</div>
-
+      <vaadin-details summary="Members (8)" opened theme="reverse">
         <ul>
           <li>Blake Martin</li>
           <li>Caroline Clark</li>

--- a/frontend/demo/component/details/details-small.ts
+++ b/frontend/demo/component/details/details-small.ts
@@ -17,9 +17,7 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-details opened theme="small">
-        <div slot="summary">Members (8)</div>
-
+      <vaadin-details summary="Members (8)" opened theme="small">
         <ul>
           <li>Blake Martin</li>
           <li>Caroline Clark</li>

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -51,7 +51,7 @@ export class Example extends LitElement {
             >
               <vaadin-icon
                 icon="vaadin:exclamation-circle"
-                style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"
+                style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s); margin-right: var(--lumo-space-xs)"
               ></vaadin-icon>
               <span>2 errors</span>
             </vaadin-horizontal-layout>

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -42,22 +42,21 @@ export class Example extends LitElement {
   protected override render() {
     return html`
       <vaadin-details opened>
-        <vaadin-horizontal-layout
-          slot="summary"
-          style="justify-content: space-between; width: 100%;"
-        >
-          <span>Contact information</span>
+        <vaadin-details-summary slot="summary">
+          <vaadin-horizontal-layout style="justify-content: space-between; width: 100%;">
+            <span>Contact information</span>
 
-          <vaadin-horizontal-layout
-            style="color: var(--lumo-error-text-color); margin-left: var(--lumo-space-s)"
-          >
-            <vaadin-icon
-              icon="vaadin:exclamation-circle"
-              style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"
-            ></vaadin-icon>
-            <span>2 errors</span>
+            <vaadin-horizontal-layout
+              style="color: var(--lumo-error-text-color); margin-left: var(--lumo-space-s)"
+            >
+              <vaadin-icon
+                icon="vaadin:exclamation-circle"
+                style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"
+              ></vaadin-icon>
+              <span>2 errors</span>
+            </vaadin-horizontal-layout>
           </vaadin-horizontal-layout>
-        </vaadin-horizontal-layout>
+        </vaadin-details-summary>
 
         <vaadin-form-layout .responsiveSteps="${this.responsiveSteps}">
           <vaadin-text-field

--- a/frontend/demo/component/virtuallist/virtual-list-basic.ts
+++ b/frontend/demo/component/virtuallist/virtual-list-basic.ts
@@ -53,6 +53,7 @@ export class Example extends LitElement {
         <span>${person.profession}</span>
 
         <vaadin-details
+          summary="Contact information"
           .opened="${live(this.expandedPeople.has(person))}"
           @click="${(e: Event) => {
             const details = e.currentTarget as Details;
@@ -63,8 +64,6 @@ export class Example extends LitElement {
             }
           }}"
         >
-          <div slot="summary">Contact information</div>
-
           <vaadin-vertical-layout>
             <span>${person.email}</span>
             <span>${person.address.phone}</span>

--- a/frontend/demo/upgrade-tool/upgrade-tool.ts
+++ b/frontend/demo/upgrade-tool/upgrade-tool.ts
@@ -63,8 +63,7 @@ export default class UpgradeTool extends LitElement {
       <div>
         <h2>Select your Vaadin versions:</h2>
         <div style="margin-bottom: 10px">${this.createSelectComponents()}</div>
-        <vaadin-details>
-          <div slot="summary">Earlier Versions</div>
+        <vaadin-details summary="Earlier Versions">
           <ul style="margin-top: 0">
             <li>
               <a href="https://vaadin.com/docs/v14/flow/upgrading/v10-13/">


### PR DESCRIPTION
## Description

Updated `vaadin-details` and `vaadin-accordion` TS examples:

1. Changed to use `summary` property shorthand where it makes sense (in most of demos),
2. Updated other demos to use `vaadin-details-summary` and `vaadin-accordion-heading`.