### PR TITLE
docs: classic components absolute layout

### DIFF
--- a/articles/advanced/classic-components.asciidoc
+++ b/articles/advanced/classic-components.asciidoc
@@ -77,6 +77,11 @@ The DOM structure of VerticalLayout and HorizontalLayout was developed to mainta
 Class names defined in the layouts are added in the same way as before.
 For example, if `custom-style` is added to a [classname]`VerticalLayout` instance, both `custom-style` and `v-verticallayout-custom-style` are added to the DOM element.
 
+=== AbsoluteLayout
+
+The Classic AbsoluteLayout resembles the Vaadin 8 version of AbsoluteLayout.
+It mimics HTML absolute positioning, letting you set an absolute position to its children.
+
 .Missing features
 [NOTE]
 [classname]`ContextClickEvent` and [classname]`LayoutClickListener` aren't yet implemented in the Classic layouts.


### PR DESCRIPTION
Add mention of `AbsoluteLayout` to the classic components page.

Fixes #2208 2208