### PR TITLE
chore: update exclusion of dev artifacts for production build

### DIFF
--- a/articles/production/production-build.adoc
+++ b/articles/production/production-build.adoc
@@ -134,7 +134,7 @@ The Vite server integration and live reload features, which are available only i
                 <exclusions>
                     <exclusion>
                         <groupId>com.vaadin</groupId>
-                        <artifactId>vaadin-dev-server</artifactId>
+                        <artifactId>vaadin-dev</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
Excluding `vaadin-dev` instead of `vaadin-dev-server` prevents also the `vaadin-dev-bundle` to being included in the production build.

BTW, this is the configuration provided by start.vaadin.com
