### PR TITLE
fix compile error in deleteContact() method

### DIFF
--- a/articles/lit/start/in-depth/type-safe-server-access-with-endpoints.adoc
+++ b/articles/lit/start/in-depth/type-safe-server-access-with-endpoints.adoc
@@ -78,7 +78,6 @@ package com.example.application.data.endpoint;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import com.example.application.data.entity.Company;
 import com.example.application.data.entity.Contact;
 import com.example.application.data.entity.Status;
@@ -169,7 +168,7 @@ public Contact saveContact(Contact contact) {
   return contactRepository.save(contact);
 }
 
-public void deleteContact(UUID contactId) {
+public void deleteContact(Long contactId) {
   contactRepository.deleteById(contactId);
 }
 ----


### PR DESCRIPTION
In the code that gets generated by `npx @hilla/cli init --preset hilla-crm-tutorial hilla-crm`, the `id` property of the `AbstractEntity` class is type `Long`, not `java.util.UUID`.  Using `UUID` as the type for the `contactId` parameter in the `deleteContact()` method results in a compile error:

```
The method deleteById(Long) in the type CrudRepository<Contact,Long> is not applicable for the arguments (UUID)
```


