### PR TITLE
chore: mark flow and lit only content on components page

### DIFF
--- a/articles/components/index.asciidoc
+++ b/articles/components/index.asciidoc
@@ -528,12 +528,14 @@ include::side-nav/index.asciidoc[tag=description]
 <<{components-path-prefix}side-nav#,See Side Navigation>>
 
 
+ifdef::flow[]
 [.component-card.commercial]
 === Spreadsheet
 
 image::{components-path-prefix}spreadsheet/spreadsheet.png["", opts=inline, role="banner"]
 
 include::spreadsheet/index.asciidoc[tag=description]
+endif::[]
 
 [.sr-only]
 <<{components-path-prefix}spreadsheet#,See Spreadsheet>>
@@ -666,6 +668,8 @@ include::split-layout/index.asciidoc[tag=description]
 // end::component-list[]
 
 
+ifdef::flow+lit[]
+
 [.cards.quiet.large]
 == Didn't Find What You Need?
 
@@ -702,6 +706,7 @@ Learn how you can integrate your own Web Components or other third-party W3C-sta
 [.sr-only]
 <<{articles}/create-ui/web-components#,Integrate Web Components>>
 
+endif::[]
 
 ++++
 <style>


### PR DESCRIPTION
This will hide `Spreadsheet` card and the "Didn't Find What You Need?" section on the component index page when `flow` (and `lit`) attribute isn't true (React components documentation).