### PR TITLE
Fix internal link in AppSec Kit documentation

### DIFF
--- a/articles/tools/appsec/advanced-topics.asciidoc
+++ b/articles/tools/appsec/advanced-topics.asciidoc
@@ -7,7 +7,7 @@ order: 20
 
 = [since:com.vaadin:vaadin@V24.2]#Advanced Topics#
 
-This page highlights some advanced topics related to AppSec Kit. For less advanced information, see the <<getting-started, Getting Started with AppSec>> page.
+This page highlights some advanced topics related to AppSec Kit. For less advanced information, see the <</tools/appsec/getting-started#, Getting Started with AppSec>> page.
 
 
 == AppSec Kit Configuration

--- a/articles/tools/appsec/getting-started.asciidoc
+++ b/articles/tools/appsec/getting-started.asciidoc
@@ -20,11 +20,11 @@ To start, you'll need to add AppSec Kit as a dependency to your application. To 
 <dependency>
     <groupId>com.vaadin</groupId>
     <artifactId>appsec-kit-v24</artifactId>
-    <version>{moduleMavenVersion:com.vaadin:appsec-kit-v24}</version>
+    <version>1.1.0</version>
 </dependency>
 ----
 
-See the https://github.com/vaadin/appsec-kit/releases[AppSec Kit releases page] for other versions of the dependency.
+See the https://github.com/vaadin/appsec-kit/releases[AppSec Kit releases page] for the latest version, or for a different version of the dependency.
 
 
 == Generating SBOM Files

--- a/pom.xml
+++ b/pom.xml
@@ -114,11 +114,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>appsec-kit-v24</artifactId>
-            <version>1.1.0.beta1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>observability-kit-starter</artifactId>
             <version>2.1.0</version>
         </dependency>


### PR DESCRIPTION
- Fixes internal link in the AppSec Kit getting started documentation
- Removes the `appsec-kit-v24` dependency from the docs project and sets the version to `1.1.0` in the documentation and updates the description for it. This is needed because the `appsec-kit-v24 `dependency requires the users of the docs project to have a license and a subscription for it because without that the docs app can't be started. This change (revert of this [commit](https://github.com/vaadin/docs/pull/2818/commits/3d4a45fe049f109fe10fd631ef369baf315f8ed9)) solves this issue.