### PR TITLE
fix: update include for Hilla React binder load docs

### DIFF
--- a/articles/react/guides/forms/binder-load.adoc
+++ b/articles/react/guides/forms/binder-load.adoc
@@ -7,4 +7,4 @@ order: 2
 
 = [since:dev.hilla:hilla@v2.2]#Loading & Saving Form Data#
 
-include::{root}/articles/lit/guides/forms/binder.adoc[tag=content]
+include::{root}/articles/lit/guides/forms/binder-load.adoc[tag=content]


### PR DESCRIPTION
The React doc was not referencing the respective Lit doc correctly.