### PR TITLE
docs: add Grid data provider examples

### DIFF
--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -432,9 +432,10 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridExternalFilteri
 ----
 --
 
+
 == Lazy Loading
 
-When you want to display a list of items that is quite large to load it whole in memory, or you want to load items from a database, data providers can be used to provide lazy loading by pagination.
+When you want to display a list of items which would be quite large to load entirely into memory, or you want to load items from a database, data providers can be used to provide lazy loading through pagination.
 
 The following example uses a data provider for lazy loading, sorting, and filtering items:
 
@@ -467,6 +468,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/PersonFilter.java[r
 --
 
 To learn more about data providers, see <<{articles}/binding-data/data-provider#, Binding Items to Components>> (Java only).
+
 
 == Item Details
 

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -262,7 +262,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnHeaderFoo
 
 === Column Visibility
 
-Columns and column groups can be hidden. You can provide the user with a menu for toggling column visibilities, for example using Menu Bar. 
+Columns and column groups can be hidden. You can provide the user with a menu for toggling column visibilities, for example using Menu Bar.
 
 Allowing the user to hide columns is useful when only a subset of the columns is relevant to their task, and if there are plenty of columns.
 
@@ -432,6 +432,41 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridExternalFilteri
 ----
 --
 
+== Lazy Loading
+
+When you want to display a list of items that is quite large to load it whole in memory, or you want to load items from a database, data providers can be used to provide lazy loading by pagination.
+
+The following example uses a data provider for lazy loading, sorting, and filtering items:
+
+[.example]
+--
+
+[source,typescript]
+----
+include::{root}/frontend/demo/component/grid/grid-data-provider.ts[render,tags=snippet,indent=0,group=TypeScript]
+
+...
+
+include::{root}/frontend/demo/component/grid/grid-data-provider.ts[render,tags=snippet2,indent=0,group=TypeScript]
+----
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDataProvider.java[render,tags=snippet,indent=0,group=Java]
+----
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/grid/PersonDataProvider.java[render,tags=snippet,indent=0,group=Java]
+----
+
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/grid/PersonFilter.java[render,tags=snippet,indent=0,group=Java]
+----
+--
+
+To learn more about data providers, see <<{articles}/binding-data/data-provider#, Binding Items to Components>> (Java only).
 
 == Item Details
 

--- a/frontend/demo/component/grid/grid-data-provider.ts
+++ b/frontend/demo/component/grid/grid-data-provider.ts
@@ -1,0 +1,121 @@
+import 'Frontend/demo/init'; // hidden-source-line
+
+import { html, LitElement } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
+import '@vaadin/text-field';
+import '@vaadin/icon';
+import '@vaadin/grid';
+import '@vaadin/grid/vaadin-grid-sort-column.js';
+import '@vaadin/grid/vaadin-grid-filter-column.js';
+import { getPeople } from 'Frontend/demo/domain/DataService';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
+import type {
+  Grid,
+  GridDataProviderCallback,
+  GridDataProviderParams,
+  GridSorterDefinition,
+  GridSorterDirection,
+} from '@vaadin/grid';
+import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
+
+function matchesTerm(value: string, searchTerm: string) {
+  return value.toLowerCase().includes(searchTerm.toLowerCase());
+}
+
+function compare(a: string, b: string, direction: GridSorterDirection) {
+  return direction === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
+}
+
+// tag::snippet[]
+async function fetchPeople(params: {
+  page: number;
+  pageSize: number;
+  searchTerm: string;
+  sortOrders: GridSorterDefinition[];
+}) {
+  const { page, pageSize, searchTerm, sortOrders } = params;
+  const { people } = await getPeople();
+
+  let result = people.map((person) => ({
+    ...person,
+    fullName: `${person.firstName} ${person.lastName}`,
+  }));
+
+  // Filtering
+  if (searchTerm) {
+    result = result.filter(
+      (p) => matchesTerm(p.fullName, searchTerm) || matchesTerm(p.profession, searchTerm)
+    );
+  }
+
+  // Sorting
+  const sortBy = Object.fromEntries(sortOrders.map(({ path, direction }) => [path, direction]));
+  if (sortBy.fullName) {
+    result = result.sort((p1, p2) => compare(p1.fullName, p2.fullName, sortBy.fullName));
+  } else if (sortBy.profession) {
+    result = result.sort((p1, p2) => compare(p1.profession, p2.profession, sortBy.profession));
+  }
+
+  // Pagination
+  const count = result.length;
+  result = result.slice(page * pageSize, pageSize);
+
+  return { people: result, count };
+}
+// end::snippet[]
+
+@customElement('grid-data-provider')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    // Apply custom theme (only supported if your app uses one)
+    applyTheme(root);
+    return root;
+  }
+
+  // tag::snippet2[]
+  @state()
+  private searchTerm = '';
+
+  @query('#grid')
+  private grid!: Grid;
+
+  private dataProvider = async (
+    params: GridDataProviderParams<Person>,
+    callback: GridDataProviderCallback<Person>
+  ) => {
+    const { page, pageSize, sortOrders } = params;
+
+    const { people, count } = await fetchPeople({
+      page,
+      pageSize,
+      sortOrders,
+      searchTerm: this.searchTerm,
+    });
+
+    callback(people, count);
+  };
+
+  protected override render() {
+    return html`
+      <vaadin-vertical-layout theme="spacing">
+        <vaadin-text-field
+          placeholder="Search"
+          style="width: 50%;"
+          @value-changed="${(e: TextFieldValueChangedEvent) => {
+            this.searchTerm = (e.detail.value || '').trim();
+            this.grid.clearCache();
+          }}"
+        >
+          <vaadin-icon slot="prefix" icon="vaadin:search"></vaadin-icon>
+        </vaadin-text-field>
+        <vaadin-grid id="grid" .dataProvider="${this.dataProvider}">
+          <vaadin-grid-sort-column path="fullName" header="Name"></vaadin-grid-sort-column>
+          <vaadin-grid-sort-column path="profession"></vaadin-grid-sort-column>
+        </vaadin-grid>
+      </vaadin-vertical-layout>
+    `;
+  }
+  // end::snippet2[]
+}

--- a/src/main/java/com/vaadin/demo/component/grid/GridDataProvider.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridDataProvider.java
@@ -1,0 +1,51 @@
+package com.vaadin.demo.component.grid;
+
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+import com.vaadin.demo.domain.Person;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
+import com.vaadin.flow.router.Route;
+
+@Route("grid-data-provider")
+public class GridDataProvider extends Div {
+
+    // tag::snippet[]
+    private PersonFilter personFilter = new PersonFilter();
+
+    private PersonDataProvider dataProvider = new PersonDataProvider();
+
+    private ConfigurableFilterDataProvider<Person, Void, PersonFilter> filterDataProvider = dataProvider
+            .withConfigurableFilter();
+
+    public GridDataProvider() {
+        Grid<Person> grid = new Grid<>();
+        grid.addColumn(Person::getFullName, "name").setHeader("Name");
+        grid.addColumn(Person::getProfession, "profession").setHeader("Profession");
+        grid.setItems(filterDataProvider);
+
+        TextField searchField = new TextField();
+        searchField.setWidth("50%");
+        searchField.setPlaceholder("Search");
+        searchField.setPrefixComponent(new Icon(VaadinIcon.SEARCH));
+        searchField.setValueChangeMode(ValueChangeMode.EAGER);
+        searchField.addValueChangeListener(e -> {
+            personFilter.setSearchTerm(e.getValue());
+            filterDataProvider.setFilter(personFilter);
+        });
+
+        VerticalLayout layout = new VerticalLayout(searchField, grid);
+        layout.setPadding(false);
+        add(layout);
+    }
+    // end::snippet[]
+
+    public static class Exporter // hidden-source-line
+            extends DemoExporter<GridDataProvider> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/grid/PersonDataProvider.java
+++ b/src/main/java/com/vaadin/demo/component/grid/PersonDataProvider.java
@@ -1,0 +1,66 @@
+package com.vaadin.demo.component.grid;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import com.vaadin.demo.domain.DataService;
+import com.vaadin.demo.domain.Person;
+import com.vaadin.flow.data.provider.AbstractBackEndDataProvider;
+import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.data.provider.QuerySortOrder;
+import com.vaadin.flow.data.provider.SortDirection;
+
+// tag::snippet[]
+public class PersonDataProvider extends AbstractBackEndDataProvider<Person, PersonFilter> {
+    final List<Person> DATABASE = new ArrayList<>(DataService.getPeople());
+
+    @Override
+    protected Stream<Person> fetchFromBackEnd(Query<Person, PersonFilter> query) {
+        // A real app should use a real database or a service
+        // to fetch, filter and sort data.
+        Stream<Person> stream = DATABASE.stream();
+
+        // Filtering
+        if (query.getFilter().isPresent()) {
+            stream = stream.filter(person -> query.getFilter().get().test(person));
+        }
+
+        // Sorting
+        if (query.getSortOrders().size() > 0) {
+            stream = stream.sorted(sortComparator(query.getSortOrders()));
+        }
+
+        // Pagination
+        return stream.skip(query.getOffset()).limit(query.getLimit());
+    }
+
+    @Override
+    protected int sizeInBackEnd(Query<Person, PersonFilter> query) {
+        return (int) fetchFromBackEnd(query).count();
+    }
+
+    private static Comparator<Person> sortComparator(List<QuerySortOrder> sortOrders) {
+        return sortOrders.stream().map(sortOrder -> {
+            Comparator<Person> comparator = personFieldComparator(sortOrder.getSorted());
+
+            if (sortOrder.getDirection() == SortDirection.DESCENDING) {
+                comparator = comparator.reversed();
+            }
+
+            return comparator;
+        }).reduce(Comparator::thenComparing).orElse((p1, p2) -> 0);
+    }
+
+    private static Comparator<Person> personFieldComparator(String sorted) {
+        if (sorted.equals("name")) {
+            return Comparator.comparing(person -> person.getFullName());
+        } else if (sorted.equals("profession")) {
+            return Comparator.comparing(person -> person.getProfession());
+        }
+        return (p1, p2) -> 0;
+    }
+}
+// end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/grid/PersonFilter.java
+++ b/src/main/java/com/vaadin/demo/component/grid/PersonFilter.java
@@ -1,0 +1,24 @@
+package com.vaadin.demo.component.grid;
+
+import com.vaadin.demo.domain.Person;
+
+// tag::snippet[]
+public class PersonFilter {
+    private String searchTerm;
+
+    public void setSearchTerm(String searchTerm) {
+        this.searchTerm = searchTerm;
+    }
+
+    public boolean test(Person person) {
+        boolean matchesFullName = matches(person.getFullName(), searchTerm);
+        boolean matchesProfession = matches(person.getProfession(), searchTerm);
+        return matchesFullName || matchesProfession;
+    }
+
+    private boolean matches(String value, String searchTerm) {
+        return searchTerm == null || searchTerm.isEmpty()
+                || value.toLowerCase().contains(searchTerm.toLowerCase());
+    }
+}
+// end::snippet[]


### PR DESCRIPTION
Added a Grid example showing basically how to use data providers for lazy loading, sorting, and filtering items.

Fixes https://github.com/vaadin/docs/issues/79, https://github.com/vaadin/docs/issues/513