### PR TITLE
fix: define font face for font icons examples

### DIFF
--- a/dspublisher/theme/global.css
+++ b/dspublisher/theme/global.css
@@ -90,6 +90,7 @@ html {
   --docs-example-render-background-color: var(--lumo-base-color, #fff);
 }
 
+
 html[theme~='dark'] {
   --docs-background-color: var(--gray-800);
   --docs-header-background-color: var(--gray-800);
@@ -232,15 +233,15 @@ dspublisher-header {
   text-decoration: none;
 }
 
-nav[aria-label='sections'] li > [class*='title'] {
+nav[aria-label=sections] li > [class*=title] {
   padding-inline-end: var(--docs-space-2xs);
 }
 
-nav[aria-label='sections'] li:not(.flat) > [class*='title'] > a {
+nav[aria-label=sections] li:not(.flat) > [class*=title] > a {
   padding-inline-start: var(--docs-space-l);
 }
 
-nav[aria-label='sections'] li > div > [class*='toggleButton'] {
+nav[aria-label=sections] li > div > [class*=toggleButton] {
   order: 1;
   transition: color 120ms;
 }
@@ -249,7 +250,7 @@ li.flat:not(:first-child) {
   margin-top: var(--docs-space-s);
 }
 
-li.flat > [class*='title'] {
+li.flat > [class*=title] {
   font-weight: var(--docs-font-weight-strong);
   color: var(--docs-heading-text-color);
   padding-inline-start: var(--docs-space-l);
@@ -259,7 +260,8 @@ li.flat > ul[class] {
   margin-inline-start: 0;
 }
 
-li.flat.components:not([class*='expanded']) {
+
+li.flat.components:not([class*=expanded]) {
   grid-template-rows: min-content 0.095fr;
   position: relative;
   margin-bottom: var(--docs-space-xl);
@@ -269,21 +271,21 @@ li.flat.components > ul > li:is(:nth-child(1), :nth-child(2), :nth-child(3), :nt
   visibility: visible;
 }
 
-li.flat.components:not([class*='expanded']) > ul > li:nth-child(4) {
+li.flat.components:not([class*=expanded]) > ul > li:nth-child(4) {
   -webkit-mask-image: linear-gradient(black, transparent 75%);
   mask-image: linear-gradient(black, transparent 75%);
 }
 
-li.flat.components > div > [class*='toggleButton'] {
+li.flat.components > div > [class*=toggleButton] {
   opacity: 1;
 }
 
-li.flat.components > div > [class*='toggleButton'] .visually-hidden {
+li.flat.components > div > [class*=toggleButton] .visually-hidden {
   display: none;
 }
 
-li.flat.components > div > [class*='toggleButton']::after {
-  content: 'Show all';
+li.flat.components > div > [class*=toggleButton]::after {
+  content: "Show all";
   position: absolute;
   z-index: 1;
   bottom: 0;
@@ -295,7 +297,7 @@ li.flat.components > div > [class*='toggleButton']::after {
   color: var(--docs-tertiary-text-color);
 }
 
-li.flat.components > div > [class*='toggleButton']:hover::after {
+li.flat.components > div > [class*=toggleButton]:hover::after {
   color: var(--docs-body-text-color);
 }
 
@@ -330,6 +332,7 @@ li.flat.components > div > [class*='toggleButton']:hover::after {
 .cards .sect2.commercial h3::after {
   vertical-align: 0.3em;
 }
+
 
 a.button.primary.water {
   color: var(--button-text-color);


### PR DESCRIPTION
In the latest CP PR (https://github.com/vaadin/docs/pull/2827), a custom font face definition was missing, which makes the font icon examples look broken.

#### Before
![a87846457be5eee1c5200d9df2e1fa63](https://github.com/vaadin/docs/assets/262432/1b09f1f0-ae9e-485d-b8ef-a48eeb93236a)

#### After
![0e6456b1828df6936eee8ea8ab97d24f](https://github.com/vaadin/docs/assets/262432/a615d759-6495-47b2-9239-572eaad4510e)
