### PR TITLE
Restructure prod build instructions

### DIFF
--- a/articles/lit/guides/production/production-build.asciidoc
+++ b/articles/lit/guides/production/production-build.asciidoc
@@ -6,12 +6,18 @@ order: 10
 
 = Production Build
 
-By default, Hilla applications are configured to run in development mode. This requires a bit more memory and CPU power, but it makes for easier debugging. When deploying your application to users, you should instead create a production build.
+To create a production build, run the following from the command-line:
 
+[source,terminal]
+----
+mvn clean package -Pproduction
+----
 
-== Production Configuration
+Executing this line builds a `JAR` file, with all of the dependencies and bundled front-end resources, ready to be deployed. You can find the file in the `target` folder after the build is finished. 
 
-The [filename]`pom.xml` file in a Hilla project has the following built-in Maven configuration to create a production build:
+== Enabling Production Builds
+
+The production build command works out-of-the-box for Hilla starter projects. For example, it works with projects that are generated using the Hilla CLI. The starter projects come with the necessary Maven configuration. If you've manually created your project's [filename]`pom.xml` file, add the following Maven profile to enable production builds:
 
 .pom.xml
 [source,xml]


### PR DESCRIPTION
Restructure production build instructions to make the simple command required to create a production build more prominent (in the same way things are done at https://vaadin.com/docs/latest/production/production-build).