### PR TITLE
fix reference to type nullability article

### DIFF
--- a/articles/lit/start/in-depth/type-safe-server-access-with-endpoints.adoc
+++ b/articles/lit/start/in-depth/type-safe-server-access-with-endpoints.adoc
@@ -142,7 +142,7 @@ Because of this, Hilla generates optional (nullable) TypeScript types for all no
 Hence, you need to ensure that you never return `null` values or collections with `null` elements.
 You do this by annotating the types with `@Nonnull`.
 This creates non-nullable TypeScript types that are easier to work with.
-You can read more about type nullability in the <<{articles}/lit/reference/endpoint-generator#type-nullability,TypeScript Endpoints Generator>> article.
+You can read more about type nullability in the <<{articles}/lit/reference/type-nullability,Type nullability>> article.
 
 Next, implement API methods to get, update, and delete data.
 


### PR DESCRIPTION
It looks like the information explaining the concept of "type nullability" was moved to its own reference article: https://hilla.dev/docs/lit/reference/type-nullability


