### PR TITLE
Clarify that it's the O11y example that is not production-ready

### DIFF
--- a/articles/tools/observability/integrations/jaeger-prometheus.asciidoc
+++ b/articles/tools/observability/integrations/jaeger-prometheus.asciidoc
@@ -10,7 +10,7 @@ This page contains instructions on how to set up local Jaeger and Prometheus, a 
 
 .Not Production-Ready
 [CAUTION]
-This setup is intended for local testing, only. It's not ready for use in production.
+This setup is intended for local testing, only. It's not ready for use in production. See the https://www.jaegertracing.io/[Jaeger documentation] for more information on how to prepare your setup for production.
 
 
 == Download & Run Jaeger


### PR DESCRIPTION
Clarify that it's the example that is not production-ready, not the observability Kit itself. 