### PR TITLE
docs: add a missing -button-visible suffix

### DIFF
--- a/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
@@ -48,8 +48,8 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <vaadin-confirm-dialog
           header="Unsaved changes"
-          cancel
-          reject
+          cancel-button-visible
+          reject-button-visible
           reject-text="Discard"
           confirm-text="Save"
           .opened="${this.dialogOpened}"

--- a/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
@@ -33,7 +33,7 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <vaadin-confirm-dialog
           header='Delete "Report Q4"?'
-          cancel
+          cancel-button-visible
           confirm-text="Delete"
           confirm-theme="error primary"
           .opened="${this.dialogOpened}"

--- a/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
@@ -33,8 +33,8 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <vaadin-confirm-dialog
           header="Unsaved changes"
-          cancel
-          reject
+          cancel-button-visible
+          reject-button-visible
           reject-text="Discard"
           confirm-text="Save"
           .opened="${this.dialogOpened}"


### PR DESCRIPTION
The `cancel` and `reject` properties were renamed to `cancel-button-visible` and `reject-button-visible` respectively in v24, see the [related ticket](https://github.com/vaadin/web-components/issues/597).

Fixes https://github.com/vaadin/web-components/issues/5753