### PR TITLE
docs: add missing imports to grid inline editor examples

### DIFF
--- a/frontend/demo/component/grid/grid-buffered-inline-editor.ts
+++ b/frontend/demo/component/grid/grid-buffered-inline-editor.ts
@@ -1,3 +1,4 @@
+import 'Frontend/demo/init';
 import '@vaadin/button';
 import '@vaadin/email-field';
 import '@vaadin/grid';

--- a/frontend/demo/component/grid/grid-unbuffered-inline-editor.ts
+++ b/frontend/demo/component/grid/grid-unbuffered-inline-editor.ts
@@ -1,3 +1,4 @@
+import 'Frontend/demo/init';
 import '@vaadin/email-field';
 import '@vaadin/grid';
 import '@vaadin/icon';


### PR DESCRIPTION
Opening the examples in new tabs did not work due to missing imports. This PR adds those imports to the 2 Java-only inline editor examples.

Fixes #810 