### PR TITLE
docs: documented simplified exclusion of legacy dependency in MPR project

### DIFF
--- a/articles/tools/mpr/introduction/1-maven-v7.asciidoc
+++ b/articles/tools/mpr/introduction/1-maven-v7.asciidoc
@@ -77,6 +77,23 @@ When using MPR, you can't use a Content Delivery Network (CDN) for the widget se
 
 A project may depend on artifacts that transitively bring in the legacy `vaadin-server` library. This artifact conflicts with `vaadin-server-mpr-jakarta`. Its presence may provoke unexpected errors at runtime. Therefore, for each of these dependencies, an exclusion of `vaadin-server` must be configured.
 
+The simplest way to exclude `vaadin-server`, is to add an explicit dependency with `provided` scope. This way, the `vaadin-server` artifact is not considered when packaging the application.
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.vaadin</groupId>
+    <artifactId>vaadin-server-mpr-jakarta</artifactId>
+    <version>{vaadin-seven-version}</version>
+    <scope>provided</scope>
+</dependency>
+----
+
+However, this approach may produce unexpected behaviors during development, since the `provided` scope means that the dependency is expected to be provided at runtime.
+For example, the IDE may give wrong code completion, open the wrong source class when inspecting code, or fail to stop at breakpoints during debugging.
+
+To avoid the above kind of issues, the legacy `vaadin-server` should not be added to the project [filename]`pom.xml` file, and exclusions should be manually added to dependencies that transitively import it.
+
 Maven `dependency:tree` goal can be used to detect the presence of a dependency that transitively imports `vaadin-server`. Using the latest version of the plugin is recommended for better results.
 
 [source,terminal]

--- a/articles/tools/mpr/introduction/1-maven-v7.asciidoc
+++ b/articles/tools/mpr/introduction/1-maven-v7.asciidoc
@@ -83,7 +83,7 @@ The simplest way to exclude `vaadin-server`, is to add an explicit dependency wi
 ----
 <dependency>
     <groupId>com.vaadin</groupId>
-    <artifactId>vaadin-server-mpr-jakarta</artifactId>
+    <artifactId>vaadin-server</artifactId>
     <version>{vaadin-seven-version}</version>
     <scope>provided</scope>
 </dependency>

--- a/articles/tools/mpr/introduction/1-maven-v8.asciidoc
+++ b/articles/tools/mpr/introduction/1-maven-v8.asciidoc
@@ -84,7 +84,7 @@ The simplest way to exclude `vaadin-server`, is to add an explicit dependency wi
 ----
 <dependency>
     <groupId>com.vaadin</groupId>
-    <artifactId>vaadin-server-mpr-jakarta</artifactId>
+    <artifactId>vaadin-server</artifactId>
     <version>{vaadin-eight-version}</version>
     <scope>provided</scope>
 </dependency>

--- a/articles/tools/mpr/introduction/1-maven-v8.asciidoc
+++ b/articles/tools/mpr/introduction/1-maven-v8.asciidoc
@@ -78,6 +78,23 @@ When using MPR, you can't use a Content Delivery Network (CDN) for the widget se
 
 The project may depend on artifacts that transitively bring in the legacy `vaadin-server` library. This artifact conflicts with `vaadin-server-mpr-jakarta`. Its presence may provoke unexpected errors at runtime. Therefore, for each of these dependencies, an exclusion of `vaadin-server` must be configured.
 
+The simplest way to exclude `vaadin-server`, is to add an explicit dependency with `provided` scope. This way, the `vaadin-server` artifact is not considered when packaging the application.
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.vaadin</groupId>
+    <artifactId>vaadin-server-mpr-jakarta</artifactId>
+    <version>{vaadin-eight-version}</version>
+    <scope>provided</scope>
+</dependency>
+----
+
+However, this approach may produce unexpected behaviors during development, since the `provided` scope means that the dependency is expected to be provided at runtime.
+For example, the IDE may give wrong code completion, open the wrong source class when inspecting code, or fail to stop at breakpoints during debugging.
+
+To avoid the above kind of issues, the legacy `vaadin-server` should not be added to the project [filename]`pom.xml` file, and exclusions should be manually added to dependencies that transitively import it.
+
 Maven `dependency:tree` goal can be used to detect the presence of dependencies that transitively import `vaadin-server`. Using the latest version of the plugin is recommended for better results.
 
 [source,terminal]


### PR DESCRIPTION
MPR documentation provides the instructions to find and add exclusion rules for dependencies that transitively import the legacy vaadin-server. This change documents an easy exclusion way, by explicitly adding the dependency to the legacy artifact with provided scope, mentioning also potential issues that may arise during development with this approach.


