### PR TITLE
Fix faulty code in security example

### DIFF
--- a/articles/security/enabling-security.adoc
+++ b/articles/security/enabling-security.adoc
@@ -187,16 +187,15 @@ public class MainLayout extends AppLayout {
 
         H1 logo = new H1("Vaadin CRM");
         logo.addClassName("logo");
-        HorizontalLayout header;
-        if (authContext.isAuthenticated()) {
-            Button logout = new Button("Logout", click ->
-                    this.authContext.logout());
-            Span loggedUser = new Span("Welcome " + 
-                authContext.getAuthenticatedUser(UserDetails.class).getUsername());
-            header = new HorizontalLayout(logo, loggedUser, logout);
-        } else {
-            header = new HorizontalLayout(logo);
-        }
+        HorizontalLayout 
+        header =
+        authContext.getAuthenticatedUser(UserDetails.class)
+                .map(user -> {
+                    Button logout = new Button("Logout", click ->
+                            this.authContext.logout());
+                    Span loggedUser = new Span("Welcome " + user.getUsername());
+                    return new HorizontalLayout(logo, loggedUser, logout);
+                }).orElseGet(() -> new HorizontalLayout(logo));
 
         // Other page components omitted.
 


### PR DESCRIPTION
The previous example returned an `Optional` object instead of the desired username.


