### PR TITLE
fix: use HTML value in RTE examples

### DIFF
--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorBasic.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorBasic.java
@@ -13,8 +13,8 @@ public class RichTextEditorBasic extends Div {
         // tag::snippet[]
         RichTextEditor rte = new RichTextEditor();
         rte.setMaxHeight("400px");
-        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        String valueAsHtml = DataService.getTemplates().getRichTextHtml();
+        rte.setValue(valueAsHtml);
         add(rte);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorMinMaxHeight.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorMinMaxHeight.java
@@ -14,8 +14,8 @@ public class RichTextEditorMinMaxHeight extends Div {
         RichTextEditor rte = new RichTextEditor();
         rte.setMaxHeight("400px");
         rte.setMinHeight("200px");
-        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        String valueAsHtml = DataService.getTemplates().getRichTextHtml();
+        rte.setValue(valueAsHtml);
         add(rte);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorReadonly.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorReadonly.java
@@ -13,8 +13,8 @@ public class RichTextEditorReadonly extends Div {
         // tag::snippet[]
         RichTextEditor rte = new RichTextEditor();
         rte.setMaxHeight("400px");
-        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        String valueAsHtml = DataService.getTemplates().getRichTextHtml();
+        rte.setValue(valueAsHtml);
         rte.setReadOnly(true);
         add(rte);
         // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeCompact.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeCompact.java
@@ -14,8 +14,8 @@ public class RichTextEditorThemeCompact extends Div {
         // tag::snippet[]
         RichTextEditor rte = new RichTextEditor();
         rte.getStyle().set("max-height", "400px");
-        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        String valueAsHtml = DataService.getTemplates().getRichTextHtml();
+        rte.setValue(valueAsHtml);
         rte.addThemeVariants(RichTextEditorVariant.LUMO_COMPACT);
         add(rte);
         // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeNoBorder.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeNoBorder.java
@@ -14,8 +14,8 @@ public class RichTextEditorThemeNoBorder extends Div {
         // tag::snippet[]
         RichTextEditor rte = new RichTextEditor();
         rte.getStyle().set("max-height", "400px");
-        String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        String valueAsHtml = DataService.getTemplates().getRichTextHtml();
+        rte.setValue(valueAsHtml);
         rte.addThemeVariants(RichTextEditorVariant.LUMO_NO_BORDER);
         add(rte);
         // end::snippet[]

--- a/src/main/java/com/vaadin/demo/domain/Templates.java
+++ b/src/main/java/com/vaadin/demo/domain/Templates.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Templates {
 
     private String richTextDelta;
+    private String richTextHtml;
 
     private String loremIpsum;
 
@@ -15,6 +16,14 @@ public class Templates {
 
     public void setRichTextDelta(String richTextDelta) {
         this.richTextDelta = richTextDelta;
+    }
+
+    public String getRichTextHtml() {
+        return richTextHtml;
+    }
+
+    public void setRichTextHtml(String richTextHtml) {
+        this.richTextHtml = richTextHtml;
     }
 
     public String getLoremIpsum() {

--- a/src/main/java/com/vaadin/demo/domain/Templates.java
+++ b/src/main/java/com/vaadin/demo/domain/Templates.java
@@ -5,18 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Templates {
 
-    private String richTextDelta;
     private String richTextHtml;
 
     private String loremIpsum;
-
-    public String getRichTextDelta() {
-        return richTextDelta;
-    }
-
-    public void setRichTextDelta(String richTextDelta) {
-        this.richTextDelta = richTextDelta;
-    }
 
     public String getRichTextHtml() {
         return richTextHtml;


### PR DESCRIPTION
As part of updating the RTE docs for v24, I missed to update the remaining examples to initialize the editor with an HTML value. Now that the component has a validation check that prevents setting delta values, this breaks every single example.