### PR TITLE
Remove link to outdated video tutorials and simplify next-steps instructions

### DIFF
--- a/articles/guide/quick-start.adoc
+++ b/articles/guide/quick-start.adoc
@@ -98,13 +98,7 @@ image::_images/completed-app.gif[Animation of adding a new ToDo item and checkin
 
 Now you have a taste of how Vaadin Flow empowers you to quickly build web applications in pure Java, without writing any HTML or JavaScript.
 
-link:https://start.vaadin.com[Download a custom project starter] to get started on your own application. 
-
-Continue exploring Vaadin Flow in the documentation, tutorials, and video courses:
-
-- <<../overview#, Flow framework overview>>
-- <<../tutorial/overview#, In-depth course: learn Vaadin Flow development in 4 hours>>
-- link:https://vaadin.com/learn/training[Free online video courses covering Vaadin basics]
+Continue learning Vaadin Flow by following the <<../tutorial/overview#, in-depth 4-hours course>>, or download a custom project starter from link:https://start.vaadin.com[start.vaadin.com] to get started on your own application.
 
 The source code of the ToDo project is link:https://github.com/vaadin/flow-quickstart-tutorial[available on GitHub].
 

--- a/articles/guide/quick-start.adoc
+++ b/articles/guide/quick-start.adoc
@@ -98,9 +98,9 @@ image::_images/completed-app.gif[Animation of adding a new ToDo item and checkin
 
 Now you have a taste of how Vaadin Flow empowers you to quickly build web applications in pure Java, without writing any HTML or JavaScript.
 
-Continue learning Vaadin Flow by following the <<../tutorial/overview#, in-depth 4-hours course>>, or download a custom project starter from link:https://start.vaadin.com[start.vaadin.com] to get started on your own application.
+Continue learning Vaadin Flow by following the <<../tutorial/overview#, in-depth 4-hour course>>, or download a custom project starter from https://start.vaadin.com[start.vaadin.com] to get started on your own application.
 
-The source code of the ToDo project is link:https://github.com/vaadin/flow-quickstart-tutorial[available on GitHub].
+The source code of the ToDo project is https://github.com/vaadin/flow-quickstart-tutorial[available on GitHub].
 
 
 [discussion-id]`4762E8FE-6BAA-405E-8C48-E62042C55239`


### PR DESCRIPTION
Remove the link to outdated video tutorials (and remove the unhelpful link to the overview page).
