### PR TITLE
docs: udpdate jetty live update info in V24

### DIFF
--- a/articles/configuration/live-reload/jetty.asciidoc
+++ b/articles/configuration/live-reload/jetty.asciidoc
@@ -6,7 +6,7 @@ order: 40
 
 = Automatic Restart with the Jetty Maven Plugin
 
-The https://www.eclipse.org/jetty/documentation/jetty-9/index.html#jetty-maven-plugin[Jetty Maven plugin] with the `scanIntervalSeconds` configuration set to a positive value performs complete application restart when the given number of seconds have elapsed since the last Java change.
+The https://www.eclipse.org/jetty/documentation/jetty-11/index.html#jetty-maven-plugin[Jetty Maven plugin] with the `scanIntervalSeconds` configuration set to a positive value performs complete application restart when the given number of seconds have elapsed since the last Java change.
 For instance:
 
 [source,xml]
@@ -15,24 +15,15 @@ For instance:
     <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.4.36.v20210114</version>
+        <version>11.0.13</version>
         <configuration>
-            <scanIntervalSeconds>2</scanIntervalSeconds>
+            <scan>2</scan>
         </configuration>
     </plugin>
 
     <!-- more plugins -->
 </plugins>
 ----
-
-.Recommended minimum version
-[NOTE]
-====
-Jetty Maven Plugin versions before `9.4.36.v20210114` have known issues:
-
-- `RouteNotFoundException` when trying to reload Java changes automatically
-- A reload loop on Windows when setting `scanIntervalSeconds` to a small positive value
-====
 
 Since the plugin performs a full server restart, all Java changes are picked up.
 This includes modifications to server startup listeners, as well as changes to code that connects front-end and back-end components, such as adding a new [classname]`LitTemplate` class, or adding a new CSS import and using it in Java via the `@CssImport` annotation.

--- a/articles/configuration/live-reload/jetty.asciidoc
+++ b/articles/configuration/live-reload/jetty.asciidoc
@@ -6,7 +6,7 @@ order: 40
 
 = Automatic Restart with the Jetty Maven Plugin
 
-The https://www.eclipse.org/jetty/documentation/jetty-11/index.html#jetty-maven-plugin[Jetty Maven plugin] with the `scanIntervalSeconds` configuration set to a positive value performs complete application restart when the given number of seconds have elapsed since the last Java change.
+The https://www.eclipse.org/jetty/documentation/jetty-11/index.html#jetty-maven-plugin[Jetty Maven plugin] with the `scan` configuration set to a positive value performs complete application restart when the given number of seconds have elapsed since the last Java change.
 For instance:
 
 [source,xml]


### PR DESCRIPTION
V24 uses Jetty 11 with Jakarta 10 support, docs update according live update.