### PR TITLE
Update instructions for Vaadin 8.20.0

### DIFF
--- a/articles/framework/portal/portal-osgi.asciidoc
+++ b/articles/framework/portal/portal-osgi.asciidoc
@@ -113,3 +113,47 @@ blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-th
 blade sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-liferay-integration/8.14.3/vaadin-liferay-integration-8.14.3.jar
 java -jar blade.jar sh start file:<path_to_liferay_portlet.jar>
 ----
+
+== Deployment on Liferay 7 when using Vaadin 8.18.0+
+
+Vaadin 8.18.0 separated out the portlet classes from the `vaadin-server` package to a `vaadin-portlet` package as part of an effort to support MPR, which requires the Jakarta namespace.
+
+Below are updated example scripts for Vaadin 8.20.0. Please note, that Vaadin 8.15.0+ requires a valid and active license to use.
+
+[source, shell]
+----
+java -jar blade.jar sh start https://repo1.maven.org/maven2/org/jsoup/jsoup/1.14.3/jsoup-1.15.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/external/gentyref/1.2.0.vaadin1/gentyref-1.2.0.vaadin1.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/external/gwt/gwt-elemental/2.8.2.vaadin2/gwt-elemental-2.8.2.vaadin2.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/license-checker/1.12.3/license-checker-1.12.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-shared/8.20.0/vaadin-shared-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-server/8.20.0/vaadin-server-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-portlet/8.20.0/vaadin-portlet-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-osgi-integration/8.20.0/vaadin-osgi-integration-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-client-compiled/8.20.0/vaadin-client-compiled-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-themes/8.20.0/vaadin-themes-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-liferay-integration/8.20.0/vaadin-liferay-integration-8.20.0.jar
+java -jar blade.jar sh start file:<path_to_liferay_portlet.jar>
+----
+
+and with compatibility packages:
+
+[source, shell]
+----
+java -jar blade.jar sh start https://repo1.maven.org/maven2/org/jsoup/jsoup/1.14.3/jsoup-1.15.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/external/gentyref/1.2.0.vaadin1/gentyref-1.2.0.vaadin1.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/external/gwt/gwt-elemental/2.8.2.vaadin2/gwt-elemental-2.8.2.vaadin2.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/license-checker/1.12.3/license-checker-1.12.3.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-shared/8.20.0/vaadin-shared-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-shared/8.20.0/vaadin-compatibility-shared-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-server/8.20.0/vaadin-server-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-server/8.20.0/vaadin-compatibility-server-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-portlet/8.20.0/vaadin-portlet-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-osgi-integration/8.20.0/vaadin-osgi-integration-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-client-compiled/8.20.0/vaadin-client-compiled-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-client-compiled/8.20.0/vaadin-compatibility-client-compiled-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-compatibility-themes/8.20.0/vaadin-compatibility-themes-8.20.0.jar
+java -jar blade.jar sh start https://repo1.maven.org/maven2/com/vaadin/vaadin-liferay-integration/8.20.0/vaadin-liferay-integration-8.20.0.jar
+java -jar blade.jar sh start file:<path_to_liferay_portlet.jar>
+----
+


### PR DESCRIPTION
Vaadin 8.18.0 introduced the portlet package that needs to be running in order for liferay-integration and any portal stuff to work. Vaadin 8.15.0 introduced a dependency on the license checker.


