### PR TITLE
docs: small improvements to Hilla React forms docs

### DIFF
--- a/articles/lit/guides/forms/binder-validation.adoc
+++ b/articles/lit/guides/forms/binder-validation.adoc
@@ -333,14 +333,14 @@ export default function ProfileView() {
   useEffect(() => {
     addValidator({
       message: 'Please check that the password is repeated correctly',
-        validate: (value: Employee) => {
+      validate: (value: Employee) => {
         if (value.password != value.repeatPassword) {
           return [{ property: model.repeatPassword }];
         }
         return [];
       }
-    })
-  });
+    });
+  }, []);
 
   return (
       <>

--- a/articles/lit/guides/forms/form-status-tracking.adoc
+++ b/articles/lit/guides/forms/form-status-tracking.adoc
@@ -41,11 +41,11 @@ The following properties are available both for the form as a whole, and for eac
 They are a part of the <<reference#binder-node,`BinderNode`>> interface.
 You can access these properties either for a single field, for example `binder.for(model.firstname).dirty`, or for the entire form, for example `binder.dirty`.
 
-- `dirty`: true if the current value is different from the value it was initialized with
-- `visited`: true if the field has gained focus
-- `invalid`: true if the field or the form has validation errors
-- `required`: true if the field is required
-- `errors`: a list of all validation errors for a field and its sub-fields or for the form
+- `dirty`: true if the value of the form or field has been modified by the user
+- `visited`: true if the form or field has been focused by the user
+- `invalid`: true if the form or field has validation errors
+- `required`: true if the form or field is required
+- `errors`: a list of all validation errors for a form or field and its sub-fields
 - `ownErrors`: a list of all the validation errors for a field (without sub-fields) or for the form (not specific to any field)
 
 

--- a/articles/lit/guides/forms/reference.adoc
+++ b/articles/lit/guides/forms/reference.adoc
@@ -26,7 +26,7 @@ The [methodname]`field()` directive does the main job of binding the form field 
 
 ifdef::react[]
 .Using the field directive
-[source,typescriptjsx]
+[source,tsx]
 ----
 import {TextField} from "@hilla/react-components/TextField.js";
 ...
@@ -61,7 +61,7 @@ However, for HTML input elements, the `invalid`, `required` and `errorMessage` s
 As a workaround, you can bind these manually in the template:
 
 ifdef::react[]
-[source,typescriptjsx]
+[source,tsx]
 ----
 import { useBinder, useBinderNode } from '@hilla/react-form';
 import {StringModel} from "@hilla/form";
@@ -267,7 +267,7 @@ Array models are iterable.
 Iterating yields binder nodes for entries:
 
 ifdef::react[]
-[source,typescriptjsx]
+[source,tsx]
 ----
 import {TextField} from "@hilla/react-components/TextField.js";
 
@@ -342,7 +342,7 @@ For [classname]`StringModel` in string expressions, the following are equivalent
 endif::[]
 
 ifdef::react[]
-[source,typescriptjsx]
+[source,tsx]
 ----
 const { model, value } = useBinder(PersonModel);
 ...
@@ -357,7 +357,7 @@ return (
 
 Then, it is possible to use the values in formulas using either of the followings:
 
-[source,typescriptjsx]
+[source,tsx]
 ----
 return (
   <>


### PR DESCRIPTION
- Fix `useEffect` usage in cross-field validation docs
- Clarify form states
- Use correct source type in form reference