### PR TITLE
docs: add Delta format details to RTE docs

### DIFF
--- a/articles/components/rich-text-editor/index.asciidoc
+++ b/articles/components/rich-text-editor/index.asciidoc
@@ -103,6 +103,37 @@ The following snippet contains an HTML document that is supported by the compone
 
 ====
 
+.Delta format details
+[%collapsible]
+====
+
+The Delta format is a JSON-based format that consists of an array of operations to apply to a document.
+Rich Text Editor specifically only uses insert operations, each operation sequentially adding content to the document.
+Operations can have attributes that provide additional details, such as whether to render a piece of content with a specific text style, or as a link.
+For the full specification of the format, please see the https://github.com/quilljs/delta[Quill Delta Github Repo].
+
+The following snippet contains a Delta document that demonstrates some of the format's features.
+Try pasting the snippet into the `Delta Value` text area in the example below and see how the editor updates.
+Then try modifying the value, either by using the editor's features, or by changing the Delta value directly.
+
+[source,json]
+----
+[
+  {"insert": "High quality rich text editor for the web\n", "attributes": {"header":  2}},
+  {"insert": "Rich text editor handles the following formatting:\n"},
+  {"insert": "Bold\n","attributes": { "bold": true, "list": "bullet" }},
+  {"insert": "Italic\n", "attributes": { "italic": true, "list": "bullet" }},
+  {"insert": "Underline\n", "attributes": { "underline": true, "list": "bullet" }},
+  {"insert": "Strike-through\n", "attributes": { "strike": true, "list": "bullet" }},
+  {"insert": "Blockquotes\n", "attributes": { "header": 3 }},
+  {"insert": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n", "attributes": { "blockquote": true }},
+  {"insert": "Code blocks\n", "attributes": { "header": 3 }},
+  {"insert": "<vaadin-rich-text-editor></vaadin-rich-text-editor>\n", "attributes": { "code-block": true }}
+]
+----
+
+====
+
 For the Flow component, to read, write, or bind the component's value with `Binder`, use:
 
 - https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/richtexteditor/RichTextEditor.html#asDelta()[`RichTextEditor.asDelta()`] for the Delta format

--- a/articles/components/rich-text-editor/index.asciidoc
+++ b/articles/components/rich-text-editor/index.asciidoc
@@ -107,10 +107,10 @@ The following snippet contains an HTML document that is supported by the compone
 [%collapsible]
 ====
 
-The Delta format is a JSON-based format that consists of an array of operations to apply to a document.
+The JSON-based Delta format consists of an array of operations to apply to a document.
 Rich Text Editor specifically only uses insert operations, each operation sequentially adding content to the document.
-Operations can have attributes that provide additional details, such as whether to render a piece of content with a specific text style, or as a link.
-For the full specification of the format, please see the https://github.com/quilljs/delta[Quill Delta Github Repo].
+Operations can have attributes, such as whether to render a piece of content with a specific text style, or as a link.
+For the full specification of the format, see the https://github.com/quilljs/delta[Quill Delta GitHub repository].
 
 The following snippet contains a Delta document that demonstrates some of the format's features.
 Try pasting the snippet into the `Delta Value` text area in the example below and see how the editor updates.


### PR DESCRIPTION
Based on #2177 

Adds a collapsible section detailling the Delta format. 

Closes https://github.com/vaadin/docs/issues/496

I'll see if I can refactor the examples to also show the templates used by `DataService`, but in a separate PR.