### PR TITLE
Move code sample to a separate file and add a prerelease banner

### DIFF
--- a/articles/_prerelease-banner.asciidoc
+++ b/articles/_prerelease-banner.asciidoc
@@ -56,7 +56,7 @@ endif::[]
 
 ifdef::artifact-id+version[]
 .Add the following to your pom.xml dependencies section:
-[source,xml]
+[source,xml,subs="verbatim,attributes"]
 ----
 <dependency>
     <groupId>com.vaadin</groupId>

--- a/articles/_prerelease-banner.asciidoc
+++ b/articles/_prerelease-banner.asciidoc
@@ -66,7 +66,7 @@ endif::[]
 [.prerelease.skip-search-index]
 [NOTE]
 ====
-{commercial-banner-content}
+{prerelease-banner-content}
 
 [.buttons]
 - https://mvnrepository.com/repos/vaadin-prereleases[Vaadin Prerelease Repository^]

--- a/articles/_prerelease-banner.asciidoc
+++ b/articles/_prerelease-banner.asciidoc
@@ -1,0 +1,73 @@
+++++
+<style>
+.admonitionblock.note.prerelease {
+  border: 0;
+  background-color: var(--blue-50);
+  font-size: var(--docs-font-size-xs);
+  font-weight: var(--docs-font-weight-emphasis);
+  color: var(--blue-900);
+  --docs-admonitionblock-icon-color: var(--blue-600);
+}
+
+.admonitionblock.note.prerelease .title {
+  font-weight: var(--docs-font-weight-strong);
+}
+
+.admonitionblock.note.prerelease .title,
+.admonitionblock.note.prerelease p {
+  margin-bottom: 0;
+}
+
+.admonitionblock.note.prerelease .icon {
+  font-size: var(--docs-font-size-m);
+  line-height: 1.25;
+}
+
+.admonitionblock.note.prerelease .buttons ul {
+  font-size: var(--docs-font-size-2xs);
+}
+
+.admonitionblock.note.prerelease .buttons ul a:any-link {
+  color: var(--blue-900);
+  border-color: var(--blue-500);
+  font-weight: var(--docs-font-weight-emphasis);
+}
+
+.admonitionblock.note.prerelease .buttons ul li:first-child a:any-link {
+  color: var(--base-white);
+  background-color: var(--blue-600);
+}
+
+.admonitionblock.note.prerelease .buttons ul a:any-link::after {
+  content: none;
+}
+
+[theme~="dark"] .admonitionblock.note.prerelease {
+  background-color: var(--blue-900);
+  color: var(--blue-50);
+  --docs-admonitionblock-icon-color: var(--blue-400);
+}
+
+[theme~="dark"] .admoninition.prerelease .buttons ul a:any-link {
+  color: inherit;
+}
+</style>
+++++
+
+ifndef::prerelease-feature[]
+:prerelease-feature: this feature
+endif::[]
+
+ifndef::prerelease-banner-content[]
+:prerelease-banner-content: The {prerelease-feature} feature has not yet been released and is only available through the prerelease repository.
+endif::[]
+
+.Prerelease feature
+[.prerelease.skip-search-index]
+[NOTE]
+====
+{commercial-banner-content}
+
+[.buttons]
+- https://mvnrepository.com/repos/vaadin-prereleases[Vaadin Prerelease Repository^]
+====

--- a/articles/_prerelease-banner.asciidoc
+++ b/articles/_prerelease-banner.asciidoc
@@ -55,19 +55,37 @@
 ++++
 
 ifndef::prerelease-feature[]
-:prerelease-feature: this feature
+:prerelease-feature: This feature
 endif::[]
 
 ifndef::prerelease-banner-content[]
-:prerelease-banner-content: The {prerelease-feature} feature has not yet been released and is only available through the prerelease repository.
+:prerelease-banner-content: {prerelease-feature} has not yet been released and is only available through the pre-release repository.
 endif::[]
 
-.Prerelease feature
+.Pre-release feature
 [.prerelease.skip-search-index]
 [NOTE]
 ====
 {prerelease-banner-content}
 
-[.buttons]
-- https://mvnrepository.com/repos/vaadin-prereleases[Vaadin Prerelease Repository^]
+.Add the following to your pom.xml repositories section:
+[source,xml]
+----
+<repository>
+    <id>vaadin-prereleases</id>
+    <url>https://maven.vaadin.com/vaadin-prereleases/</url>
+</repository>
+----
+
+ifdef::artifact-id+version[]
+.Add the following to your pom.xml dependencies section:
+[source,xml]
+----
+<dependency>
+    <groupId>com.vaadin</groupId>
+    <artifactId>{artifact-id}</artifactId>
+    <version>{version}</version>
+</dependency>
+----
+endif::[]
 ====

--- a/articles/tools/observability/configuration.asciidoc
+++ b/articles/tools/observability/configuration.asciidoc
@@ -98,12 +98,12 @@ The instrumentation modules that are disabled by default are: `jetty`, `servlet`
 otel.instrumentation.${instrumentationName}.enabled=true
 ----
 
+== Frontend Observability Configuration
 
-:prerelease-feature: Frontend Observability Configuration
+:prerelease-feature: Frontend Observability
+:artifact-id: observability-kit-starter
+:version: 2.1-SNAPSHOT
 include::{articles}/_prerelease-banner.asciidoc[opts=optional]
-
-Frontend observability is enabled by default, with all the client-side instrumentation active.
-The configuration can be tuned in two ways:
 
 Frontend observability is enabled by default, with all of the client-side instrumentation active. The configuration can be tuned in two ways: statically by editing the [filename]`agent.properties` file, or by providing environment variables or system properties; or dynamically by implementing the [interfacename]`ObservabilityClientConfigurer` interface, which applies changes at runtime.
 

--- a/articles/tools/observability/configuration.asciidoc
+++ b/articles/tools/observability/configuration.asciidoc
@@ -159,7 +159,7 @@ The following properties can be used to tune frontend instrumentation:
 
 |===
 
-For more information about the frontend instrumentation, consult the <<./reference#,Observability Kit Reference>> page.
+For more information about the frontend instrumentation, consult the <<./reference#frontend-traces,Observability Kit Reference>> page.
 
 
 === Frontend Observability Runtime Configuration

--- a/articles/tools/observability/configuration.asciidoc
+++ b/articles/tools/observability/configuration.asciidoc
@@ -227,7 +227,7 @@ For this example, the file looks like this:
 `com.vaadin.observability.ObservabilityClientConfigurer`
 [source]
 ----
-`org.example.UserBasedFrontendObservability`
+org.example.UserBasedFrontendObservability
 ----
 
 For details on observability client settings, consult the Javadocs of the [interfacename]`ObservabilityClientConfiguration` interface.

--- a/articles/tools/observability/configuration.asciidoc
+++ b/articles/tools/observability/configuration.asciidoc
@@ -111,8 +111,11 @@ otel.instrumentation.${instrumentationName}.enabled=true
 
 == Frontend Observability Configuration
 
+:prerelease-feature: Frontend Observability
+include::{articles}/_prerelease-banner.asciidoc[opts=optional]
+
 Frontend observability is enabled by default, with all the client-side instrumentation active.
-The configuration can be tuned in two ways: 
+The configuration can be tuned in two ways:
 
 * Statically, by editing the [filename]`agent.properties` file or by providing environment variables or system properties.
 * Dynamically, by implementing the [interfacename]`ObservabilityClientConfigurer` interface that applies changes at runtime.
@@ -176,47 +179,7 @@ For example, the following implementation shows how to set up observability base
 .`UserBasedFrontendObservability.java`
 [source,java]
 ----
-package org.example;
-
-import java.security.Principal;
-
-import org.example.UserObservabilityConfig;
-
-import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.observability.ObservabilityClientConfiguration;
-import com.vaadin.observability.ObservabilityClientConfigurer;
-
-public class UserBasedFrontendObservability implements ObservabilityClientConfigurer {
-
-    @Override
-    public void configure(ObservabilityClientConfiguration config) {
-        var request = VaadinRequest.getCurrent();
-        var userSettings = fetchConfiguration(request.getUserPrincipal());
-        if (userSettings != null && userSettings.isEnabled()) {
-            config.setEnabled(true);
-            config.setDocumentLoadEnabled(userSettings.isDocumentLoad());
-            config.setUserInteractionEnabled(userSettings.isUserInteraction());
-            config.setLongTaskEnabled(userSettings.isLongTask());
-            config.setXMLHttpRequestEnabled(userSettings.isXmlHTTPRequest());
-            config.setFrontendErrorEnabled(userSettings.isFrontendError());
-        } else {
-            config.setEnabled(false);
-        }
-    }
-
-    // UserObservabilityConfig represent a simple DTO that carries user
-    // related information used to tune ObservabilityClientConfiguration
-    private UserObservabilityConfig fetchConfiguration(Principal user) {
-        if (user != null) {
-            // fetch the configuration for the given user from some storage
-            // e.g. in-memory data structure, database table, properties file, ...
-            return config;
-        }
-        // user not logged-in, return null or a default configuration
-        return null;
-    }
-
-}
+include::{root}/src/main/java/com/vaadin/demo/observability/UserBasedFrontendObservability.java[tags=full-class;indent=0]
 ----
 
 With the above implementation, the configuration can (for example) be fetched from a database table, allowing changes to be applied at runtime after a browser page reload.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
     "@hilla/generator-typescript-plugin-push": "2.1.0-alpha1",
     "@hilla/generator-typescript-utils": "2.1.0-alpha1",
     "@material/mwc-slider": "0.27.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.35.0",
+    "@opentelemetry/instrumentation": "0.35.0",
+    "@opentelemetry/instrumentation-document-load": "0.31.0",
+    "@opentelemetry/instrumentation-long-task": "0.32.0",
+    "@opentelemetry/instrumentation-user-interaction": "0.32.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.34.0",
+    "@opentelemetry/sdk-trace-web": "1.8.0",
     "@polymer/polymer": "3.5.1",
     "@vaadin/accordion": "24.1.0-alpha4",
     "@vaadin/app-layout": "24.1.0-alpha4",
@@ -141,6 +148,13 @@
       "@hilla/generator-typescript-plugin-push": "2.1.0-alpha1",
       "@hilla/generator-typescript-utils": "2.1.0-alpha1",
       "@material/mwc-slider": "0.27.0",
+      "@opentelemetry/exporter-trace-otlp-http": "0.35.0",
+      "@opentelemetry/instrumentation": "0.35.0",
+      "@opentelemetry/instrumentation-document-load": "0.31.0",
+      "@opentelemetry/instrumentation-long-task": "0.32.0",
+      "@opentelemetry/instrumentation-user-interaction": "0.32.0",
+      "@opentelemetry/instrumentation-xml-http-request": "0.34.0",
+      "@opentelemetry/sdk-trace-web": "1.8.0",
       "@polymer/polymer": "3.5.1",
       "@vaadin/accordion": "24.1.0-alpha4",
       "@vaadin/app-layout": "24.1.0-alpha4",
@@ -231,7 +245,7 @@
       "workbox-core": "6.5.4",
       "workbox-precaching": "6.5.4"
     },
-    "hash": "2c8b9c450f0ac7a44cb7f7b72f13db6ff33f1e10fe080d7838ae9028520c7f83"
+    "hash": "aaba74113229d59a0497e65fbb8e07501c52f028463fbc73ef3acd30d7a54c69"
   },
   "overrides": {
     "@vaadin/accordion": "$@vaadin/accordion",
@@ -320,6 +334,13 @@
     "@vaadin/tabsheet": "$@vaadin/tabsheet",
     "@vaadin/tooltip": "$@vaadin/tooltip",
     "@vaadin/overlay": "$@vaadin/overlay",
-    "@material/mwc-slider": "$@material/mwc-slider"
+    "@material/mwc-slider": "$@material/mwc-slider",
+    "@opentelemetry/instrumentation-xml-http-request": "$@opentelemetry/instrumentation-xml-http-request",
+    "@opentelemetry/instrumentation-document-load": "$@opentelemetry/instrumentation-document-load",
+    "@opentelemetry/exporter-trace-otlp-http": "$@opentelemetry/exporter-trace-otlp-http",
+    "@opentelemetry/instrumentation": "$@opentelemetry/instrumentation",
+    "@opentelemetry/instrumentation-user-interaction": "$@opentelemetry/instrumentation-user-interaction",
+    "@opentelemetry/sdk-trace-web": "$@opentelemetry/sdk-trace-web",
+    "@opentelemetry/instrumentation-long-task": "$@opentelemetry/instrumentation-long-task"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>observability-kit-starter</artifactId>
+            <version>2.1.0.beta1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring-boot-starter</artifactId>
             <exclusions>
                 <!-- Excluding so that webjars are not included. -->

--- a/src/main/java/com/vaadin/demo/observability/UserBasedFrontendObservability.java
+++ b/src/main/java/com/vaadin/demo/observability/UserBasedFrontendObservability.java
@@ -1,0 +1,95 @@
+package com.vaadin.demo.observability;
+
+import java.security.Principal;
+
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.observability.ObservabilityClientConfiguration;
+import com.vaadin.observability.ObservabilityClientConfigurer;
+
+// tag::full-class[]
+public class UserBasedFrontendObservability implements ObservabilityClientConfigurer {
+    @Override
+    public void configure(ObservabilityClientConfiguration config) {
+        var request = VaadinRequest.getCurrent();
+        var userSettings = fetchConfiguration(request.getUserPrincipal());
+
+        config.setEnabled(userSettings.isEnabled());
+        config.setDocumentLoadEnabled(userSettings.isDocumentLoad());
+        config.setUserInteractionEnabled(userSettings.isUserInteraction());
+        config.setLongTaskEnabled(userSettings.isLongTask());
+        config.setXMLHttpRequestEnabled(userSettings.isXmlHttpRequest());
+        config.setFrontendErrorEnabled(userSettings.isFrontendError());
+    }
+
+    private UserObservabilityConfig fetchConfiguration(Principal user) {
+        if (user != null) {
+            // fetch the configuration for the given user from some storage
+            // e.g. in-memory data structure, database table, properties file, ...
+            UserObservabilityConfig config = new UserObservabilityConfig();
+            config.setXmlHttpRequest(false);
+
+            return config;
+        }
+        // user not logged-in, return null or a default configuration
+        return new UserObservabilityConfig();
+    }
+
+    static class UserObservabilityConfig {
+        private boolean enabled = true;
+        private boolean documentLoad = true;
+
+        private boolean userInteraction = true;
+        private boolean longTask = true;
+        private boolean xmlHttpRequest = true;
+        private boolean frontendError = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isDocumentLoad() {
+            return enabled && documentLoad;
+        }
+
+        public void setDocumentLoad(boolean documentLoad) {
+            this.documentLoad = documentLoad;
+        }
+
+        public boolean isUserInteraction() {
+            return enabled && userInteraction;
+        }
+
+        public void setUserInteraction(boolean userInteraction) {
+            this.userInteraction = userInteraction;
+        }
+
+        public boolean isLongTask() {
+            return enabled && longTask;
+        }
+
+        public void setLongTask(boolean longTask) {
+            this.longTask = longTask;
+        }
+
+        public boolean isXmlHttpRequest() {
+            return enabled && xmlHttpRequest;
+        }
+
+        public void setXmlHttpRequest(boolean xmlHttpRequest) {
+            this.xmlHttpRequest = xmlHttpRequest;
+        }
+
+        public boolean isFrontendError() {
+            return enabled && frontendError;
+        }
+
+        public void setFrontendError(boolean frontendError) {
+            this.frontendError = frontendError;
+        }
+    }
+}
+// end::full-class[]


### PR DESCRIPTION
This extracts a code sample to its own file for two reasons:
1. So that everything required to get the code sample working is available on the page.
2. So that the validity of the code is checked and changes to the API will force the example to change.