### PR TITLE
fix: properly escape regex in textfield examples

### DIFF
--- a/frontend/demo/component/textfield/text-field-constraints.ts
+++ b/frontend/demo/component/textfield/text-field-constraints.ts
@@ -21,7 +21,7 @@ export class Example extends LitElement {
         required
         min-length="5"
         max-length="18"
-        pattern="^[+]?[(]?[0-9]{3}[)]?[-s.]?[0-9]{3}[-s.]?[0-9]{4,6}$"
+        pattern="^[+]?[\\(]?[0-9]{3}[\\)]?[\\-s.]?[0-9]{3}[\\-s.]?[0-9]{4,6}$"
         allowed-char-pattern="[0-9()+-]"
         label="Phone number"
         helper-text="Format: +(123)456-7890"


### PR DESCRIPTION
Due to a [recent change in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1412729#c55), the pattern validation in the textfield examples doesn't work because the regex can not be parsed:
```
text-field#constraints:1 Pattern attribute value ^[+]?[(]?[0-9]{3}[)]?[-s.]?[0-9]{3}[-s.]?[0-9]{4,6}$ is not a valid regular expression: Uncaught SyntaxError: Invalid regular expression: /^[+]?[(]?[0-9]{3}[)]?[-s.]?[0-9]{3}[-s.]?[0-9]{4,6}$/v: Invalid character in character class
```
This fixes the regex by properly escaping problematic characters in character groups.

Fixes https://github.com/vaadin/web-components/issues/6274