### PR TITLE
Add sign-in and sign-out to vocabulary

### DIFF
--- a/.github/styles/Vocab/Docs/accept.txt
+++ b/.github/styles/Vocab/Docs/accept.txt
@@ -128,6 +128,8 @@ Roboto
 [sS]ervlets?
 Segoe
 Shiro
+Sign-in
+Sign-out
 spacekey
 [sS]trikethrough
 [sS]ubcomponents?


### PR DESCRIPTION
It only works without the dash at the moment. It becomes apparent when "Sign-in" is in a title.


