### PR TITLE
docs: do not remove aria-labelledby when setting aria-label

### DIFF
--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -6,6 +6,8 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/select';
 import '@vaadin/text-field';
 import { applyTheme } from 'Frontend/generated/theme';
+import { TextField } from '@vaadin/text-field';
+import { Select } from '@vaadin/select';
 
 @customElement('custom-field-size-variants')
 export class Example extends LitElement {
@@ -16,11 +18,11 @@ export class Example extends LitElement {
     return root;
   }
 
-  @query('#amount > input')
-  private amount!: HTMLInputElement;
+  @query('#amount')
+  private amount!: TextField;
 
-  @query('#currency > [slot="value"]')
-  private currency!: HTMLElement;
+  @query('#currency')
+  private currency!: Select;
 
   @state()
   private currencies = [
@@ -35,11 +37,8 @@ export class Example extends LitElement {
 
   protected override firstUpdated() {
     // Set `aria-label` for screen readers
-    this.amount.setAttribute('aria-label', 'Amount');
-    this.amount.removeAttribute('aria-labelledby');
-
-    this.currency.setAttribute('aria-label', 'Currency');
-    this.currency.removeAttribute('aria-labelledby');
+    this.amount.focusElement!.setAttribute('aria-label', 'Amount');
+    this.currency.focusElement!.setAttribute('aria-label', 'Currency');
   }
 
   protected override render() {

--- a/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
@@ -21,20 +21,13 @@ public class MoneyField extends CustomField<Money> {
 
     public MoneyField() {
         amount = new TextField();
+        // Sets `aria-label` for screen readers
+        amount.getElement().executeJs("this.focusElement.setAttribute('aria-label', 'Amount');");
 
-        currency = new Select();
+        currency = new Select<>();
         currency.setItems("AUD", "CAD", "CHF", "EUR", "GBP", "JPY", "USD");
         currency.setWidth("6em");
-
-        // aria-label for screen readers
-        amount.getElement()
-                .executeJs("const amount = this.inputElement;"
-                        + "amount.setAttribute('aria-label', 'Amount');"
-                        + "amount.removeAttribute('aria-labelledby');");
-        currency.getElement()
-                .executeJs("const currency = this.focusElement;"
-                        + "currency.setAttribute('aria-label', 'Currency');"
-                        + "currency.removeAttribute('aria-labelledby');");
+        currency.getElement().executeJs("this.focusElement.setAttribute('aria-label', 'Currency');");
 
         HorizontalLayout layout = new HorizontalLayout(amount, currency);
         // Removes default spacing


### PR DESCRIPTION
The fields' `aria-labelledby` attribute no longer contains the label id if the label is empty, which means we don't have to remove `aria-labelledby` when setting `aria-label`.

Part of #1941 

Depends on:
- https://github.com/vaadin/web-components/pull/5577