### PR TITLE
docs: use title instead of aria-label in Custom Field examples

### DIFF
--- a/frontend/demo/component/custom-field/custom-field-basic.ts
+++ b/frontend/demo/component/custom-field/custom-field-basic.ts
@@ -7,6 +7,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 import { Binder, field } from '@hilla/form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
 import { differenceInDays, parseISO, isAfter } from 'date-fns';
+import { DatePicker } from '@vaadin/date-picker';
 
 @customElement('custom-field-basic')
 export class Example extends LitElement {
@@ -17,21 +18,18 @@ export class Example extends LitElement {
     return root;
   }
 
-  @query('#start > input')
-  private start!: HTMLInputElement;
+  @query('#start')
+  private start!: DatePicker;
 
-  @query('#end > input')
-  private end!: HTMLInputElement;
+  @query('#end')
+  private end!: DatePicker;
 
   private binder = new Binder(this, AppointmentModel);
 
   protected override firstUpdated() {
-    // Set `aria-label` for screen readers
-    this.start.setAttribute('aria-label', 'Start date');
-    this.start.removeAttribute('aria-labelledby');
-
-    this.end.setAttribute('aria-label', 'End date');
-    this.end.removeAttribute('aria-labelledby');
+    // Set title for screen readers
+    this.start.focusElement!.setAttribute('title', 'Start date');
+    this.end.focusElement!.setAttribute('title', 'End date');
 
     this.binder.for(this.binder.model.enrollmentPeriod).addValidator({
       message: 'Dates cannot be more than 30 days apart',

--- a/frontend/demo/component/custom-field/custom-field-basic.ts
+++ b/frontend/demo/component/custom-field/custom-field-basic.ts
@@ -6,8 +6,7 @@ import '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 import { Binder, field } from '@hilla/form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
-import { differenceInDays, parseISO, isAfter } from 'date-fns';
-import { DatePicker } from '@vaadin/date-picker';
+import type { DatePicker } from '@vaadin/date-picker';
 
 @customElement('custom-field-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -6,8 +6,8 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/select';
 import '@vaadin/text-field';
 import { applyTheme } from 'Frontend/generated/theme';
-import { TextField } from '@vaadin/text-field';
-import { Select } from '@vaadin/select';
+import type { Select } from '@vaadin/select';
+import type { TextField } from '@vaadin/text-field';
 
 @customElement('custom-field-size-variants')
 export class Example extends LitElement {

--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -6,6 +6,8 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/select';
 import '@vaadin/text-field';
 import { applyTheme } from 'Frontend/generated/theme';
+import { TextField } from '@vaadin/text-field';
+import { Select } from '@vaadin/select';
 
 @customElement('custom-field-size-variants')
 export class Example extends LitElement {
@@ -16,11 +18,11 @@ export class Example extends LitElement {
     return root;
   }
 
-  @query('#amount > input')
-  private amount!: HTMLInputElement;
+  @query('#amount')
+  private amount!: TextField;
 
-  @query('#currency > [slot="value"]')
-  private currency!: HTMLElement;
+  @query('#currency')
+  private currency!: Select;
 
   @state()
   private currencies = [
@@ -34,12 +36,9 @@ export class Example extends LitElement {
   ];
 
   protected override firstUpdated() {
-    // Set `aria-label` for screen readers
-    this.amount.setAttribute('aria-label', 'Amount');
-    this.amount.removeAttribute('aria-labelledby');
-
-    this.currency.setAttribute('aria-label', 'Currency');
-    this.currency.removeAttribute('aria-labelledby');
+    // Set title for screen readers
+    this.amount.focusElement!.setAttribute('title', 'Amount');
+    this.currency.focusElement!.setAttribute('title', 'Currency');
   }
 
   protected override render() {

--- a/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
@@ -19,11 +19,13 @@ public class DateRangePicker extends CustomField<LocalDateRange> {
         start = new DatePicker();
         start.setPlaceholder("Start date");
         // Sets title for screen readers
-        start.getElement().executeJs("this.focusElement.setAttribute('title', 'Start date')");
+        start.getElement().executeJs(
+                "this.focusElement.setAttribute('title', 'Start date')");
 
         end = new DatePicker();
         end.setPlaceholder("End date");
-        end.getElement().executeJs("this.focusElement.setAttribute('title', 'End date')");
+        end.getElement().executeJs(
+                "this.focusElement.setAttribute('title', 'End date')");
 
         add(start, new Text(" – "), end);
     }

--- a/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
@@ -18,19 +18,12 @@ public class DateRangePicker extends CustomField<LocalDateRange> {
     public DateRangePicker() {
         start = new DatePicker();
         start.setPlaceholder("Start date");
+        // Sets title for screen readers
+        start.getElement().executeJs("this.focusElement.setAttribute('title', 'Start date')");
 
         end = new DatePicker();
         end.setPlaceholder("End date");
-
-        // aria-label for screen readers
-        start.getElement()
-                .executeJs("const start = this.inputElement;"
-                        + "start.setAttribute('aria-label', 'Start date');"
-                        + "start.removeAttribute('aria-labelledby');");
-        end.getElement()
-                .executeJs("const end = this.inputElement;"
-                        + "end.setAttribute('aria-label', 'End date');"
-                        + "end.removeAttribute('aria-labelledby');");
+        end.getElement().executeJs("this.focusElement.setAttribute('title', 'End date')");
 
         add(start, new Text(" – "), end);
     }

--- a/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
@@ -22,12 +22,14 @@ public class MoneyField extends CustomField<Money> {
     public MoneyField() {
         amount = new TextField();
         // Sets title for screen readers
-        amount.getElement().executeJs("this.focusElement.setAttribute('title', 'Amount')");
+        amount.getElement()
+                .executeJs("this.focusElement.setAttribute('title', 'Amount')");
 
         currency = new Select<>();
         currency.setItems("AUD", "CAD", "CHF", "EUR", "GBP", "JPY", "USD");
         currency.setWidth("6em");
-        currency.getElement().executeJs("this.focusElement.setAttribute('title', 'Currency')");
+        currency.getElement().executeJs(
+                "this.focusElement.setAttribute('title', 'Currency')");
 
         HorizontalLayout layout = new HorizontalLayout(amount, currency);
         // Removes default spacing

--- a/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
@@ -21,20 +21,13 @@ public class MoneyField extends CustomField<Money> {
 
     public MoneyField() {
         amount = new TextField();
+        // Sets title for screen readers
+        amount.getElement().executeJs("this.focusElement.setAttribute('title', 'Amount')");
 
-        currency = new Select();
+        currency = new Select<>();
         currency.setItems("AUD", "CAD", "CHF", "EUR", "GBP", "JPY", "USD");
         currency.setWidth("6em");
-
-        // aria-label for screen readers
-        amount.getElement()
-                .executeJs("const amount = this.inputElement;"
-                        + "amount.setAttribute('aria-label', 'Amount');"
-                        + "amount.removeAttribute('aria-labelledby');");
-        currency.getElement()
-                .executeJs("const currency = this.focusElement;"
-                        + "currency.setAttribute('aria-label', 'Currency');"
-                        + "currency.removeAttribute('aria-labelledby');");
+        currency.getElement().executeJs("this.focusElement.setAttribute('title', 'Currency')");
 
         HorizontalLayout layout = new HorizontalLayout(amount, currency);
         // Removes default spacing


### PR DESCRIPTION
We internally agreed with @web-padawan that we will use the `title` attribute instead of `aria-label` in Custom Field examples until https://github.com/vaadin/web-components/issues/5580 is fixed.