### PR TITLE
fix: incorrect description of where to find "edit page" link

### DIFF
--- a/articles/contributing-docs/authoring/getting-started.asciidoc
+++ b/articles/contributing-docs/authoring/getting-started.asciidoc
@@ -6,7 +6,7 @@ layout: page
 
 = Getting Started with Vaadin Documentation
 
-To make quick corrections or suggestions to the Vaadin Docs, click the *GitHub* link in the upper-right corner of any page to start making a contribution through GitHub and then do a pull request.
+To make quick corrections or suggestions to the Vaadin Docs, click the *GitHub* link in the bottom-right corner of any page to start making a contribution through GitHub and then do a pull request.
 You should pay note to the instructions and limitations for <<editing-tools#github, editing in GitHub>>.
 
 A more flexible way is to use a local editor and tools.


### PR DESCRIPTION
Is it possible that the link moved from upper-right corner to the bottom-right corner? Or do I missed something?
There is definitely a link for page editing in bottom right part of every docu page (at least for V24)