### PR TITLE
fix broken link to "spacing properties"

### DIFF
--- a/articles/lit/start/basics/index.adoc
+++ b/articles/lit/start/basics/index.adoc
@@ -378,7 +378,7 @@ todo-view {
   padding: var(--lumo-space-m) var(--lumo-space-l); /* <1> */
 }
 ----
-<1> The `padding` property is defined using the https://vaadin.com/docs/ds/foundation/size-space#space[spacing properties] to be consistent with the rest of the app.
+<1> The `padding` property is defined using the https://vaadin.com/docs/latest/styling/lumo/lumo-style-properties/size-space#space[spacing properties] to be consistent with the rest of the app.
 
 [discrete]
 === Define the HTML template


### PR DESCRIPTION
The link to the word "spacing properties" redirects to `https://vaadin.com/docs/latest/styling/lumo/design-tokens/size-space#space` which results in a 404 not found error.  The corrected link now takes you to the correct Lumo Style page: `https://vaadin.com/docs/latest/styling/lumo/lumo-style-properties/size-space#space`


