### PR TITLE
Fix Azure registration-id in SSO tutorial

### DIFF
--- a/articles/tools/sso/integrations/azure-ad.asciidoc
+++ b/articles/tools/sso/integrations/azure-ad.asciidoc
@@ -59,7 +59,7 @@ You can use secret identifications to establish a secure connection with your Va
 .`application.properties`
 [source,properties]
 ----
-spring.security.oauth2.client.registration.azure.active-directory.client-secret=Paste your Client secret here
+spring.security.oauth2.client.registration.azure.client-secret=Paste your Client secret here
 ----
 
 === Access Tokens
@@ -116,11 +116,11 @@ Then add the key to your `application.properties` file. It should look something
 # SSO Kit configuration
 
 
-vaadin.sso.login-route=/oauth2/authorization/azure.active-directory
-spring.security.oauth2.client.registration.azure.active-directory.client-secret=Paste your Client secret here
-spring.security.oauth2.client.registration.azure.active-directory.client-id=Paste your Client ID here
-spring.security.oauth2.client.registration.azure.active-directory.scope=openid
-spring.security.oauth2.client.provider.azure.active-directory.issuer-uri=https://login.microsoftonline.com/common/
+vaadin.sso.login-route=/oauth2/authorization/azure
+spring.security.oauth2.client.registration.azure.client-secret=Paste your Client secret here
+spring.security.oauth2.client.registration.azure.client-id=Paste your Client ID here
+spring.security.oauth2.client.registration.azure.scope=openid
+spring.security.oauth2.client.provider.azure.issuer-uri=https://login.microsoftonline.com/common/
 security.oauth2.client.access-token-uri=https://login.microsoftonline.com/common/oauth2/v2.0/token
 security.oauth2.client.user-authorization-uri=https://login.microsoftonline.com/common/oauth2/v2.0/authorize
 


### PR DESCRIPTION
Looks like Spring doesn't like dotted registration-ids for OpenID providers, let's use one without it to be safe.