### PR TITLE
Update antMatchers to SpringBoot3 style

### DIFF
--- a/articles/security/enabling-security.adoc
+++ b/articles/security/enabling-security.adoc
@@ -227,7 +227,7 @@ public class SecurityConfiguration
 
         // Configure your static resources with public access before calling
         // super.configure(HttpSecurity) as it adds final anyRequest matcher
-        http.authorizeRequests().antMatchers("/public/**")
+        http.authorizeHttpRequests().requestMatchers(new AntPathRequestMatcher("/public/**"))
             .permitAll();
 
         super.configure(http); // <3>


### PR DESCRIPTION
In Spring Boot 3 there is no http.authorizeRequests().antMatchers... anymore. I replaced it in spring boot 3 style.


