### PR TITLE
docs: update RTE value example to show Delta value

### DIFF
--- a/articles/components/rich-text-editor/index.asciidoc
+++ b/articles/components/rich-text-editor/index.asciidoc
@@ -122,7 +122,11 @@ Rich Text Editor natively uses the JSON-based https://github.com/quilljs/delta[D
 
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=htmlsnippet;snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=htmlsnippet,indent=0,group=TypeScript]
+
+...
+
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,java]

--- a/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
@@ -3,7 +3,11 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/rich-text-editor';
-import type { RichTextEditor, RichTextEditorChangeEvent } from '@vaadin/rich-text-editor';
+import type {
+  RichTextEditor,
+  RichTextEditorHtmlValueChangedEvent,
+  RichTextEditorValueChangedEvent,
+} from '@vaadin/rich-text-editor';
 import '@vaadin/text-area';
 import type { TextAreaChangeEvent } from '@vaadin/text-area';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -20,6 +24,9 @@ export class Example extends LitElement {
   @state()
   private htmlValue = '';
 
+  @state()
+  private deltaValue = '';
+
   @query('vaadin-rich-text-editor')
   private richTextEditor!: RichTextEditor;
 
@@ -28,17 +35,31 @@ export class Example extends LitElement {
       <!-- tag::htmlsnippet[] -->
       <vaadin-rich-text-editor
         style="height: 400px;"
-        @change="${(event: RichTextEditorChangeEvent) => {
-          this.htmlValue = event.target.htmlValue ?? '';
+        .value="${this.deltaValue}"
+        @value-changed="${(event: RichTextEditorValueChangedEvent) => {
+          this.deltaValue = event.detail.value;
+        }}"
+        @html-value-changed="${(event: RichTextEditorHtmlValueChangedEvent) => {
+          this.htmlValue = event.detail.value;
         }}"
       ></vaadin-rich-text-editor>
 
       <vaadin-text-area
-        label="Html Value"
-        @change="${(e: TextAreaChangeEvent) => this.setHtmlValue(e.target.value)}"
-        placeholder="Type html string here to set it as value to the Rich Text Editor above..."
+        label="HTML Value"
+        helper-text="Shows the HTML representation of the edited document. You can also modify or paste HTML here to see the changes reflected in the editor above. Note that you have to leave (blur) this field in order for the editor to update."
         style="width: 100%;"
         .value="${this.htmlValue}"
+        @change="${(e: TextAreaChangeEvent) => this.setHtmlValue(e.target.value)}"
+      ></vaadin-text-area>
+
+      <vaadin-text-area
+        label="Delta Value"
+        helper-text="Shows the Delta representation of the edited document. You can also modify or paste the Delta JSON here to see the changes reflected in the editor above. Note that you have to leave (blur) this field in order for the editor to update."
+        style="width: 100%;"
+        .value="${this.deltaValue}"
+        @change="${(e: TextAreaChangeEvent) => {
+          this.deltaValue = e.target.value;
+        }}"
       ></vaadin-text-area>
       <!-- end::htmlsnippet[] -->
     `;
@@ -46,7 +67,9 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   setHtmlValue(htmlValue: string) {
+    this.htmlValue = htmlValue;
     this.richTextEditor.dangerouslySetHtmlValue(htmlValue);
   }
+
   // end::snippet[]
 }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorBasic.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorBasic.java
@@ -14,7 +14,7 @@ public class RichTextEditorBasic extends Div {
         RichTextEditor rte = new RichTextEditor();
         rte.setMaxHeight("400px");
         String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        rte.asDelta().setValue(valueAsDelta);
         add(rte);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorMinMaxHeight.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorMinMaxHeight.java
@@ -15,7 +15,7 @@ public class RichTextEditorMinMaxHeight extends Div {
         rte.setMaxHeight("400px");
         rte.setMinHeight("200px");
         String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        rte.asDelta().setValue(valueAsDelta);
         add(rte);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorReadonly.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorReadonly.java
@@ -14,7 +14,7 @@ public class RichTextEditorReadonly extends Div {
         RichTextEditor rte = new RichTextEditor();
         rte.setMaxHeight("400px");
         String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        rte.asDelta().setValue(valueAsDelta);
         rte.setReadOnly(true);
         add(rte);
         // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java
@@ -3,29 +3,44 @@ package com.vaadin.demo.component.richtexteditor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.richtexteditor.RichTextEditor;
 import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+import java.util.Objects;
 
 @Route("rich-text-editor-set-get-value")
 public class RichTextEditorSetGetValue extends Div {
 
     public RichTextEditorSetGetValue() {
         // tag::snippet[]
-        TextArea textArea = new TextArea("Html Value",
-                "Type html string here to set it as value to the Rich Text Editor above...");
-        textArea.setWidthFull();
-
         RichTextEditor rte = new RichTextEditor();
         rte.getStyle().set("max-height", "400px");
+        rte.setValueChangeMode(ValueChangeMode.TIMEOUT);
 
-        rte.asHtml()
-                .addValueChangeListener(e -> textArea.setValue(e.getValue()));
-        textArea.addValueChangeListener(e -> {
-            if (!rte.asHtml().getValue().equals(e.getValue())) {
+        // HTML value
+        TextArea htmlTextArea = new TextArea("HTML Value");
+        htmlTextArea.setHelperText("Shows the HTML representation of the edited document. You can also modify or paste HTML here to see the changes reflected in the editor above. Note that you have to leave (blur) this field in order for the editor to update.");
+        htmlTextArea.setWidthFull();
+        rte.asHtml().addValueChangeListener(e -> htmlTextArea.setValue(e.getValue() == null ? "" : e.getValue()));
+        htmlTextArea.addValueChangeListener(e -> {
+            if (!Objects.equals(rte.asHtml().getValue(), e.getValue())) {
                 rte.asHtml().setValue(e.getValue());
             }
         });
-        add(rte, textArea);
+
+        // Delta value
+        TextArea deltaTextArea = new TextArea("Delta Value");
+        deltaTextArea.setHelperText("Shows the Delta representation of the edited document. You can also modify or paste the Delta JSON here to see the changes reflected in the editor above. Note that you have to leave (blur) this field in order for the editor to update.");
+        deltaTextArea.setWidthFull();
+        rte.asDelta().addValueChangeListener(e -> deltaTextArea.setValue(e.getValue()));
+        deltaTextArea.addValueChangeListener(e -> {
+            if (!rte.asDelta().getValue().equals(e.getValue())) {
+                rte.asDelta().setValue(e.getValue());
+            }
+        });
+
+        add(rte, htmlTextArea, deltaTextArea);
         // end::snippet[]
     }
 

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeCompact.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeCompact.java
@@ -15,7 +15,7 @@ public class RichTextEditorThemeCompact extends Div {
         RichTextEditor rte = new RichTextEditor();
         rte.getStyle().set("max-height", "400px");
         String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        rte.asDelta().setValue(valueAsDelta);
         rte.addThemeVariants(RichTextEditorVariant.LUMO_COMPACT);
         add(rte);
         // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeNoBorder.java
+++ b/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeNoBorder.java
@@ -15,7 +15,7 @@ public class RichTextEditorThemeNoBorder extends Div {
         RichTextEditor rte = new RichTextEditor();
         rte.getStyle().set("max-height", "400px");
         String valueAsDelta = DataService.getTemplates().getRichTextDelta();
-        rte.setValue(valueAsDelta);
+        rte.asDelta().setValue(valueAsDelta);
         rte.addThemeVariants(RichTextEditorVariant.LUMO_NO_BORDER);
         add(rte);
         // end::snippet[]


### PR DESCRIPTION
Updates the example under `Value format` to also show the Delta value, and allow editing it. This is adapted from the updated example from v24: https://github.com/vaadin/docs/pull/2027

There are some differences in the example compared to v24:
- It uses an improved helper text instead of a placeholder. I'll add that for v24 in a separate PR.
- In the Java example, changing the Delta value does not update the HTML value. That is not supported by the Flow component in v23.

The PR also updates the other examples to not use the deprecated `setValue` method.