### PR TITLE
Don't say "Vaadin uses Spring Boot"

### DIFF
--- a/articles/production/native.asciidoc
+++ b/articles/production/native.asciidoc
@@ -6,7 +6,7 @@ order: 40
 
 = [since:com.vaadin:vaadin@V24]#Native Image Compilation with GraalVM#
 
-Vaadin uses Spring Boot 3 and supports native image compilation with GraalVM. By compiling your application into a native image, you can benefit from much faster startup times (milliseconds) and lower memory consumption compared to running the application on the JVM.
+For Spring Boot-based applications, Vaadin supports native image compilation with GraalVM. By compiling your application into a native image, you can benefit from much faster startup times (milliseconds) and lower memory consumption compared to running the application on the JVM.
 
 == Requirements
 


### PR DESCRIPTION
Saying "Vaadin uses Spring Boot" makes it sounds as if Vaadin only supports Spring Boot. What we want to say is that native image compilation is only available for Spring Boot apps.