### PR TITLE
fix: ensure string ID in grid dynamic height TS example

### DIFF
--- a/frontend/demo/component/grid/grid-dynamic-height.ts
+++ b/frontend/demo/component/grid/grid-dynamic-height.ts
@@ -57,7 +57,7 @@ export class Example extends LitElement {
         <vaadin-button
           theme="primary"
           @click="${() => {
-            const person = this.items.find((p) => p.id === parseInt(this.selectedValue));
+            const person = this.items.find((p) => String(p.id) === this.selectedValue);
             const isInvited = person && this.invitedPeople.some((p) => p.id === person.id);
             if (person && !isInvited) {
               this.invitedPeople = [...this.invitedPeople, person];


### PR DESCRIPTION
Fixes #2800

While `Person.id` has type `number`, the actual value from JSON is of `string` type.
Updated the comparison to ensure the ID returned from the server is also a string.