### PR TITLE
Correct label for `last-row-cell` and standardize order of even/odd

### DIFF
--- a/articles/components/grid/styling.asciidoc
+++ b/articles/components/grid/styling.asciidoc
@@ -31,9 +31,9 @@ Cell contents:: `vaadin-grid-cell-content`
 Cell in first column:: `vaadin-grid+++<wbr>+++**::part(first-column-cell)**`
 Cell in last column:: `vaadin-grid+++<wbr>+++**::part(last-column-cell)**`
 Cell in first row:: `vaadin-grid+++<wbr>+++**::part(first-row-cell)**`
-Cell in last column:: `vaadin-grid+++<wbr>+++**::part(last-row-cell)**`
-Cell in odd row:: `vaadin-grid+++<wbr>+++**::part(odd-row-cell)**`
+Cell in last row:: `vaadin-grid+++<wbr>+++**::part(last-row-cell)**`
 Cell in even row:: `vaadin-grid+++<wbr>+++**::part(even-row-cell)**`
+Cell in odd row:: `vaadin-grid+++<wbr>+++**::part(odd-row-cell)**`
 Cell in selected row:: `vaadin-grid+++<wbr>+++**::part(selected-row-cell)**`
 Cell in first header row:: `vaadin-grid+++<wbr>+++**::part(first-header-row-cell)**`
 Cell in last header row:: `vaadin-grid+++<wbr>+++**::part(last-header-row-cell)**`


### PR DESCRIPTION
Corrects the label for `last-row-cell` to be "Cell in last row". Also reverses the order of `even-row-cell` and `odd-row-cell` to match `even-row` and `odd-row`.