### PR TITLE
Add compatibility matrix for V23

### DIFF
--- a/articles/compatibility.adoc
+++ b/articles/compatibility.adoc
@@ -1,12 +1,12 @@
 ---
 title: Supported Technologies
-description: See the mimimun required version of compatible technlogies, such as Spring Boot and browsers, for Vaadin {moduleMavenVersion:com.vaadin:vaadin}.
+description: See the mimimun required version of compatible technlogies, such as Spring Boot and browsers, for Vaadin 23.
 order: 901
 ---
 
 = List of Supported Technologies
 
-This page shows the minimum required version of supported technologies for *Vaadin {moduleMavenVersion:com.vaadin:vaadin}*. See the https://github.com/vaadin/platform/releases/tag/{moduleMavenVersion:com.vaadin:vaadin}[release notes] for more details.
+This page shows the minimum required version of supported technologies for *Vaadin 23*. See the https://github.com/vaadin/platform/releases/tag/23.0.0[release notes] for more details.
 
 [cols="1,1"]
 |===

--- a/articles/compatibility.adoc
+++ b/articles/compatibility.adoc
@@ -1,12 +1,14 @@
 ---
 title: Supported Technologies
-description: See the mimimun required version of compatible technlogies, such as Spring Boot and browsers, for Vaadin 23.
+description: The mimimun required version of compatible technlogies for Vaadin 23, such as Spring Boot and browsers.
 order: 901
 ---
 
 = List of Supported Technologies
 
-This page shows the minimum required version of supported technologies for *Vaadin 23*. See the https://github.com/vaadin/platform/releases/tag/23.0.0[release notes] for more details.
+This page shows the minimum required versions of supported technologies for *Vaadin 23*. See the https://github.com/vaadin/platform/releases/tag/23.0.0[release notes] for more details.
+
+pass:[<!-- vale Vaadin.Abbr = NO -->]
 
 [cols="1,1"]
 |===
@@ -38,7 +40,7 @@ a|
 
 == Browser Compatibility
 
-Vaadin 23 is supported by the following browsers:
+Vaadin 23 supported by several web browsers. The following is a list of compatible desktop browsers and mobile browsers.
 
 === Desktop Browsers
 
@@ -61,3 +63,5 @@ Vaadin 23 is supported by the following browsers:
 | Chrome | Evergreen
 | Safari | 14.1 or later
 |===
+
+pass:[<!-- vale Vaadin.Abbr = YES -->]

--- a/articles/compatibility.adoc
+++ b/articles/compatibility.adoc
@@ -1,0 +1,63 @@
+---
+title: Supported Technologies
+description: See the mimimun required version of compatible technlogies, such as Spring Boot and browsers, for Vaadin 23.
+order: 901
+---
+
+= List of Supported Technologies
+
+This page shows the minimum required version of supported technologies for *Vaadin 23*. See the https://github.com/vaadin/platform/releases/tag/23.0.0[release notes] for more details.
+
+[cols="1,1"]
+|===
+|Technology|Version
+
+| Java| 11, 17
+| Spring Boot| 2.7.8
+| Node.js| 16.14 or later
+| Maven| 3.5
+| Gradle| 5.0
+| Servlet| 3.1 or later
+| Application servers
+a| 
+
+* Apache Tomcat 8.0.x, 8.5, 9
+* Apache TomEE 8.0
+* Oracle WebLogic Server 14c
+* IBM WebSphere Application Server v9.0.5 Liberty Profile
+* RedHat JBoss EAP 7.2
+* WildFly 15, 16
+* Jetty 9.4
+* Payara Server (platform 5.194)
+* Payara Micro (platform 5.194)
+* Karaf 4.2 or newer
+| Portlet| 3.0
+| OSGi| 7.0.0
+| Karaf| 4.0.0
+|===
+
+== Browser Compatibility
+
+Vaadin 23 is supported by the following browsers:
+
+=== Desktop Browsers
+
+[cols="1,1"]
+|===
+| Browser | Version
+
+| Chrome | Evergreen
+| Firefox | Evergreen, ESR
+| Safari | 14.1 or later
+| Edge | Evergreen, Chromium
+|===
+
+=== Mobile Browsers
+
+[cols="1,1"]
+|===
+| Browser | Version
+
+| Chrome | Evergreen
+| Safari | 14.1 or later
+|===

--- a/articles/compatibility.adoc
+++ b/articles/compatibility.adoc
@@ -17,7 +17,7 @@ This page shows the minimum required version of supported technologies for *Vaad
 | Node.js| 16.14 or later
 | Maven| 3.5
 | Gradle| 5.0
-| Servlet| 3.1 or later
+| Servlet| 3.1 or 4.0
 | Application servers
 a| 
 

--- a/articles/compatibility.adoc
+++ b/articles/compatibility.adoc
@@ -1,12 +1,12 @@
 ---
 title: Supported Technologies
-description: See the mimimun required version of compatible technlogies, such as Spring Boot and browsers, for Vaadin 23.
+description: See the mimimun required version of compatible technlogies, such as Spring Boot and browsers, for Vaadin {moduleMavenVersion:com.vaadin:vaadin}.
 order: 901
 ---
 
 = List of Supported Technologies
 
-This page shows the minimum required version of supported technologies for *Vaadin 23*. See the https://github.com/vaadin/platform/releases/tag/23.0.0[release notes] for more details.
+This page shows the minimum required version of supported technologies for *Vaadin {moduleMavenVersion:com.vaadin:vaadin}*. See the https://github.com/vaadin/platform/releases/tag/{moduleMavenVersion:com.vaadin:vaadin}[release notes] for more details.
 
 [cols="1,1"]
 |===

--- a/articles/compatibility.adoc
+++ b/articles/compatibility.adoc
@@ -38,7 +38,7 @@ a|
 
 == Browser Compatibility
 
-Vaadin 23 is supported by the following browsers:
+Vaadin {moduleMavenVersion:com.vaadin:vaadin} is supported by the following browsers:
 
 === Desktop Browsers
 

--- a/articles/compatibility.adoc
+++ b/articles/compatibility.adoc
@@ -38,7 +38,7 @@ a|
 
 == Browser Compatibility
 
-Vaadin {moduleMavenVersion:com.vaadin:vaadin} is supported by the following browsers:
+Vaadin 23 is supported by the following browsers:
 
 === Desktop Browsers
 


### PR DESCRIPTION
Added a list of supported technologies for V23, same as https://github.com/vaadin/docs/pull/2419 for latest