### PR TITLE
Addition of proper constructor

### DIFF
--- a/articles/tutorial/forms-and-validation.adoc
+++ b/articles/tutorial/forms-and-validation.adoc
@@ -48,7 +48,7 @@ Instantiate a Binder and use it to bind the input fields like this:
 [source,java]
 ----
 // Other fields omitted
-Binder<Contact> binder = new BeanValidationBinder<>(Contact.class); // <1>
+BeanValidationBinder<Contact> binder = new BeanValidationBinder<>(Contact.class); // <1>
 
 public ContactForm(List<Company> companies, List<Status> statuses) {
     addClassName("contact-form");


### PR DESCRIPTION
Binder<Contact> binder = new BeanValidationBinder<>(Contact.class); ❌

⬇️

BeanValidationBinder<Contact> binder = new BeanValidationBinder<>(Contact.class); ✅