### PR TITLE
docs: use proper error messages to fix examples a11y findings

### DIFF
--- a/frontend/demo/component/datepicker/date-picker-min-max.ts
+++ b/frontend/demo/component/datepicker/date-picker-min-max.ts
@@ -21,34 +21,25 @@ export class Example extends LitElement {
   private errorMessage = '';
 
   @state()
-  private today = '';
+  private minDate = new Date();
 
   @state()
-  private upperLimit = '';
-
-  protected override firstUpdated() {
-    this.today = formatISO(Date.now(), { representation: 'date' });
-
-    const upperLimit = addDays(Date.now(), 60);
-    this.upperLimit = formatISO(upperLimit, { representation: 'date' });
-  }
+  private maxDate = addDays(new Date(), 60);
 
   protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-picker
-        .min="${this.today}"
-        .max="${this.upperLimit}"
         label="Appointment date"
         helper-text="Must be within 60 days from today"
+        .min="${formatISO(this.minDate, { representation: 'date' })}"
+        .max="${formatISO(this.maxDate, { representation: 'date' })}"
         .errorMessage="${this.errorMessage}"
         @change="${({ target }: DatePickerChangeEvent) => {
-          const [value, min, max] = [target.value, this.today, this.upperLimit].map((date) =>
-            dateFnsParse(date ?? '', 'yyyy-MM-dd', new Date())
-          );
-          if (isBefore(value, min)) {
+          const date = dateFnsParse(target.value ?? '', 'yyyy-MM-dd', new Date());
+          if (isBefore(date, this.minDate)) {
             this.errorMessage = 'Too early, choose another date';
-          } else if (isAfter(value, max)) {
+          } else if (isAfter(date, this.maxDate)) {
             this.errorMessage = 'Too late, choose another date';
           } else {
             this.errorMessage = '';

--- a/frontend/demo/component/datepicker/date-picker-min-max.ts
+++ b/frontend/demo/component/datepicker/date-picker-min-max.ts
@@ -3,8 +3,10 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/date-picker';
+import type { DatePickerChangeEvent } from '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
-import { addDays, formatISO } from 'date-fns';
+import { addDays, formatISO, isAfter, isBefore } from 'date-fns';
+import dateFnsParse from 'date-fns/parse';
 
 @customElement('date-picker-min-max')
 export class Example extends LitElement {
@@ -14,6 +16,9 @@ export class Example extends LitElement {
     applyTheme(root);
     return root;
   }
+
+  @state()
+  private errorMessage = '';
 
   @state()
   private today = '';
@@ -36,6 +41,19 @@ export class Example extends LitElement {
         .max="${this.upperLimit}"
         label="Appointment date"
         helper-text="Must be within 60 days from today"
+        .errorMessage="${this.errorMessage}"
+        @change="${({ target }: DatePickerChangeEvent) => {
+          const [value, min, max] = [target.value, this.today, this.upperLimit].map((date) =>
+            dateFnsParse(date ?? '', 'yyyy-MM-dd', new Date())
+          );
+          if (isBefore(value, min)) {
+            this.errorMessage = 'Too early, choose another date';
+          } else if (isAfter(value, max)) {
+            this.errorMessage = 'Too late, choose another date';
+          } else {
+            this.errorMessage = '';
+          }
+        }}"
       ></vaadin-date-picker>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts
@@ -19,9 +19,11 @@ export class Example extends LitElement {
   // tag::snippet[]
   private binder = new Binder(this, AppointmentModel);
 
+  private errorMessage = 'The selected day of week or time is not available';
+
   protected override firstUpdated() {
     this.binder.for(this.binder.model.startDateTime).addValidator({
-      message: 'The selected day of week is not available',
+      message: this.errorMessage,
       validate: (startDateTime: string) => {
         const date = new Date(startDateTime);
         const validWeekDay = date.getDay() >= 1 && date.getDay() <= 5;
@@ -29,7 +31,7 @@ export class Example extends LitElement {
       },
     });
     this.binder.for(this.binder.model.startDateTime).addValidator({
-      message: 'The selected time is not available',
+      message: this.errorMessage,
       validate: (startDateTime: string) => {
         const time = startDateTime.split('T')[1];
         const validTime =

--- a/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts
@@ -1,18 +1,28 @@
 import 'Frontend/demo/init'; // hidden-source-line
 
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/date-time-picker';
+import type { DateTimePickerChangeEvent } from '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
-import { format, addDays } from 'date-fns';
+import { addDays, format, isAfter, isBefore, parseISO } from 'date-fns';
 
 const dateTimeFormat = `yyyy-MM-dd'T'HH:00:00`;
-const minValue = format(new Date(), dateTimeFormat);
-const initialValue = format(addDays(new Date(), 7), dateTimeFormat);
-const maxValue = format(addDays(new Date(), 60), dateTimeFormat);
 
 @customElement('date-time-picker-min-max')
 export class Example extends LitElement {
+  @state()
+  private errorMessage = '';
+
+  @state()
+  private initialValue = addDays(new Date(), 7);
+
+  @state()
+  private minDate = new Date();
+
+  @state()
+  private maxDate = addDays(new Date(), 60);
+
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
@@ -26,9 +36,20 @@ export class Example extends LitElement {
       <vaadin-date-time-picker
         label="Appointment date and time"
         helper-text="Must be within 60 days from today"
-        .value="${initialValue}"
-        .min="${minValue}"
-        .max="${maxValue}"
+        .value="${format(this.initialValue, dateTimeFormat)}"
+        .min="${format(this.minDate, dateTimeFormat)}"
+        .max="${format(this.maxDate, dateTimeFormat)}"
+        .errorMessage="${this.errorMessage}"
+        @change="${({ target }: DateTimePickerChangeEvent) => {
+          const date = parseISO(target.value ?? '');
+          if (isBefore(date, this.minDate)) {
+            this.errorMessage = 'Too early, choose another date and time';
+          } else if (isAfter(date, this.maxDate)) {
+            this.errorMessage = 'Too late, choose another date and time';
+          } else {
+            this.errorMessage = '';
+          }
+        }}"
       ></vaadin-date-time-picker>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/timepicker/time-picker-min-max.ts
+++ b/frontend/demo/component/timepicker/time-picker-min-max.ts
@@ -1,12 +1,16 @@
 import 'Frontend/demo/init'; // hidden-source-line
 
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/time-picker';
+import type { TimePickerChangeEvent } from '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-min-max')
 export class Example extends LitElement {
+  @state()
+  protected errorMessage = '';
+
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
@@ -24,6 +28,17 @@ export class Example extends LitElement {
         min="08:00"
         max="16:00"
         .step="${60 * 30}"
+        error-message="${this.errorMessage}"
+        @change="${(event: TimePickerChangeEvent) => {
+          const { min, max, value } = event.target;
+          if (value < min) {
+            this.errorMessage = 'Too early, choose another time';
+          } else if (value > max) {
+            this.errorMessage = 'Too late, choose another time';
+          } else {
+            this.errorMessage = '';
+          }
+        }}"
       ></vaadin-time-picker>
       <!-- end::snippet[] -->
     `;

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerMinMax.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerMinMax.java
@@ -19,6 +19,16 @@ public class DatePickerMinMax extends Div {
         datePicker.setMin(now);
         datePicker.setMax(now.plusDays(60));
         datePicker.setHelperText("Must be within 60 days from today");
+        datePicker.addValueChangeListener(event -> {
+            LocalDate value = datePicker.getValue();
+            if (value.compareTo(datePicker.getMin()) < 0) {
+                datePicker.setErrorMessage("Too early, choose another date");
+            } else if (value.compareTo(datePicker.getMax()) > 0) {
+                datePicker.setErrorMessage("Too late, choose another date");
+            } else {
+                datePicker.setErrorMessage(null);
+            }
+        });
         // end::snippet[]
 
         add(datePicker);

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerMinMax.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerMinMax.java
@@ -21,13 +21,15 @@ public class DatePickerMinMax extends Div {
         datePicker.setHelperText("Must be within 60 days from today");
         datePicker.addValueChangeListener(event -> {
             LocalDate value = datePicker.getValue();
-            if (value.compareTo(datePicker.getMin()) < 0) {
-                datePicker.setErrorMessage("Too early, choose another date");
-            } else if (value.compareTo(datePicker.getMax()) > 0) {
-                datePicker.setErrorMessage("Too late, choose another date");
-            } else {
-                datePicker.setErrorMessage(null);
+            String errorMessage = null;
+            if (value != null) {
+                if (value.compareTo(datePicker.getMin()) < 0) {
+                    errorMessage = "Too early, choose another date";
+                } else if (value.compareTo(datePicker.getMax()) > 0) {
+                    errorMessage = "Too late, choose another date";
+                }
             }
+            datePicker.setErrorMessage(errorMessage);
         });
         // end::snippet[]
 

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerCustomValidation.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerCustomValidation.java
@@ -23,23 +23,22 @@ public class DateTimePickerCustomValidation extends Div {
         dateTimePicker.setStep(Duration.ofMinutes(30));
         add(dateTimePicker);
 
+        String errorMessage = "The selected day of week or time is not available";
         Binder<Appointment> binder = new Binder<>(Appointment.class);
         binder.forField(dateTimePicker).withValidator(startDateTime -> {
             boolean validWeekDay = startDateTime.getDayOfWeek().getValue() >= 1
                     && startDateTime.getDayOfWeek().getValue() <= 5;
             return validWeekDay;
-        }, "The selected day of week is not available")
-                .withValidator(startDateTime -> {
-                    LocalTime startTime = LocalTime.of(startDateTime.getHour(),
-                            startDateTime.getMinute());
-                    boolean validTime = !(LocalTime.of(8, 0).isAfter(startTime)
-                            || (LocalTime.of(12, 0).isBefore(startTime)
-                                    && LocalTime.of(13, 0).isAfter(startTime))
-                            || LocalTime.of(16, 0).isBefore(startTime));
-                    return validTime;
-                }, "The selected time is not available")
-                .bind(Appointment::getStartDateTime,
-                        Appointment::setStartDateTime);
+        }, errorMessage).withValidator(startDateTime -> {
+            LocalTime startTime = LocalTime.of(startDateTime.getHour(),
+                    startDateTime.getMinute());
+            boolean validTime = !(LocalTime.of(8, 0).isAfter(startTime)
+                    || (LocalTime.of(12, 0).isBefore(startTime)
+                            && LocalTime.of(13, 0).isAfter(startTime))
+                    || LocalTime.of(16, 0).isBefore(startTime));
+            return validTime;
+        }, errorMessage).bind(Appointment::getStartDateTime,
+                Appointment::setStartDateTime);
         // end::snippet[]
     }
 

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinMax.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinMax.java
@@ -20,6 +20,18 @@ public class DateTimePickerMinMax extends Div {
         dateTimePicker.setMin(LocalDateTime.now());
         dateTimePicker.setMax(LocalDateTime.now().plusDays(60));
         dateTimePicker.setValue(LocalDateTime.now().plusDays(7));
+        dateTimePicker.addValueChangeListener(event -> {
+            LocalDateTime value = event.getValue();
+            if (value.compareTo(dateTimePicker.getMin()) < 0) {
+                dateTimePicker.setErrorMessage(
+                        "Too early, choose another date and time");
+            } else if (value.compareTo(dateTimePicker.getMax()) > 0) {
+                dateTimePicker.setErrorMessage(
+                        "Too late, choose another date and time");
+            } else {
+                dateTimePicker.setErrorMessage(null);
+            }
+        });
         add(dateTimePicker);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinMax.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinMax.java
@@ -22,15 +22,15 @@ public class DateTimePickerMinMax extends Div {
         dateTimePicker.setValue(LocalDateTime.now().plusDays(7));
         dateTimePicker.addValueChangeListener(event -> {
             LocalDateTime value = event.getValue();
-            if (value.compareTo(dateTimePicker.getMin()) < 0) {
-                dateTimePicker.setErrorMessage(
-                        "Too early, choose another date and time");
-            } else if (value.compareTo(dateTimePicker.getMax()) > 0) {
-                dateTimePicker.setErrorMessage(
-                        "Too late, choose another date and time");
-            } else {
-                dateTimePicker.setErrorMessage(null);
+            String errorMessage = null;
+            if (value != null) {
+                if (value.compareTo(dateTimePicker.getMin()) < 0) {
+                    errorMessage = "Too early, choose another date and time";
+                } else if (value.compareTo(dateTimePicker.getMax()) > 0) {
+                    errorMessage = "Too late, choose another date and time";
+                }
             }
+            dateTimePicker.setErrorMessage(errorMessage);
         });
         add(dateTimePicker);
         // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/timepicker/TimePickerMinMax.java
+++ b/src/main/java/com/vaadin/demo/component/timepicker/TimePickerMinMax.java
@@ -19,8 +19,18 @@ public class TimePickerMinMax extends Div {
         timePicker.setHelperText("Open 8:00-16:00");
         timePicker.setStep(Duration.ofMinutes(30));
         timePicker.setValue(LocalTime.of(8, 30));
-        timePicker.setMinTime(LocalTime.of(8, 0));
-        timePicker.setMaxTime(LocalTime.of(16, 0));
+        timePicker.setMin(LocalTime.of(8, 0));
+        timePicker.setMax(LocalTime.of(16, 0));
+        timePicker.addValueChangeListener(event -> {
+            LocalTime value = event.getValue();
+            if (value.compareTo(timePicker.getMin()) < 0) {
+                timePicker.setErrorMessage("Too early, choose another time");
+            } else if (value.compareTo(timePicker.getMax()) > 0) {
+                timePicker.setErrorMessage("Too late, choose another time");
+            } else {
+                timePicker.setErrorMessage(null);
+            }
+        });
         add(timePicker);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/timepicker/TimePickerMinMax.java
+++ b/src/main/java/com/vaadin/demo/component/timepicker/TimePickerMinMax.java
@@ -23,13 +23,15 @@ public class TimePickerMinMax extends Div {
         timePicker.setMax(LocalTime.of(16, 0));
         timePicker.addValueChangeListener(event -> {
             LocalTime value = event.getValue();
-            if (value.compareTo(timePicker.getMin()) < 0) {
-                timePicker.setErrorMessage("Too early, choose another time");
-            } else if (value.compareTo(timePicker.getMax()) > 0) {
-                timePicker.setErrorMessage("Too late, choose another time");
-            } else {
-                timePicker.setErrorMessage(null);
+            String errorMessage = null;
+            if (value != null) {
+                if (value.compareTo(timePicker.getMin()) < 0) {
+                    errorMessage = "Too early, choose another time";
+                } else if (value.compareTo(timePicker.getMax()) > 0) {
+                    errorMessage = "Too late, choose another time";
+                }
             }
+            timePicker.setErrorMessage(errorMessage);
         });
         add(timePicker);
         // end::snippet[]


### PR DESCRIPTION
## Description

This PR aims to fix accessibility review findings for the following components:

- [x] `DatePicker`
- [x] `DateTimePicker`
- [x] `TimePicker`

Fixes https://github.com/vaadin/web-components/issues/104
Fixes https://github.com/vaadin/web-components/issues/105
Fixes https://github.com/vaadin/web-components/issues/109

## Note

The part about old "Custom validator" example in https://github.com/vaadin/web-components/issues/104 is no longer relevant:

> The same happens for the [Custom validator](https://vaadin.com/components/date-picker/html-examples/date-picker-validation-demos#custom-validator) example if the user chooses a date that is not a working day.

> The date picker with an invalid date - only the background colour of the control is changed