### PR TITLE
fix: use lumo colors in the grid styling example

### DIFF
--- a/frontend/themes/docs/components/vaadin-grid-styling.css
+++ b/frontend/themes/docs/components/vaadin-grid-styling.css
@@ -1,11 +1,11 @@
 /* frontend/theme/[my-theme]/components/vaadin-grid.css */
 
 .high-rating {
-    background-color: #b1ffb7;
+    background-color: var(--lumo-success-color-10pct);
 }
 
 .low-rating {
-    background-color: #ffd9d9;
+    background-color: var(--lumo-error-color-10pct);
 }
 
 .font-weight-bold {


### PR DESCRIPTION
Fixes: https://github.com/vaadin/docs/issues/2024

Light:
![Screenshot 2023-02-15 at 14 53 03](https://user-images.githubusercontent.com/1222264/219032523-d2b63abd-74e2-4778-902e-d6c7c6a7738a.png)

Dark:
![Screenshot 2023-02-15 at 14 53 14](https://user-images.githubusercontent.com/1222264/219032553-7e459bcb-ae22-47af-a672-4184537498f9.png)