### PR TITLE
Docs/input field borders

### DIFF
--- a/articles/components/_input-field-common-features.adoc
+++ b/articles/components/_input-field-common-features.adoc
@@ -210,6 +210,6 @@ The helper can be rendered above the field, below the label.
 .[since:com.vaadin:vaadin@V24.1]#Borders#
 [%collapsible]
 ====
-Borders can be added by providing a value (e.g., 1px) to the `--vaadin-input-field-border-width` style property. This can be applied globally to all input fields or to individual component instances. Borders are required to achieve https://www.w3.org/TR/WCAG21/#non-text-contrast[WCAG 2.1 level AA] conformant color contrast with the default Lumo styling of fields.
+Borders can be applied to the field surface by providing a value (e.g., `1px`) to the `--vaadin-input-field-border-width` style property. This can be applied globally to all input fields or to individual component instances. Borders are required to achieve https://www.w3.org/TR/WCAG21/#non-text-contrast[WCAG 2.1 level AA] conformant color contrast with the default Lumo styling of fields.
 ====
 //end::borders[]

--- a/articles/components/_input-field-common-features.adoc
+++ b/articles/components/_input-field-common-features.adoc
@@ -210,6 +210,8 @@ The helper can be rendered above the field, below the label.
 .[since:com.vaadin:vaadin@V24.1]#Borders#
 [%collapsible]
 ====
-Borders can be applied to the field surface by providing a value (e.g., `1px`) to the `--vaadin-input-field-border-width` style property. This can be applied globally to all input fields or to individual component instances. Borders are required to achieve https://www.w3.org/TR/WCAG21/#non-text-contrast[WCAG 2.1 level AA] conformant color contrast with the default Lumo styling of fields.
+Borders can be applied to the field surface by providing a value (e.g., `1px`) to the `--vaadin-input-field-border-width` CSS property. This can be applied globally to all input fields (using the `html` selector) or to individual component instances. Borders are required to achieve https://www.w3.org/TR/WCAG21/#non-text-contrast[WCAG 2.1 level AA] conformant color contrast with the default Lumo styling of fields.
+
+The default border color can be overriden using the `--vaadin-input-field-border-color` property.
 ====
 //end::borders[]

--- a/articles/components/checkbox/index.asciidoc
+++ b/articles/components/checkbox/index.asciidoc
@@ -148,7 +148,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBa
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/combo-box/index.asciidoc
+++ b/articles/components/combo-box/index.asciidoc
@@ -260,7 +260,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxReadonl
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/date-picker/index.asciidoc
+++ b/articles/components/date-picker/index.asciidoc
@@ -351,7 +351,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerRea
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/date-time-picker/index.asciidoc
+++ b/articles/components/date-time-picker/index.asciidoc
@@ -239,7 +239,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimeP
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/email-field/index.asciidoc
+++ b/articles/components/email-field/index.asciidoc
@@ -96,7 +96,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldRea
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/number-field/index.asciidoc
+++ b/articles/components/number-field/index.asciidoc
@@ -166,7 +166,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldR
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/password-field/index.asciidoc
+++ b/articles/components/password-field/index.asciidoc
@@ -102,7 +102,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFi
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/radio-button/index.asciidoc
+++ b/articles/components/radio-button/index.asciidoc
@@ -157,7 +157,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonG
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/select/index.asciidoc
+++ b/articles/components/select/index.asciidoc
@@ -113,7 +113,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/select/SelectReadonlyAnd
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/text-area/index.asciidoc
+++ b/articles/components/text-area/index.asciidoc
@@ -122,7 +122,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaReadonl
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/text-field/index.asciidoc
+++ b/articles/components/text-field/index.asciidoc
@@ -85,7 +85,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldReado
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/components/time-picker/index.asciidoc
+++ b/articles/components/time-picker/index.asciidoc
@@ -186,7 +186,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerRea
 
 // Style Variants
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field]
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
 
 [.example]
 --

--- a/articles/styling/styling-components/sharing-styles.adoc
+++ b/articles/styling/styling-components/sharing-styles.adoc
@@ -88,24 +88,22 @@ The universal selector `*` can be omitted in the above selectors. It's used here
 [role="since:com.vaadin:vaadin@V24.1"]
 === Input Field Borders
 
-Borders can be easily enabled on all input field components by providing a non-zero value to the `--vaadin-input-field-border-width` CSS property. Using the default Lumo colors, this provides https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html[WCAG 2.1 level AA] conformant contrast between the background and the field surface.
+Borders can be easily enabled on all input field components by providing a non-zero value to the `--vaadin-input-field-border-width` CSS property. Using the default Lumo colors, this provides https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html[WCAG 2.1 level AA conformant contrast between the background and the field surface.
 
 The default border color can be overriden with the `--vaadin-input-field-border-color` property.
 
 These properties can be set globally, by applying them to the `html` selector, or scoped to any element using a more specific CSS selector.
-
 
 [.example.show-code]
 --
 
 [source,css]
 ----
-include::{root}/frontend/demo/component/inputfields/input-field-borders.css[]
+include::{root}/frontend/demo/component/inputfields/input-field-borders.ts[tags=css, indent=0]
 ----
 
 [source,html]
 ----
 include::{root}/frontend/demo/component/inputfields/input-field-borders.ts[render, tags=snippet, indent=0]
 ----
-
 --

--- a/articles/styling/styling-components/sharing-styles.adoc
+++ b/articles/styling/styling-components/sharing-styles.adoc
@@ -83,3 +83,29 @@ Error message:: `*::part(error-message)`
 ====
 The universal selector `*` can be omitted in the above selectors. It's used here only to make the shadow part selectors easier to understand.
 ====
+
+
+[role="since:com.vaadin:vaadin@V24.1"]
+=== Input Field Borders
+
+Borders can be easily enabled on all input field components by providing a non-zero value to the `--vaadin-input-field-border-width` CSS property. Using the default Lumo colors, this provides https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html[WCAG 2.1 level AA] conformant contrast between the background and the field surface.
+
+The default border color can be overriden with the `--vaadin-input-field-border-color` property.
+
+These properties can be set globally, by applying them to the `html` selector, or scoped to any element using a more specific CSS selector.
+
+
+[.example.show-code]
+--
+
+[source,css]
+----
+include::{root}/frontend/demo/component/inputfields/input-field-borders.css[]
+----
+
+[source,html]
+----
+include::{root}/frontend/demo/component/inputfields/input-field-borders.ts[render, tags=snippet, indent=0]
+----
+
+--

--- a/frontend/demo/component/checkbox/checkbox-group-styles.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-styles.ts
@@ -18,7 +18,8 @@ export class Example extends LitElement {
     return html`
         <!-- tag::snippet[] -->
         <vaadin-checkbox-group theme="helper-above-field"
-          label="Label" helper-text="Helper text">
+          label="Label" helper-text="Helper text"
+          style="--vaadin-input-field-border-width: 1px;">
           <!-- end::snippet[] -->
           <vaadin-checkbox value="1" label="Item 1"></vaadin-checkbox>
           <vaadin-checkbox value="2" label="Item 2"></vaadin-checkbox>

--- a/frontend/demo/component/combobox/combo-box-styles.ts
+++ b/frontend/demo/component/combobox/combo-box-styles.ts
@@ -19,7 +19,8 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <vaadin-combo-box theme="align-right small helper-above-field"
           label="Label" helper-text="Helper text"
-          .items="${['Value']}" value="Value">
+          .items="${['Value']}" value="Value"
+          style="--vaadin-input-field-border-width: 1px;">
         </vaadin-combo-box>
         <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/datepicker/date-picker-styles.ts
+++ b/frontend/demo/component/datepicker/date-picker-styles.ts
@@ -18,7 +18,8 @@ export class Example extends LitElement {
     return html`
         <!-- tag::snippet[] -->
         <vaadin-date-picker theme="align-right small helper-above-field"
-          label="Label" helper-text="Helper text" value="2020-06-12">
+          label="Label" helper-text="Helper text" value="2020-06-12"
+          style="--vaadin-input-field-border-width: 1px;">
         </vaadin-date-picker>
         <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/datetimepicker/date-time-picker-styles.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-styles.ts
@@ -18,7 +18,8 @@ export class Example extends LitElement {
     return html`
         <!-- tag::snippet[] -->
         <vaadin-date-time-picker theme="align-right small helper-above-field"
-          label="Label" helper-text="Helper text" value="2020-06-12T12:30">
+          label="Label" helper-text="Helper text" value="2020-06-12T12:30"
+          style="--vaadin-input-field-border-width: 1px;">
         </vaadin-date-time-picker>
         <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/emailfield/email-field-styles.ts
+++ b/frontend/demo/component/emailfield/email-field-styles.ts
@@ -18,7 +18,8 @@ export class Example extends LitElement {
     return html`
         <!-- tag::snippet[] -->
         <vaadin-email-field theme="align-right small helper-above-field"
-          label="Label" helper-text="Helper text" value="foo@bar.com">
+          label="Label" helper-text="Helper text" value="foo@bar.com"
+          style="--vaadin-input-field-border-width: 1px;">
         </vaadin-email-field>
         <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/inputfields/input-field-borders.css
+++ b/frontend/demo/component/inputfields/input-field-borders.css
@@ -1,0 +1,7 @@
+html {
+    --vaadin-input-field-border-width: 1px;
+}
+
+.custom-border {
+    --vaadin-input-field-border-color: #14b900;
+}

--- a/frontend/demo/component/inputfields/input-field-borders.css
+++ b/frontend/demo/component/inputfields/input-field-borders.css
@@ -1,7 +1,0 @@
-html {
-    --vaadin-input-field-border-width: 1px;
-}
-
-.custom-border {
-    --vaadin-input-field-border-color: #14b900;
-}

--- a/frontend/demo/component/inputfields/input-field-borders.ts
+++ b/frontend/demo/component/inputfields/input-field-borders.ts
@@ -1,20 +1,13 @@
 import 'Frontend/demo/init'; // hidden-source-line
 
-import { html, LitElement, css } from 'lit';
+import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import '@vaadin/text-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-borders')
 export class Example extends LitElement {
-    static styles = css`
-    * {
-        --vaadin-input-field-border-width: 1px;
-    }
-    .custom-border {
-        --vaadin-input-field-border-color: #14b900;
-    }
-    `;
+
     protected override createRenderRoot() {
         const root = super.createRenderRoot();
         // Apply custom theme (only supported if your app uses one)
@@ -24,6 +17,18 @@ export class Example extends LitElement {
 
     protected override render() {
         return html`
+          <style>
+            :host,
+            /* tag::css[] */
+            html {
+                --vaadin-input-field-border-width: 1px;
+            }
+            .custom-border {
+                --vaadin-input-field-border-color: #14b900;
+            }
+            /* end::css[] */
+          </style>
+          
           <div style="display: flex; gap: 1em;">
             <!-- tag::snippet[] -->
               <vaadin-text-field label="Bordered field"></vaadin-text-field>

--- a/frontend/demo/component/inputfields/input-field-borders.ts
+++ b/frontend/demo/component/inputfields/input-field-borders.ts
@@ -1,0 +1,36 @@
+import 'Frontend/demo/init'; // hidden-source-line
+
+import { html, LitElement, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import '@vaadin/text-field';
+import { applyTheme } from 'Frontend/generated/theme';
+
+@customElement('input-field-borders')
+export class Example extends LitElement {
+    static styles = css`
+    * {
+        --vaadin-input-field-border-width: 1px;
+    }
+    .custom-border {
+        --vaadin-input-field-border-color: #14b900;
+    }
+    `;
+    protected override createRenderRoot() {
+        const root = super.createRenderRoot();
+        // Apply custom theme (only supported if your app uses one)
+        applyTheme(root);
+        return root;
+    }
+
+    protected override render() {
+        return html`
+          <div style="display: flex; gap: 1em;">
+            <!-- tag::snippet[] -->
+              <vaadin-text-field label="Bordered field"></vaadin-text-field>
+              <vaadin-text-field label="Bordered invalid field" invalid></vaadin-text-field>
+              <vaadin-text-field label="Custom border color" class="custom-border"></vaadin-text-field>
+            <!-- end::snippet[] -->
+          </div>
+    `;
+    }
+}

--- a/frontend/demo/component/numberfield/number-field-styles.ts
+++ b/frontend/demo/component/numberfield/number-field-styles.ts
@@ -18,7 +18,8 @@ export class Example extends LitElement {
     return html`
         <!-- tag::snippet[] -->
         <vaadin-number-field theme="align-right small helper-above-field"
-          label="Label" helper-text="Helper text" value="123.45">
+          label="Label" helper-text="Helper text" value="123.45"
+          style="--vaadin-input-field-border-width: 1px;">
         </vaadin-number-field>
         <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/passwordfield/password-field-styles.ts
+++ b/frontend/demo/component/passwordfield/password-field-styles.ts
@@ -18,7 +18,8 @@ export class Example extends LitElement {
     return html`
         <!-- tag::snippet[] -->
         <vaadin-password-field theme="align-right small helper-above-field"
-          label="Label" helper-text="Helper text" value="Ex@mplePassw0rd">
+          label="Label" helper-text="Helper text" value="Ex@mplePassw0rd"
+          style="--vaadin-input-field-border-width: 1px;">
         </vaadin-password-field>
         <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/radiobutton/radio-button-group-styles.ts
+++ b/frontend/demo/component/radiobutton/radio-button-group-styles.ts
@@ -18,7 +18,8 @@ export class Example extends LitElement {
     return html`
         <!-- tag::snippet[] -->
         <vaadin-radio-group theme="helper-above-field"
-          label="Label" helper-text="Helper text">
+          label="Label" helper-text="Helper text"
+          style="--vaadin-input-field-border-width: 1px;">
           <!-- end::snippet[] -->
           <vaadin-radio-button value="1" label="Item 1"></vaadin-radio-button>
           <vaadin-radio-button value="2" label="Item 2"></vaadin-radio-button>

--- a/frontend/demo/component/select/select-styles.ts
+++ b/frontend/demo/component/select/select-styles.ts
@@ -19,6 +19,7 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <vaadin-select theme="align-right small helper-above-field"
           label="Label" helper-text="Helper text"
+          style="--vaadin-input-field-border-width: 1px;"
           .items="${this.items}" value="${this.items[0].value}">
         </vaadin-select>
         <!-- end::snippet[] -->

--- a/frontend/demo/component/textarea/text-area-styles.ts
+++ b/frontend/demo/component/textarea/text-area-styles.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <vaadin-text-area theme="align-right small helper-above-field"
           label="Label" helper-text="Helper text" value="Value"
-          style="width:100%">
+          style="--vaadin-input-field-border-width: 1px; width: 100%;">
         </vaadin-text-area>
         <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/textfield/text-field-styles.ts
+++ b/frontend/demo/component/textfield/text-field-styles.ts
@@ -18,7 +18,8 @@ export class Example extends LitElement {
     return html`
         <!-- tag::snippet[] -->
         <vaadin-text-field theme="align-right small helper-above-field"
-          label="Label" helper-text="Helper text" value="Value">
+          label="Label" helper-text="Helper text" value="Value"
+          style="--vaadin-input-field-border-width: 1px;">
         </vaadin-text-field>
         <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/timepicker/time-picker-styles.ts
+++ b/frontend/demo/component/timepicker/time-picker-styles.ts
@@ -18,7 +18,8 @@ export class Example extends LitElement {
     return html`
         <!-- tag::snippet[] -->
         <vaadin-time-picker theme="align-right small helper-above-field"
-          label="Label" helper-text="Helper text" value="07:00">
+          label="Label" helper-text="Helper text" value="07:00"
+          style="--vaadin-input-field-border-width: 1px;">
         </vaadin-time-picker>
         <!-- end::snippet[] -->
     `;

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupStyles.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupStyles.java
@@ -15,6 +15,7 @@ public class CheckboxGroupStyles extends HorizontalLayout {
         // tag::snippet[]
         CheckboxGroup<String> field = new CheckboxGroup<>();
         field.addThemeVariants(CheckboxGroupVariant.LUMO_HELPER_ABOVE_FIELD);
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxStyles.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxStyles.java
@@ -19,6 +19,7 @@ public class ComboBoxStyles extends HorizontalLayout {
             ComboBoxVariant.LUMO_ALIGN_RIGHT,
             ComboBoxVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerStyles.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerStyles.java
@@ -22,6 +22,7 @@ public class DatePickerStyles extends HorizontalLayout {
             DatePickerVariant.LUMO_ALIGN_RIGHT,
             DatePickerVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerStyles.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerStyles.java
@@ -22,6 +22,7 @@ public class DateTimePickerStyles extends HorizontalLayout {
             DateTimePickerVariant.LUMO_ALIGN_RIGHT,
             DateTimePickerVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldStyles.java
+++ b/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldStyles.java
@@ -19,6 +19,7 @@ public class EmailFieldStyles extends HorizontalLayout {
             TextFieldVariant.LUMO_ALIGN_RIGHT,
             TextFieldVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStyles.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStyles.java
@@ -19,6 +19,7 @@ public class NumberFieldStyles extends HorizontalLayout {
             TextFieldVariant.LUMO_ALIGN_RIGHT,
             TextFieldVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldStyles.java
+++ b/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldStyles.java
@@ -19,6 +19,7 @@ public class PasswordFieldStyles extends HorizontalLayout {
             TextFieldVariant.LUMO_ALIGN_RIGHT,
             TextFieldVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupStyles.java
+++ b/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupStyles.java
@@ -15,6 +15,7 @@ public class RadioButtonGroupStyles extends HorizontalLayout {
         // tag::snippet[]
         RadioButtonGroup<String> field = new RadioButtonGroup<>();
         field.addThemeVariants(RadioGroupVariant.LUMO_HELPER_ABOVE_FIELD);
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/select/SelectStyles.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectStyles.java
@@ -19,6 +19,7 @@ public class SelectStyles extends HorizontalLayout {
             SelectVariant.LUMO_ALIGN_RIGHT,
             SelectVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/textarea/TextAreaStyles.java
+++ b/src/main/java/com/vaadin/demo/component/textarea/TextAreaStyles.java
@@ -19,6 +19,7 @@ public class TextAreaStyles extends HorizontalLayout {
             TextAreaVariant.LUMO_ALIGN_RIGHT,
             TextAreaVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/textfield/TextFieldStyles.java
+++ b/src/main/java/com/vaadin/demo/component/textfield/TextFieldStyles.java
@@ -19,6 +19,7 @@ public class TextFieldStyles extends HorizontalLayout {
             TextFieldVariant.LUMO_ALIGN_RIGHT,
             TextFieldVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");

--- a/src/main/java/com/vaadin/demo/component/timepicker/TimePickerStyles.java
+++ b/src/main/java/com/vaadin/demo/component/timepicker/TimePickerStyles.java
@@ -22,6 +22,7 @@ public class TimePickerStyles extends HorizontalLayout {
             TimePickerVariant.LUMO_ALIGN_RIGHT,
             TimePickerVariant.LUMO_HELPER_ABOVE_FIELD
         );
+        field.getStyle().set("--vaadin-input-field-border-width", "1px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");


### PR DESCRIPTION
Adds documentation for optional input field borders to:
- [The list of common selectors for all input fields (in docs/styling)](https://vaadin.com/docs/latest/styling/styling-components/sharing-styles/#common-to-all-input-fields)
- The Style Variants section on each component page

And applied a border on the combined style variants sample for each component.