### PR TITLE
fix: use file URL for dynamic `import()`

### DIFF
--- a/webpack.dspublisher.js
+++ b/webpack.dspublisher.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const url = require('url');
 const fs = require('fs');
 const settings = require('./target/vaadin-dev-server-settings.json');
 
@@ -61,8 +62,8 @@ const themesPath = usesProjectTheme ? projectThemePath : themeResourceFolder;
 const applyThemePath = path.resolve(frontendGeneratedFolder, 'theme.js');
 
 module.exports = async function (config) {
-  const { ApplicationThemePlugin, extractThemeName, findParentThemes } = await import(
-    buildDirectory + '/plugins/application-theme-plugin/application-theme-plugin.js'
+  const { ApplicationThemePlugin, extractThemeName, findParentThemes } = await import(url.pathToFileURL(
+    buildDirectory + '/plugins/application-theme-plugin/application-theme-plugin.js').href
   );
 
   const allFlowImportsPath = path.resolve(__dirname, 'frontend/generated/flow/generated-flow-imports.js');


### PR DESCRIPTION
The `webpack.dspublisher.js` file is imported using a dynamic `require()` call in DSP (`gatsby-node.js`). This fails on Windows in the type of error in the following screenshot:

![Screenshot 2023-07-17 at 15 53 44](https://github.com/vaadin/docs-app/assets/66382/4dbb1d4e-1083-4b11-bf51-40c381e8e0d0)

Using a file URL for the dynamic `import()` call in the `webpack.dspublisher.js` file resolves the issue.

Tested locally on Windows 11 and macOS 13.4 (Ventura), both running Node v18.