### PR TITLE
fix: Improve navigation menu discoverability

### DIFF
--- a/articles/react/components/index.asciidoc
+++ b/articles/react/components/index.asciidoc
@@ -1,6 +1,6 @@
 ---
 title: Components
-section-nav: expanded flat
+section-nav: flat components
 order: 15
 layout: index
 

--- a/dspublisher/theme/global.css
+++ b/dspublisher/theme/global.css
@@ -250,6 +250,42 @@ li.flat > ul[class] {
   margin-inline-start: 0;
 }
 
+
+li.flat.components:not([class*=expanded]) {
+  grid-template-rows: min-content 0.075fr;
+  position: relative;
+  margin-bottom: var(--docs-space-xl);
+}
+
+li.flat.components > ul > li:is(:nth-child(1), :nth-child(2), :nth-child(3)) {
+  visibility: visible;
+}
+
+li.flat.components > div > [class*=toggleButton] {
+  opacity: 1;
+}
+
+li.flat.components > div > [class*=toggleButton] .visually-hidden {
+  display: none;
+}
+
+li.flat.components > div > [class*=toggleButton]::after {
+  content: "Show all";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding-inline-start: var(--docs-space-l);
+  text-align: start;
+  padding-top: 4em;
+  background: linear-gradient(transparent, var(--docs-background-color) 50%);
+  color: var(--docs-tertiary-text-color);
+}
+
+li.flat.components > div > [class*=toggleButton]:hover::after {
+  color: var(--docs-body-text-color);
+}
+
 [class*='menuItem'].commercial > div > a::after,
 .section-outline dt.commercial::after,
 .cards .sect2.commercial h3::after,


### PR DESCRIPTION
Show the first few items in the components navigation even when collapsed, making the following category more easily discoverable.

Before:
<img width="1060" alt="Screenshot 2023-09-04 at 13 24 03" src="https://github.com/vaadin/docs/assets/66382/82f0eac8-c78a-4a54-a99b-c8cc65232282">


After:
<img width="858" alt="Screenshot 2023-09-04 at 13 22 00" src="https://github.com/vaadin/docs/assets/66382/74cb09b2-52d7-45cc-94fe-28cedc6f6ff8">
