### PR TITLE
Fix typo in SSO Azure tutorial

### DIFF
--- a/articles/tools/sso/integrations/azure-ad.asciidoc
+++ b/articles/tools/sso/integrations/azure-ad.asciidoc
@@ -116,7 +116,7 @@ Then add the key to your `application.properties` file. It should look something
 # SSO Kit configuration
 
 
-vaadin.sso.login-route=/oauth/authorization/azure.active-directory
+vaadin.sso.login-route=/oauth2/authorization/azure.active-directory
 spring.security.oauth2.client.registration.azure.active-directory.client-secret=Paste your Client secret here
 spring.security.oauth2.client.registration.azure.active-directory.client-id=Paste your Client ID here
 spring.security.oauth2.client.registration.azure.active-directory.scope=openid


### PR DESCRIPTION
This fixes a typo in the Azure AD tutorial for SSO Kit, where the login path should start with `/oauth2` (not `/oauth`).