### PR TITLE
feat: setup react live examples for hilla

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,6 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'prettier/@typescript-eslint',
     'plugin:prettier/recommended'
   ],
   parser: '@typescript-eslint/parser',

--- a/dspublisher/config/default.json
+++ b/dspublisher/config/default.json
@@ -1,0 +1,3 @@
+{
+  "hiddenContent": [{ "path": "/react/components", "categories": ["Java", "TypeScript"] }]
+}

--- a/dspublisher/dspublisher-scripts.js
+++ b/dspublisher/dspublisher-scripts.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const http = require('http');
 
-const DSP_VERSION = '2.1.1';
+const DSP_VERSION = '2.2.0-alpha.1';
 
 async function checkPreConditions() {
   try {

--- a/dspublisher/theme/global.css
+++ b/dspublisher/theme/global.css
@@ -301,3 +301,8 @@ li.experimental:not([class*=active]) > [class*=title] a::after {
   color: var(--violet-100);
   background-color: var(--violet-900);
 }
+
+/* Hide the discussion id from Hilla documentation */
+main article .discussion-id {
+  display: none;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@hilla/generator-typescript-plugin-model": "2.0.0",
         "@hilla/generator-typescript-plugin-push": "2.0.0",
         "@hilla/generator-typescript-utils": "2.0.0",
+        "@hilla/react-components": "2.1.0",
         "@polymer/polymer": "3.5.1",
         "@vaadin/accordion": "24.0.0",
         "@vaadin/app-layout": "24.0.0",
@@ -92,12 +93,16 @@
         "lit": "2.6.1",
         "proj4": "2.8.1",
         "promise-file-reader": "^1.0.3",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "vanilla-colorful": "^0.5.3"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "5.0.2",
         "@rollup/pluginutils": "5.0.2",
         "@types/iframe-resizer": "^3.5.9",
+        "@types/react": "^18.2.11",
+        "@types/react-dom": "^18.2.4",
         "@typescript-eslint/eslint-plugin": "^5.39.0",
         "@typescript-eslint/parser": "^5.39.0",
         "async": "3.2.2",
@@ -2880,6 +2885,84 @@
         "node": ">= 16.13"
       }
     },
+    "node_modules/@hilla/react-components": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hilla/react-components/-/react-components-2.1.0.tgz",
+      "integrity": "sha512-2eYTsBob7/58jOuuER8MxMmfUQhePZ7Zsfj2Ez3jCC+mT7T1sDPLZhFoIjzE50sjfOSMYzh017QXjBqdeCrj3g==",
+      "dependencies": {
+        "@vaadin/accordion": "24.1.0",
+        "@vaadin/app-layout": "24.1.0",
+        "@vaadin/avatar": "24.1.0",
+        "@vaadin/avatar-group": "24.1.0",
+        "@vaadin/board": "24.1.0",
+        "@vaadin/button": "24.1.0",
+        "@vaadin/charts": "24.1.0",
+        "@vaadin/checkbox": "24.1.0",
+        "@vaadin/checkbox-group": "24.1.0",
+        "@vaadin/combo-box": "24.1.0",
+        "@vaadin/confirm-dialog": "24.1.0",
+        "@vaadin/context-menu": "24.1.0",
+        "@vaadin/cookie-consent": "24.1.0",
+        "@vaadin/crud": "24.1.0",
+        "@vaadin/custom-field": "24.1.0",
+        "@vaadin/date-picker": "24.1.0",
+        "@vaadin/date-time-picker": "24.1.0",
+        "@vaadin/details": "24.1.0",
+        "@vaadin/dialog": "24.1.0",
+        "@vaadin/email-field": "24.1.0",
+        "@vaadin/field-base": "24.1.0",
+        "@vaadin/field-highlighter": "24.1.0",
+        "@vaadin/form-layout": "24.1.0",
+        "@vaadin/grid": "24.1.0",
+        "@vaadin/grid-pro": "24.1.0",
+        "@vaadin/horizontal-layout": "24.1.0",
+        "@vaadin/icon": "24.1.0",
+        "@vaadin/icons": "24.1.0",
+        "@vaadin/input-container": "24.1.0",
+        "@vaadin/integer-field": "24.1.0",
+        "@vaadin/item": "24.1.0",
+        "@vaadin/list-box": "24.1.0",
+        "@vaadin/login": "24.1.0",
+        "@vaadin/map": "24.1.0",
+        "@vaadin/menu-bar": "24.1.0",
+        "@vaadin/message-input": "24.1.0",
+        "@vaadin/message-list": "24.1.0",
+        "@vaadin/multi-select-combo-box": "24.1.0",
+        "@vaadin/notification": "24.1.0",
+        "@vaadin/number-field": "24.1.0",
+        "@vaadin/password-field": "24.1.0",
+        "@vaadin/progress-bar": "24.1.0",
+        "@vaadin/radio-group": "24.1.0",
+        "@vaadin/rich-text-editor": "24.1.0",
+        "@vaadin/scroller": "24.1.0",
+        "@vaadin/select": "24.1.0",
+        "@vaadin/split-layout": "24.1.0",
+        "@vaadin/tabs": "24.1.0",
+        "@vaadin/tabsheet": "24.1.0",
+        "@vaadin/text-area": "24.1.0",
+        "@vaadin/text-field": "24.1.0",
+        "@vaadin/time-picker": "24.1.0",
+        "@vaadin/tooltip": "24.1.0",
+        "@vaadin/upload": "24.1.0",
+        "@vaadin/vertical-layout": "24.1.0",
+        "@vaadin/virtual-list": "24.1.0"
+      },
+      "peerDependencies": {
+        "@lit-labs/react": "^1.1.0",
+        "@types/react": "^18.0.25",
+        "@types/react-dom": "^18.0.8",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -2988,6 +3071,12 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
+    "node_modules/@lit-labs/react": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.2.0.tgz",
+      "integrity": "sha512-AIfHLsy4Uk0MSxZTVLrtmdkGnAgCOoAvBCAvTdOXsqp60Vb4zZTUpc0C3CJQ6e8FjM6JL0avOFFBo3XcfARq2Q==",
+      "peer": true
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.0.0",
@@ -3198,6 +3287,32 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "devOptional": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.13.tgz",
+      "integrity": "sha512-vJ+zElvi/Zn9cVXB5slX2xL8PZodPCwPRDpittQdw43JR2AJ5k3vKdgJJyneV/cYgIbLQUwXa9JVDvUZXGba+Q==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
+      "integrity": "sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -3206,6 +3321,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -5420,6 +5541,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
+    },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "devOptional": true
     },
     "node_modules/dash-ast": {
       "version": "1.0.0",
@@ -7775,6 +7902,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -8765,6 +8903,29 @@
         "quickselect": "^2.0.0"
       }
     },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -9278,6 +9439,14 @@
       "integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/secure-json-parse": {
@@ -12622,6 +12791,69 @@
         "typescript": "^4.5.2"
       }
     },
+    "@hilla/react-components": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hilla/react-components/-/react-components-2.1.0.tgz",
+      "integrity": "sha512-2eYTsBob7/58jOuuER8MxMmfUQhePZ7Zsfj2Ez3jCC+mT7T1sDPLZhFoIjzE50sjfOSMYzh017QXjBqdeCrj3g==",
+      "requires": {
+        "@vaadin/accordion": "24.0.0",
+        "@vaadin/app-layout": "24.0.0",
+        "@vaadin/avatar": "24.0.0",
+        "@vaadin/avatar-group": "24.0.0",
+        "@vaadin/board": "24.0.0",
+        "@vaadin/button": "24.0.0",
+        "@vaadin/charts": "24.0.0",
+        "@vaadin/checkbox": "24.0.0",
+        "@vaadin/checkbox-group": "24.0.0",
+        "@vaadin/combo-box": "24.0.0",
+        "@vaadin/confirm-dialog": "24.0.0",
+        "@vaadin/context-menu": "24.0.0",
+        "@vaadin/cookie-consent": "24.0.0",
+        "@vaadin/crud": "24.0.0",
+        "@vaadin/custom-field": "24.0.0",
+        "@vaadin/date-picker": "24.0.0",
+        "@vaadin/date-time-picker": "24.0.0",
+        "@vaadin/details": "24.0.0",
+        "@vaadin/dialog": "24.0.0",
+        "@vaadin/email-field": "24.0.0",
+        "@vaadin/field-base": "24.0.0",
+        "@vaadin/field-highlighter": "24.0.0",
+        "@vaadin/form-layout": "24.0.0",
+        "@vaadin/grid": "24.0.0",
+        "@vaadin/grid-pro": "24.0.0",
+        "@vaadin/horizontal-layout": "24.0.0",
+        "@vaadin/icon": "24.0.0",
+        "@vaadin/icons": "24.0.0",
+        "@vaadin/input-container": "24.0.0",
+        "@vaadin/integer-field": "24.0.0",
+        "@vaadin/item": "24.0.0",
+        "@vaadin/list-box": "24.0.0",
+        "@vaadin/login": "24.0.0",
+        "@vaadin/map": "24.0.0",
+        "@vaadin/menu-bar": "24.0.0",
+        "@vaadin/message-input": "24.0.0",
+        "@vaadin/message-list": "24.0.0",
+        "@vaadin/multi-select-combo-box": "24.0.0",
+        "@vaadin/notification": "24.0.0",
+        "@vaadin/number-field": "24.0.0",
+        "@vaadin/password-field": "24.0.0",
+        "@vaadin/progress-bar": "24.0.0",
+        "@vaadin/radio-group": "24.0.0",
+        "@vaadin/rich-text-editor": "24.0.0",
+        "@vaadin/scroller": "24.0.0",
+        "@vaadin/select": "24.0.0",
+        "@vaadin/split-layout": "24.0.0",
+        "@vaadin/tabs": "24.0.0",
+        "@vaadin/tabsheet": "24.0.0",
+        "@vaadin/text-area": "24.0.0",
+        "@vaadin/text-field": "24.0.0",
+        "@vaadin/time-picker": "24.0.0",
+        "@vaadin/tooltip": "24.0.0",
+        "@vaadin/upload": "24.0.0",
+        "@vaadin/vertical-layout": "24.0.0",
+        "@vaadin/virtual-list": "24.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -12710,6 +12942,12 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
+    "@lit-labs/react": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.2.0.tgz",
+      "integrity": "sha512-AIfHLsy4Uk0MSxZTVLrtmdkGnAgCOoAvBCAvTdOXsqp60Vb4zZTUpc0C3CJQ6e8FjM6JL0avOFFBo3XcfARq2Q==",
+      "peer": true
     },
     "@lit-labs/ssr-dom-shim": {
       "version": "1.0.0",
@@ -12882,6 +13120,32 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "devOptional": true
+    },
+    "@types/react": {
+      "version": "18.2.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.13.tgz",
+      "integrity": "sha512-vJ+zElvi/Zn9cVXB5slX2xL8PZodPCwPRDpittQdw43JR2AJ5k3vKdgJJyneV/cYgIbLQUwXa9JVDvUZXGba+Q==",
+      "devOptional": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "18.2.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
+      "integrity": "sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==",
+      "devOptional": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -12890,6 +13154,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
+      "devOptional": true
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -14501,6 +14771,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
+    },
+    "csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "devOptional": true
     },
     "dash-ast": {
       "version": "1.0.0",
@@ -16220,6 +16496,14 @@
         }
       }
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -16964,6 +17248,23 @@
         "quickselect": "^2.0.0"
       }
     },
+    "react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      }
+    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -17331,6 +17632,14 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
       "integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA=="
+    },
+    "scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "secure-json-parse": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@hilla/generator-typescript-plugin-model": "2.0.0",
     "@hilla/generator-typescript-plugin-push": "2.0.0",
     "@hilla/generator-typescript-utils": "2.0.0",
+    "@hilla/react-components": "2.1.0",
     "@polymer/polymer": "3.5.1",
     "@vaadin/accordion": "24.0.0",
     "@vaadin/app-layout": "24.0.0",
@@ -85,12 +86,16 @@
     "lit": "2.6.1",
     "proj4": "2.8.1",
     "promise-file-reader": "^1.0.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "vanilla-colorful": "^0.5.3"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "5.0.2",
     "@rollup/pluginutils": "5.0.2",
     "@types/iframe-resizer": "^3.5.9",
+    "@types/react": "^18.2.11",
+    "@types/react-dom": "^18.2.4",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
     "async": "3.2.2",
@@ -218,7 +223,10 @@
     "@hilla/form": "$@hilla/form",
     "@hilla/generator-typescript-plugin-backbone": "$@hilla/generator-typescript-plugin-backbone",
     "@hilla/generator-typescript-cli": "$@hilla/generator-typescript-cli",
-    "@vaadin/overlay": "$@vaadin/overlay"
+    "@vaadin/overlay": "$@vaadin/overlay",
+    "@hilla/react-components": "$@hilla/react-components",
+    "react": "$react",
+    "react-dom": "$react-dom"
   },
   "vaadin": {
     "dependencies": {
@@ -322,6 +330,6 @@
       "workbox-core": "6.5.4",
       "workbox-precaching": "6.5.4"
     },
-    "hash": "03c50d1da3b5e09c131ada0478897ce98b9765ce00dd5a082420e2c965f30297"
+    "hash": "ca0d1daf372bcdc66360ec98ae6ee0f69f1bc3a2614cb355a1bad5cf40e3b7d0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
     "noImplicitReturns": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "experimentalDecorators": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
In preparation for adding live React examples on hilla.dev this PR adds the setup necessary to run the examples.

Related to https://github.com/vaadin/docs/pull/2506

Since this PR doesn't yet include any changes to the existing components pages, it should be safe to merge.