### PR TITLE
docs: document using model properties in LitRenderer

### DIFF
--- a/articles/components/grid/flow.asciidoc
+++ b/articles/components/grid/flow.asciidoc
@@ -737,6 +737,43 @@ grid.addColumn(LitRenderer.<Person>of(
 * The functions defined by the [methodname]`withFunction()` method can be called with any number of additional parameters.
 * The additional argument of type [classname]`String` (the updated profession) is obtained from the second handler parameter with [methodname]`args.getString(0)`, where the number is the index of the argument in the [classname]`JsonArray`.
 
+==== Accessing Model Properties
+
+In addition to the most commonly used `item` and `index`, `Grid` has the following meta properties associated with each item.
+The properties can be accessed in the template via the `model` object.
+
+- `model.expanded` Expanded state of the item (relevant only in `TreeGrid`)
+- `model.level` Hierarchy level index of the item (relevant only in `TreeGrid`)
+- `model.selected` Selected state of the item
+- `model.detailsOpened` Details opened state of the item
+
+*Example*: Creating a custom tree toggle for the `TreeGrid`
+[source,java]
+----
+// The click listener needs to check if the event gets canceled (by
+// vaadin-grid-tree-toggle) and only invoke the callback if it does.
+// vaadin-grid-tree-toggle will cancel the event if the user clicks on
+// a non-focusable element inside the toggle.
+var clickListener = "e => requestAnimationFrame(() => { e.defaultPrevented && onClick(e) })";
+
+grid.addColumn(LitRenderer.<Person> of(
+    "<vaadin-grid-tree-toggle @click=${" + clickListener + "} .leaf=${item.leaf} .expanded=${model.expanded} .level=${model.level}>"
+            + "${item.name}</vaadin-grid-tree-toggle>")
+    .withProperty("leaf",
+            item -> !grid.getDataCommunicator().hasChildren(item))
+    .withProperty("name",
+            item -> item.getName())
+    .withFunction("onClick", item -> {
+        if (grid.getDataCommunicator().hasChildren(item)) {
+            if (grid.isExpanded(item)) {
+                grid.collapse(item);
+            } else {
+                grid.expand(item);
+            }
+        }
+    }));
+----
+
 === Using Component Renderers
 
 You can use any component in the grid cells by providing a [classname]`ComponentRenderer` for a column.

--- a/articles/components/grid/flow.asciidoc
+++ b/articles/components/grid/flow.asciidoc
@@ -740,12 +740,19 @@ grid.addColumn(LitRenderer.<Person>of(
 ==== Accessing Model Properties
 
 In addition to the most commonly used `item` and `index`, `Grid` has the following meta properties associated with each item.
-The properties can be accessed in the template via the `model` object.
+You can access these properties in the template via the `model` object.
 
-- `model.expanded` Expanded state of the item (relevant only in `TreeGrid`)
-- `model.level` Hierarchy level index of the item (relevant only in `TreeGrid`)
-- `model.selected` Selected state of the item
-- `model.detailsOpened` Details opened state of the item
+`model.expanded`::
+Indicates whether the item is expanded or collapsed (relevant only for `TreeGrid`).
+
+`model.level`::
+Indicates the the hierarchy level of the item (relevant only for `TreeGrid`).
+
+`model.selected`::
+Indicates whether the item is selected or not.
+
+`model.detailsOpened`::
+Indicates whether the details row for the item is opened or closed.
 
 *Example*: Creating a custom tree toggle for the `TreeGrid`
 [source,java]


### PR DESCRIPTION
## Description

Document using model properties in LitRenderer.
This is only relevant for Vaadin 24 (targeting `next` branch).

Related internal Slack [discussion](https://vaadin.slack.com/archives/C3TGRP4HY/p1676534800750329)