### PR TITLE
Tab hover only as CSS pseudo-class

### DIFF
--- a/articles/components/tabs/styling.asciidoc
+++ b/articles/components/tabs/styling.asciidoc
@@ -34,7 +34,7 @@ Selected:: `vaadin-tab+++<wbr>+++**[selected]**`
 Focused:: `vaadin-tab+++<wbr>+++**[focused]**`
 Keyboard focused:: `vaadin-tab+++<wbr>+++**[focus-ring]**`
 Pressed:: `vaadin-tab+++<wbr>+++**[active]**`
-Hovered:: `vaadin-tab+++<wbr>+++**::hover**`
+Hovered:: `vaadin-tab+++<wbr>+++**:hover**`
 Disabled:: `vaadin-tab+++<wbr>+++**[disabled]**`
 Selection indicator:: `vaadin-tab+++<wbr>+++**::before**`
 Icon in tab:: `vaadin-tab+++<wbr>+++** > vaadin-icon**`


### PR DESCRIPTION
Hovering of a vaadin-tab is only possible via CSS pseudo-class e.g. `vaadin-tab:hover { ... }` and not via CSS pseudo-element `vaadin-tab::hover { ... }`.

Therefore, the documentation should be adapted.