### PR TITLE
feat: add cherry-pick config for hilla react components

### DIFF
--- a/scripts/pick/cherry-pick-config-hilla-react-components.js
+++ b/scripts/pick/cherry-pick-config-hilla-react-components.js
@@ -1,38 +1,3 @@
-/**
- * A helper function for removing lines from the given content.
- * The argument startIdentifier is string that identifies the start of the block to be removed
- * whereas endIdentifier identifies the end of the block to be removed.
- * StartOffset and endOffset are used to adjust the start and end of the block to be removed.
- */
-function removeLines(
-  content,
-  startIdentifier,
-  endIdentifier = startIdentifier,
-  startOffset = 0,
-  endOffset = 0
-) {
-  while (content.includes(startIdentifier)) {
-    const lines = content.split('\n');
-    const start = lines.findIndex((line) => line.includes(startIdentifier));
-    const end = lines.findIndex(
-      (line, index) => {
-        if (index >= start) {
-          if (typeof endIdentifier === 'function') {
-            return endIdentifier(line);
-          } else {
-            return line.includes(endIdentifier);
-          }
-        }
-      }
-        
-    );
-    content = lines
-      .filter((_line, index) => index < start + startOffset || index > end + endOffset)
-      .join('\n');
-  }
-  return content;
-}
-
 const config = {
   source: {
     // paths in 'latest' to copy, they should be relative to the root folder
@@ -132,12 +97,18 @@ const config = {
         content = content.replace(/{articles}\/components/g, '{articles}/react/components');
 
         // Remove discussion ids
-        content = removeLines(content, '[discussion-id]');
+        content = content.replace(/\[discussion-id\].*/g, '');
 
         // Remove page links (components/index and individual component pages)
-        const pageLinksEndIdentifier = line => !line.includes('page-links') && !line.startsWith('  - ');
-        content = removeLines(content, 'page-links', pageLinksEndIdentifier, 0, -1);
-        
+        if (content.includes('page-links')) {
+          const lines = content.split('\n');
+          const start = lines.findIndex((line) => line.includes('page-links'));
+          const end = lines.findIndex((line, index) => index > start && !line.startsWith('  - ')) - 1;
+          content = lines
+            .filter((_line, index) => index < start || index > end)
+            .join('\n');
+        }
+
         return content;
       },
     },

--- a/scripts/pick/cherry-pick-config-hilla-react-components.js
+++ b/scripts/pick/cherry-pick-config-hilla-react-components.js
@@ -5,10 +5,13 @@
  * StartOffset and endOffset are used to adjust the start and end of the block to be removed.
  */
 function removeLines(content, startIdentifier, endIdentifier = startIdentifier, startOffset = 0, endOffset = 0) {
-  const lines = content.split('\n');
-  const start = lines.findIndex((line) => line.includes(startIdentifier));
-  const end = lines.findIndex((line, index) => index >= start && line.includes(endIdentifier));
-  return lines.filter((_line, index) => index < start + startOffset || index > end + endOffset).join('\n');
+  while (content.includes(startIdentifier) && content.includes(endIdentifier)) {
+    const lines = content.split('\n');
+    const start = lines.findIndex((line) => line.includes(startIdentifier));
+    const end = lines.findIndex((line, index) => index >= start && line.includes(endIdentifier));
+    content = lines.filter((_line, index) => index < start + startOffset || index > end + endOffset).join('\n');
+  }
+  return content;
 }
 
 const config = {
@@ -151,6 +154,12 @@ const config = {
         if (content.includes('== Didn\'t Find What You Need?') && content.includes('++++')) {
           content = removeLines(content, '== Didn\'t Find What You Need?', '++++', -1, -1);
         }
+
+        // Remove all Flow-specific content
+        content = removeLines(content, 'ifdef::flow[]', 'endif::');
+
+        // Remove all Lit-specific content
+        content = removeLines(content, 'ifdef::lit[]', 'endif::');
 
         return content;
       }

--- a/scripts/pick/cherry-pick-config-hilla-react-components.js
+++ b/scripts/pick/cherry-pick-config-hilla-react-components.js
@@ -109,6 +109,11 @@ const config = {
             .join('\n');
         }
 
+        // Add :react: at the top of the file before the title ("= ").
+        if (content.includes('ifdef::react[]')) {
+          content = content.replace(/= .*/, ':react:\n\n$&');
+        }
+
         return content;
       },
     },

--- a/scripts/pick/cherry-pick-config-hilla-react-components.js
+++ b/scripts/pick/cherry-pick-config-hilla-react-components.js
@@ -110,22 +110,6 @@ const config = {
         // replace all instances of "{articles}/components" with "{articles}/react/components"
         content = content.replace(/{articles}\/components/g, '{articles}/react/components');
 
-        // Remove Spreadsheet from the components index page
-        if (content.includes('=== Spreadsheet')) {
-          content = removeLines(content, '=== Spreadsheet', '[.component-card', -1, -1);
-        }
-
-        // Remove the "Didn't Find What You Need?" section on the index page
-        if (content.includes('== Didn\'t Find What You Need?') && content.includes('++++')) {
-          content = removeLines(content, '== Didn\'t Find What You Need?', '++++', -1, -1);
-        }
-
-        // Remove all Flow-specific content
-        content = removeLines(content, 'ifdef::flow[]', 'endif::');
-
-        // Remove all Lit-specific content
-        content = removeLines(content, 'ifdef::lit[]', 'endif::');
-
         return content;
       }
         

--- a/scripts/pick/cherry-pick-config-hilla-react-components.js
+++ b/scripts/pick/cherry-pick-config-hilla-react-components.js
@@ -22,15 +22,12 @@ const config = {
     copy: [
       // folders
       'articles',
-      'articles/react/components',
       'src',
       'frontend',
       // files
     ],
     // paths in 'latest' to ignore (since they shouldn't be copied to 'hilla')
     ignore: [
-      // /(^|\/)\..+/, // hidden files
-
       /* Ignore temporarily until Vaadin version update */
       'articles/components/map',
       'articles/components/menubar',
@@ -46,20 +43,6 @@ const config = {
       'articles/components/avatar',
       'articles/components/cookieconsent',
 
-      'src/main/java/com/vaadin/demo/component/map',
-      'src/main/java/com/vaadin/demo/component/menubar',
-      'src/main/java/com/vaadin/demo/component/notification',
-      'src/main/java/com/vaadin/demo/component/sidenav',
-      'src/main/java/com/vaadin/demo/component/splitlayout',
-      'src/main/java/com/vaadin/demo/component/tabs',
-      'src/main/java/com/vaadin/demo/component/grid',
-      'src/main/java/com/vaadin/demo/component/button',
-      'src/main/java/com/vaadin/demo/component/applayout',
-      'src/main/java/com/vaadin/demo/component/datetimepicker',
-      'src/main/java/com/vaadin/demo/component/login',
-      'src/main/java/com/vaadin/demo/component/avatar',
-      'src/main/java/com/vaadin/demo/component/cookieconsent',
-
       'frontend/demo/component/datetimepicker',
       'frontend/demo/component/login',
       'frontend/demo/component/avatar',
@@ -67,36 +50,17 @@ const config = {
       'frontend/demo/component/cookieconsent',
       /* END Ignore */
 
+      // Ignore Spreadsheet
       'articles/components/spreadsheet',
-      'articles/guide',
-      'articles/advanced',
-      'articles/configuration',
-      'articles/tutorial',
-      'articles/tools',
-      'articles/api.adoc',
-      'articles/security',
-      'articles/contributing',
-      'articles/create-ui',
-      'articles/binding-data',
-      'articles/integrations',
-      'articles/testing',
-      'articles/styling',
-      'articles/kb',
 
-      'articles/index.asciidoc',
-      'articles/compatibility.adoc',
-      'articles/overview.asciidoc',
-      'articles/contributing-docs',
-      'articles/upgrading',
-      'articles/application',
-      'articles/routing',
-      'articles/production',
-      'articles/_images',
-      'articles/_vaadin-version.adoc',
-      'articles/_commercial-banner.asciidoc',
-      'articles/_terminal.asciidoc',
-      'articles/404.asciidoc',
-      'articles/_figma-banner.adoc',
+      // Regex to ignore everything but "components" under articles
+      /articles\/(?!components).*/,
+
+      // Ignore all Java examples
+      /src\/main\/java\/com\/vaadin\/demo\/component\/.*/,
+      
+      // Ignore all TypeScript examples (not react nor icons)
+      /frontend\/demo\/component\/(?!icons)[a-z-]+\/(?!react).*/,
 
       'frontend/demo/component/spreadsheet',
       'frontend/demo/fusion',
@@ -115,6 +79,7 @@ const config = {
       'src/main/java/com/vaadin/demo/observability',
       'frontend/themes',
       'src/main/java/com/vaadin/demo/DemoExporter.java',
+      'src/main/resources/testsheets',
     ],
   },
   rename: {

--- a/scripts/pick/cherry-pick-config-hilla-react-components.js
+++ b/scripts/pick/cherry-pick-config-hilla-react-components.js
@@ -1,0 +1,162 @@
+/**
+ * A helper function for removing lines from the given content.
+ * The argument startIdentifier is string that identifies the start of the block to be removed
+ * whereas endIdentifier identifies the end of the block to be removed.
+ * StartOffset and endOffset are used to adjust the start and end of the block to be removed.
+ */
+function removeLines(content, startIdentifier, endIdentifier = startIdentifier, startOffset = 0, endOffset = 0) {
+  const lines = content.split('\n');
+  const start = lines.findIndex((line) => line.includes(startIdentifier));
+  const end = lines.findIndex((line, index) => index >= start && line.includes(endIdentifier));
+  return lines.filter((_line, index) => index < start + startOffset || index > end + endOffset).join('\n');
+}
+
+const config = {
+  source: {
+    // paths in 'latest' to copy, they should be relative to the root folder
+    // All their content are copied unless exceptions in the "ignore" section
+    // they are copied in the same path unless exceptions in "rename" section
+    copy: [
+      // folders
+      'articles',
+      'articles/react/components',
+      'src',
+      'frontend',
+      // files
+    ],
+    // paths in 'latest' to ignore (since they shouldn't be copied to 'hilla')
+    ignore: [
+      // /(^|\/)\..+/, // hidden files
+
+      /* Ignore temporarily until Vaadin version update */
+      'articles/components/map',
+      'articles/components/menubar',
+      'articles/components/notification',
+      'articles/components/sidenav',
+      'articles/components/splitlayout',
+      'articles/components/tabs',
+      'articles/components/grid',
+      'articles/components/button',
+      'articles/components/applayout',
+      'articles/components/datetimepicker',
+      'articles/components/login',
+      'articles/components/avatar',
+      'articles/components/cookieconsent',
+
+      'src/main/java/com/vaadin/demo/component/map',
+      'src/main/java/com/vaadin/demo/component/menubar',
+      'src/main/java/com/vaadin/demo/component/notification',
+      'src/main/java/com/vaadin/demo/component/sidenav',
+      'src/main/java/com/vaadin/demo/component/splitlayout',
+      'src/main/java/com/vaadin/demo/component/tabs',
+      'src/main/java/com/vaadin/demo/component/grid',
+      'src/main/java/com/vaadin/demo/component/button',
+      'src/main/java/com/vaadin/demo/component/applayout',
+      'src/main/java/com/vaadin/demo/component/datetimepicker',
+      'src/main/java/com/vaadin/demo/component/login',
+      'src/main/java/com/vaadin/demo/component/avatar',
+      'src/main/java/com/vaadin/demo/component/cookieconsent',
+
+      'frontend/demo/component/datetimepicker',
+      'frontend/demo/component/login',
+      'frontend/demo/component/avatar',
+      'frontend/demo/component/grid',
+      'frontend/demo/component/cookieconsent',
+      /* END Ignore */
+
+      'articles/components/spreadsheet',
+      'articles/guide',
+      'articles/advanced',
+      'articles/configuration',
+      'articles/tutorial',
+      'articles/tools',
+      'articles/api.adoc',
+      'articles/security',
+      'articles/contributing',
+      'articles/create-ui',
+      'articles/binding-data',
+      'articles/integrations',
+      'articles/testing',
+      'articles/styling',
+      'articles/kb',
+
+      'articles/index.asciidoc',
+      'articles/compatibility.adoc',
+      'articles/overview.asciidoc',
+      'articles/contributing-docs',
+      'articles/upgrading',
+      'articles/application',
+      'articles/routing',
+      'articles/production',
+      'articles/_images',
+      'articles/_vaadin-version.adoc',
+      'articles/_commercial-banner.asciidoc',
+      'articles/_terminal.asciidoc',
+      'articles/404.asciidoc',
+      'articles/_figma-banner.adoc',
+
+      'frontend/demo/component/spreadsheet',
+      'frontend/demo/fusion',
+      'frontend/demo/upgrade-tool',
+      'frontend/demo/tools',
+      'frontend/demo/flow',
+      'frontend/demo/init.ts',
+      'frontend/demo/init-flow-components.ts',
+
+      'src/main/java/com/vaadin/demo/ui',
+      'src/main/java/com/vaadin/demo/component/spreadsheet',
+
+      'src/main/java/com/vaadin/demo/flow',
+      'src/main/java/com/vaadin/demo/sso',
+      'src/main/java/com/vaadin/demo/collaboration',
+      'src/main/java/com/vaadin/demo/observability',
+      'frontend/themes',
+      'src/main/java/com/vaadin/demo/DemoExporter.java',
+    ],
+  },
+  rename: {
+    // paths in 'latest' to copy to different paths in 'hilla'
+    'articles/components': 'articles/react/components',
+  },
+  target: {
+    // paths in 'hilla' to keep (since they shouldn't be removed, even if they don't exist in latest)
+    keep: [
+      'articles/lit',
+      'articles/react',
+      'articles/404.asciidoc',
+      'articles/index.adoc',
+      'articles/_commercial-banner.asciidoc',
+      'src/main/java/com/vaadin/demo/fusion',
+      'src/main/java/com/vaadin/demo/DemoExporter.java',
+      'frontend/demo/fusion',
+      'frontend/themes',
+      'frontend/demo/init.ts',
+    ],
+  },
+  // callbacks for changing the content of certain files
+  callback: [
+    {
+      // Regex to match all asciidoc files under articles/components
+      path: /articles\/components\/.*\.asciidoc/,
+      callback: (content) => {
+        // replace all instances of "{articles}/components" with "{articles}/react/components"
+        content = content.replace(/{articles}\/components/g, '{articles}/react/components');
+
+        // Remove Spreadsheet from the components index page
+        if (content.includes('=== Spreadsheet')) {
+          content = removeLines(content, '=== Spreadsheet', '[.component-card', -1, -1);
+        }
+
+        // Remove the "Didn't Find What You Need?" section on the index page
+        if (content.includes('== Didn\'t Find What You Need?') && content.includes('++++')) {
+          content = removeLines(content, '== Didn\'t Find What You Need?', '++++', -1, -1);
+        }
+
+        return content;
+      }
+        
+    },
+  ],
+};
+
+exports.config = config;

--- a/scripts/pick/cherry-pick-config-hilla-react-components.js
+++ b/scripts/pick/cherry-pick-config-hilla-react-components.js
@@ -110,6 +110,9 @@ const config = {
         // replace all instances of "{articles}/components" with "{articles}/react/components"
         content = content.replace(/{articles}\/components/g, '{articles}/react/components');
 
+        // Remove discussion ids
+        content = removeLines(content, '[discussion-id]');
+
         return content;
       }
         

--- a/scripts/pick/cherry-pick-config-hilla-react-components.js
+++ b/scripts/pick/cherry-pick-config-hilla-react-components.js
@@ -4,12 +4,20 @@
  * whereas endIdentifier identifies the end of the block to be removed.
  * StartOffset and endOffset are used to adjust the start and end of the block to be removed.
  */
-function removeLines(content, startIdentifier, endIdentifier = startIdentifier, startOffset = 0, endOffset = 0) {
+function removeLines(
+  content,
+  startIdentifier,
+  endIdentifier = startIdentifier,
+  startOffset = 0,
+  endOffset = 0
+) {
   while (content.includes(startIdentifier) && content.includes(endIdentifier)) {
     const lines = content.split('\n');
     const start = lines.findIndex((line) => line.includes(startIdentifier));
     const end = lines.findIndex((line, index) => index >= start && line.includes(endIdentifier));
-    content = lines.filter((_line, index) => index < start + startOffset || index > end + endOffset).join('\n');
+    content = lines
+      .filter((_line, index) => index < start + startOffset || index > end + endOffset)
+      .join('\n');
   }
   return content;
 }
@@ -58,7 +66,7 @@ const config = {
 
       // Ignore all Java examples
       /src\/main\/java\/com\/vaadin\/demo\/component\/.*/,
-      
+
       // Ignore all TypeScript examples (not react nor icons)
       /frontend\/demo\/component\/(?!icons)[a-z-]+\/(?!react).*/,
 
@@ -69,10 +77,9 @@ const config = {
       'frontend/demo/flow',
       'frontend/demo/init.ts',
       'frontend/demo/init-flow-components.ts',
+      'frontend/demo/foundation/material-tokens.ts',
 
       'src/main/java/com/vaadin/demo/ui',
-      'src/main/java/com/vaadin/demo/component/spreadsheet',
-
       'src/main/java/com/vaadin/demo/flow',
       'src/main/java/com/vaadin/demo/sso',
       'src/main/java/com/vaadin/demo/collaboration',
@@ -80,6 +87,8 @@ const config = {
       'frontend/themes',
       'src/main/java/com/vaadin/demo/DemoExporter.java',
       'src/main/resources/testsheets',
+      'src/main/resources/META-INF/resources/icons/icon.png',
+      'src/main/resources/application.properties',
     ],
   },
   rename: {
@@ -96,6 +105,7 @@ const config = {
       'articles/_commercial-banner.asciidoc',
       'src/main/java/com/vaadin/demo/fusion',
       'src/main/java/com/vaadin/demo/DemoExporter.java',
+      'src/main/resources/application.properties',
       'frontend/demo/fusion',
       'frontend/themes',
       'frontend/demo/init.ts',
@@ -114,8 +124,7 @@ const config = {
         content = removeLines(content, '[discussion-id]');
 
         return content;
-      }
-        
+      },
     },
   ],
 };


### PR DESCRIPTION
# Description

This PR adds a [cherry-pick](https://github.com/vaadin/docs/tree/latest/scripts/pick) config for cloning the component documentation from `latest` to `hilla` branch.

The script can be run with:
```
node ./scripts/pick/cherry-pick.js -t hilla -c ./scripts/pick/cherry-pick-config-hilla-react-components.js
```

Here's an example PR generated with this configuration: https://github.com/vaadin/docs/pull/2600