### PR TITLE
fix: update Spring Boot parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.6</version>
+        <version>2.7.4</version>
     </parent>
     <!-- end::spring-version[] -->
 


### PR DESCRIPTION
Needed after https://github.com/vaadin/docs/pull/2178 to fix `Field vaadinDefaultRequestCache in com.vaadin.flow.spring.security.VaadinWebSecurity required a bean of type 'com.vaadin.flow.spring.security.VaadinDefaultRequestCache' that could not be found.`

Thanks @mcollovati for finding the solution.