### PR TITLE
chore: use branch main instead of master

### DIFF
--- a/articles/contributing/overview.asciidoc
+++ b/articles/contributing/overview.asciidoc
@@ -24,8 +24,8 @@ When reviewing pull requests, however, refrain from approving or rejecting a PR.
 
 == Basic Requirements
 
-All contributions should target the `master` branch.
-Project teams picks the changes to correct version branches from the `master`.
+All contributions should target the `main` branch.
+Project teams picks the changes to correct version branches from the `main`.
 
 .Requirements for new features and enhancements
 [IMPORTANT]
@@ -160,7 +160,7 @@ Such changes are often required to align API with a new features being actively 
 It's best to keep the conversation going in review comments and resolve all reviewer comments.
 If the PR isn't approved by the reviewer and there is no response from the author in a reasonable time, PR is likely to be rejected as abandoned.
 
-Another aspect to consider is that, as time passes, more and more new features and fixes are merged into the `master` branch.
+Another aspect to consider is that, as time passes, more and more new features and fixes are merged into the `main` branch.
 As a result, the more PR is waiting to be merged, the higher is the probability of merge conflicts.
 Such conflicts must be resolved before the merge.
 


### PR DESCRIPTION
Apparently, the `master`-branch has been renamed to `main`.