### PR TITLE
Update download links to point to v2.0.0

### DIFF
--- a/articles/tools/observability/getting-started.asciidoc
+++ b/articles/tools/observability/getting-started.asciidoc
@@ -31,13 +31,13 @@ The Starter dependency can be added to your project by adding the following to t
 </dependency>
 ----
 
-The Agent is based on the OpenTelemetry standard and is packaged as a jar file. See the <<{articles}/tools/observability/reference#,Observability Kit Reference>> documentation page for more information.  
+The Agent is based on the OpenTelemetry standard and is packaged as a jar file. See the <<{articles}/tools/observability/reference#,Observability Kit Reference>> documentation page for more information.
 
 .Download the Agent jar file
 [IMPORTANT]
 The Agent cannot be used as a dependency. It must be downloaded separately.
 
-link:https://repo1.maven.org/maven2/com/vaadin/observability/vaadin-opentelemetry-javaagent/2.1.0/vaadin-opentelemetry-javaagent-2.1.0.jar[Download Observability Kit Agent, role="button secondary water"]
+link:https://repo1.maven.org/maven2/com/vaadin/observability-kit-agent/2.0.0/observability-kit-agent-2.0.0.jar[Download Observability Kit Agent, role="button secondary water"]
 
 Once the Agent has finished downloading to the project directory, it needs to be configured to export telemetry to one or more observability tools. In this guide, traces are exported to Jaeger; metrics are sent to Prometheus. To do this, create an [filename]`agent.properties` file in the project directory with the following content:
 

--- a/articles/tools/observability/index.asciidoc
+++ b/articles/tools/observability/index.asciidoc
@@ -16,7 +16,7 @@ At its core, Observability Kit is a custom Java agent that runs together with a 
 
 Download the latest version from the following link:
 
-https://repo1.maven.org/maven2/com/vaadin/observability/vaadin-opentelemetry-javaagent/1.0.0/vaadin-opentelemetry-javaagent-1.0.0.jar[Download Observability Kit,role="button primary water"]
+https://repo1.maven.org/maven2/com/vaadin/observability-kit-agent/2.0.0/observability-kit-agent-2.0.0.jar[Download Observability Kit,role="button primary water"]
 
 == Topics
 


### PR DESCRIPTION
The download buttons for the Observability Kit agent do not point to the correct versions.
This updates them to V2.0.0. Note: This will need to be changed to V2.1.0 for V24.1 of the docs.