### PR TITLE
Add Descriptions - Advanced to Components

### DIFF
--- a/articles/advanced/classic-components.asciidoc
+++ b/articles/advanced/classic-components.asciidoc
@@ -1,6 +1,7 @@
 ---
 title: Upgrading from Vaadin 7 or 8 using Classic Components
 order: 40
+description: How to upgrade while still being backwards-compatible using classic components.
 page-links:
   - https://vaadin.com/api/com.vaadin/vaadin-classic-components-flow/[API docs]
 ---

--- a/articles/advanced/classic-components.asciidoc
+++ b/articles/advanced/classic-components.asciidoc
@@ -1,7 +1,7 @@
 ---
 title: Upgrading from Vaadin 7 or 8 using Classic Components
 order: 40
-description: How to upgrade while still being backwards-compatible using classic components.
+description: Build on the latest Vaadin version with familiar component APIs.
 page-links:
   - https://vaadin.com/api/com.vaadin/vaadin-classic-components-flow/[API docs]
 ---

--- a/articles/components/accordion/index.asciidoc
+++ b/articles/components/accordion/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Accordion
+description: How to add Accordion components to your project and various ways to configure them.
 tab-title: Usage
 layout: tabbed-page
 page-links:

--- a/articles/components/app-layout/index.asciidoc
+++ b/articles/components/app-layout/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: App Layout
+description: How to use App Layout for constructing common application layouts.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/app-layout}/#/elements/vaadin-app-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/applayout/AppLayout.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/app-layout}/packages/app-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-app-layout-flow-parent[Java]'

--- a/articles/components/avatar/index.asciidoc
+++ b/articles/components/avatar/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Avatar
+description: How to include an avatar in your project to represent an object, or a person or organization.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/avatar}/#/elements/vaadin-avatar[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/avatar/Avatar.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/avatar}/packages/avatar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-avatar-flow-parent[Java]'

--- a/articles/components/badge/index.asciidoc
+++ b/articles/components/badge/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Badge
+description: How to add badges to your project, colored text elements containing small bits of info.
 page-links:
   - 'Source: https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/badge.js[TypeScript]'
 ---

--- a/articles/components/basic-layouts/index.asciidoc
+++ b/articles/components/basic-layouts/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Basic Layouts
+description: How to render content with vertical and horizontal layout components.
 section-nav: hidden
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/ordered-layout}/#/elements/vaadin-vertical-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/orderedlayout/VerticalLayout.html[Java]'

--- a/articles/components/board/index.asciidoc
+++ b/articles/components/board/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Board
+description: How to use the Board component to organize the layout of a view, adjusting automatically for screen size.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/board}/#/elements/vaadin-board[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/board/Board.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/board}/packages/board[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-board-flow-parent[Java]'

--- a/articles/components/button/index.asciidoc
+++ b/articles/components/button/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Button
+description: How to add a button for users to click to perform actions in your project.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/button}/#/elements/vaadin-button[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/button/Button.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/button}/packages/button[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-button-flow-parent[Java]'

--- a/articles/components/charts/basic-use.asciidoc
+++ b/articles/components/charts/basic-use.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Basic Use
+description: The basic use of charts in a view.
 order: 3
 ---
 

--- a/articles/components/charts/charttypes.asciidoc
+++ b/articles/components/charts/charttypes.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Chart Types
+description: A list of chart types available and information on using and configuring them.
 order: 4
 ---
 

--- a/articles/components/charts/configuration.asciidoc
+++ b/articles/components/charts/configuration.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Chart Configuration
+description: How to configure the various types of charts.
 order: 5
 ---
 

--- a/articles/components/charts/css-styling.asciidoc
+++ b/articles/components/charts/css-styling.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Chart Styling
+description: How to style a chart with CSS in your project.
 order: 6
 ---
 

--- a/articles/components/charts/data.asciidoc
+++ b/articles/components/charts/data.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Chart Data
+description: Explains the storage and use of chart data.
 order: 6
 ---
 

--- a/articles/components/charts/figma-library.asciidoc
+++ b/articles/components/charts/figma-library.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Figma Library
+description: Using Figma in a project.
 order: 1001
 url: https://www.figma.com/community/file/1030435514000803214
 ---

--- a/articles/components/charts/index.asciidoc
+++ b/articles/components/charts/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Charts
+description: Vaadin offers many and varied charts for use in your projects.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/charts}/#/elements/vaadin-chart[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/charts/Chart.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/charts}/packages/charts[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-charts-flow-parent[Java]'

--- a/articles/components/charts/installing.asciidoc
+++ b/articles/components/charts/installing.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Installing Charts for Vaadin Flow
+description: How to install charts in a project.
 order: 2
 ---
 

--- a/articles/components/charts/installing.asciidoc
+++ b/articles/components/charts/installing.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: Installing Charts for Vaadin Flow
-description: How to install charts in a project.
+description: How to install Charts in a project.
 order: 2
 ---
 

--- a/articles/components/charts/migrating-from-earlier-versions.asciidoc
+++ b/articles/components/charts/migrating-from-earlier-versions.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Migrating from Earlier Versions
+description: Information on migrating chart components from earlier versions of Vaadin.
 order: 8
 ---
 

--- a/articles/components/charts/svg-generator.asciidoc
+++ b/articles/components/charts/svg-generator.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Exporting Charts as SVG
+description: How to export charts to SVG format.
 order: 9
 ---
 

--- a/articles/components/charts/timeline.asciidoc
+++ b/articles/components/charts/timeline.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Timeline
+description: How to add the ability to select different time ranges for charts.
 order: 8
 ---
 

--- a/articles/components/charts/webcomponents-api-external.asciidoc
+++ b/articles/components/charts/webcomponents-api-external.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Elements API
+description: The external API for web components.
 order: 1000
 url: https://charts.demo.vaadin.com/vaadin-charts/
 ---

--- a/articles/components/checkbox/index.asciidoc
+++ b/articles/components/checkbox/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Checkbox
+description: How to add easily a checkbox to a view.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/checkbox}/#/elements/vaadin-checkbox[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/checkbox/Checkbox.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/checkbox}/packages/checkbox[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-checkbox-flow-parent[Java]'

--- a/articles/components/combo-box/index.asciidoc
+++ b/articles/components/combo-box/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Combo Box
+description: How to add a combo box overlay for users to select values.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/combo-box}/#/elements/vaadin-combo-box[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/combobox/ComboBox.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/combo-box}/packages/combo-box[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-combo-box-flow-parent[Java]'

--- a/articles/components/confirm-dialog/index.asciidoc
+++ b/articles/components/confirm-dialog/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Confirm Dialog
+description: How to add a confirmation dialog box for users to confirm an action.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/confirm-dialog}/#/elements/vaadin-confirm-dialog[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/confirmdialog/ConfirmDialog.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/confirm-dialog}/packages/confirm-dialog[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-confirm-dialog-flow-parent[Java]'

--- a/articles/components/context-menu/index.asciidoc
+++ b/articles/components/context-menu/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Context Menu
+description: How to add a context menu to a project.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/context-menu}/#/elements/vaadin-context-menu[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/contextmenu/ContextMenu.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/context-menu}/packages/context-menu[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-context-menu-flow-parent[Java]'

--- a/articles/components/cookie-consent/index.asciidoc
+++ b/articles/components/cookie-consent/index.asciidoc
@@ -1,6 +1,7 @@
 ---
 tab-title: Usage
 title: Cookie Consent
+description: How to add a dialog box for the user to consent to the use of cookies.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/cookie-consent}/#/elements/vaadin-cookie-consent[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/cookieconsent/CookieConsent.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/cookie-consent}/packages/cookie-consent[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-cookie-consent-flow-parent[Java]'

--- a/articles/components/crud/index.asciidoc
+++ b/articles/components/crud/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: CRUD
+description: How to add a component for displaying, editing, creating, and deleting of items.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/crud}/#/elements/vaadin-crud[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/crud/Crud.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/crud}/packages/crud[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-crud-flow-parent[Java]'

--- a/articles/components/custom-field/index.asciidoc
+++ b/articles/components/custom-field/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Custom Field
+description: How to add a custom field for placing multiple components into.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/custom-field}/#/elements/vaadin-custom-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/customfield/CustomField.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/custom-field}/packages/custom-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-custom-field-flow-parent[Java]'

--- a/articles/components/date-picker/index.asciidoc
+++ b/articles/components/date-picker/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Date Picker
+description: How to add an input field for users to enter a date, either by typing or selected from a calendar overlay.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/date-picker}/#/elements/vaadin-date-picker[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/datepicker/DatePicker.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/date-picker}/packages/date-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-date-picker-flow-parent[Java]'

--- a/articles/components/date-picker/index.asciidoc
+++ b/articles/components/date-picker/index.asciidoc
@@ -2,7 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Date Picker
-description: How to add an input field for users to enter a date, either by typing or selected from a calendar overlay.
+description: How to add an input field for users to enter a date, either by typing or selecting from a calendar overlay.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/date-picker}/#/elements/vaadin-date-picker[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/datepicker/DatePicker.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/date-picker}/packages/date-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-date-picker-flow-parent[Java]'

--- a/articles/components/date-time-picker/index.asciidoc
+++ b/articles/components/date-time-picker/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Date Time Picker
+description: How to add an input field for select both a date and a time.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/date-time-picker}/#/elements/vaadin-date-time-picker[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/datetimepicker/DateTimePicker.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/date-time-picker}/packages/date-time-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-date-time-picker-flow-parent[Java]'

--- a/articles/components/date-time-picker/index.asciidoc
+++ b/articles/components/date-time-picker/index.asciidoc
@@ -2,7 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Date Time Picker
-description: How to add an input field for select both a date and a time.
+description: How to add an input field for selecting a date and a time.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/date-time-picker}/#/elements/vaadin-date-time-picker[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/datetimepicker/DateTimePicker.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/date-time-picker}/packages/date-time-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-date-time-picker-flow-parent[Java]'

--- a/articles/components/details/index.asciidoc
+++ b/articles/components/details/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Details
+description: How to add an expandable panel for displaying additional content.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/details}/#/elements/vaadin-details[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/details/Details.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/details}/packages/details[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-details-flow-parent[Java]'

--- a/articles/components/dialog/index.asciidoc
+++ b/articles/components/dialog/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Dialog
+description: How to add a dialog box to your project for displaying information to the user.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/dialog}/#/elements/vaadin-dialog[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/dialog/Dialog.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/dialog}/packages/dialog[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-dialog-flow-parent[Java]'

--- a/articles/components/email-field/index.asciidoc
+++ b/articles/components/email-field/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Email Field
+description: How to add a text field for the user to enter an email address.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/text-field}/#/elements/vaadin-email-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/EmailField.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/text-field}/packages/email-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'

--- a/articles/components/figma.adoc
+++ b/articles/components/figma.adoc
@@ -1,6 +1,6 @@
 ---
 title: Figma Libraries
-description: A list of Figma libraries.
+description: A list of official Vaadin Figma libraries.
 order: 5000
 layout: index
 ---

--- a/articles/components/figma.adoc
+++ b/articles/components/figma.adoc
@@ -1,5 +1,6 @@
 ---
 title: Figma Libraries
+description: A list of Figma libraries.
 order: 5000
 layout: index
 ---

--- a/articles/components/form-layout/index.asciidoc
+++ b/articles/components/form-layout/index.asciidoc
@@ -1,6 +1,7 @@
 ---
 tab-title: Usage
 title: Form Layout
+description: How to construct responsive forms with multiple columns.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/form-layout}/#/elements/vaadin-form-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/formlayout/FormLayout.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/form-layout}/packages/form-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-form-layout-flow-parent[Java]'

--- a/articles/components/grid-pro/index.asciidoc
+++ b/articles/components/grid-pro/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Grid Pro
+description: An extension of the Grid component that provides inline editing with full keyboard navigation.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/grid-pro}/#/elements/vaadin-grid-pro[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/gridpro/GridPro.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/grid-pro}/packages/grid-pro[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-grid-pro-flow-parent[Java]'

--- a/articles/components/grid/flow.asciidoc
+++ b/articles/components/grid/flow.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Flow Usage
+description: How to handle the selections made within a grid.
 order: 50
 ---
 

--- a/articles/components/grid/flow.asciidoc
+++ b/articles/components/grid/flow.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: Flow Usage
-description: How to handle the selections made within a grid.
+description: How to handle selections made within a grid.
 order: 50
 ---
 

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Grid
+description: How to add a grid to a view, which can contain text and other components that may be selected.
 tab-title: Usage
 layout: tabbed-page
 page-links:

--- a/articles/components/horizontal-layout/index.asciidoc
+++ b/articles/components/horizontal-layout/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Horizontal Layout
+description: Used for the horizontal layout of other components in a row.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/ordered-layout}/#/elements/vaadin-horizontal-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/orderedlayout/HorizontalLayout.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/ordered-layout}/packages/horizontal-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-ordered-layout-flow-parent[Java]'

--- a/articles/components/icons/index.asciidoc
+++ b/articles/components/icons/index.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: Icons
-description: How to make use of Lumo and Vaadin icons.
+description: How to make use of Lumo and Vaadin icons in your project.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-lumo-styles}/#/elements/vaadin-icon[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/icon/Icon.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/vaadin-iconset.js[Lumo Icons] / https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/icons/vaadin-iconset.js[Vaadin Icons]'

--- a/articles/components/icons/index.asciidoc
+++ b/articles/components/icons/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Icons
+description: How to make use of Lumo and Vaadin icons.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:vaadin-lumo-styles}/#/elements/vaadin-icon[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/icon/Icon.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/vaadin-lumo-styles/vaadin-iconset.js[Lumo Icons] / https://github.com/vaadin/web-components/blob/v{moduleNpmVersion:vaadin-lumo-styles}/packages/icons/vaadin-iconset.js[Vaadin Icons]'

--- a/articles/components/index.asciidoc
+++ b/articles/components/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Components
+description: A list of available Vaadin components.
 order: 15
 layout: index
 page-links:

--- a/articles/components/list-box/index.asciidoc
+++ b/articles/components/list-box/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: List Box
+description: How to add a list box for users to be able to select from a list of items.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/list-box}/#/elements/vaadin-list-box[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/listbox/ListBox.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/list-box}/packages/list-box[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-list-box-flow-parent[Java]'

--- a/articles/components/login/index.asciidoc
+++ b/articles/components/login/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Login
+description: How easily to add a login form to your project.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/login}/#/elements/vaadin-login-overlay[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/login/LoginOverlay.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/login}/packages/login[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-login-flow-parent[Java]'

--- a/articles/components/map/index.asciidoc
+++ b/articles/components/map/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Map
+description: How to add a map to your project for displaying locations based on given data.
 page-links:
   - 'API: https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/map/Map.html[Java]'
   - 'Source: https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-map-flow-parent[Java]'

--- a/articles/components/menu-bar/index.asciidoc
+++ b/articles/components/menu-bar/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Menu Bar
+description: How to add to your project a horizontal button bar with drop-down menus.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/menu-bar}/#/elements/vaadin-menu-bar[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/menubar/MenuBar.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/menu-bar}/packages/menu-bar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-menu-bar-flow-parent[Java]'

--- a/articles/components/message-input/index.asciidoc
+++ b/articles/components/message-input/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Message Input
+description: How to add an input box for users to enter messages, including a button for submitting them.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/message-input}/#/elements/vaadin-message-input[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/messages/MessageInput.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/message-input}/packages/message-input[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-messages-flow-parent[Java]'

--- a/articles/components/message-list/index.asciidoc
+++ b/articles/components/message-list/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Message List
+description: How to display a list of messages, along with information about the sender and other data related to the messages.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/message-list}/#/elements/vaadin-message-list[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/messages/MessageList.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/message-list}/packages/message-list[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-messages-flow-parent[Java]'

--- a/articles/components/multi-select-combo-box/index.asciidoc
+++ b/articles/components/multi-select-combo-box/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Multi-Select Combo Box
+description: How to add a combo box to your project for users to be able to make multiple selections.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:multi-select-combo-box}/#/elements/vaadin-multi-select-combo-box[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/combobox/MultiSelectComboBox.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:multi-select-combo-box}/packages/multi-select-combo-box[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-combo-box-flow-parent[Java]'

--- a/articles/components/number-field/index.asciidoc
+++ b/articles/components/number-field/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Number Field
+description: How to add to your project an input field that only accepts numeric data.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/text-field}/#/elements/vaadin-number-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/NumberField.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/text-field}/packages/number-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'

--- a/articles/components/password-field/index.asciidoc
+++ b/articles/components/password-field/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Password Field
+description: How to add a field for the user to enter securely a password.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/text-field}/#/elements/vaadin-password-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/PasswordField.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/text-field}/packages/password-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'

--- a/articles/components/progress-bar/index.asciidoc
+++ b/articles/components/progress-bar/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Progress Bar
+description: How to add a progress bar to your project to indicate the progress on the completion of a task or process.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/progress-bar}/#/elements/vaadin-progress-bar[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/progressbar/ProgressBar.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/progress-bar}/packages/progress-bar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-progress-bar-flow-parent[Java]'

--- a/articles/components/progress-bar/index.asciidoc
+++ b/articles/components/progress-bar/index.asciidoc
@@ -2,7 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Progress Bar
-description: How to add a progress bar to your project to indicate the progress on the completion of a task or process.
+description: How to add a progress bar to your project to indicate the amount of completion of a task or process.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/progress-bar}/#/elements/vaadin-progress-bar[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/progressbar/ProgressBar.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/progress-bar}/packages/progress-bar[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-progress-bar-flow-parent[Java]'

--- a/articles/components/radio-button/index.asciidoc
+++ b/articles/components/radio-button/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Radio Button
+description: How to add radio buttons for users to select one value among multiple choices.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/radio-group}/#/elements/vaadin-radio-group[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/radiobutton/RadioButtonGroup.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/radio-group}/packages/radio-group[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-radio-button-flow-parent[Java]'

--- a/articles/components/rich-text-editor/index.asciidoc
+++ b/articles/components/rich-text-editor/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Rich Text Editor
+description: How to add an input field to a view for entering rich text.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/rich-text-editor}/#/elements/vaadin-rich-text-editor[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/richtexteditor/RichTextEditor.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/rich-text-editor}/packages/rich-text-editor[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-rich-text-editor-flow-parent[Java]'

--- a/articles/components/scroller/index.asciidoc
+++ b/articles/components/scroller/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Scroller
+description: How to add a scrollable container in a view.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/ordered-layout}/#/elements/vaadin-scroller[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/orderedlayout/Scroller.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/ordered-layout}/packages/scroller[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-ordered-layout-flow-parent[Java]'

--- a/articles/components/select/index.asciidoc
+++ b/articles/components/select/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Select
+description: How to add an overlay containing a list of choices for users to select one.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/select}/#/elements/vaadin-select[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/select/Select.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/select}/packages/select[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-select-flow-parent[Java]'

--- a/articles/components/side-nav/index.asciidoc
+++ b/articles/components/side-nav/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Side Navigation
+description: How to add a vertical list of navigation links, generally placed to one side of a view.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/side-nav}/#/elements/vaadin-side-nav[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/sidenav/SideNav.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/side-nav}/packages/side-nav[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-side-nav-flow-parent[Java]'

--- a/articles/components/split-layout/index.asciidoc
+++ b/articles/components/split-layout/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Split Layout
+description: How to set up a split layout of two content areas in which items may be selected and dragged between each area.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/split-layout}/#/elements/vaadin-split-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/splitlayout/SplitLayout.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/split-layout}/packages/split-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-split-layout-flow-parent[Java]'

--- a/articles/components/split-layout/index.asciidoc
+++ b/articles/components/split-layout/index.asciidoc
@@ -2,7 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Split Layout
-description: How to set up a split layout of two content areas in which items may be selected and dragged between each area.
+description: How to set up a split layout of two content areas in which items may be selected and dragged between each.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/split-layout}/#/elements/vaadin-split-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/splitlayout/SplitLayout.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/split-layout}/packages/split-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-split-layout-flow-parent[Java]'

--- a/articles/components/spreadsheet/index.asciidoc
+++ b/articles/components/spreadsheet/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Spreadsheet
+description: How to load and display a spreadsheet file in a view.
 page-links:
   - 'API: https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/spreadsheet/Spreadsheet.html[Java]'
   - 'Source: https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-spreadsheet-flow-parent[Java]'

--- a/articles/components/tabs/index.asciidoc
+++ b/articles/components/tabs/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Tabs
+description: How to use tabs to organize content into sections.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/tabs}/#/elements/vaadin-tabs[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/tabs/Tabs.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/tabs}/packages/tabs[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-tabs-flow-parent[Java]'

--- a/articles/components/text-area/index.asciidoc
+++ b/articles/components/text-area/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Text Area
+description: How to add an input field in a view that allows entry of multiple lines of text.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/text-field}/#/elements/vaadin-text-area[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/TextArea.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/text-field}/packages/text-area[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'

--- a/articles/components/text-field/index.asciidoc
+++ b/articles/components/text-field/index.asciidoc
@@ -2,7 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Text Field
-description: How to add a text field into a view for users to enter text.
+description: How to add a text field in a view for users to enter text.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/text-field}/#/elements/vaadin-text-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/TextField.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/text-field}/packages/text-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'

--- a/articles/components/text-field/index.asciidoc
+++ b/articles/components/text-field/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Text Field
+description: How to add a text field into a view for users to enter text.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/text-field}/#/elements/vaadin-text-field[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/textfield/TextField.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/text-field}/packages/text-field[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-text-field-flow-parent[Java]'

--- a/articles/components/time-picker/index.asciidoc
+++ b/articles/components/time-picker/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Time Picker
+description: How to add an input field used for entering or select a time.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/time-picker}/#/elements/vaadin-time-picker[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/timepicker/TimePicker.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/time-picker}/packages/time-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-time-picker-flow-parent[Java]'

--- a/articles/components/time-picker/index.asciidoc
+++ b/articles/components/time-picker/index.asciidoc
@@ -2,7 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Time Picker
-description: How to add an input field used for entering or select a time.
+description: How to add an input field used for entering or selecting a time.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/time-picker}/#/elements/vaadin-time-picker[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/timepicker/TimePicker.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/time-picker}/packages/time-picker[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-time-picker-flow-parent[Java]'

--- a/articles/components/tooltip/index.asciidoc
+++ b/articles/components/tooltip/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Tooltip
+description: How to include small pop-up for providing addition information when hovering a mouse pointer over an element.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:tooltip}/#/elements/vaadin-tooltip[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/shared/HasTooltip.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/tooltip}/packages/tooltip[TypeScript] / https://github.com/vaadin/flow-components/blob/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java[Java]'

--- a/articles/components/tooltip/index.asciidoc
+++ b/articles/components/tooltip/index.asciidoc
@@ -2,7 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Tooltip
-description: How to include small pop-up for providing addition information when hovering a mouse pointer over an element.
+description: How to include small pop-ups for providing addition information when hovering a mouse pointer over an element.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:tooltip}/#/elements/vaadin-tooltip[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/shared/HasTooltip.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/tooltip}/packages/tooltip[TypeScript] / https://github.com/vaadin/flow-components/blob/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-flow-components-shared-parent/vaadin-flow-components-base/src/main/java/com/vaadin/flow/component/shared/HasTooltip.java[Java]'

--- a/articles/components/tree-grid/index.asciidoc
+++ b/articles/components/tree-grid/index.asciidoc
@@ -2,6 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Tree Grid
+description: How to set up a tree grid for displaying hierarchical tabular data.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/grid}/#/elements/vaadin-grid-tree-column[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/treegrid/TreeGrid.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/grid}/packages/grid[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-grid-flow-parent[Java]'

--- a/articles/components/tree-grid/index.asciidoc
+++ b/articles/components/tree-grid/index.asciidoc
@@ -2,7 +2,7 @@
 tab-title: Usage
 layout: tabbed-page
 title: Tree Grid
-description: How to set up a tree grid for displaying hierarchical tabular data.
+description: How to display hierarchical tabular data in a tree grid.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/grid}/#/elements/vaadin-grid-tree-column[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/treegrid/TreeGrid.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/grid}/packages/grid[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-grid-flow-parent[Java]'

--- a/articles/components/upload/flow.asciidoc
+++ b/articles/components/upload/flow.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Flow Usage
+description: Explains how to use the Upload component in Vaadin Flow.
 order: 60
 ---
 

--- a/articles/components/upload/index.asciidoc
+++ b/articles/components/upload/index.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: Upload
-description: How to add the ability for the user to be able to upload files.
+description: How to add the ability for the user to upload files.
 tab-title: Usage
 layout: tabbed-page
 page-links:

--- a/articles/components/upload/index.asciidoc
+++ b/articles/components/upload/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Upload
+description: How to add the ability for the user to be able to upload files.
 tab-title: Usage
 layout: tabbed-page
 page-links:

--- a/articles/components/vertical-layout/index.asciidoc
+++ b/articles/components/vertical-layout/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Vertical Layout
+description: How to organize vertically other components.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/ordered-layout}/#/elements/vaadin-vertical-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/orderedlayout/VerticalLayout.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/ordered-layout}/packages/vertical-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-ordered-layout-flow-parent[Java]'

--- a/articles/components/virtual-list/index.asciidoc
+++ b/articles/components/virtual-list/index.asciidoc
@@ -1,5 +1,6 @@
 ---
 title: Virtual List
+description: How to add a scrollable container for listing items as the user scrolls.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/virtual-list}/#/elements/vaadin-virtual-list[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/virtuallist/VirtualList.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/virtual-list}/packages/virtual-list[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-virtual-list-flow-parent[Java]'


### PR DESCRIPTION
As a docs. improvement project, we're adding any missing 'description' meta-tags. Checking the repo. alphabetically, this PR covers from the 'advanced' to the 'components' directories.