### PR TITLE
docs: improve Flow grid sorting section

### DIFF
--- a/articles/components/grid/flow.asciidoc
+++ b/articles/components/grid/flow.asciidoc
@@ -886,23 +886,23 @@ var isSortable = column.isSortable();
 ```
 
 Depending on how the column was created, it may need additional configuration.
-In order to figure out whether that is the case, let's first consider the two sorting mechanisms supported by Grid:
+In order to figure out whether that is the case, we need to consider the two sorting mechanisms supported by Grid:
 
 * *In-memory sorting* is sorting that is automatically applied by the framework when using an in-memory data provider.
 Items are sorted using a `Comparator` that can either be created automatically by the column or has to be specified manually by the developer.
 
-* *Back-end sorting* is applied by providing a list of [classname]`QuerySortOrder` objects a custom [classname]`DataProvider` implemented by the developer.
+* *Backend sorting* is applied by providing a list of [classname]`QuerySortOrder` objects a custom [classname]`DataProvider` implemented by the developer.
 Sort order objects contain the property names that the developer must use for sorting items in their backend, such as a database.
 See <<{articles}/binding-data/data-provider#Sorting,Data Providers>> for more.
 
-With that in mind, let's see which columns are automatically configured for in-memory, or back-end sorting:
+With that in mind, we can break down which columns are automatically configured for in-memory, or backend sorting:
 
 - For columns created from a property name, in-memory sorting is automatically configured if the type of the property implements `Comparable`.
 Otherwise, a custom comparator must be provided by the developer.
-Back-end sorting is configured automatically in any case, as the column knows the property name to pass to the data provider.
+Backend sorting is configured automatically in any case, as the column knows the property name to pass to the data provider.
 - For columns created from a `ValueProvider` only in-memory sorting is configured automatically, where the value provider is used to build a comparator.
-Back-end sorting is not configured automatically, as the column does not know which property name to pass to the data provider.
-- For columns created from a renderer, neither in-memory sorting, nor back-end sorting is configured automatically.
+Backend sorting is not configured automatically, as the column does not know which property name to pass to the data provider.
+- For columns created from a renderer, neither in-memory sorting, nor backend sorting is configured automatically.
 The column can not create a comparator from the renderer, nor does it know the property name to pass to the data provider.
 
 If either sort mechanism is not configured automatically, it can be configured manually as explained in the following sections.
@@ -937,11 +937,11 @@ grid.addColumn(Person::getName)
 ----
 
 
-==== Configuring Back-End Sorting
+==== Configuring Backend Sorting
 
-For back-end sorting, the sort properties that are passed to a data provider can be configured using `Column.setSortProperty`.
+For backend sorting, the sort properties that are passed to a data provider can be configured using `Column.setSortProperty`.
 The method allows providing multiple sort properties, which are passed to the data provider in the specified order.
-Use this if a column is not automatically configured for back-end sorting, or if you want to customize the back-end sorting behavior.
+Use this if a column is not automatically configured for backend sorting, or if you want to customize the backend sorting behavior.
 
 *Example*: Configuring sort properties for a column created from a value provider.
 
@@ -966,11 +966,11 @@ grid.addColumn(LitRenderer.<Person>of(
     .setHeader("Person");
 ----
 
-An alternative way to configure back-end sorting is using a [classname]`SortOrderProvider`, which is called on demand when the sort order is changed.
+An alternative way to configure backend sorting is using a [classname]`SortOrderProvider`, which is called on demand when the sort order is changed.
 
 Use this if you need fine-grained control over how [classname]`QuerySortOrder` objects are created and sent to the [classname]`DataProvider`.
 
-*Example*: Defining a [classname]`SortOrderProvider` for back-end sorting.
+*Example*: Defining a [classname]`SortOrderProvider` for backend sorting.
 
 [source,java]
 ----

--- a/articles/components/grid/flow.asciidoc
+++ b/articles/components/grid/flow.asciidoc
@@ -866,54 +866,54 @@ If multi-sorting is enabled, the user can sort by multiple columns.
 The first click sorts the first column.
 Subsequent clicks on second and more sortable column headers add secondary and more sort criteria.
 
-=== Defining Column Sorting
+=== Enabling Column Sorting
 
-The difference between in-memory and back-end sorting is key to understanding the sorting mechanism:
+For columns that have been created from a property name (`grid.addColumn("firstName")`) sorting is enabled by default, if the type of the property implements `Comparable`.
+In general this only applies to grids that have been created from a class name (`new Grid(Person.class)`).
 
-* *In-memory sorting* is sorting that's applied by the framework to items fetched from the backend, before returning them to the client.
+For columns that have been created from a `ValueProvider` (`grid.addColumn(Person::getFirstName)`), or from a renderer such as `LitRenderer` (`grid.addColumn(new LitRenderer<Person>(...))`), sorting is not enabled by default.
 
-* *Back-end sorting* is applied by providing a list of [classname]`QuerySortOrder` objects to your [classname]`DataProvider`.
-These typically pass the sort hints to the back-end code and, sometimes, all the way to database queries.
+Sorting for a column can be enabled or disabled manually:
+```java
+// Enabled sorting for a column
+column.setSortable(true);
+
+// Disable sorting for a column
+column.setSortable(false);
+
+// Check whether a column is sortable
+var isSortable = column.isSortable();
+```
+
+Depending on how the column was created, it may need additional configuration.
+In order to figure out whether that is the case, let's first consider the two sorting mechanisms supported by Grid:
+
+* *In-memory sorting* is sorting that is automatically applied by the framework when using an in-memory data provider.
+Items are sorted using a `Comparator` that can either be created automatically by the column or has to be specified manually by the developer.
+
+* *Back-end sorting* is applied by providing a list of [classname]`QuerySortOrder` objects a custom [classname]`DataProvider` implemented by the developer.
+Sort order objects contain the property names that the developer must use for sorting items in their backend, such as a database.
 See <<{articles}/binding-data/data-provider#Sorting,Data Providers>> for more.
 
-The sorting mechanism is flexible; you can configure in-memory and back-end sorting together or separately.
+With that in mind, let's see which columns are automatically configured for in-memory, or back-end sorting:
 
-The sections that follow detail options you can use to set up sorting for your grid.
+- For columns created from a property name, in-memory sorting is automatically configured if the type of the property implements `Comparable`.
+Otherwise, a custom comparator must be provided by the developer.
+Back-end sorting is configured automatically in any case, as the column knows the property name to pass to the data provider.
+- For columns created from a `ValueProvider` only in-memory sorting is configured automatically, where the value provider is used to build a comparator.
+Back-end sorting is not configured automatically, as the column does not know which property name to pass to the data provider.
+- For columns created from a renderer, neither in-memory sorting, nor back-end sorting is configured automatically.
+The column can not create a comparator from the renderer, nor does it know the property name to pass to the data provider.
 
-==== Using a Sort Property Name
+If either sort mechanism is not configured automatically, it can be configured manually as explained in the following sections.
 
-By using a sort property, you can override or customize the property or multiple properties that are used for sorting the column.
-This option includes both in-memory and back-end sorting.
-The property is defined at the time of column construction and uses a sort property name.
+==== Configuring In-Memory Sorting
 
-You can use the [methodname]`addColumn()` method to set a sort property to be used for back-end sorting when the column is added to the grid.
+For in-memory sorting, a custom comparator can be configured using `Column.setComparator`.
+Use this if a column is not automatically configured for in-memory sorting, or if you want to customize the in-memory sorting behavior.
 
-*Example*: Using the [methodname]`addColumn()` method to set a column sort property.
-
-[source,java]
-----
-grid.addColumn(Person::getAge, "age").setHeader("Age");
-----
-
-* The `Age` column uses the values returned by the [methodname]`Person::getAge()` method to do in-memory sorting.
-* The column uses the `age` string to build a [classname]`QuerySortOrder` that's sent to the [classname]`DataProvider` to do the back-end sorting.
-
-You can also define multiple properties.
-
-*Example*:  Using the [methodname]`addColumn()` method to set multiple column sort properties.
-
-[source,java]
-----
-grid.addColumn(person -> person.getName() + " " +
-        person.getLastName(), "name", "lastName"
-).setHeader("Name");
-----
-
-* With multiple properties, the [classname]`QuerySortOrder` objects are created in the order they are declared.
-
-You can also use properties created for your [classname]`LitRenderer`.
-
-*Example*: Using the [methodname]`addColumn()` method with [classname]`LitRenderer` to set column sort properties.
+*Example*: Configuring a comparator for a column using a [classname]`LitRenderer`.
+The renderer shows the person's name and email address, for sorting only the email address is used.
 
 [source,java]
 ----
@@ -921,21 +921,12 @@ grid.addColumn(LitRenderer.<Person>of(
         "<div>${item.name}<br>" +
         "<small>${item.email}</small></div>")
         .withProperty("name", Person::getName)
-        .withProperty("email", Person::getEmail),
-    "name", "email")
+        .withProperty("email", Person::getEmail))
+    .setComparator(Person::getEmail)
     .setHeader("Person");
 ----
-* For in-memory sorting to work correctly, the values returned by the [classname]`ValueProviders` in the [classname]`LitRenderer`
-([methodname]`Person::getName()` and [methodname]`Person::getEmail()` in this example) should implement [interfacename]`Comparable`.
-* The names of the sort properties must match the names of the properties in the template (set via [methodname]`withProperty()`).
 
-==== Using a Comparator
-
-This option is for in-memory sorting only, and uses a custom comparator.
-
-If you need custom logic to compare items for sorting, or if your underlying data isn't [interfacename]`Comparable`, you can set a [classname]`Comparator` for your column.
-
-*Example*: Using the [methodname]`setComparator()` method to configure a comparator for a column.
+*Example*: Customizing the in-memory sorting for a column created from a value provider by implementing a comparator that is not case-sensitive.
 [source,java]
 ----
 grid.addColumn(Person::getName)
@@ -946,14 +937,13 @@ grid.addColumn(Person::getName)
 ----
 
 
-==== Setting Back-End Sort Properties
+==== Configuring Back-End Sorting
 
-This option is for back-end sorting only, and uses a sort property name.
-It's similar to <<Using a Sort Property Name>>, but excludes in-memory sorting.
+For back-end sorting, the sort properties that are passed to a data provider can be configured using `Column.setSortProperty`.
+The method allows providing multiple sort properties, which are passed to the data provider in the specified order.
+Use this if a column is not automatically configured for back-end sorting, or if you want to customize the back-end sorting behavior.
 
-You can use the [methodname]`setSortProperty()` method to set strings describing back-end properties to be used when sorting the column.
-
-*Example*: Using the [methodname]`setSortProperty()` method to define sorting.
+*Example*: Configuring sort properties for a column created from a value provider.
 
 [source,java]
 ----
@@ -961,14 +951,24 @@ grid.addColumn(Person::getName)
         .setSortProperty("name", "email")
         .setHeader("Person");
 ----
-* Unlike using the sorting properties in the [methodname]`addColumn()` method directly, calling [methodname]`setSortProperty()` doesn't configure any in-memory sorting.
-* A [classname]`SortOrderProvider` is created automatically when the sort properties are set.
 
-==== Setting a SortOrderProvider
+*Example*: Setting a sort property for a column using a [classname]`LitRenderer`.
+The renderer shows the person's name and email address, for sorting only the email address is used.
 
-This option is for back-end sorting and uses a [classname]`SortOrderProvider`.
+[source,java]
+----
+grid.addColumn(LitRenderer.<Person>of(
+        "<div>${item.name}<br>" +
+        "<small>${item.email}</small></div>")
+        .withProperty("name", Person::getName)
+        .withProperty("email", Person::getEmail))
+    .setSortProperty("email")
+    .setHeader("Person");
+----
 
-If you need fine-grained control over how [classname]`QuerySortOrder` objects are created and sent to the [classname]`DataProvider`, you can define a [classname]`SortOrderProvider`.
+An alternative way to configure back-end sorting is using a [classname]`SortOrderProvider`, which is called on demand when the sort order is changed.
+
+Use this if you need fine-grained control over how [classname]`QuerySortOrder` objects are created and sent to the [classname]`DataProvider`.
 
 *Example*: Defining a [classname]`SortOrderProvider` for back-end sorting.
 
@@ -980,30 +980,6 @@ grid.addColumn(Person::getName)
                 new QuerySortOrder("email", direction))
         .stream())
     .setHeader("Person");
-----
-
-=== Enabling and Disabling Column Sorting
-
-When a column is `sortable`, it displays the sorter element in the column header.
-
-You can use the [methodname]`setSortable()` method to toggle the sorter element on and off.
-
-*Example*: Using the [methodname]`setSortable()` method to disable sorting.
-
-[source,java]
-----
-column.setSortable(false);
-----
-
-Setting a column as not `sortable` doesn't delete a [classname]`Comparator`, sort property, or [classname]`SortOrderProvider` that was previously set.
-You can toggle the `sortable` flag on and off, without reconfiguration.
-
-To check if a column is currently `sortable`, you can use the [methodname]`isSortable()` method.
-
-*Example*: Checking if a column is sortable.
-[source,java]
-----
-column.isSortable();
 ----
 
 === Enabling Multi-Sorting

--- a/articles/components/grid/flow.asciidoc
+++ b/articles/components/grid/flow.asciidoc
@@ -7,10 +7,9 @@ order: 50
 
 == Binding to Data
 
-By default, `Grid` is bound to a [classname]`List` of items.
-You can use the [methodname]`setItems()` method to set the items.
+`Grid` is bound to a [classname]`List` of items, by default. You can use the [methodname]`setItems()` method to set the items.
 
-*Example*: Showing a list of beans in a `Grid`.
+For example, to show a list of beans in a `Grid`, you could do something like this:
 
 [source,java]
 ----
@@ -30,29 +29,21 @@ grid.addColumn(Person::getYearOfBirth)
 layout.add(grid);
 ----
 
-Behind the scenes, `Grid` uses the [interfacename]`DataProvider` interface to communicate with the backend.
-The [methodname]`setItems()` method is a shorthand to create a [classname]`ListDataProvider`.
-For a large amount of data or other advanced use cases, you should probably use the [interfacename]`DataProvider` interface and lazy loading.
-See <<{articles}/binding-data/data-provider#,Data Providers>> for more.
+Behind the scenes, `Grid` uses the [interfacename]`DataProvider` interface to communicate with the backend. The [methodname]`setItems()` method is a shorthand to create a [classname]`ListDataProvider`. For a large amount of data or other advanced use cases, you should probably use the [interfacename]`DataProvider` interface and lazy loading. See <<{articles}/binding-data/data-provider#,Data Providers>> for more.
 
 include::{articles}/binding-data/_items-identities.adoc[]
 
+
 == Handling Selection Changes
 
-The `Grid` doesn't implement the [interfacename]`HasValue` interface directly.
-Other selection components do typically implement this interface.
-For this reason, selection handling in the `Grid` is different from typical selection components.
-The `Grid` supports three selection options: single selection, multiple selection, and no selection.
-Each option is defined by a specific selection model.
+The `Grid` doesn't implement directly the [interfacename]`HasValue` interface. Other selection components do typically implement this interface. Therefore, selection handling in the `Grid` is different from typical selection components. The `Grid` supports three selection options: single selection, multiple selection, and no selection. Each option is defined by a specific selection model.
 
-For basic switching between selection models, you can use the [methodname]`setSelectionMode(SelectionMode)` method.
-Possible options are `SINGLE` (default), `MULTI`, or `NONE`.
+For basic switching between selection models, you can use the [methodname]`setSelectionMode(SelectionMode)` method. Possible options are `SINGLE` (default), `MULTI`, or `NONE`.
 
-To access the selection API or to use Grid as an input field with [classname]`Binder`, you can use [methodname]`asSingleSelect()` or [methodname]`asMultiSelect()`, depending on the currently defined selection mode.
-Both the [interfacename]`SingleSelect` and [interfacename]`MultiSelect` interfaces implement the [interfacename]`HasValue` interface.
-In the [interfacename]`MultiSelect` interface, the value type is a [classname]`Set` of the item type.
+To access the selection API or to use Grid as an input field with [classname]`Binder`, you can use [methodname]`asSingleSelect()` or [methodname]`asMultiSelect()`, depending on the currently defined selection mode. Both the [interfacename]`SingleSelect` and [interfacename]`MultiSelect` interfaces implement the [interfacename]`HasValue` interface. In the [interfacename]`MultiSelect` interface, the value type is a [classname]`Set` of the item type.
 
-*Example*: Using the [interfacename]`HasValue` interface with single and multi-select mode.
+For example, when using the [interfacename]`HasValue` interface with single and multi-select mode, you could do something like this:
+
 [source,java]
 ----
 Grid<Person> grid = new Grid<>();
@@ -74,10 +65,10 @@ multiSelect.addValueChangeListener(e -> {
 });
 ----
 
-Alternatively, you can use a grid-specific selection API.
-To get the selected value or values in any selection model, you can use a [classname]`SelectionListener`, with the provided generic [classname]`SelectionEvent`, to get the selected value or values.
+Alternatively, you can use a grid-specific selection API. To get the selected value or values in any selection model, you can use a [classname]`SelectionListener`, with the provided generic [classname]`SelectionEvent`, to get the selected value or values.
 
-*Example*: Using [methodname]`addSelectionListener()` to get all selected items.
+To use [methodname]`addSelectionListener()` to get all selected items, for example, you could do this:
+
 [source,java]
 ----
 Grid<Person> grid = new Grid<>();
@@ -90,14 +81,13 @@ grid.addSelectionListener(event -> {
    message.setText(selected.size() + " items selected");
 });
 ----
+
 [NOTE]
-The listener is attached to the selection model and not the grid.
-It stops getting events when the selection mode is changed.
+The listener is attached to the selection model and not the grid. It stops getting events when the selection mode is changed.
 
-You can use the [methodname]`select(T)` method to programmatically select values.
-In multi-selection mode, this adds the given item to the selection.
+You can use the [methodname]`select(T)` method to select values, programmatically. In multi-selection mode, this adds the given item to the selection.
 
-*Example*: Using the [methodname]`select(T)` method.
+The example here is using the [methodname]`select(T)` method:
 
 [source,java]
 ----
@@ -110,29 +100,26 @@ grid.setSelectionMode(SelectionMode.MULTI);
 people.subList(2, 3).forEach(grid::select);
 ----
 
-You can get the current selection from the `Grid` using the [methodname]`getSelectedItems()` method.
-The returned [classname]`Set` contains one item in single-selection mode, or several items in multi-selection mode.
+You can get the current selection from the `Grid` using the [methodname]`getSelectedItems()` method. The returned [classname]`Set` contains one item in single-selection mode, or several items in multi-selection mode.
 
 [WARNING]
 ====
-If you change the grid's selection mode, it clears the selection and fires a selection event.
-To keep the previous selection, reset the selection afterwards, using the [methodname]`select()` method.
+If you change the grid's selection mode, it clears the selection and fires a selection event. To keep the previous selection, reset the selection afterwards using the [methodname]`select()` method.
 ====
 
 [WARNING]
 ====
-If you change the grid's items with either [methodname]`setItems()` or the used [classname]`DataProvider`, it clears the selection and fires a selection event.
-To maintain the previous selection, reset the selection afterwards, using the [methodname]`select()` method.
+If you change the grid's items with either [methodname]`setItems()` or the used [classname]`DataProvider`, it clears the selection and fires a selection event. To maintain the previous selection, reset the selection afterwards using the [methodname]`select()` method.
 ====
+
 
 === Selection Models
 
-You can access the used selection model using the [methodname]`getSelectionModel()` method.
-The return type is the [classname]`GridSelectionModel`, which has a generic selection model API, but you can cast that to the specific selection model type, typically either [classname]`SingleSelectionModel` or [classname]`MultiSelectionModel`.
+You can access the used selection model using the [methodname]`getSelectionModel()` method. The return type is the [classname]`GridSelectionModel`, which has a generic selection model API. However, you can cast that to the specific selection model type, typically either [classname]`SingleSelectionModel` or [classname]`MultiSelectionModel`.
 
 You can also get the selection model using the [methodname]`setSelectionMode(SelectionMode)` method.
 
-*Example*: Using the [methodname]`setSelectionMode(SelectionMode)` method to get the selection model.
+You could use the [methodname]`setSelectionMode(SelectionMode)` method, for example, to get the selection model like so:
 
 [source,java]
 ----
@@ -147,16 +134,16 @@ GridMultiSelectionModel<Person> selectionModel =
         .setSelectionMode(SelectionMode.MULTI);
 ----
 
+
 ==== Single-Selection Model
 
 Obtaining a reference to the [classname]`SingleSelectionModel` allows you access to a fine-grained API for the single-selection use case.
 
 You can use the [methodname]`addSingleSelect(SingleSelectionListener)` method to access [classname]`SingleSelectionEvent`, which includes additional convenience methods and API options.
 
-In single-selection mode, it's possible to control whether the empty (null) selection is allowed.
-This is enabled by default.
+In single-selection mode, it's possible to control whether the empty (null) selection is allowed. This is enabled by default.
 
-*Example*: Disallowing empty (null) selection using the [methodname]`setDeselectAllowed()` method.
+Disallowing empty (null) selection, for example, using the [methodname]`setDeselectAllowed()` method would look like this:
 
 [source,java]
 ----
@@ -171,6 +158,7 @@ GridSingleSelectionModel<Person> singleSelect =
 singleSelect.setDeselectAllowed(false);
 ----
 
+
 ==== Multi-Selection Model
 
 In multi-selection mode, a user can select multiple items by selecting checkboxes in the left column.
@@ -179,7 +167,7 @@ Obtaining a reference to the [classname]`MultiSelectionModel` allows you access 
 
 You can use the [methodname]`addMultiSelectionListener(MultiSelectionListener)` method to access [classname]`MultiSelectionEvent`, which includes additional convenience methods and API options.
 
-*Example*: Using the [methodname]`addMultiSelectionListener()` method to access selection changes.
+For example, you could use the [methodname]`addMultiSelectionListener()` method to access selection changes like this:
 
 [source,java]
 ----
@@ -204,12 +192,12 @@ selectionModel.addMultiSelectionListener(event -> {
 });
 ----
 
+
 == Handling Item-Click Events
 
-It's possible to handle item-click or double-click events, in addition to handling selection events.
-These can be used with selection events or on their own.
+It's possible to handle item-click or double-click events, in addition to handling selection events. These can be used with selection events or on their own.
 
-*Example*: Disabling the selection mode using `SelectionMode.NONE`, but still getting item-click events.
+For example, to disable the selection mode using `SelectionMode.NONE`, but still get item-click events, you would do this:
 
 [source,java]
 ----
@@ -218,12 +206,9 @@ grid.addItemClickListener(event -> System.out
         .println(("Clicked Item: " + event.getItem())));
 ----
 
-* The clicked item, together with other information about the click, is available via the event.
-* Selection events are no longer available, and no visual selection is displayed when a row is clicked.
+The clicked item here, together with other information about the click, is available via the event. Selection events are no longer available, and no visual selection is displayed when a row is clicked.
 
-It's possible to get separate selection and click events.
-
-*Example*: Using `Grid` in multi-selection mode with an added click (or double-click) listener.
+It's possible to get separate selection and click events. An example of this follows, using `Grid` in multi-selection mode with an added click or double-click listener:
 
 [source,java]
 ----
@@ -232,18 +217,16 @@ grid.addItemDoubleClickListener(event ->
         copy(grid.getSelectedItems()));
 ----
 
-* In the example code, the local [methodname]`copy()` method is called with the currently selected items when the user double-clicks a row.
+In the example code here, the local [methodname]`copy()` method is called with the currently selected items when the user double-clicks a row.
+
 
 == Configuring Columns
 
-The [methodname]`addColumn()` method allows you to add columns to the `Grid`.
-
-The column configuration is defined in `Grid.Column` objects that are returned by the [methodname]`addColumn()` method.
-The [methodname]`getColumns()` method returns a list of currently configured columns.
+The [methodname]`addColumn()` method allows you to add columns to the `Grid`. The column configuration is defined in `Grid.Column` objects that are returned by the [methodname]`addColumn()` method. The [methodname]`getColumns()` method returns a list of currently configured columns.
 
 The setter methods in [classname]`Column` have fluent-API functionality, making it easy to chain configuration calls for columns.
 
-*Example*: Chaining column configuration calls.
+Below is an example of chaining column configuration calls:
 
 [source,java]
 ----
@@ -255,12 +238,12 @@ Column<Person> nameColumn = grid
     .setResizable(false);
 ----
 
+
 === Column Keys
 
-You can set an identifier key for a column using the [methodname]`setKey()` method.
-This allows you to retrieve the column from the grid at any time.
+You can set an identifier key for a column using the [methodname]`setKey()` method. This allows you to retrieve the column from the grid at any time.
 
-*Example*: Using the [methodname]`setKey()` method to set an identifier key for a column.
+Below is an example using the [methodname]`setKey()` method to set an identifier key for a column:
 
 [source,java]
 ----
@@ -268,12 +251,12 @@ nameColumn.setKey("name");
 grid.getColumnByKey("name").setWidth("100px");
 ----
 
+
 === Automatically Adding Columns
 
-You can configure `Grid` to automatically add columns for every property in a bean by passing the class of the bean type to the grid's constructor.
-The property names are set as the column keys, and you can use them to further configure the columns.
+You can configure `Grid` to add columns automatically for every property in a bean by passing the class of the bean type to the grid's constructor. The property names are set as the column keys, and you can use them to further configure the columns.
 
-*Example*: Automatically adding columns by passing the bean-type class to the constructor.
+Below is an example in which columns are added automatically by passing the bean-type class to the constructor:
 
 [source,java]
 ----
@@ -281,27 +264,25 @@ Grid<Person> grid = new Grid<>(Person.class);
 grid.getColumnByKey("yearOfBirth").setFrozen(true);
 ----
 
-* This constructor only adds columns for the direct properties of the bean type
-* The values are displayed as strings.
+This constructor only adds columns for the direct properties of the bean type. The values are displayed as strings.
 
 You can add columns for nested properties by using the dot notation with the [methodname]`setColumn(String)` method.
 
-*Example*: Adding a column for `postalCode`.
-Assumes [classname]`Person` has a reference to an [classname]`Address` object that has a `postalCode` property.
+Below is an example of adding a column for `postalCode`. It assumes [classname]`Person` has a reference to an [classname]`Address` object that has a `postalCode` property.
 
 [source,java]
 ----
 grid.addColumn("address.postalCode");
 ----
 
-* The column's key is "address.postalCode" and its header is "Postal Code".
-* To use these [classname]`String` properties in [methodname]`addColumn()`, you need to use the `Grid` constructor, which takes a bean-class parameter.
+The column's key here is "address.postalCode" and its header is "Postal Code". To use these [classname]`String` properties in [methodname]`addColumn()`, you need to use the `Grid` constructor, which takes a bean-class parameter.
 
-==== Defining and Ordering Automatically Added Columns
 
-You can define which columns display, and the order in which they display, in the grid, using the [methodname]`setColumns()` method.
+==== Defining & Ordering Automatically Added Columns
 
-*Example*: Defining columns and their order using the [methodname]`setColumns()` method.
+You can define which columns display, and the order in which they are displayed, in the grid, using the [methodname]`setColumns()` method.
+
+Below is an example in which columns are defined and they're ordered using the [methodname]`setColumns()` method:
 
 [source,java]
 ----
@@ -315,10 +296,9 @@ You can also use the [methodname]`setColumns()` method to reorder the columns yo
 [NOTE]
 When calling [methodname]`setColumns()`, all columns that are currently present in the grid are removed, and only those passed as parameters are added.
 
-To add custom columns before the auto-generated columns, use the [methodname]`addColumns()` method instead.
-You can avoid creating the auto-generated columns using the [methodname]`Grid(Class, boolean)` constructor.
+To add custom columns before the auto-generated columns, use instead the [methodname]`addColumns()` method. You can avoid creating the auto-generated columns by using the [methodname]`Grid(Class, boolean)` constructor.
 
-*Example*: Adding custom columns.
+Below is an example of adding custom columns:
 
 [source,java]
 ----
@@ -329,20 +309,20 @@ grid.addColumns("age", "address.postalCode");
 ----
 
 [NOTE]
-An `IllegalArgumentException` is thrown if you try to add columns that are already present the grid.
+An `IllegalArgumentException` is thrown if you try to add columns that are already present in the grid.
+
 
 ==== Sortable Automatic Columns
 
-By default, all property-based columns are sortable, if the property type implements [interfacename]`Comparable`.
+All property-based columns are sortable, by default, if the property type implements [interfacename]`Comparable`.
 
-Many data types, such as [classname]`String`, [classname]`Number`, primitive types and [classname]`Date`/[classname]`LocalDate`/[classname]`LocalDateTime` are [interfacename]`Comparable`, and therefore also sortable, by default.
+Many data types, such as [classname]`String`, [classname]`Number`, primitive types and [classname]`Date`/[classname]`LocalDate`/[classname]`LocalDateTime` are [interfacename]`Comparable`, and therefore also sortable by default.
 
-To make the column of a non-comparable property type sortable, you need to define a custom [classname]`Comparator`.
-See <<Column Sorting>> for more.
+To make the column of a non-comparable property type sortable, you need to define a custom [classname]`Comparator`. See <<Column Sorting>> for more.
 
-You can disable sorting for a specific column using the [methodname]`setSortable()` method.
+You can disable sorting for a specific column by using the [methodname]`setSortable()` method.
 
-*Example*: Disabling sorting on the `address.postalCode` column.
+Below is an example of this, disabling sorting on the `address.postalCode` column:
 
 [source,java]
 ----
@@ -350,10 +330,9 @@ grid.getColumnByKey("address.postalCode")
         .setSortable(false);
 ----
 
-You can also define a list of columns as sortable using the [methodname]`setSortableColumns()` method.
-This makes all other columns not sortable.
+You can also define a list of columns as sortable by using the [methodname]`setSortableColumns()` method. This makes all other columns not sortable.
 
-*Example*: Setting defined columns as sortable.
+The example here shows how to set defined columns as sortable:
 
 [source,java]
 ----
@@ -362,13 +341,12 @@ This makes all other columns not sortable.
 grid.setSortableColumns("name", "yearOfBirth");
 ----
 
-=== Column Headers and Footers
 
-By default, columns don't have a header or footer.
-These need to be set explicitly using the [methodname]`setHeader()` and [methodname]`setFooter()` methods.
-Both methods have two overloads; one accepts a plain text string and the other a [classname]`LitRenderer`.
+=== Column Headers & Footers
 
-*Examples*: Setting headers and footers.
+By default, columns don't have a header or a footer. They need to be set explicitly using the [methodname]`setHeader()` and [methodname]`setFooter()` methods. Both methods have two overloads: one accepts a plain text string, and the other a [classname]`LitRenderer`.
+
+Below is an example of how to set headers and footers:
 
 [source,java]
 ----
@@ -383,14 +361,14 @@ nameColumn.setFooter("Name");
 nameColumn.setFooter(new Html("<b>Name</b>"));
 ----
 
-See <<Using Lit Renderers>> for more.
+See <<Using Lit Renderers>> for more information.
+
 
 === Column Reordering
 
-Column reordering isn't enabled by default.
-You can use the [methodname]`setColumnReorderingAllowed()` method to allow column reordering by dragging.
+Column reordering isn't enabled by default. You can use the [methodname]`setColumnReorderingAllowed()` method to allow column reordering by dragging.
 
-*Example*: Enabling column reordering.
+Below is an example of how to enable column reordering:
 
 [source,java]
 ----
@@ -400,10 +378,7 @@ grid.setColumnReorderingAllowed(true);
 ////
 NOT IMPLEMENTED YET
 
-You can set the order of columns with `setColumnOrder()` for the
-grid. Columns that aren't given for the method are placed after the specified
-columns in their natural order.
-
+You can set the order of columns with `setColumnOrder()` for the grid. Columns that aren't given for the method are placed after the specified columns in their natural order.
 
 [source,java]
 ----
@@ -412,58 +387,53 @@ grid.setColumnOrder(firstnameColumn, lastnameColumn,
                     diedColumn);
 ----
 
-The method can't be used to hide columns. You can hide columns with `Column()`, as described later.
+This method can't be used to hide columns. You can hide columns with `Column()`, as described later.
 ////
+
 
 === Hiding Columns
 
 Columns can be hidden by calling the [methodname]`setVisible()` method in [classname]`Column`.
 
 [NOTE]
-A hidden column still sends the data required to render it to the client side.
-Best practice is to remove (or not add) columns if the data isn't needed on the client side.
-This reduces the amount of data sent and lessens the load on the client.
+A hidden column still sends the data required to render it to the client side. The best practice is to remove -- or not add -- columns if the data isn't needed on the client side. This reduces the amount of data sent, and it thereby lessens the load on the client.
+
 
 === Removing Columns
 
-You can remove a single column using the [methodname]`removeColumn(Column)` and [methodname]`removeColumnByKey(String)` methods.
-You can also remove all currently configured columns using the [methodname]`removeAllColumns()` method.
+You can remove a single column using the [methodname]`removeColumn(Column)` and [methodname]`removeColumnByKey(String)` methods. You can also remove all currently configured columns using the [methodname]`removeAllColumns()` method.
+
 
 === Setting Column Widths
 
-By default, columns don't have a defined width.
-They resize automatically based on the data displayed.
+By default, columns don't have a defined width. They resize automatically based on the data displayed.
 
-You can set the column width:
+You can set the column width either relatively, using flex grow ratios by using the [methodname]`setFlexGrow()` method, or you can set them explicitly using a CSS string value with [methodname]`setWidth()` -- with flex grow set to `0`.
 
-* relatively, using flex grow ratios, by using the [methodname]`setFlexGrow()` method, or
-* explicitly, using a CSS string value with [methodname]`setWidth()` (with flex grow set to `0`).
-
-You can also enable user column resizing using the [methodname]`setResizable()` method.
-The column is resized by dragging the column divider.
+You can also enable user column resizing using the [methodname]`setResizable()` method. The column is resized by dragging the column divider.
 
 
 === Setting Frozen Columns
 
-You can freeze columns using the [methodname]`setFrozen()` method.
-This ensures that the set number of columns on the left remain static (and visible) when the user scrolls horizontally.
+You can freeze columns using the [methodname]`setFrozen()` method. This ensures the set number of columns on the left remain static and visible when the user scrolls horizontally.
 
 When columns are frozen, user reordering is limited to the frozen columns.
 
-*Example*: Setting a column as frozen.
+Below is an example of setting a column as frozen:
+
 [source,java]
 ----
 nameColumn.setFrozen(true);
 ----
 
+
 === Grouping Columns
 
 You can group multiple columns together by adding them in the [classname]`HeaderRow` of the grid.
 
-When you retrieve the [classname]`HeaderRow`, using the [methodname]`prependHeaderRow()` or [methodname]`appendHeaderRow()` methods, you can then group the columns using the [methodname]`join()` method.
-In addition, you can use the [methodname]`setText()` and [methodname]`setComponent()` methods on the join result to set the text or component for the joined columns.
+When you retrieve the [classname]`HeaderRow`, using the [methodname]`prependHeaderRow()` or [methodname]`appendHeaderRow()` methods, you can then group the columns using the [methodname]`join()` method. Additionally, you can use the [methodname]`setText()` and [methodname]`setComponent()` methods on the join result to set the text or component for the joined columns.
 
-*Example*: Grouping columns
+For example, you can group columns like so:
 
 [source,java]
 ----
@@ -479,25 +449,26 @@ topRow.join(streetColumn, postalCodeColumn)
         .setComponent(new Label("Address Information"));
 ----
 
+
 == Using Renderers in Columns
 
-You can configure columns to use a renderer to show the data in the cells.
+You can configure columns to use a renderer to show the data in the cells. Conceptually, there are three types of renderer:
 
-Conceptually, there are three types of renderer:
+. *Basic Renderer*: Renders basic values, such as dates and numbers.
+. *Lit Renderer*: Renders content using HTML markup and Lit data-binding syntax.
+. *Component Renderer*: Renders content using arbitrary components.
 
-. *Basic renderer*: Renders basic values, such as dates and numbers.
-. *Lit renderer*: Renders content using HTML markup and Lit data-binding syntax.
-. *Component renderer*: Renders content using arbitrary components.
 
 === Using Basic Renderers
 
 You can use several basic renderers to configure grid columns.
 
+
 ==== Local Date Renderer
 
 Use [classname]`LocalDateRenderer` to render [classname]`LocalDate` objects in the cells.
 
-*Example*: Using [classname]`LocalDateRenderer` with the [methodname]`addColumn()` method.
+An example of this is below, which is using [classname]`LocalDateRenderer` with the [methodname]`addColumn()` method:
 
 [source,java]
 ----
@@ -510,7 +481,7 @@ grid.addColumn(new LocalDateRenderer<>(
 
 [classname]`LocalDateRenderer` works with a [classname]`DateTimeFormatter` or a [classname]`String` format to render [classname]`LocalDate` objects.
 
-*Example*: Using a [classname]`String` format to render the [classname]`LocalDate` object.
+Here is an example using a [classname]`String` format to render the [classname]`LocalDate` object:
 
 [source,java]
 ----
@@ -520,11 +491,12 @@ grid.addColumn(new LocalDateRenderer<>(
     .setHeader("Estimated delivery date");
 ----
 
+
 ==== Local Date Time Renderer
 
 Use [classname]`LocalDateTimeRenderer` to render [classname]`LocalDateTime` objects in the cells.
 
-*Example*: Using [classname]`LocalDateTimeRenderer` with the [methodname]`addColumn()` method.
+Below is an example using [classname]`LocalDateTimeRenderer` with the [methodname]`addColumn()` method:
 
 [source,java]
 ----
@@ -536,9 +508,9 @@ grid.addColumn(new LocalDateTimeRenderer<>(
     .setHeader("Purchase date and time");
 ----
 
-[classname]`LocalDateTimeRenderer` also works with [classname]`DateTimeFormatter` (with separate styles for date and time) or a [classname]`String` format to render [classname]`LocalDateTime` objects.
+[classname]`LocalDateTimeRenderer` also works with [classname]`DateTimeFormatter` -- with separate styles for date and time -- or a [classname]`String` format to render [classname]`LocalDateTime` objects.
 
-*Example*: Using a [classname]`String` format to render the [classname]`LocalDateTime` object.
+Here is an example using a [classname]`String` format to render the [classname]`LocalDateTime` object:
 
 [source,java]
 ----
@@ -548,12 +520,12 @@ grid.addColumn(new LocalDateTimeRenderer<>(
 ).setHeader("Purchase date and time");
 ----
 
+
 ==== Number Renderer
 
-Use [classname]`NumberRenderer` to render any type of [classname]`Number` in the cells.
-It's especially useful for rendering floating-point values.
+Use [classname]`NumberRenderer` to render any type of [classname]`Number` in the cells. It's especially useful for rendering floating-point values.
 
-*Example*: Using [classname]`NumberRenderer` with the [methodname]`addColumn()` method.
+The example here is using [classname]`NumberRenderer` with the [methodname]`addColumn()` method:
 
 [source,java]
 ----
@@ -564,7 +536,7 @@ grid.addColumn(new NumberRenderer<>(Item::getPrice,
 
 It's possible to set up the [classname]`NumberRenderer` with a [classname]`String` format, and an optional null representation.
 
-*Example*: Using a [classname]`String` format to render a price.
+For example, to use a [classname]`String` format to render a price do something like this:
 
 [source,java]
 ----
@@ -574,13 +546,12 @@ grid.addColumn(new NumberRenderer<>(
 ).setHeader("Price");
 ----
 
+
 ==== Native Button Renderer
 
-Use [classname]`NativeButtonRenderer` to create a clickable button in the cells.
-This creates a native `<button>` on the client side.
-Click and tap (for touch devices) events are handled on the server side.
+Use [classname]`NativeButtonRenderer` to create a clickable button in the cells. This creates a native `<button>` on the client side. Click events -- or tap for touch devices -- are handled on the server side.
 
-*Example*: Using [classname]`NativeButtonRenderer` with the [methodname]`addColumn()` method.
+Below is an example using [classname]`NativeButtonRenderer` with the [methodname]`addColumn()` method:
 
 [source,java]
 ----
@@ -594,7 +565,7 @@ grid.addColumn(
 
 You can configure a custom label for each item.
 
-*Example*: Configuring [classname]`NativeButtonRenderer` to use a custom label.
+The example here is configuring [classname]`NativeButtonRenderer` to use a custom label:
 
 [source,java]
 ----
@@ -606,11 +577,12 @@ grid.addColumn(new NativeButtonRenderer<>(
 );
 ----
 
+
 === Using Lit Renderers
 
 Providing a [classname]`LitRenderer` for a column allows you to define the content of cells using HTML markup, and to use Lit notations for data binding and event handling.
 
-*Example*: Using [classname]`LitRenderer` to embolden the names of the persons.
+The example here is using [classname]`LitRenderer` to embolden the names of the persons:
 
 [source,java]
 ----
@@ -623,20 +595,16 @@ grid.addColumn(LitRenderer
 ).setHeader("Name");
 ----
 
-* The template string is passed for the static [methodname]`LitRenderer.of()` method.
-* Every property in the template needs to be defined in the [methodname]`withProperty()` method.
-* `${item.name}` is the Lit syntax for interpolating properties into the template.
-See the https://lit.dev/docs/templates/overview/[Lit documentation] for more.
-* When using a custom Web Component or a Vaadin element in a Lit renderer, remember to import the component.
-This can be done using link:https://vaadin.com/api/platform/com/vaadin/flow/component/dependency/JsModule.html[`@JsModule`] or link:https://vaadin.com/api/platform/com/vaadin/flow/component/dependency/Uses.html[`@Uses`], if the component has a server-side counterpart.
-This ensures that all `StyleSheet`, `HtmlImport`, and `JavaScript` dependencies for the component are loaded when the Grid is used.
+The template string here is passed for the static [methodname]`LitRenderer.of()` method. Every property in the template needs to be defined in the [methodname]`withProperty()` method. The `${item.name}` is the Lit syntax for interpolating properties into the template. See the https://lit.dev/docs/templates/overview/[Lit documentation] for more.
+
+When using a custom Web Component or a Vaadin element in a Lit renderer, remember to import the component. This can be done using link:https://vaadin.com/api/platform/com/vaadin/flow/component/dependency/JsModule.html[`@JsModule`] or link:https://vaadin.com/api/platform/com/vaadin/flow/component/dependency/Uses.html[`@Uses`], if the component has a server-side counterpart. It ensures that all `StyleSheet`, `HtmlImport`, and `JavaScript` dependencies for the component are loaded when the Grid is used.
+
 
 ==== Creating Custom Properties
 
-You can use a [classname]`LitRenderer` to create and display new properties (that is, properties the item didn't originally contain).
+You can use a [classname]`LitRenderer` to create and display new properties, properties the item didn't originally contain.
 
-*Example*: Using [classname]`LitRenderer` to compute the approximate age of each person and add it in a new column.
-Age is the current year minus the birth year.
+The example below is using [classname]`LitRenderer` to compute the approximate age of each person and add it in a new column. Age is the current year minus the birth year.
 
 [source,java]
 ----
@@ -648,11 +616,12 @@ grid.addColumn(LitRenderer
 ).setHeader("Age");
 ----
 
+
 ==== Using Expressions
 
 Lit templates can include any type of JavaScript expression, not limited to binding single property values.
 
-*Example*: By evaluating the person's age in the template expression, the age column could also be written as:
+For example, by evaluating the person's age in the template expression, the age column could also be written as this:
 
 [source,java]
 ----
@@ -662,16 +631,16 @@ grid.addColumn(LitRenderer
 ).setHeader("Age");
 ----
 
+
 ==== Binding Beans
 
-If an object contains a bean property that has sub-properties, it's only necessary to make the bean accessible by calling the [methodname]`withProperty()` method.
-The sub-properties become accessible automatically.
+If an object contains a bean property that has sub-properties, it's only necessary to make the bean accessible by calling the [methodname]`withProperty()` method. The sub-properties become accessible automatically.
 
 [WARNING]
-All properties of the bean, even ones which aren't used in the template, are sent to the client, so use this feature with caution.
+All properties of the bean, even ones which aren't used in the template, are sent to the client. Therefore, use this feature with caution.
 
-*Example*: Using the [methodname]`withProperty()` method to access multiple sub-properties.
-This assumes that [classname]`Person` has a field for the [classname]`Address` bean, which has `street`, `number` and `postalCode` fields with corresponding getter and setter methods.
+The example that follows is using the [methodname]`withProperty()` method to access multiple sub-properties. This assumes that [classname]`Person` has a field for the [classname]`Address` bean, which has `street`, `number` and `postalCode` fields with corresponding getter and setter methods.
+
 [source,java]
 ----
 grid.addColumn(LitRenderer.<Person>of(
@@ -683,14 +652,12 @@ grid.addColumn(LitRenderer.<Person>of(
     .setHeader("Address");
 ----
 
+
 ==== Handling Events
 
-You can define event handlers for the elements in your template, and hook them to server-side code, by calling the [methodname]`withFunction()` method on your [classname]`LitRenderer`.
-This is useful for editing items in the grid.
+You can define event handlers for the elements in your template, and hook them to server-side code, by calling the [methodname]`withFunction()` method on your [classname]`LitRenderer`. This is useful for editing items in the grid.
 
-*Example*: Using the [methodname]`withFunction()` method to map defined method names to server-side code.
-The snippet adds a new column with two buttons: one to edit a property of the item and one to remove the item.
-Both buttons define a method to call for `click` events.
+The example that follows is using the [methodname]`withFunction()` method to map defined method names to server-side code. The snippet adds a new column with two buttons: one to edit a property of the item; and one to remove the item. Both buttons define a method to call for `click` events.
 
 [source,java]
 ----
@@ -709,19 +676,14 @@ grid.addColumn(LitRenderer.<Person>of(
     })).setHeader("Actions");
 ----
 
-* When the server-side data used by the grid is edited, the grid's [classname]`DataProvider` is refreshed by calling the [methodname]`refreshItem()` method.
-This ensures that the changes show up in the element.
-* When an item is removed, the [methodname]`refreshAll()` method call ensures that all the data is updated.
-* You need to use Lit notation for event handlers.
-`@click` is Lit syntax for the native `click`.
-* [classname]`LitRenderer` has a fluent API, so you can chain the commands, like
+When the server-side data used by the grid here is edited, the grid's [classname]`DataProvider` is refreshed by calling the [methodname]`refreshItem()` method. This ensures that the changes are in the element. When an item is removed, the [methodname]`refreshAll()` method call ensures that all of the data is updated. 
+
+You will need to use Lit notation for event handlers. The `@click` is Lit syntax for the native `click`. The  [classname]`LitRenderer` has a fluent API, so you can chain the commands, like
 `LitRenderer.of().withProperty().withProperty().withFunction()...`
 
-The [methodname]`withFunction()` handler can also receive more data in addition to the item.
-To pass additional data from client to the server-side handler, you need to invoke the function in the Lit template with the desired extra parameters.
-The additional data can be accessed via the second handler parameter (of type [classname]`JsonArray`).
+The [methodname]`withFunction()` handler can also receive more data in addition to the item. To pass additional data from client to the server-side handler, you need to invoke the function in the Lit template with the desired extra parameters. The additional data can be accessed via the second handler parameter -- of type [classname]`JsonArray`.
 
-*Example*:
+Below is an example of this:
 
 [source,java]
 ----
@@ -734,16 +696,14 @@ grid.addColumn(LitRenderer.<Person>of(
     }).withProperty("profession", Person::getProfession));
 ----
 
-* The functions defined by the [methodname]`withFunction()` method can be called with any number of additional parameters.
-* The additional argument of type [classname]`String` (the updated profession) is obtained from the second handler parameter with [methodname]`args.getString(0)`, where the number is the index of the argument in the [classname]`JsonArray`.
+The functions defined by the [methodname]`withFunction()` method can be called with any number of additional parameters. The additional argument of type [classname]`String` (the updated profession) is obtained from the second handler parameter with [methodname]`args.getString(0)`, where the number is the index of the argument in the [classname]`JsonArray`.
+
 
 === Using Component Renderers
 
-You can use any component in the grid cells by providing a [classname]`ComponentRenderer` for a column.
+You can use any component in the grid cells by providing a [classname]`ComponentRenderer` for a column. To define how the component is generated for each item, you need to pass a [classname]`Function` for the [classname]`ComponentRenderer`.
 
-To define how the component is generated for each item, you need to pass a [classname]`Function` for the [classname]`ComponentRenderer`.
-
-*Example*: Adding a column that contains a different icon depending on the person's gender.
+For example, to add a column that contains a different icon depending on the person's gender, you would do something like this:
 
 [source,java]
 ----
@@ -761,7 +721,8 @@ grid.addColumn(new ComponentRenderer<>(person -> {
 
 It's also possible to provide a separate [classname]`Supplier` to create the component, and a [classname]`Consumer` to configure it for each item.
 
-*Example*: Using [classname]`ComponentRenderer` with a [classname]`Consumer`.
+The example below uses [classname]`ComponentRenderer` with a [classname]`Consumer`:
+
 [source,java]
 ----
 SerializableBiConsumer<Div, Person> consumer =
@@ -771,9 +732,10 @@ grid.addColumn(
     .setHeader("Name");
 ----
 
-If the component is the same for every item, you only need to provide the [classname]`Supplier`.
+If the component is the same for each item, you only need to provide the [classname]`Supplier`.
 
-*Example*: Using [classname]`ComponentRenderer` with a [classname]`Supplier`.
+The example here is using [classname]`ComponentRenderer` with a [classname]`Supplier`:
+
 [source,java]
 ----
 grid.addColumn(
@@ -783,7 +745,8 @@ grid.addColumn(
 
 You can create complex content for the grid cells by using the component APIs.
 
-*Example*: Using [classname]`ComponentRenderer` to create complex content that listens for events and wraps multiple components in layouts.
+This example is using [classname]`ComponentRenderer` to create complex content that listens for events and wraps multiple components in layouts:
+
 [source,java]
 ----
 grid.addColumn(new ComponentRenderer<>(person -> {
@@ -814,22 +777,20 @@ grid.addColumn(new ComponentRenderer<>(person -> {
     return new VerticalLayout(name, buttons);
 })).setHeader("Actions");
 ----
+
 [NOTE]
 [methodname]`addComponentColumn()` is a shorthand for [methodname]`addColumn()` with a [classname]`ComponentRenderer`.
 
-* Editing grid items requires refreshing the grid's [classname]`DataProvider`.
-The reasoning is the same as for <<Handling Events>> mentioned earlier.
+Editing grid items requires refreshing the grid's [classname]`DataProvider`. The reasoning is the same as for <<Handling Events>> mentioned earlier. See <<{articles}/binding-data/data-provider#,Data Providers>> for more.
 
-See <<{articles}/binding-data/data-provider#,Data Providers>> for more.
 
 == Enabling Expanding Rows
 
-The `Grid` supports expanding rows that reveal more detail about the items.
-The additional information is hidden, unless the user chooses to reveal it, keeping the grid appearance clean and simple, while simultaneously allowing detailed explanations.
+The `Grid` supports expanding rows that reveal more details about the items. The additional information is hidden, unless the user chooses to reveal it, keeping the grid appearance clean and simple, while simultaneously allowing detailed explanations.
 
 You can enable expanding rows using the [methodname]`setItemDetailsRenderer()` method, which allows either a [classname]`LitRenderer` or a [classname]`ComponentRenderer` to define how the details are rendered.
 
-*Example*: Using the [methodname]`setItemDetailsRenderer()` method with a [classname]`ComponentRenderer`.
+Below is an example using the [methodname]`setItemDetailsRenderer()` method with a [classname]`ComponentRenderer`:
 
 [source,java]
 ----
@@ -845,35 +806,27 @@ grid.setItemDetailsRenderer(
 }));
 ----
 
-By default, the row's detail opens by clicking the row.
-Clicking the row again, or clicking another row (to open its detail), automatically closes the first row's detail.
-You can disable this behavior by calling the [methodname]`grid.setDetailsVisibleOnClick(false)` method.
-You can show and hide item details programmatically using the [methodname]`setDetailsVisible()` method, and test whether an item's detail is visible using the [methodname]`isDetailsVisible()` method.
+By default, the row's detail opens by clicking the row. Clicking the row again, or clicking another row to open its detail, automatically closes the first row's detail. You can disable this behavior by calling the [methodname]`grid.setDetailsVisibleOnClick(false)` method. You can show and hide item details programmatically using the [methodname]`setDetailsVisible()` method, and test whether an item's detail is visible using the [methodname]`isDetailsVisible()` method.
 
 [NOTE]
-By default, items are selected by clicking them.
-If you want the click action only to show the item details without selection, you need to use the [methodname]`grid.setSelectionMode(SelectionMode.NONE)` method.
+By default, items are selected by clicking them. If you want the click action only to show the item details without selection, you need to use the [methodname]`grid.setSelectionMode(SelectionMode.NONE)` method.
+
 
 == Column Sorting
 
-By default, this is how column sorting in the grid works:
+Column sorting in the grid has an order to its process. The first click on the column header sorts the column. The second click reverses the sort order. And the third click resets the column to its unsorted state.
 
-* The first click on the column header sorts the column.
-* The second click reverses the sort order.
-* The third click resets the column to its unsorted state.
+If multi-sorting is enabled, the user can sort by multiple columns. Then the first click sorts the first column, while subsequent clicks on a second and more sortable column headers, add secondary and more sort criteria.
 
-If multi-sorting is enabled, the user can sort by multiple columns.
-The first click sorts the first column.
-Subsequent clicks on second and more sortable column headers add secondary and more sort criteria.
 
 === Enabling Column Sorting
 
-For columns that have been created from a property name (`grid.addColumn("firstName")`) sorting is enabled by default, if the type of the property implements `Comparable`.
-In general this only applies to grids that have been created from a class name (`new Grid(Person.class)`).
+For columns that have been created from a property name (`grid.addColumn("firstName")`), sorting is enabled by default -- if the type of the property implements `Comparable`. In general this only applies to grids that have been created from a class name (`new Grid(Person.class)`).
 
 For columns that have been created from a `ValueProvider` (`grid.addColumn(Person::getFirstName)`), or from a renderer such as `LitRenderer` (`grid.addColumn(new LitRenderer<Person>(...))`), sorting is not enabled by default.
 
 Sorting for a column can be enabled or disabled manually:
+
 ```java
 // Enabled sorting for a column
 column.setSortable(true);
@@ -885,35 +838,26 @@ column.setSortable(false);
 var isSortable = column.isSortable();
 ```
 
-Depending on how the column was created, it may need additional configuration.
-In order to figure out whether that is the case, we need to consider the two sorting mechanisms supported by Grid:
+Depending on how the column was created, it may need additional configuration. In order to determine this, you need to consider the two sorting mechanisms supported by Grid: in-memory sorting or backend sorting.
 
-* *In-memory sorting* is sorting that is automatically applied by the framework when using an in-memory data provider.
-Items are sorted using a `Comparator` that can either be created automatically by the column or has to be specified manually by the developer.
+In-memory sorting is sorting that is automatically applied by the framework when using an in-memory data provider. Items are sorted using a `Comparator` that can either be created automatically by the column or has to be specified manually by the developer.
 
-* *Backend sorting* is applied by providing a list of [classname]`QuerySortOrder` objects a custom [classname]`DataProvider` implemented by the developer.
-Sort order objects contain the property names that the developer must use for sorting items in their backend, such as a database.
-See <<{articles}/binding-data/data-provider#Sorting,Data Providers>> for more.
+Backend sorting is applied by providing a list of [classname]`QuerySortOrder` objects a custom [classname]`DataProvider` implemented by the developer. Sort order objects contain the property names that the developer must use for sorting items in their backend, such as a database. See <<{articles}/binding-data/data-provider#Sorting,Data Providers>> for more.
 
-With that in mind, we can break down which columns are automatically configured for in-memory, or backend sorting:
+With that in mind, you can determine which columns are automatically configured for in-memory or backend sorting:
 
-- For columns created from a property name, in-memory sorting is automatically configured if the type of the property implements `Comparable`.
-Otherwise, a custom comparator must be provided by the developer.
-Backend sorting is configured automatically in any case, as the column knows the property name to pass to the data provider.
-- For columns created from a `ValueProvider` only in-memory sorting is configured automatically, where the value provider is used to build a comparator.
-Backend sorting is not configured automatically, as the column does not know which property name to pass to the data provider.
-- For columns created from a renderer, neither in-memory sorting, nor backend sorting is configured automatically.
-The column can not create a comparator from the renderer, nor does it know the property name to pass to the data provider.
+- For columns created from a property name, in-memory sorting is automatically configured if the type of the property implements `Comparable`. Otherwise, a custom comparator must be provided by the developer. Backend sorting is configured automatically in any case, as the column knows the property name to pass to the data provider.
+- For columns created from a `ValueProvider`, only in-memory sorting is configured automatically, where the value provider is used to build a comparator. Backend sorting is not configured automatically, as the column does not know which property name to pass to the data provider.
+- For columns created from a renderer, neither in-memory sorting, nor backend sorting is configured automatically. The column cannot create a comparator from the renderer, nor does it know the property name to pass to the data provider.
 
 If either sort mechanism is not configured automatically, it can be configured manually as explained in the following sections.
 
+
 ==== Configuring In-Memory Sorting
 
-For in-memory sorting, a custom comparator can be configured using `Column.setComparator`.
-Use this if a column is not automatically configured for in-memory sorting, or if you want to customize the in-memory sorting behavior.
+For in-memory sorting, a custom comparator can be configured using `Column.setComparator`. Use this if a column is not automatically configured for in-memory sorting, or if you want to customize the in-memory sorting behavior.
 
-*Example*: Configuring a comparator for a column using a [classname]`LitRenderer`.
-The renderer shows the person's name and email address, for sorting only the email address is used.
+The example below shows how to configure a comparator for a column using a [classname]`LitRenderer`. The renderer shows the person's name and email address, for sorting only the email address is used.
 
 [source,java]
 ----
@@ -926,7 +870,8 @@ grid.addColumn(LitRenderer.<Person>of(
     .setHeader("Person");
 ----
 
-*Example*: Customizing the in-memory sorting for a column created from a value provider by implementing a comparator that is not case-sensitive.
+This next example is customizing the in-memory sorting for a column created from a value provider by implementing a comparator that is not case-sensitive:
+
 [source,java]
 ----
 grid.addColumn(Person::getName)
@@ -939,11 +884,9 @@ grid.addColumn(Person::getName)
 
 ==== Configuring Backend Sorting
 
-For backend sorting, the sort properties that are passed to a data provider can be configured using `Column.setSortProperty`.
-The method allows providing multiple sort properties, which are passed to the data provider in the specified order.
-Use this if a column is not automatically configured for backend sorting, or if you want to customize the backend sorting behavior.
+For backend sorting, the sort properties that are passed to a data provider can be configured using `Column.setSortProperty`. The method allows for providing multiple sort properties, which are passed to the data provider in the specified order. Use this if a column is not automatically configured for backend sorting, or if you want to customize the backend sorting behavior.
 
-*Example*: Configuring sort properties for a column created from a value provider.
+The example here is configuring sort properties for a column created from a value provider:
 
 [source,java]
 ----
@@ -952,8 +895,7 @@ grid.addColumn(Person::getName)
         .setHeader("Person");
 ----
 
-*Example*: Setting a sort property for a column using a [classname]`LitRenderer`.
-The renderer shows the person's name and email address, for sorting only the email address is used.
+The next example is setting a sort property for a column using a [classname]`LitRenderer`. The renderer shows the person's name and email address, for sorting only the email address is used.
 
 [source,java]
 ----
@@ -966,11 +908,9 @@ grid.addColumn(LitRenderer.<Person>of(
     .setHeader("Person");
 ----
 
-An alternative way to configure backend sorting is using a [classname]`SortOrderProvider`, which is called on demand when the sort order is changed.
+An alternative way to configure backend sorting is to use a [classname]`SortOrderProvider`, which is called on demand when the sort order is changed. Use this if you need fine-grained control over how [classname]`QuerySortOrder` objects are created and sent to the [classname]`DataProvider`.
 
-Use this if you need fine-grained control over how [classname]`QuerySortOrder` objects are created and sent to the [classname]`DataProvider`.
-
-*Example*: Defining a [classname]`SortOrderProvider` for backend sorting.
+This example is defining a [classname]`SortOrderProvider` for backend sorting:
 
 [source,java]
 ----
@@ -982,23 +922,25 @@ grid.addColumn(Person::getName)
     .setHeader("Person");
 ----
 
+
 === Enabling Multi-Sorting
 
 To allow users to sort by more than one column at the same time, you can use the [methodname]`setMultiSort()` method to enable multi-sorting at the grid level.
 
-*Example*: Using the [methodname]`setMultiSort()` method to enable multi-sorting.
+This example is using the [methodname]`setMultiSort()` method to enable multi-sorting:
+
 [source,java]
 ----
 grid.setMultiSort(true);
 ----
 
+
 === Receiving Sort Events
 
-You can add a [classname]`SortListener` to the grid to receive general sort events.
-Every time sorting of the grid is changed, an event is fired.
-You can access the [classname]`DataCommunicator` to receive the sorting details.
+You can add a [classname]`SortListener` to the grid to receive general sort events. Each time sorting of the grid is changed, an event is fired. You can access the [classname]`DataCommunicator` to receive the sorting details.
 
-*Example*: Using the [methodname]`addSortListener()` method to add a [classname]`SortListener`.
+The example below is using the [methodname]`addSortListener()` method to add a [classname]`SortListener`:
+
 [source,java]
 ----
 grid.addSortListener(event -> {
@@ -1015,17 +957,14 @@ grid.addSortListener(event -> {
 });
 ----
 
+
 == Styling the Grid
 
-Styling the `Grid` component (or any Vaadin component) requires some Web Component and shadow-DOM knowledge.
-Styling depends on the component's position in the DOM:
+Styling the `Grid` component or any Vaadin component requires some Web Component and shadow-DOM knowledge. Styling depends on the component's position in the DOM: If the component is in the shadow DOM, you can apply styling within the component or using variables. If the component is in the "normal" DOM (i.e., not in the shadow DOM), normal CSS styling applies.
 
-* If the component is in the shadow DOM, you can apply styling within the component or using variables.
-* If the component is in the "normal" DOM (not in the shadow DOM), normal CSS styling applies.
+Additionally, the `Grid` supports the `theme` attribute, which allows you to customize component styling.
 
-In addition, the `Grid` supports the `theme` attribute, which allows you to customize component styling.
-
-*Example*: `Celebrity` grid used in styling examples below.
+`Celebrity` grid is used in styling examples below:
 
 [source,java]
 ----
@@ -1061,12 +1000,12 @@ grid.addColumn(new ComponentRenderer<>(person -> {
 
 ----
 
+
 === Styling with the Theme Property
 
-The default Lumo theme includes different variations that you can use to style the grid.
-You can provide one or more variations.
+The default Lumo theme includes different variations that you can use to style the grid. You can provide one or more variations.
 
-*Example*: Using the [methodname]`addThemeVariants()` method to define theme variations for the grid.
+This example uses the [methodname]`addThemeVariants()` method to define theme variations for the grid:
 
 [source,java]
 ----
@@ -1077,10 +1016,9 @@ grid.addThemeVariants(GridVariant.LUMO_NO_ROW_BORDERS,
 
 === Styling with CSS
 
-You can use normal CSS styling for the content in the grid cells.
-Although the `Grid` component itself is in the shadow DOM, the actual values (cell contents) are in slots and therefore in the light DOM.
+You can use normal CSS styling for the content in grid cells. Although the `Grid` component itself is in the shadow DOM, the actual values (i.e., cell contents) are in slots and therefore in the light DOM.
 
-*Example*: Setting the maximum size for images in the grid cells.
+For example, you can set the maximum size for images in the grid cells like so:
 
 [source,css]
 ----
@@ -1088,11 +1026,10 @@ vaadin-grid vaadin-grid-cell-content img {
     max-height: 4em;
 }
 ----
-* `vaadin-grid-cell-content` is in the light DOM, and the selector `vaadin-grid vaadin-grid-cell-content` points to all the grid's cells.
 
-You can also use a class to apply styles to a specific component instance.
+The `vaadin-grid-cell-content` is in the light DOM, and the selector `vaadin-grid vaadin-grid-cell-content` points to all of the grid's cells.
 
-*Example*: Applying rounded borders and centering images in a grid with a "styled" class name.
+You can also use a class to apply styles to a specific component instance. For example, to apply rounded borders and center images in a grid with a "styled" class name, you would do something like this:
 
 [source,css]
 ----

--- a/articles/components/grid/flow.asciidoc
+++ b/articles/components/grid/flow.asciidoc
@@ -5,6 +5,8 @@ order: 50
 
 = Using Grid in Flow
 
+Grid is a feature-rich component and therefore complex. Due to the server-driven nature of the component, there are some exclusive features available for the Java API and when using Grid together with Vaadin Flow. This page shows how to use Grid in a Flow application. It also explains the unique features, such as configuring Lit renderers instead of generic component renderers and styling the component with the Theme property.
+
 == Binding to Data
 
 `Grid` is bound to a [classname]`List` of items, by default. You can use the [methodname]`setItems()` method to set the items.

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -37,9 +37,7 @@ include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags
 
 == Content
 
-A basic Grid uses plain text to display information in rows and columns.
-Rich content can be used to provide additional information in a more legible fashion.
-Components such as <<../input-fields#,input fields>> and <<../button#,Button>> are also supported.
+A basic Grid uses plain text to display information in rows and columns. Rich content can be used to provide additional information in a more legible fashion. Components such as <<../input-fields#,input fields>> and <<../button#,Button>> are also supported.
 
 [.example]
 --
@@ -59,47 +57,37 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContent.java[re
 ----
 --
 
+
 === Component Renderer vs. Lit Renderer (Flow Only)
 
 As demonstrated in the previous example, custom content can be rendered using component renderers or Lit renderers.
 
+
 ==== Component Renderer
 
-Component renderers are easy to build, but slow to render.
-For a given column, they generate a component for each item in the dataset.
-The rendered components are fully controllable on the server side.
+Component renderers are easy to build, but slow to render. For a given column, they generate a component for each item in the dataset. The rendered components are fully controllable on the server side.
 
-For each rendered cell, Grid creates a corresponding component instance on the server side.
-A dataset of 100 items and 10 columns using component renderer adds up to 1,000 components that need to be managed.
-The more components you use in a component renderer, the greater the impact on performance.
+For each rendered cell, Grid creates a corresponding component instance on the server side. A dataset of 100 items and 10 columns using component renderer produce up to 1,000 components that need to be managed. The more components you use in a component renderer, the greater the impact on performance.
 
-Component renderers are very flexible and easy to use, but should be used with caution.
-They are better suited as editors, since only a single row can be edited at a time.
-They can also be used for detail rows.
+Component renderers are very flexible and easy to use, but should be used with caution. They're better suited as editors since only a single row can be edited at a time. They can also be used for detail rows.
+
 
 ==== Lit Renderer
 
-Lit renderers render quickly, but require you to write HTML.
-To use components with Lit renderers, you need to use their HTML format.
-Lit templates are immutable, meaning that the state of the components can't be managed on the server side.
-However, the template can have different representations, depending on the state of the item.
+Lit renderers will render quickly, but require you to write HTML. To use components with Lit renderers, you need to use their HTML format. Lit templates are immutable, meaning the state of the components can't be managed on the server side. However, the template can have different representations, depending on the state of the item.
 
 The only data sent from the server, other than the template itself -- which is sent only once -- is the extra name property of each item.
 
-Lit templates still enable event handling on the server side. However, you can't, for example, disable or change the text of a button from the event handler.
-For such situations, use editors instead.
+Lit templates still enable event handling on the server side. However, you can't, for example, disable or change the text of a button from the event handler. For such situations, use editors instead.
 
-With Lit renderers, the server doesn't keep track of the components in each cell.
-It only manages the state of the item in each row.
-The client side doesn't need to wait for the server to send missing information about what needs to be rendered. It can use the template and stamp away all the information it needs.
+With Lit renderers, the server doesn't keep track of the components in each cell. It only manages the state of the item in each row. The client side doesn't have to wait for the server to send missing information about what needs to be rendered. It can use the template to render all of the cells it needs.
 
-For more in-depth documentation, see <<flow#using-lit-renderers, Using Lit Renderers with Grid>>.
+For more in-depth information, see <<flow#using-lit-renderers, Using Lit Renderers with Grid>>.
 
 
 === Wrap Cell Content
 
-Overflowing cell content is clipped or truncated by default.
-This variant makes the content wrap instead.
+Overflowing cell content is clipped or truncated by default. This variant makes the content wrap instead.
 
 [.example]
 --
@@ -120,12 +108,9 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridWrapCellContent
 
 == Dynamic Height
 
-Grid has a default height of 400 pixels.
-It becomes scrollable when its items overflow the allocated space.
+Grid has a default height of 400 pixels. It becomes scrollable when its items overflow the allocated space.
 
-In addition to setting any fixed or relative value, the height of a grid can be set by the number of items in the dataset. The grid grows and shrinks based on the row count.
-
-This disables scrolling and shouldn't be used for large data sets, to avoid performance issues.
+In addition to setting any fixed or relative value, the height of a grid can be set by the number of items in the dataset. The grid grows and shrinks based on the row count. This disables scrolling and shouldn't be used for large data sets to avoid performance issues.
 
 [.example]
 --
@@ -141,15 +126,15 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDynamicHeight.j
 ----
 --
 
+
 == Selection
 
-Selection isn't enabled by default.
-Grid supports single and multi-select.
-Single select the user to select only one item, while multi-select enables multiple items to be selected.
+Selection isn't enabled by default. Grid supports single- and multi-select. Single-select allows the user to select only one item, while multi-select permits multiple items to be selected.
 
-=== Single Selection Mode
 
-In single selection mode, the user can select and deselect rows by clicking anywhere on the row.
+=== Single-Selection Mode
+
+In single-selection mode, the user can select and deselect rows by clicking anywhere on the row.
 
 [.example]
 --
@@ -164,6 +149,7 @@ include::{root}/frontend/demo/component/grid/grid-single-selection-mode.ts[rende
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridSingleSelectionMode.java[render,tags=snippet,indent=0,group=Java]
 ----
 --
+
 
 === Multi-Select Mode
 
@@ -183,17 +169,17 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridMultiSelectionM
 ----
 --
 
+
 == Columns
 
-Column alignment, freezing (fixed position), grouping, headers and footers, visibility, and width can be configured.
-Users can be enabled to resize and reorder columns.
+Column alignment, freezing (i.e., fixed positioning), grouping, headers and footers, visibility, and width can be configured. Users can be permitted to resize and reorder columns.
+
 
 === Column Alignment
 
 Three different column alignments are supported: left (default), center, and right.
 
-Right align is useful when comparing numeric values, as it helps with readability and scannability.
-Tabular numbers -- if the font offers them -- or a monospace font could be used to further improve digit alignment.
+Right alignment is useful when comparing numeric values, as it helps with readability and scannability. Tabular numbers -- if the font offers them -- or a monospace font could be used to further improve digit alignment.
 
 [.example]
 --
@@ -210,11 +196,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnAlignment
 ----
 --
 
+
 === Column Freezing
 
-Columns and column groups can be frozen – made “sticky” – to exclude them from scrolling a grid, horizontally.
-This can be useful for keeping the most important columns always visible in a grid with many columns.
-[since:com.vaadin:vaadin@V23.1]#Freezing columns at the end of the grid# is useful, for example, for keeping row actions always visible.
+Columns and column groups can be frozen -- made _sticky_ -- to exclude them from scrolling a grid, horizontally. This can be useful for keeping the most important columns always visible in a grid with many columns. [since:com.vaadin:vaadin@V23.1]#Freezing columns at the end of the grid# is useful, for example, for keeping row actions always visible.
 
 [.example]
 --
@@ -235,9 +220,7 @@ Although it's technically possible to freeze any column, it should be used prima
 
 === Column Grouping
 
-It's possible to group columns together.
-Grouped columns share a common header and footer.
-Use this feature to better visualize and organize related or hierarchical data.
+It's possible to group columns together. Grouped columns share a common header and footer. Use this feature to better visualize and organize related or hierarchical data.
 
 [.example]
 --
@@ -253,12 +236,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnGrouping.
 ----
 --
 
+
 === Column Headers & Footers
 
-Each column has its own customizable header and footer.
-A basic column header shows the name in plain text.
-Footers are empty and thus hidden by default.
-Both can contain rich content and components.
+Each column has its own customizable header and footer. A basic column header shows the name in plain text. Footers are empty and thus hidden by default. Both can contain rich content and components.
 
 [.example]
 --
@@ -278,12 +259,12 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnHeaderFoo
 ----
 --
 
+
 === Column Visibility
 
-Columns and column groups can be hidden.
-You can provide the user with a menu for toggling column visibilities, for example using Menu Bar.
+Columns and column groups can be hidden. You can provide the user with a menu for toggling column visibilities, for example using Menu Bar. 
 
-Allowing the user to hide columns is useful when only a subset of the columns are relevant to their task, and if there are a plenty of columns.
+Allowing the user to hide columns is useful when only a subset of the columns is relevant to their task, and if there are plenty of columns.
 
 [.example]
 --
@@ -303,12 +284,12 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnVisibilit
 ----
 --
 
+
 === Column Reordering & Resizing
 
-Enabling the user to reorder columns is useful when they wish to compare data that isn't adjacent by default.
-Grouped columns can only be reordered within their group.
+Enabling the user to reorder columns is useful when they want to compare data that isn't adjacent by default. Grouped columns can only be reordered within their group.
 
-Resizing is helpful when a column’s content doesn't fit and gets cut off or varies in length.
+Resizing is helpful when a column's content doesn't fit and is cut off or varies in length.
 
 [.example]
 --
@@ -324,16 +305,14 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnReorderin
 ----
 --
 
+
 === Column Width
 
-All columns are the same width by default.
-You can set a specific width for any column, or allow the Grid to set the width automatically based on the contents.
+All columns are the same width by default. You can set a specific width for any column, or allow the Grid to set the width automatically based on the contents.
 
-Column widths can be fixed or non-fixed (default).
-Fixed width columns don't grow or shrink as the available space changes, while non-fixed width columns do.
+Column widths can be fixed or non-fixed (default). Fixed width columns don't grow or shrink as the available space changes, while non-fixed width columns do.
 
-In the following example, the first and last columns have fixed widths.
-The second column’s width is set to be based on the content, while the third column takes up the remaining space.
+In the following example, the first and last columns have fixed widths. The second column's width is set to be based on the content, while the third column takes up the remaining space.
 
 [.example]
 --
@@ -349,10 +328,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnWidth.jav
 ----
 --
 
+
 == Sorting
 
-Any column can be made sortable.
-Enable sorting to allow the user to sort items alphabetically, numerically, by date, etc.
+Any column can be made sortable. Enable sorting to allow the user to sort items alphabetically, numerically, by date, etc.
 
 For detailed information on how to configure sorting in Flow, see <<flow#column-sorting, Column Sorting>>.
 
@@ -370,10 +349,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridSorting.java[re
 ----
 --
 
+
 === Sorting by Multiple Columns
-The Grid can be sorted by multiple columns simultaneously by enabling multi-sort mode, in which clicking a column header adds that column as a sort criterion instead of replacing the current sort column.
-A separate [since:com.vaadin:vaadin@V23.3]#multi-sort on shift-click mode# combines the two by multi-sorting only when the column header is clicked while holding shift.
-The order in which multi-sort criteria (columns) are evaluated is determined by the multi-sort priority setting.
+
+The Grid can be sorted by multiple columns simultaneously by enabling multi-sort mode. When this is enabled, clicking a column header adds that column as a sort criterion instead of replacing the current sort column. A separate [since:com.vaadin:vaadin@V23.3]#multi-sort on shift-click mode# combines the two by multi-sorting only when the column header is clicked while holding shift. The order in which multi-sort criteria (columns) are evaluated is determined by the multi-sort priority setting.
 
 [.example]
 --
@@ -391,12 +370,12 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridMultiSort.java[
 
 .Shift-Click Multi-Sorting has Accessibility Issues
 [NOTE]
-The multi-sort on shift-click mode is not recommended for applications where accessibility is important.
-The feature is unlikely to work well with assistive technologies, and the lack of visual affordances makes it difficult to discover for sighted users.
+The multi-sort on shift-click mode is not recommended for applications for which accessibility is important. The feature is unlikely to work well with assistive technologies, and the lack of visual affordances makes it difficult to discover for sighted users.
+
 
 === Specifying the Sort Property
-Columns with rich or custom content can be sorted by defining which property to sort by.
-For example, you can have a column containing a person’s profile picture, name and email sorted by the person’s last name.
+
+Columns with rich or custom content can be sorted by defining the property by which to sort. For example, you can have a column containing a person's profile picture, name and email sorted by the person's last name.
 
 [.example]
 --
@@ -412,12 +391,12 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridRichContentSort
 ----
 --
 
-Sorting helps users find and analyze the data. Therefore, it's recommended to enable sorting for all applicable columns. An exception would be where the order is an essential part of the data itself, such as with prioritized lists.
+Sorting helps users find and analyze data. Therefore, it's recommended to enable sorting for all applicable columns. An exception would be where the order is an essential part of the data itself, such as with prioritized lists.
+
 
 == Filtering
 
-Filtering allows the user to find quickly a specific item or subset of items.
-You can add filters to Grid columns or use external filter fields.
+Filtering allows the user to find quickly a specific item or subset of items. You can add filters to Grid columns or use external filter fields.
 
 [.example]
 --
@@ -437,10 +416,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnFiltering
 ----
 --
 
-Place filters outside the grid when:
-
-* The filter is based on multiple columns; or
-* A bigger field or more complex filter UI is needed, which wouldn’t comfortably fit in a column.
+Place filters outside the grid when the filter is based on multiple columns, or when a bigger field or more complex filter UI is needed, one which wouldn't fit well in a column.
 
 [.example]
 --
@@ -456,10 +432,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridExternalFilteri
 ----
 --
 
+
 == Item Details
 
-Item details are expandable content areas that can be displayed below the regular content of a row. They can be used to display more information about an item.
-By default, an item’s details are toggled by clicking on the item’s row.
+Item details are expandable content areas that can be displayed below the regular content of a row. They can be used to display more information about an item. By default, an item's details are toggled by clicking on the item's row.
 
 [.example]
 --
@@ -501,14 +477,12 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridItemDetailsTogg
 
 <<tooltips,Tooltips>> can be used as a lightweight alternative to the item details panel.
 
+
 == Context Menu
 
-You can use Context Menu to provide shortcuts to the user.
-It appears on a right-click by default or a left click.
-In a mobile browser, a long press opens the menu.
+You can use Context Menu to provide shortcuts for the user. It appears on a right-click by default or a left click. In a mobile browser, a long press opens the menu.
 
-Using a context menu shouldn't be the only way of accomplishing a task.
-The same functionality needs to be accessible elsewhere in the UI as well.
+Using a context menu shouldn't be the only way of accomplishing a task. The same functionality needs to be accessible elsewhere in the UI.
 
 See <<../context-menu#,Context Menu>> for more information.
 
@@ -531,14 +505,11 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContextMenuExam
 ----
 --
 
+
 [role="since:com.vaadin:vaadin@V23.3"]
 == Tooltips
 
-Tooltips on cells can be used for many different use cases:
-
-* For providing additional details on the contents of a cell -- if an <<item-details,item details panel>> would be overkill or otherwise undesirable;
-* For providing the full text of a cell if it's too long to fit feasibly into the cell itself -- if <<wrap-cell-content,wrapping the cell contents>> is insufficient or otherwise undesirable; or
-* For providing textual explanations for non-text content, such as status icons
+Tooltips on cells can be used for many different use cases: They can be used for providing additional details on the contents of a cell -- if an <<item-details,item details panel>> would be overkill or otherwise undesirable. They can provide the full text of a cell if it's too long to fit feasibly into the cell itself -- if <<wrap-cell-content,wrapping the cell contents>> is insufficient or otherwise undesirable. Or they can provide textual explanations for non-text content, such as status icons.
 
 [.example]
 --
@@ -562,35 +533,34 @@ See <<../tooltip#,Tooltips documentation>> for details on tooltip configuration.
 // Allow 'drag and drop'
 pass:[<!-- vale Vaadin.Wordiness = NO -->]
 
+
 == Drag and Drop
 
-Grid supports drag and drop. For example, this feature might be used to reorder rows and to drag rows between grids.
+Grid supports drag-and-drop actions. For example, this feature might be used to reorder rows and to drag rows between grids.
 
 pass:[<!-- vale Vaadin.Wordiness = YES -->]
 
+
 === Drop Mode
 
-The drop mode of a grid determines where a drop can happen.
-Vaadin offers four different drop modes:
+The drop mode of a grid determines where a drop can happen. Vaadin offers four different drop modes:
 
 |===
 |Drop Mode |Description
 
 |<<#drag-rows-between-grids,On Grid>>
-|Drops can occur on the grid as a whole, not on top of or between individual rows.
-Use this option when the order isn't important.
+|Drops can occur on the grid as a whole, not on top of rows or between individual rows. Use this option when the order isn't important.
 
 |<<#row-reordering,Between>>
-|Drops can happen between rows.
-Use this mode when the order is important.
+|Drops can happen between rows. Use this mode when the order is important.
 
 |<<#drag-and-drop-filters,On Top>>
-|Drops can take place on top of rows.
-This is useful when creating relationships between items or moving an item into another item, such placing a file inside a folder.
+|Drops can take place on top of rows. This is useful when creating relationships between items or moving an item into another item, such as placing a file inside a folder.
 
 |On Top or Between
-|Drops can occur on top of or between rows.
+|Drops can occur on top of rows or between rows.
 |===
+
 
 === Row Reordering
 
@@ -610,9 +580,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridRowReordering.j
 ----
 --
 
+
 === Drag Rows between Grids
 
-Rows can be dragged from one grid to another. You might want to use this feature to move, copy or link items from different datasets.
+Rows can be dragged from one grid to another. You might use this feature to move, copy or link items from different datasets.
 
 [.example]
 --
@@ -631,10 +602,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDragRowsBetween
 // Allow 'drag and drop'
 pass:[<!-- vale Vaadin.Wordiness = NO -->]
 
+
 === Drag and Drop Filters
 
-Drag and drop filters determine which rows are draggable and which rows are valid drop targets, respectively.
-The filters function on a per row basis.
+Drag and drop filters determine which rows are draggable and which rows are valid drop targets. The filters function on a per row basis.
 
 pass:[<!-- vale Vaadin.Wordiness = NO -->]
 
@@ -652,11 +623,11 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters
 ----
 --
 
+
 == Inline Editing (Java Only)
 
-Grid can be configured to allow inline editing.
-Editing can be either buffered or non-buffered.
-Buffered means changes must be explicitly committed, while non-buffered automatically commit changes on blur -- when a field loses focus.
+Grid can be configured to allow inline editing. Editing can be either buffered or non-buffered. Buffered means changes must be explicitly committed, while non-buffered automatically commit changes on blur -- when a field loses focus.
+
 
 === Buffered
 
@@ -678,10 +649,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/ValidationMessage.j
 ----
 --
 
+
 === Non-Buffered
 
-In the example below, double-click a row to start editing.
-Press kbd:[Escape], or click on a different row to stop editing.
+In the example below, double-click a row to start editing. Press kbd:[Escape], or click on a different row to stop editing.
 
 [.example]
 --
@@ -703,9 +674,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/ValidationMessage.j
 
 Alternatively, use <<../grid-pro#,Grid Pro>> for more streamlined inline-editing, or <<../crud#,CRUD>> for editing in a separate side panel or dialog.
 
-== Styling Rows and Columns
 
-You can style individual cells based on the data. For example, you might do this to highlight changes or important information.
+== Styling Rows & Columns
+
+You can style individual cells based on the data. You might do this, for example, to highlight changes or important information.
 
 [.example]
 --
@@ -726,18 +698,19 @@ include::{root}/frontend/themes/docs/components/vaadin-grid-styling.css[]
 ----
 --
 
+
 == Theme Variants
 
-Grid variants can reduce the white space inside the grid, adjust the border and row highlight visibility, and control cell content overflow behavior.
+Grid variants can reduce the white space inside the grid, adjust the border and row to highlight visibility, and control cell content overflow behavior.
 
 Variants can be combined together.
+
 
 === Compact
 
 The `compact` theme variant makes a grid more dense by reducing the header and row heights, as well as the spacing between columns.
 
-This is useful for displaying more information on-screen without having to scroll.
-It can also help improve scannability and comparability between rows.
+This is useful for displaying more information on-screen without having to scroll. It can also help improve scannability and comparability between rows.
 
 [.example]
 --
@@ -752,6 +725,7 @@ include::{root}/frontend/demo/component/grid/grid-compact.ts[render,tags=snippet
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridCompact.java[render,tags=snippet,indent=0,group=Java]
 ----
 --
+
 
 === No Border
 
@@ -771,11 +745,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridNoBorder.java[r
 ----
 --
 
+
 === No Row Border
 
-This theme variant removes the horizontal row borders.
-It's best suited for small datasets.
-Parsing larger sets may be difficult unless paired with the `row-stripes` theme variant.
+This theme variant removes the horizontal row borders. It's best suited for small datasets. Parsing larger datasets may be difficult unless paired with the `row-stripes` theme variant.
 
 [.example]
 --
@@ -791,10 +764,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridNoRowBorder.jav
 ----
 --
 
+
 === Column Borders
 
-You can add vertical borders between columns by using the `column-borders` theme variant.
-Data sets with a lot of columns packed tightly together, or where content gets truncated, can benefit from the additional separation that vertical borders bring.
+You can add vertical borders between columns by using the `column-borders` theme variant. Datasets with a lot of columns packed tightly together, or where content is truncated, can benefit from the additional separation that vertical borders bring.
 
 [.example]
 --
@@ -810,10 +783,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnBorders.j
 ----
 --
 
+
 === Row Stripes
 
-The `row-stripes` theme produces a background color for every other row.
-This can have a positive effect on scannability.
+The `row-stripes` theme produces a background color for every other row. This can have a positive effect on scannability.
 
 [.example]
 --
@@ -829,6 +802,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridRowStripes.java
 ----
 --
 
+
 == Cell Focus
 
 Cells can be focused by clicking on a cell or with the keyboard.
@@ -837,8 +811,8 @@ The following keyboard shortcuts are available:
 
 [cols="1,5"]
 |====
-| kbd:[Tab] | Switches focus between sections of the grid (header, body, footer).
-| kbd:[Left], kbd:[Up], kbd:[Right], and kbd:[Down] arrow keys | Moves focus between cells within a section of the grid.
+| kbd:[Tab] | Switches focus between sections of the grid (i.e., header, body, footer).
+| kbd:[Left], kbd:[Up], kbd:[Right], and kbd:[Down] Arrow Keys | Moves focus between cells within a section of the grid.
 | kbd:[Page Up] | Moves cell focus up by one page of visible rows.
 | kbd:[Page Down] | Moves cell focus down by one page of visible rows.
 | kbd:[Home] | Moves focus to the first cell in a row.
@@ -847,8 +821,7 @@ The following keyboard shortcuts are available:
 
 The cell focus event can be used to get notified when the user changes focus between cells.
 
-By default, the focus outline is only visible when using keyboard navigation.
-For demonstration purposes, the example below also uses custom styles to show the focus outline when clicking on cells:
+By default, the focus outline is only visible when using keyboard navigation. For illustrative purposes, the example below also uses custom styles to show the focus outline when clicking on cells:
 
 [.example]
 --
@@ -870,10 +843,11 @@ include::{root}/frontend/themes/docs/components/vaadin-grid-cell-focus.css[]
 
 --
 
+
 == Related Components
 
 |===
-|Component |Usage recommendations
+|Component |Usage Recommendations
 
 |<<../crud#,CRUD>>
 |Component for creating, displaying, updating and deleting tabular data.

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -354,7 +354,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnWidth.jav
 Any column can be made sortable.
 Enable sorting to allow the user to sort items alphabetically, numerically, by date, etc.
 
-For detailed information on how to configure sorting in Flow, see <<flow#column_sorting, Column Sorting>>.
+For detailed information on how to configure sorting in Flow, see <<flow#column-sorting, Column Sorting>>.
 
 [.example]
 --

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -354,6 +354,8 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnWidth.jav
 Any column can be made sortable.
 Enable sorting to allow the user to sort items alphabetically, numerically, by date, etc.
 
+For detailed information on how to configure sorting in Flow, see <<flow#column_sorting, Column Sorting>>.
+
 [.example]
 --
 


### PR DESCRIPTION
Reworks the Flow-specific `Column Sorting` section. While the content was good, there were some confusing or missing parts, and usage of deprecated or removed API.

I tried to address the following issues:
- Start by explaining how to enable sorting in the first place, when it is enabled automatically, and when it is not.
- In addition to explaining in-memory and back-end sorting, also explain when a column is automatically configured for either method. 
- Removed section that used deprected methods of setting sort property names directly in `Grid.addColumn(String, String...)`. This is also required in v24, where these methods have been removed.
- Reworked the following two sections to be explicitely about configuring in-memory sorting, and back-end sorting, rather than about which API methods they use.
- Removed confusing part that mentions that both in-memory and back-end sorting can be used together. It didn't bother explaining how that would work, so it seems better to remove it.

Closes https://github.com/vaadin/docs/issues/385