### PR TITLE
docs: use part name generator for grid styling

### DIFF
--- a/frontend/demo/component/grid/grid-styling.ts
+++ b/frontend/demo/component/grid/grid-styling.ts
@@ -39,7 +39,7 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-grid .items="${this.items}" .cellClassNameGenerator="${this.cellClassNameGenerator}">
+      <vaadin-grid .items="${this.items}" .cellPartNameGenerator="${this.cellPartNameGenerator}">
         <vaadin-grid-column path="firstName"></vaadin-grid-column>
         <vaadin-grid-column path="lastName"></vaadin-grid-column>
         <vaadin-grid-column path="profession"></vaadin-grid-column>
@@ -55,7 +55,7 @@ export class Example extends LitElement {
     <span>${this.ratingFormatter.format(person.customerRating)}</span>
   `;
 
-  private cellClassNameGenerator(column: GridColumn, model: GridItemModel<PersonWithRating>) {
+  private cellPartNameGenerator(column: GridColumn, model: GridItemModel<PersonWithRating>) {
     const item = model.item;
     let classes = '';
     // Make the customer rating column bold

--- a/frontend/themes/docs/components/vaadin-grid-styling.css
+++ b/frontend/themes/docs/components/vaadin-grid-styling.css
@@ -1,13 +1,13 @@
 /* frontend/theme/[my-theme]/components/vaadin-grid.css */
 
-.high-rating {
+[part~='high-rating'] {
     background-color: #b1ffb7;
 }
 
-.low-rating {
+[part~='low-rating'] {
     background-color: #ffd9d9;
 }
 
-.font-weight-bold {
+[part~='font-weight-bold']{
     font-weight: bold;
 }

--- a/src/main/java/com/vaadin/demo/component/grid/GridStyling.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridStyling.java
@@ -21,7 +21,7 @@ public class GridStyling extends Div {
         grid.addColumn(PersonWithRating::getFormattedRating)
                 .setHeader("Customer rating (0-10)");
 
-        grid.setClassNameGenerator(person -> {
+        grid.setPartNameGenerator(person -> {
             if (person.getRating() >= 8)
                 return "high-rating";
             if (person.getRating() <= 4)


### PR DESCRIPTION
Use part name generator instead of class name generator for the "Styling Rows and Columns" example in Grid.

See related [issue](https://github.com/vaadin/web-components/issues/4293) and [PR](https://github.com/vaadin/flow-components/pull/4231).