### PR TITLE
Don't show Figma libraries at the top

### DIFF
--- a/articles/react/components/figma.adoc
+++ b/articles/react/components/figma.adoc
@@ -1,7 +1,6 @@
 ---
 title: Figma Libraries
 description: A list of official Vaadin Figma libraries.
-order: 5000
 layout: index
 ---
 


### PR DESCRIPTION
Re-introduce the change made in #2785 that was (I suppose mistakenly) reverted in #2827. 

FYI, @jouni.