### PR TITLE
chore: bump DSP to 2.2.0-alpha.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This repository does not generate the [vaadin.com/docs](https://vaadin.com/docs)
 
 The `latest` branch is for Vaadin documentation and selected by default. Select the `hilla` branch if you wish to contribute to Hilla documentation.
 As an exception, any contributions to component documentation (including that related to Hilla) should be done to the `latest` branch.
-To unhide the React live examples for local development, remove the `hiddenContent` config from `dspublisher/config/default.json`.
 
 ## Contents
 

--- a/articles/components/accordion/index.asciidoc
+++ b/articles/components/accordion/index.asciidoc
@@ -28,7 +28,7 @@ include::{root}/frontend/demo/component/accordion/accordion-basic.ts[render,tags
 include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/accordion/react/accordion-basic.tsx[render,tags=snippet,indent=0,group=React]

--- a/articles/components/accordion/index.asciidoc
+++ b/articles/components/accordion/index.asciidoc
@@ -28,10 +28,12 @@ include::{root}/frontend/demo/component/accordion/accordion-basic.ts[render,tags
 include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/accordion/react/accordion-basic.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 --
 
 

--- a/articles/components/app-layout/index.asciidoc
+++ b/articles/components/app-layout/index.asciidoc
@@ -28,7 +28,7 @@ include::{root}/frontend/demo/component/app-layout/app-layout-basic.ts[render,fr
 include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java[render,frame,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/app-layout/react/app-layout-basic.tsx[render,frame,tags=snippet,indent=0,group=React]

--- a/articles/components/app-layout/index.asciidoc
+++ b/articles/components/app-layout/index.asciidoc
@@ -28,10 +28,12 @@ include::{root}/frontend/demo/component/app-layout/app-layout-basic.ts[render,fr
 include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java[render,frame,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/app-layout/react/app-layout-basic.tsx[render,frame,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 --
 
 The layout consists of three sections: a horizontal navigation bar (*navbar*), a collapsible navigation drawer (*drawer*) and a content area.

--- a/articles/components/avatar/index.asciidoc
+++ b/articles/components/avatar/index.asciidoc
@@ -26,10 +26,12 @@ include::{root}/frontend/demo/component/avatar/avatar-basic.ts[render,tags=snipp
 include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/avatar/react/avatar-basic.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 
 --
 

--- a/articles/components/avatar/index.asciidoc
+++ b/articles/components/avatar/index.asciidoc
@@ -26,7 +26,7 @@ include::{root}/frontend/demo/component/avatar/avatar-basic.ts[render,tags=snipp
 include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/avatar/react/avatar-basic.tsx[render,tags=snippet,indent=0,group=React]

--- a/articles/components/badge/index.asciidoc
+++ b/articles/components/badge/index.asciidoc
@@ -24,10 +24,12 @@ include::{root}/frontend/demo/component/badge/badge-basic.ts[render,tags=snippet
 include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/badge/react/badge-basic.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 
 --
 

--- a/articles/components/badge/index.asciidoc
+++ b/articles/components/badge/index.asciidoc
@@ -24,7 +24,7 @@ include::{root}/frontend/demo/component/badge/badge-basic.ts[render,tags=snippet
 include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/badge/react/badge-basic.tsx[render,tags=snippet,indent=0,group=React]

--- a/articles/components/button/index.asciidoc
+++ b/articles/components/button/index.asciidoc
@@ -29,7 +29,7 @@ include::{root}/frontend/demo/component/button/button-basic.ts[render,tags=snipp
 include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/button/react/button-basic.tsx[render,tags=snippet,indent=0,group=React]
@@ -337,7 +337,7 @@ Below are some best practice recommendations related to buttons and their labels
 
 === Button Labels
 
-A label should describe the action, preferably using active verbs, such as _"View Details"_ rather than _"Details"_. To avoid ambiguity, also specify the object of the verb, such as _"Save Changes"_ instead of _"Save"_. They also should be brief, ideally less than three words or twenty-five characters. 
+A label should describe the action, preferably using active verbs, such as _"View Details"_ rather than _"Details"_. To avoid ambiguity, also specify the object of the verb, such as _"Save Changes"_ instead of _"Save"_. They also should be brief, ideally less than three words or twenty-five characters.
 
 Button groups representing options, such as the buttons of a <<../confirm-dialog#,Confirm Dialog>>, should state what each option represents (e.g., _"Save Changes"_). Don't label a button _"Yes"_ since that requires the user to read the question being asked. It'll increase the risk of selecting the wrong option.
 

--- a/articles/components/button/index.asciidoc
+++ b/articles/components/button/index.asciidoc
@@ -29,10 +29,12 @@ include::{root}/frontend/demo/component/button/button-basic.ts[render,tags=snipp
 include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/button/react/button-basic.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 
 --
 

--- a/articles/components/combo-box/index.asciidoc
+++ b/articles/components/combo-box/index.asciidoc
@@ -38,7 +38,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxBasic.j
 include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Java,tags=*,indent=0]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/combobox/react/combo-box-basic.tsx[render,tags=snippet,indent=0,group=React]
@@ -213,7 +213,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxFilteri
 
 // Basic Features
 
-include::{articles}/components/_input-field-common-features.adoc[tags=basic-intro;label;helper;placeholder;tooltip;clear-button;prefix;aria-labels] 
+include::{articles}/components/_input-field-common-features.adoc[tags=basic-intro;label;helper;placeholder;tooltip;clear-button;prefix;aria-labels]
 
 [.example]
 --

--- a/articles/components/combo-box/index.asciidoc
+++ b/articles/components/combo-box/index.asciidoc
@@ -38,10 +38,12 @@ include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxBasic.j
 include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Java,tags=*,indent=0]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/combobox/react/combo-box-basic.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 --
 
 The overlay opens when the user clicks the field using a pointing device. Using the Up/Down arrow keys or typing a character -- found in at least one of the options -- when the field is focused also opens the popup.

--- a/articles/components/date-picker/index.asciidoc
+++ b/articles/components/date-picker/index.asciidoc
@@ -39,7 +39,7 @@ The date can be entered directly using the keyboard in the format of the current
 
 Date Picker can be configured to display dates and parse user input in a specific format.
 
-ifdef::Flow[]
+ifdef::flow[]
 === Using Java Locales (Java Only)
 
 By default, Date Picker displays and parses dates using the user's locale (<<{articles}/advanced/i18n-localization.asciidoc#locale-selection-for-new-session,reference>>). Alternatively, setting a specific locale ensures that all users consistently see the same format. In the example here, the Date Picker is set to the date format used in Finland.

--- a/articles/components/date-picker/index.asciidoc
+++ b/articles/components/date-picker/index.asciidoc
@@ -39,7 +39,7 @@ The date can be entered directly using the keyboard in the format of the current
 
 Date Picker can be configured to display dates and parse user input in a specific format.
 
-ifeval::[{hide-category-Java} != true]
+ifdef::Flow[]
 === Using Java Locales (Java Only)
 
 By default, Date Picker displays and parses dates using the user's locale (<<{articles}/advanced/i18n-localization.asciidoc#locale-selection-for-new-session,reference>>). Alternatively, setting a specific locale ensures that all users consistently see the same format. In the example here, the Date Picker is set to the date format used in Finland.

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -40,10 +40,12 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridBasic.java[rend
 include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=snippet]
 ----
 
+ifdef::React[]
 [source,typescript]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-basic.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 
 --
 
@@ -52,7 +54,7 @@ pass:[<!-- vale Vaadin.Will = YES -->]
 
 == Content
 
-A basic grid uses plain text to display information in rows and columns. Rich content can be included to provide additional information for more legibility. Components such as <<../text-field#,Text Field>>, <<../date-picker#,Date Picker>>, <<../select#,Select>>, and <<../button#,Button>> are also supported. 
+A basic grid uses plain text to display information in rows and columns. Rich content can be included to provide additional information for more legibility. Components such as <<../text-field#,Text Field>>, <<../date-picker#,Date Picker>>, <<../select#,Select>>, and <<../button#,Button>> are also supported.
 
 Notice how much nicer and richer the grid content is rendered in the table below compared to the first example:
 
@@ -73,10 +75,12 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContent.java[re
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContent.java[render,tags=snippet2,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-content.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 --
 
 
@@ -248,7 +252,7 @@ Although it's technically possible to freeze any column, it should be used prima
 
 === Column Grouping
 
-It's possible to group columns together. They share a common header and footer. Use this feature to better visualize and organize related or hierarchical data. 
+It's possible to group columns together. They share a common header and footer. Use this feature to better visualize and organize related or hierarchical data.
 
 In the example below, the first and last names are grouped under _Name_. Whereas, the street address, the city, and so forth are grouped under _Address_.
 
@@ -292,7 +296,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnHeaderFoo
 
 === Column Visibility
 
-When you want, columns and column groups can be hidden. You can provide the user with a menu for toggling column visibilities, for example, using Menu Bar. Allowing the user to hide columns is useful when only a subset of the columns is relevant to their task, and if there are plenty of columns. 
+When you want, columns and column groups can be hidden. You can provide the user with a menu for toggling column visibilities, for example, using Menu Bar. Allowing the user to hide columns is useful when only a subset of the columns is relevant to their task, and if there are plenty of columns.
 
 In the example here, notice that the email address and telephone numbers are not fully visible because the data doesn't wrap and won't fit in the width provided. Now click on the link labeled, _Show/Hide Columns_ to see a menu of choices to reduce the number of columns. Notice that all of the columns are checked. Deselect the _First Name_ and then the _Profession_ column. That should allow the email addresses and telephone numbers to be fully visible. Incidentally, if you don't deselect any columns, you can still right-click on an email address to copy it: You'll still get the whole address, even if it's not visible.
 
@@ -317,7 +321,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnVisibilit
 
 === Column Reordering & Resizing
 
-Enabling the user to reorder columns is useful when they want to compare data that isn't adjacent by default. Grouped columns can only be reordered within their group. Resizing is helpful when a column's content doesn't fit and is cut off or varies in length. 
+Enabling the user to reorder columns is useful when they want to compare data that isn't adjacent by default. Grouped columns can only be reordered within their group. Resizing is helpful when a column's content doesn't fit and is cut off or varies in length.
 
 Instead of hiding columns as in the earlier example, in the example here the user can resize a truncated column to be able to read it, fully. Try doing that. Hover your mouse pointer over the space on the header row between the _Street_ and _City_ columns, until the mouse pointer changes to a resizing tool. Then, while holding the left mouse button, pull on the right edge of the _Street_ column until you can see all of the street addresses.
 
@@ -334,10 +338,12 @@ include::{root}/frontend/demo/component/grid/grid-column-reordering-resizing.ts[
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnReorderingResizing.java[render,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-column-reordering-resizing.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 --
 
 
@@ -436,7 +442,7 @@ Sorting helps users find and examine data. Therefore, it's recommended to enable
 // Allow 'Arianna'
 pass:[<!-- vale Vale.Spelling = NO -->]
 
-Filtering allows the user to find a specific item or subset of items. You can add filters to Grid columns or use external filter fields. 
+Filtering allows the user to find a specific item or subset of items. You can add filters to Grid columns or use external filter fields.
 
 For instance, try typing `anna` in the input box for _Name_ below. When you're finished, the data shown is only people who have _anna_ in their name. That includes some with the names Anna and Annabelle, as well as some with Arianna and Brianna.
 
@@ -511,7 +517,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/PersonFilter.java[r
 ----
 --
 
-ifeval::[{hide-category-Java} != true]
+ifdef::Flow[]
 To learn more about data providers, see the <<{articles}/binding-data/data-provider#, Binding Items to Components>> (Java only) documentation page.
 endif::[]
 
@@ -547,10 +553,12 @@ include::{root}/frontend/demo/component/grid/grid-lazy-column-rendering.ts[rende
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridLazyColumnRendering.java[render,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-lazy-column-rendering.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 --
 
 
@@ -737,7 +745,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters
 ----
 --
 
-ifeval::[{hide-category-Java} != true]
+ifdef::Flow[]
 == Inline Editing (Java Only)
 
 Grid can be configured to allow inline editing. Editing can be either buffered or non-buffered. Buffered means changes must be explicitly committed, while non-buffered means it automatically commits changes on blur -- that is to say, when a field loses focus.
@@ -812,10 +820,12 @@ include::{root}/frontend/demo/component/grid/grid-styling.ts[render,tags=snippet
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridStyling.java[render,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,typescript]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-styling.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 
 [source,css]
 ----
@@ -934,22 +944,22 @@ Many of the explanations and examples above alluded to giving the focus to rows 
 |===
 |Keys |Action
 
-| kbd:[Tab] 
+| kbd:[Tab]
 | Switches focus between sections of the grid (i.e., header, body, footer).
 
-| kbd:[Left], kbd:[Up], kbd:[Right], and kbd:[Down] Arrow Keys 
+| kbd:[Left], kbd:[Up], kbd:[Right], and kbd:[Down] Arrow Keys
 | Moves focus between cells within a section of the grid.
 
-| kbd:[Page Up] 
+| kbd:[Page Up]
 | Moves cell focus up by one page of visible rows.
 
-| kbd:[Page Down] 
+| kbd:[Page Down]
 | Moves cell focus down by one page of visible rows.
 
-| kbd:[Home] 
+| kbd:[Home]
 | Moves focus to the first cell in a row.
 
-| kbd:[End] 
+| kbd:[End]
 | Moves focus to the last cell in a row.
 |===
 

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -40,7 +40,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridBasic.java[rend
 include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=snippet]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,typescript]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-basic.tsx[render,tags=snippet,indent=0,group=React]
@@ -75,7 +75,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContent.java[re
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContent.java[render,tags=snippet2,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-content.tsx[render,tags=snippet,indent=0,group=React]
@@ -338,7 +338,7 @@ include::{root}/frontend/demo/component/grid/grid-column-reordering-resizing.ts[
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnReorderingResizing.java[render,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-column-reordering-resizing.tsx[render,tags=snippet,indent=0,group=React]
@@ -517,7 +517,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/PersonFilter.java[r
 ----
 --
 
-ifdef::Flow[]
+ifdef::flow[]
 To learn more about data providers, see the <<{articles}/binding-data/data-provider#, Binding Items to Components>> (Java only) documentation page.
 endif::[]
 
@@ -553,7 +553,7 @@ include::{root}/frontend/demo/component/grid/grid-lazy-column-rendering.ts[rende
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridLazyColumnRendering.java[render,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-lazy-column-rendering.tsx[render,tags=snippet,indent=0,group=React]
@@ -745,7 +745,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters
 ----
 --
 
-ifdef::Flow[]
+ifdef::flow[]
 == Inline Editing (Java Only)
 
 Grid can be configured to allow inline editing. Editing can be either buffered or non-buffered. Buffered means changes must be explicitly committed, while non-buffered means it automatically commits changes on blur -- that is to say, when a field loses focus.
@@ -820,7 +820,7 @@ include::{root}/frontend/demo/component/grid/grid-styling.ts[render,tags=snippet
 include::{root}/src/main/java/com/vaadin/demo/component/grid/GridStyling.java[render,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,typescript]
 ----
 include::{root}/frontend/demo/component/grid/react/grid-styling.tsx[render,tags=snippet,indent=0,group=React]

--- a/articles/components/login/index.asciidoc
+++ b/articles/components/login/index.asciidoc
@@ -37,7 +37,7 @@ include::{root}/frontend/demo/component/login/login-basic.ts[render,tags=snippet
 include::{root}/src/main/java/com/vaadin/demo/component/login/LoginBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/login/react/login-basic.tsx[render,tags=snippet,indent=0,group=React]

--- a/articles/components/login/index.asciidoc
+++ b/articles/components/login/index.asciidoc
@@ -37,10 +37,12 @@ include::{root}/frontend/demo/component/login/login-basic.ts[render,tags=snippet
 include::{root}/src/main/java/com/vaadin/demo/component/login/LoginBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/login/react/login-basic.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 --
 
 == Basic Login Component/Form

--- a/articles/components/notification/index.asciidoc
+++ b/articles/components/notification/index.asciidoc
@@ -59,10 +59,12 @@ include::{root}/frontend/demo/component/notification/notification-basic.ts[rende
 include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
+ifdef::React[]
 [source,typescript]
 ----
 include::{root}/frontend/demo/component/notification/react/notification-basic.tsx[render,tags=snippet,indent=0,group=React]
 ----
+endif::[]
 --
 
 

--- a/articles/components/notification/index.asciidoc
+++ b/articles/components/notification/index.asciidoc
@@ -59,7 +59,7 @@ include::{root}/frontend/demo/component/notification/notification-basic.ts[rende
 include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationBasic.java[render,tags=snippet,indent=0,group=Java]
 ----
 
-ifdef::React[]
+ifdef::react[]
 [source,typescript]
 ----
 include::{root}/frontend/demo/component/notification/react/notification-basic.tsx[render,tags=snippet,indent=0,group=React]
@@ -238,7 +238,7 @@ A duration of at least five seconds (i.e., `5000` milliseconds) is recommended -
 
 === Persistent Notifications
 
-Setting the duration to `0` milliseconds disables auto-closing. It keeps the notification visible until it's explicitly dismissed by the user. This should be used for notifications that provide vital information to the user, such as errors. 
+Setting the duration to `0` milliseconds disables auto-closing. It keeps the notification visible until it's explicitly dismissed by the user. This should be used for notifications that provide vital information to the user, such as errors.
 
 Persistent notifications should contain a Button that closes the notification, or allows the user to take appropriate action. Less-important notifications shouldn't be persistent, and instead disappear automatically after an appropriate delay.
 

--- a/articles/components/tabs/index.asciidoc
+++ b/articles/components/tabs/index.asciidoc
@@ -74,10 +74,10 @@ You can disable a tab to mark it as unavailable. Disabled tabs can't be focused 
 
 Disabling can be preferable to hiding an element to prevent changes in layout when the element's visibility changes. They can also make users aware of its existence even when unavailable.
 
-ifeval::[{hide-category-Java} != true]
+ifdef::Flow[]
 === Autoselect (Java Only)
 
-The first tab you add to Tabs or Tab Sheet is automatically selected. Similarly, when a selected tab is removed, the next available tab is automatically selected. 
+The first tab you add to Tabs or Tab Sheet is automatically selected. Similarly, when a selected tab is removed, the next available tab is automatically selected.
 
 Autoselect is enabled by default, but you can disable this behavior if needed. Notice how none of the tabs in the example below are initially selected.
 
@@ -145,7 +145,7 @@ Hiding the scroll buttons isn't recommended, though, for UIs designed to be oper
 
 pass:[<!-- vale Vaadin.Wordiness = NO -->]
 
-Vertical tabs can sometimes be a better choice for a large number of items. It's easier for the user to scan a vertical list of options. However, they may not always be easy to understand and associate with the content. 
+Vertical tabs can sometimes be a better choice for a large number of items. It's easier for the user to scan a vertical list of options. However, they may not always be easy to understand and associate with the content.
 
 Vertical tabs also provide scrolling on overflow, but no scroll buttons. Incidentally, vertical orientation is not available for Tab Sheets.
 

--- a/articles/components/tabs/index.asciidoc
+++ b/articles/components/tabs/index.asciidoc
@@ -74,7 +74,7 @@ You can disable a tab to mark it as unavailable. Disabled tabs can't be focused 
 
 Disabling can be preferable to hiding an element to prevent changes in layout when the element's visibility changes. They can also make users aware of its existence even when unavailable.
 
-ifdef::Flow[]
+ifdef::flow[]
 === Autoselect (Java Only)
 
 The first tab you add to Tabs or Tab Sheet is automatically selected. Similarly, when a selected tab is removed, the next available tab is automatically selected.

--- a/articles/components/upload/index.asciidoc
+++ b/articles/components/upload/index.asciidoc
@@ -29,7 +29,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadBasic.java[
 ----
 --
 
-ifdef::Flow[]
+ifdef::flow[]
 == Handling Uploaded Files (Java Only)
 
 The Java Flow Upload component provides an API to handle uploaded file data directly, without having to set up an endpoint or a servlet. It uses a [classname]`Receiver` implementation to write the incoming file data into an [classname]`OutputStream`.

--- a/articles/components/upload/index.asciidoc
+++ b/articles/components/upload/index.asciidoc
@@ -29,7 +29,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadBasic.java[
 ----
 --
 
-ifeval::[{hide-category-Java} != true]
+ifdef::Flow[]
 == Handling Uploaded Files (Java Only)
 
 The Java Flow Upload component provides an API to handle uploaded file data directly, without having to set up an endpoint or a servlet. It uses a [classname]`Receiver` implementation to write the incoming file data into an [classname]`OutputStream`.
@@ -41,7 +41,7 @@ The following default implementations of [classname]`Receiver` are available:
 |Implementation |Description |Explanation
 
 |[classname]`MemoryBuffer`
-|Handles a single file upload at once. Writes the file data into an in-memory buffer. 
+|Handles a single file upload at once. Writes the file data into an in-memory buffer.
 |Using [classname]`MemoryBuffer` automatically configures the component so that only a single file can be selected.
 
 |[classname]`MultiFileMemoryBuffer`
@@ -49,7 +49,7 @@ The following default implementations of [classname]`Receiver` are available:
 |
 
 |[classname]`FileBuffer`
-|Handles a single file upload at once. Saves a file on the system. 
+|Handles a single file upload at once. Saves a file on the system.
 |Files are saved into the current working directory of the Java application. Using [classname]`FileBuffer` automatically configures the component so that only a single file can be selected.
 
 |[classname]`MultiFileBuffer`
@@ -76,7 +76,7 @@ endif::[]
 
 == Handling Upload Requests (Client-Side Only)
 
-When using the Upload web component standalone, you need to set up an upload file handler or endpoint in your backend to handle the file upload request. By default, the Upload component sends a request with the method type `POST`, the content type `multipart/form-data`, and the request URL (i.e., the current browser location). 
+When using the Upload web component standalone, you need to set up an upload file handler or endpoint in your backend to handle the file upload request. By default, the Upload component sends a request with the method type `POST`, the content type `multipart/form-data`, and the request URL (i.e., the current browser location).
 
 Use the `target` attribute to specify a different URL that should handle the upload request. It's also possible to customize other aspects of the request, such as the method or request headers.
 
@@ -481,7 +481,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18
 
 |===
 
-|<<../progress-bar#,Progress Bar>> 
+|<<../progress-bar#,Progress Bar>>
 |Component for showing task completion progress.
 
 |===

--- a/dspublisher/config/default.json
+++ b/dspublisher/config/default.json
@@ -1,6 +1,6 @@
 {
   "asciidocAttributes": {
-    "Flow": true,
-    "React": true
+    "flow": true,
+    "react": true
   }
 }

--- a/dspublisher/config/default.json
+++ b/dspublisher/config/default.json
@@ -1,6 +1,6 @@
 {
   "asciidocAttributes": {
     "Flow": true,
-    "React": false
+    "React": true
   }
 }

--- a/dspublisher/config/production.json
+++ b/dspublisher/config/production.json
@@ -1,6 +1,6 @@
 {
   "asciidocAttributes": {
-    "Flow": true,
-    "React": false
+    "flow": true,
+    "react": false
   }
 }

--- a/dspublisher/dspublisher-scripts.js
+++ b/dspublisher/dspublisher-scripts.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const http = require('http');
 
-const DSP_VERSION = '2.2.0-alpha.1';
+const DSP_VERSION = '2.2.0-alpha.2';
 
 async function checkPreConditions() {
   try {

--- a/src/main/java/com/vaadin/dspublisher/licensecheck/Check.java
+++ b/src/main/java/com/vaadin/dspublisher/licensecheck/Check.java
@@ -6,7 +6,7 @@ import com.vaadin.pro.licensechecker.LicenseChecker;
 public class Check {
     public static void main(String[] args) {
         try {
-            LicenseChecker.checkLicense("vaadin-dspublisher", "2.2.0-alpha.1",
+            LicenseChecker.checkLicense("vaadin-dspublisher", "2.2.0-alpha.2",
                     (BuildType) null);
         } catch (Exception e) {
             System.exit(1);


### PR DESCRIPTION
- Bumps DSP to 2.2.0-alpha.2
- Updates configuration to remove the `hiddenContent` setting that was removed, and adds attributes for frameworks that should be enabled
- Wrap React examples into conditional so that they are only shown when `React` attribute is defined
- Update conditionals for Flow / Java-only content

For now this only adds / updates conditionals that are required to properly display content for the Vaadin docs site. I'll open follow-up PRs to:
- Introduce a `lit` attribute, and wrap all examples with a respective conditional (`flow`, `lit`, `react`)
- Do the same version bump and configuration update in the `hilla` branch