### PR TITLE
Update links in mixins documentation

### DIFF
--- a/articles/create-ui/creating-components/mixins.asciidoc
+++ b/articles/create-ui/creating-components/mixins.asciidoc
@@ -18,7 +18,7 @@ The most important predefined mixins are provided by the [interfacename]`HasSize
 
 If your component implements the [interfacename]`HasSize` interface, you can set the size of the component using the [methodname]`setWidth(String)` and [methodname]`setHeight(String)` methods.
 
-This interface extends [interfacename]`HasElement` mixin. https://vaadin.com/api/platform/current/com/vaadin/flow/component/HasSize.html#method-summary[Full method summary of the [interfacename]`HasSize` interface].
+This interface extends [interfacename]`HasElement` mixin. https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/HasSize.html#method-summary[Full method summary of the [interfacename]`HasSize` interface].
 
 == HasComponents Interface
 
@@ -26,14 +26,14 @@ If your component implements the [interfacename]`HasComponents` interface, you c
 
 It should generally be implemented by layouts or components whose primary function is to host child components. It shouldn't be, for example, implemented by non-layout components such as fields.
 
-https://vaadin.com/api/platform/current/com/vaadin/flow/component/HasComponents.html#method-summary[Full method summary of the [interfacename]`HasComponents` interface].
+https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/HasComponents.html#method-summary[Full method summary of the [interfacename]`HasComponents` interface].
 
 
 == HasStyle Interface
 
 The [interfacename]`HasStyle` interface adds a class attribute and supports inline styles. It's implemented in [classname]`Component`, by default. It extends [interfacename]`HasElement` mixin.
 
-https://vaadin.com/api/platform/current/com/vaadin/flow/component/HasStyle.html#method-summary[Full method summary of the [interfacename]`HasStyle` interface].
+https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/HasStyle.html#method-summary[Full method summary of the [interfacename]`HasStyle` interface].
 
 
 == Using Mixin Interfaces


### PR DESCRIPTION
Links to API should use {moduleMavenVersion:com.vaadin:vaadin} attribute to be synced with documentation version.

Related-to: vaadin/flow#10761


