### PR TITLE
Add asciidoc Language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Make documentation files detectable on GitHub Languages calculation.
+
+*.adoc linguist-vendored=false
+*.adoc linguist-generated=false
+*.adoc linguist-documentation=false
+*.adoc linguist-detectable=true
+
+*.asciidoc linguist-vendored=false
+*.asciidoc linguist-generated=false
+*.asciidoc linguist-documentation=false
+*.asciidoc linguist-detectable=true

--- a/scripts/pick/cherry-pick-config.js
+++ b/scripts/pick/cherry-pick-config.js
@@ -84,6 +84,8 @@ const config = {
       "dspublisher/theme",
       
       "PULL_REQUEST_TEMPLATE.md",
+
+      ".gitattributes",
     ],
   },
   rename: {


### PR DESCRIPTION
Creating .gitattributes file for recognizing ascii doc files, used in GitHub's language calculation.