### PR TITLE
fix: sync sample code with sample image

### DIFF
--- a/articles/lit/guides/forms/binder-validation.adoc
+++ b/articles/lit/guides/forms/binder-validation.adoc
@@ -335,7 +335,7 @@ export default function ProfileView() {
       message: 'Please check that the password is repeated correctly',
       validate: (value: Employee) => {
         if (value.password != value.repeatPassword) {
-          return [{ property: model.repeatPassword }];
+          return [{ property: model.password }];
         }
         return [];
       }


### PR DESCRIPTION
Sample image for the cross-field validation was showing the validation error for the password
while the React sample code was returning the `repeatedPassword` property.