### PR TITLE
Docs/minor fixes

### DIFF
--- a/articles/components/button/styling.asciidoc
+++ b/articles/components/button/styling.asciidoc
@@ -30,6 +30,7 @@ Icon:: `vaadin-button+++<wbr>+++** > vaadin-icon**`
 === Style Variants
 
 Primary:: `vaadin-button+++<wbr>+++**[theme~="primary"]**`
+Secondary (default):: `vaadin-button+++<wbr>+++**:not([theme])**`
 Tertiary:: `vaadin-button+++<wbr>+++**[theme~="tertiary"]**`
 Icon-only:: `vaadin-button+++<wbr>+++**[theme~="icon"]**`
 Danger / Error:: `vaadin-button+++<wbr>+++**[theme~="error"]**`

--- a/articles/components/radio-button/styling.asciidoc
+++ b/articles/components/radio-button/styling.asciidoc
@@ -44,7 +44,7 @@ Radio buttons:: `vaadin-radio-group+++<wbr>+++** > vaadin-radio-button**`
 
 ==== Label
 
-Checkbox group with label:: `vaadin-radio-group+++<wbr>+++**[has-label]**`
+Radio group with label:: `vaadin-radio-group+++<wbr>+++**[has-label]**`
 Label:: `vaadin-radio-group+++<wbr>+++**::part(label)**`
 Label text:: `vaadin-radio-group+++<wbr>+++** > label**`
 Required indicator:: `vaadin-radio-group+++<wbr>+++**::part(required-indicator)**`

--- a/articles/styling/advanced/themes-for-embedded.adoc
+++ b/articles/styling/advanced/themes-for-embedded.adoc
@@ -8,6 +8,9 @@ order: 90
 It's possible to <<{articles}/integrations/embedding#, embed>> an entire Vaadin application, parts of one or custom Flow-based components, into other web pages. The mechanism for doing so generates a custom Web Component that wraps the embedded UI inside its <<shadow-dom-styling#, Shadow DOM>>. This has certain implications for theming, which are covered in more detail in the <<{articles}/integrations/embedding/theming#, Theming Embedded Applications>> section. Below is a brief summary of things to keep in mind related to this:
 
 * The `@Theme` annotation can be used to apply a theme to the embedded UI. It's applied to the class extending the `WebComponentExporter` class.
-* Because of the Shadow DOM wrapping the embedded UI, styling must be done partially through <<shadow-dom-styling#, Shadow DOM injection>>.
+* The applied theme is injected into the Shadow DOM of the wrapper Web Component. Because of this...
 * Any CSS applied to the `html` or `body` root element selectors must also be applied to the `:host()` root selector of the embedded UI. So use the selector `html,:host() {...}` if you want the styles to work both in embedded and non-embedded contexts.
-* Font-face declarations in CSS must be declared in a stylesheet called `document.css` in the root of the theme folder to work. This ensures that they are applied at the page root level rather than the Shadow DOM root.
+* The theme's CSS must be divided into two stylesheets:
+** `document.css`: any CSS that needs to work in an overlay (e.g. a Dialog), as well as `@font-face` declarations. These styles are loaded into the root of the parent page.
+** `styles.css`: any CSS that should _not_ be loaded into the parent page, e.g. for risk of conflicts with the parent page's CSS.
+* <<../lumo/utility-classes#, Lumo Utility Classes>> do not work in overlays (e.g. Dialog) in embedded UIs.

--- a/articles/styling/lumo/utility-classes.adoc
+++ b/articles/styling/lumo/utility-classes.adoc
@@ -52,6 +52,12 @@ image::../_images/utility-class-usage-example.png[Effects of the above applicati
 The Lumo utility classes are primarily designed to be used with native HTML elements, Vaadin layout components and custom UI structures. Although some of them do work as expected on some Vaadin components, this is not their intended use. They especially cannot be used to style the inner parts of components.
 ====
 
+.Lumo Utility Classes do not work in embedded overlays
+[NOTE]
+====
+Due to the way overlays (e.g. Dialogs or the Combo Box dropdown) are rendered in <<{articles}/integrations/embedding#, embedded>> Flow UIs, the Utility Classes do not currently work in them. See https://github.com/vaadin/flow/issues/16083 for details.
+====
+
 
 == List of Utility Classes
 // Workaround the limitation in DS Publisher that hidden source code imports can't be persistent

--- a/articles/styling/lumo/utility-classes.adoc
+++ b/articles/styling/lumo/utility-classes.adoc
@@ -55,7 +55,7 @@ The Lumo utility classes are primarily designed to be used with native HTML elem
 .Lumo Utility Classes do not work in embedded overlays
 [NOTE]
 ====
-Due to the way overlays (e.g. Dialogs or the Combo Box dropdown) are rendered in <<{articles}/integrations/embedding#, embedded>> Flow UIs, the Utility Classes do not currently work in them. See https://github.com/vaadin/flow/issues/16083 for details.
+Due to the way overlays (e.g. Dialogs or the Combo Box drop-down) are rendered in <<{articles}/integrations/embedding#, embedded>> Flow UIs, the Utility Classes do not currently work in them. See https://github.com/vaadin/flow/issues/16083 for details.
 ====
 
 


### PR DESCRIPTION
- Fixes an copypaste-error and adds a missing selector to selector lists.
- Adds more info on caveats with themes in embedded UIs