### PR TITLE
fix: Incorrect date format in DateTimePicker example

### DIFF
--- a/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
@@ -1,9 +1,13 @@
 import 'Frontend/demo/init'; // hidden-source-line
 
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, query } from 'lit/decorators.js';
 import '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
+import type { DateTimePicker } from '@vaadin/date-time-picker';
+import dateFnsFormat from 'date-fns/format';
+import dateFnsParse from 'date-fns/parse';
+import type { DatePickerDate } from '@vaadin/date-picker';
 
 @customElement('date-time-picker-input-format')
 export class Example extends LitElement {
@@ -12,6 +16,30 @@ export class Example extends LitElement {
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
+  }
+
+  @query('vaadin-date-time-picker')
+  private dateTimePicker!: DateTimePicker;
+
+  protected override firstUpdated() {
+    const _formatDate = (dateParts: DatePickerDate): string => {
+      const { year, month, day } = dateParts;
+      const date = new Date(year, month, day);
+
+      return dateFnsFormat(date, 'dd/MM/yyyy');
+    };
+
+    const _parseDate = (inputValue: string): DatePickerDate => {
+      const date = dateFnsParse(inputValue, 'dd/MM/yyyy', new Date());
+
+      return { year: date.getFullYear(), month: date.getMonth(), day: date.getDate() };
+    };
+
+    this.dateTimePicker.i18n = {
+      ...this.dateTimePicker.i18n,
+      formatDate: _formatDate,
+      parseDate: _parseDate,
+    };
   }
 
   protected override render() {

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInputFormat.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInputFormat.java
@@ -1,5 +1,6 @@
 package com.vaadin.demo.component.datetimepicker;
 
+import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
@@ -11,8 +12,12 @@ public class DateTimePickerInputFormat extends Div {
 
     public DateTimePickerInputFormat() {
         // tag::snippet[]
+    	DatePickerI18n dateFormat = new DatePickerI18n();
+        dateFormat.setDateFormat("dd/MM/yyyy");
+        
         DateTimePicker dateTimePicker = new DateTimePicker();
         dateTimePicker.setLabel("Select date and time");
+        dateTimePicker.setDatePickerI18n(dateFormat);
         dateTimePicker.setHelperText("Format: DD/MM/YYYY and HH:MM");
         dateTimePicker.setDatePlaceholder("Date");
         dateTimePicker.setTimePlaceholder("Time");


### PR DESCRIPTION
Sets the date format to "dd/MM/yyyy" in both TS and Java examples so that the behaviour matches with what's written in helper text. Otherwise it takes the server locale into account.

Note that the time part in Java example still not correct because of https://github.com/vaadin/flow-components/issues/2831

Fixes https://github.com/vaadin/web-components/issues/172