### PR TITLE
fix: move itemHasChildrenPath property to the grid element

### DIFF
--- a/frontend/demo/component/grid/grid-drag-drop-filters.ts
+++ b/frontend/demo/component/grid/grid-drag-drop-filters.ts
@@ -77,6 +77,7 @@ export class Example extends LitElement {
       <vaadin-grid
         .dataProvider="${this.dataProvider}"
         .itemIdPath="${'id'}"
+        .itemHasChildrenPath="${'manager'}"
         .expandedItems="${this.expandedItems}"
         @expanded-items-changed="${(event: GridExpandedItemsChangedEvent<Person>) => {
           this.expandedItems = event.detail.value;
@@ -111,10 +112,7 @@ export class Example extends LitElement {
           );
         }}"
       >
-        <vaadin-grid-tree-column
-          path="firstName"
-          item-has-children-path="manager"
-        ></vaadin-grid-tree-column>
+        <vaadin-grid-tree-column path="firstName"></vaadin-grid-tree-column>
         <vaadin-grid-column path="lastName"></vaadin-grid-column>
         <vaadin-grid-column path="email"></vaadin-grid-column>
       </vaadin-grid>

--- a/frontend/demo/component/tree-grid/tree-grid-basic.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-basic.ts
@@ -36,11 +36,8 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-grid .dataProvider="${this.dataProvider}">
-        <vaadin-grid-tree-column
-          path="firstName"
-          item-has-children-path="manager"
-        ></vaadin-grid-tree-column>
+      <vaadin-grid .itemHasChildrenPath="${'manager'}" .dataProvider="${this.dataProvider}">
+        <vaadin-grid-tree-column path="firstName"></vaadin-grid-tree-column>
         <vaadin-grid-column path="lastName"></vaadin-grid-column>
         <vaadin-grid-column path="email"></vaadin-grid-column>
       </vaadin-grid>

--- a/frontend/demo/component/tree-grid/tree-grid-column.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-column.ts
@@ -57,12 +57,10 @@ export class Example extends LitElement {
       <vaadin-grid
         .dataProvider="${this.dataProvider}"
         .itemIdPath="${'id'}"
+        .itemHasChildrenPath="${'manager'}"
         .expandedItems="${this.expandedItems}"
       >
-        <vaadin-grid-tree-column
-          path="firstName"
-          item-has-children-path="manager"
-        ></vaadin-grid-tree-column>
+        <vaadin-grid-tree-column path="firstName"></vaadin-grid-tree-column>
         <vaadin-grid-column path="lastName"></vaadin-grid-column>
         <vaadin-grid-column path="email"></vaadin-grid-column>
       </vaadin-grid>


### PR DESCRIPTION
The deprecated property `itemHasChildrenPath` was removed from `<vaadin-grid-tree-column>` in https://github.com/vaadin/web-components/pull/4942