### PR TITLE
Don't show Figma libraries at the top

### DIFF
--- a/articles/react/components/figma.adoc
+++ b/articles/react/components/figma.adoc
@@ -1,6 +1,5 @@
 ---
 title: Figma Libraries
-order: 5000
 layout: index
 ---
 


### PR DESCRIPTION
I don't think Figma libraries belong to the top of the Flow components list either, but I can see the appeal of the argument given that there are many developers building large apps with Flow. This argument doesn't hold as much for Hilla, however, where we should put a much higher weight on the experience of new developers evaluating Hilla.