### PR TITLE
Change V7 end of free support note

### DIFF
--- a/articles/index.asciidoc
+++ b/articles/index.asciidoc
@@ -16,9 +16,9 @@ nav[aria-label=breadcrumb] {
 </style>
 ++++
 
-.Official support for Vaadin 7 has ended
+.Free support for Vaadin 7 has ended
 [IMPORTANT]
-Official support for Vaadin 7 ended in February 2019. Extended commercial support is available up until 2029. See https://vaadin.com/support/vaadin-7-extended-maintenance[Vaadin 7 extended maintenance] for more information.
+Free support for Vaadin 7 ended in February 2019. Extended commercial support is available up until 2029. See https://vaadin.com/support/vaadin-7-extended-maintenance[Vaadin 7 extended maintenance] for more information.
 
 [.cards.quiet.large.hide-title]
 == Sections


### PR DESCRIPTION
It's the _free_ support that ended. The existing commercial support is also "official".