### PR TITLE
PRO badges in Components page

### DIFF
--- a/articles/components/index.asciidoc
+++ b/articles/components/index.asciidoc
@@ -225,7 +225,7 @@ include::radio-button/index.asciidoc[tag=description]
 <<{components-path-prefix}radio-button#,See Radio Button>>
 
 
-[.component-card]
+[.component-card.commercial]
 === Rich Text Editor
 
 image::{components-path-prefix}rich-text-editor/rich-text-editor.png["", opts=inline, role="banner"]
@@ -340,7 +340,7 @@ include::button/index.asciidoc[tag=description]
 <<{components-path-prefix}button#,See Button>>
 
 
-[.component-card]
+[.component-card.commercial]
 === Charts
 
 image::{components-path-prefix}charts/charts.png["", opts=inline, role="banner"]
@@ -373,7 +373,7 @@ include::context-menu/index.asciidoc[tag=description]
 <<{components-path-prefix}context-menu#,See Context Menu>>
 
 
-[.component-card]
+[.component-card.commercial]
 === Cookie Consent
 
 image::{components-path-prefix}cookie-consent/cookie-consent.png["", opts=inline, role="banner"]
@@ -384,7 +384,7 @@ include::cookie-consent/index.asciidoc[tag=description]
 <<{components-path-prefix}cookie-consent#,See Cookie Consent>>
 
 
-[.component-card]
+[.component-card.commercial]
 === CRUD
 
 image::{components-path-prefix}crud/crud.png["", opts=inline, role="banner"]
@@ -428,7 +428,7 @@ include::grid/index.asciidoc[tag=description]
 <<{components-path-prefix}grid#,See Grid>>
 
 
-[.component-card]
+[.component-card.commercial]
 === Grid Pro
 
 image::{components-path-prefix}grid-pro/grid-pro.png["", opts=inline, role="banner"]
@@ -450,7 +450,7 @@ Over 600 built-in icons for business applications.
 <<{components-path-prefix}icons#, See Icons>>
 
 
-[.component-card]
+[.component-card.commercial]
 === Map
 
 image::{components-path-prefix}map/map.png["", opts=inline, role="banner"]
@@ -528,7 +528,7 @@ include::side-nav/index.asciidoc[tag=description]
 <<{components-path-prefix}side-nav#,See Side Navigation>>
 
 
-[.component-card]
+[.component-card.commercial]
 === Spreadsheet
 
 image::{components-path-prefix}spreadsheet/spreadsheet.png["", opts=inline, role="banner"]
@@ -599,7 +599,7 @@ include::app-layout/index.asciidoc[tag=description]
 <<{components-path-prefix}app-layout#,See App Layout>>
 
 
-[.component-card]
+[.component-card.commercial]
 === Board
 
 image::{components-path-prefix}board/board.png["", opts=inline, role="banner"]
@@ -699,6 +699,21 @@ include::split-layout/index.asciidoc[tag=description]
 }
 .ds.cards .sect2:not(:hover) .imageblock {
   border-color: var(--card-color, --docs-divider-color-1);
+}
+
+.component-cards .sect2.commercial h3::after {
+  content: 'PRO';
+  display: inline-block;
+  border-radius: 1em;
+  vertical-align: middle;
+  margin-inline-start: 1em;
+  margin-block-end: 0.2em;
+  padding-inline: 0.5em;
+  padding-block: 0.1em;
+  font-size: 12px;
+  font-weight: 600;
+  background-color: var(--violet-400);
+  color: var(--docs-background-color);
 }
 
 .cat-dataentry {

--- a/dspublisher/theme/global.css
+++ b/dspublisher/theme/global.css
@@ -144,14 +144,18 @@ dspublisher-header #haas-container {
 }
 
 [class*='menuItem'].commercial:not(.incomplete) > div > a::after {
-  content: '';
+  content: 'PRO';
   display: inline-block;
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
+  border-radius: 1em;
   vertical-align: middle;
-  margin-inline-start: 0.4em;
-  background-color: var(--violet-600);
+  margin-inline-start: 1em;
+  margin-block-end: 0.1em;
+  padding-inline: 0.5em;
+  padding-block: 0.1em;
+  font-size: 10px;
+  font-weight: 600;
+  background-color: var(--violet-400);
+  color: var(--docs-background-color);
 }
 
 .section-outline dt.commercial::after {


### PR DESCRIPTION
Better PRO indicators for components page:
<img width="209" alt="image" src="https://github.com/vaadin/docs/assets/4611559/2cede190-9e22-414a-97a0-e1b85fbfb182">
<img width="217" alt="image" src="https://github.com/vaadin/docs/assets/4611559/8a34957b-4615-4bd6-a9b3-5176797e31b5">
![image](https://github.com/vaadin/docs/assets/4611559/37d279af-a8a9-491e-9232-b766efc3c10c)
