### PR TITLE
Migrate Back-End & Front-End

### DIFF
--- a/.github/styles/Vaadin/Terms-FrontendBackend.yml
+++ b/.github/styles/Vaadin/Terms-FrontendBackend.yml
@@ -1,7 +1,0 @@
-extends: existence
-message: "Use 'front-end' and 'back-end' when used as adjectives."
-level: warning
-ignorecase: true
-tokens:
-  # Keep in sync with Terms.yml
-  - '(?:frontend|backend) (?:code|dependency|dependencies|development|developers?|teams?|sources?|resources?|files?|build|states?|tests?|testing|servers?|proxy|proxies|changes?|bundle|reloading|directory|directories|packages?|modules?|installation|compilation|customizations?|re-customizations?|services?|logic|applications?|traces?|spans?|endpoints?|tools?)'

--- a/.github/styles/Vaadin/Terms.yml
+++ b/.github/styles/Vaadin/Terms.yml
@@ -14,15 +14,11 @@ swap:
   Ajax: AJAX
   apps: applications
   approx\.: approximately
-  back end: backend
-  # Keep in sync with Terms-FrontendBackend.yml
-  'back-end(?! code| dependency| dependencies| development| developers?| teams?| sources?| resources?| files?| build| states?| tests?| testing| servers?| proxy| proxies| changes?| bundle| reloading| directory| directories| packages?| modules?| installation| customizations?| re-customizations?| compilation| services?| logic| applications?| traces?| spans?| endpoints?| tools?)': backend
+  back[\s|-]end: backend
   cellular data: mobile data
   cellular network: mobile network
   dropdown: drop-down
-  front end: frontend
-  # Keep in sync with Terms-FrontendBackend.yml
-  'front-end(?! code| dependency| dependencies| development| developers?| teams?| sources?| resources?| files?| build| states?| tests?| testing| servers?| proxy| proxies| changes?| bundle| reloading| directory| directories| packages?| modules?| installation| customizations?| re-customizations?| compilation| services?| logic| applications?| traces?| spans?| endpoints?| tools?)': frontend
+  front[\s|-]end: frontend
   grayed-out: unavailable
   NPM: npm
   # open-source: open source

--- a/articles/lit/acceleration-kits/observability-kit/getting-started.adoc
+++ b/articles/lit/acceleration-kits/observability-kit/getting-started.adoc
@@ -9,7 +9,7 @@ order: 100
 
 = Getting Started with Observability Kit
 
-To use Observability Kit, you'll have to create a Hilla application, as well as download and configure the Kit. Then you'll have to setup an infrastructure and a front-end package. Once you've done all of that, you can run the application. The sections that follow explain these steps. 
+To use Observability Kit, you'll have to create a Hilla application, as well as download and configure the Kit. Then you'll have to setup an infrastructure and a frontend package. Once you've done all of that, you can run the application. The sections that follow explain these steps. 
 
 
 [role="since:dev.hilla:hilla@V2.1"]
@@ -131,7 +131,7 @@ Open a terminal to the Prometheus directory and start Prometheus with the config
 Remember to substitute the correct path to your [filename]`config.yml` file.
 
 
-== Setup Front-End Package
+== Setup Frontend Package
 
 To complete the setup process, you need to install and initialize the client-side component of the kit.
 

--- a/articles/lit/acceleration-kits/sso-kit/getting-started.adoc
+++ b/articles/lit/acceleration-kits/sso-kit/getting-started.adoc
@@ -165,7 +165,7 @@ Some providers support a custom theme for their login pages. Learn more about th
 
 === Secure the Application
 
-A Hilla application includes front-end code and backend endpoints. Both of them can and should benefit from authentication protection.
+A Hilla application includes frontend code and backend endpoints. Both of them can and should benefit from authentication protection.
 
 
 ==== Protect Example Endpoint

--- a/articles/lit/guides/architecture.adoc
+++ b/articles/lit/guides/architecture.adoc
@@ -132,10 +132,10 @@ See <<routing#,Routing and navigation>> for more details.
 
 
 [[endpoints]]
-== Accessing Back-end Data
+== Accessing Backend Data
 
-Hilla provides a type-safe and secure way to access data from the backend in front-end views by using generated TypeScript code.
-Hilla scans the back-end code during development and generates TypeScript code that can be used to call the corresponding Java methods.
+Hilla provides a type-safe and secure way to access data from the backend in frontend views by using generated TypeScript code.
+Hilla scans the backend code during development and generates TypeScript code that can be used to call the corresponding Java methods.
 The generated code is processed in the same way as other TypeScript views.
 Only the necessary code is included in the production application bundle.
 

--- a/articles/lit/guides/client-middleware.adoc
+++ b/articles/lit/guides/client-middleware.adoc
@@ -142,7 +142,7 @@ Middleware can also replace the response by returning a custom [interfacename]`R
 ----
 import { Middleware, MiddlewareContext, MiddlewareNext } from '@hilla/frontend';
 
-// An example middleware that returns an empty response instead of calling the back-end endpoint
+// An example middleware that returns an empty response instead of calling the backend endpoint
 export const MyStubMiddleware: Middleware = async function(
   context: MiddlewareContext,
   next: MiddlewareNext

--- a/articles/lit/guides/endpoints.adoc
+++ b/articles/lit/guides/endpoints.adoc
@@ -1,6 +1,6 @@
 ---
 title: Endpoints
-description: A server-side Java endpoint is a back-end method that's exposed so to call it from client-side TypeScript code.
+description: A server-side Java endpoint is a backend method that's exposed so to call it from client-side TypeScript code.
 order: 30
 ---
 :lit:

--- a/articles/lit/guides/forms/binder-validation.adoc
+++ b/articles/lit/guides/forms/binder-validation.adoc
@@ -10,7 +10,7 @@ order: 3
 
 // tag::content[]
 
-Hilla helps you validate user input based on the back-end Java data model.
+Hilla helps you validate user input based on the backend Java data model.
 It reads the Bean Validation (https://beanvalidation.org/2.0-jsr380/spec[JSR-380]) annotations on your Java data types and applies these constraints to the user input.
 Validation is enabled by default in all forms created with the Hilla `Binder` API.
 

--- a/articles/lit/guides/forms/binder.adoc
+++ b/articles/lit/guides/forms/binder.adoc
@@ -11,7 +11,7 @@ order: 1
 
 Hilla provides a way for binding input fields to a data model.
 
-The client-side [classname]`Binder` supports Java back-end endpoints for loading and saving the form data, and reuses the metadata from Java Bean validation annotations for client-side validation.
+The client-side [classname]`Binder` supports Java backend endpoints for loading and saving the form data, and reuses the metadata from Java Bean validation annotations for client-side validation.
 
 == API Basics
 

--- a/articles/lit/guides/index.adoc
+++ b/articles/lit/guides/index.adoc
@@ -8,7 +8,7 @@ section-nav: expanded flat
 = Hilla Guides
 
 // Hilla is an application framework in which you write client-side code with TypeScript.
-// Hilla views connect with server-side Java endpoints that can provide business data and logic, and can connect further with back-end services.
+// Hilla views connect with server-side Java endpoints that can provide business data and logic, and can connect further with backend services.
 
 // This chapter gives a more thorough and practical overview of Hilla application basics.
 // The various topics in this chapter are described in more detail in the further documentation.

--- a/articles/lit/guides/production/production-build.asciidoc
+++ b/articles/lit/guides/production/production-build.asciidoc
@@ -14,7 +14,7 @@ If you generated your application with Hilla CLI, you can create a production bu
 mvn clean package -Pproduction
 ----
 
-Executing this line builds a `JAR` file, with all of the dependencies and bundled front-end resources, ready to be deployed. You can find the file in the `target` folder after the build is finished. 
+Executing this line builds a `JAR` file, with all of the dependencies and bundled frontend resources, ready to be deployed. You can find the file in the `target` folder after the build is finished. 
 
 
 == Enabling Production Builds
@@ -52,7 +52,7 @@ The actual content of the profile depends on the environment in which your appli
 
 == Creating a Production Build
 
-To create a production build, you can execute `mvn clean package -Pproduction`. This builds a `JAR` or `WAR` file with all of the dependencies and front-end resources compiled and ready to be deployed. The file is created in the `target` folder after the build completes.
+To create a production build, you can execute `mvn clean package -Pproduction`. This builds a `JAR` or `WAR` file with all of the dependencies and frontend resources compiled and ready to be deployed. The file is created in the `target` folder after the build completes.
 
 If you don't have the production Maven profile in your `POM` file, the easiest way to get it is to create a project base using the CLI. Then copy the production profile from the downloaded `POM` file.
 
@@ -111,7 +111,7 @@ Bundling is an optimization in which multiple files are merged into a single col
 
 === The `prepare-frontend` Goal
 
-The `prepare-frontend` goal validates whether the `node` and `npm` tools are installed and aren't too old (i.e., not earlier than version 10 of `node`, and not earlier than version 5.6  of `npm`). It also automatically installs them, if they're missing, in the `.vaadin` folder, located in the user's home directory. If they're installed globally but they're too old, an error message suggests that you install newer versions. `Node.js` is needed to run `npm` to install front-end dependencies and `Vite`, which bundles the front-end files served to the client.
+The `prepare-frontend` goal validates whether the `node` and `npm` tools are installed and aren't too old (i.e., not earlier than version 10 of `node`, and not earlier than version 5.6  of `npm`). It also automatically installs them, if they're missing, in the `.vaadin` folder, located in the user's home directory. If they're installed globally but they're too old, an error message suggests that you install newer versions. `Node.js` is needed to run `npm` to install frontend dependencies and `Vite`, which bundles the frontend files served to the client.
 
 Additionally, it visits all resources used by the application and copies them to the `node_modules` folder. This is so that they're available when `Vite` builds the frontend. It also creates or updates the [filename]`package.json`, [filename]`tsconfig.json` and [filename]`vite.generated.json` files.
 
@@ -142,7 +142,7 @@ There are a few parameters for this goal. They're listed here with the default v
 
 === The `build-frontend` Goal
 
-This goal builds the front-end bundle. It's a complex process involving several steps:
+This goal builds the frontend bundle. It's a complex process involving several steps:
 
 - Update [filename]`package.json` with all the `@NpmPackage` annotation values found in the classpath and automatically install these dependencies.
 - Update the JavaScript files containing code to import everything used in the application. These files are generated in the `target/frontend` folder, and are used as the entry point of the application.
@@ -160,10 +160,10 @@ pass:[<!-- vale Vaadin.ThereIs = YES -->]
     The folder where Flow puts generated files that'll be used by `webpack`.
 
 *frontendDirectory* (`${project.basedir}/frontend`)::
-    The directory with the project's front-end source files.
+    The directory with the project's frontend source files.
 
 *generateBundle* (`true`)::
-    Whether to generate a bundle from the project front-end sources.
+    Whether to generate a bundle from the project frontend sources.
 
 *runNpmInstall* (`true`)::
     Whether to run `pnpm install` -- or `npm install`, depending on the *pnpmEnable* parameter value -- after updating dependencies.
@@ -172,10 +172,10 @@ pass:[<!-- vale Vaadin.ThereIs = YES -->]
     Whether to generate embedded web components from [classname]`WebComponentExporter` inheritors.
 
 *optimizeBundle* (`true`)::
-    Whether to include only front-end resources used from application entry points -- the default -- or to include all resources found on the classpath. It should normally be left to the default, but a value of `false` can be useful for faster production builds or debugging discrepancies between development and production builds.
+    Whether to include only frontend resources used from application entry points -- the default -- or to include all resources found on the classpath. It should normally be left to the default, but a value of `false` can be useful for faster production builds or debugging discrepancies between development and production builds.
 
 *pnpmEnable* (`false`)::
-    Whether to use the `pnpm` or `npm` tool to handle front-end resources. The default is `npm`.
+    Whether to use the `pnpm` or `npm` tool to handle frontend resources. The default is `npm`.
 
 *useGlobalPnpm* (`false`)::
     Whether to use a globally installed `pnpm` tool instead of the default supported version of `pnpm`.

--- a/articles/lit/guides/routing.adoc
+++ b/articles/lit/guides/routing.adoc
@@ -369,7 +369,7 @@ For example, the paths `/user/1` and `/user/42` can both have the same route to 
 The `/user/` part is static, and `1` and `42` are the parameter values.
 
 Route parameters are defined using an `express.js`-like syntax.
-The implementation is based on the `path-to-regexp` library, which is commonly used in modern front-end libraries and frameworks.
+The implementation is based on the `path-to-regexp` library, which is commonly used in modern frontend libraries and frameworks.
 
 The following features are supported:
 

--- a/articles/lit/guides/security/spring-stateless.adoc
+++ b/articles/lit/guides/security/spring-stateless.adoc
@@ -17,10 +17,10 @@ Unlike server-side authentication storage solutions, which commonly rely on sess
 Using stateless authentication brings benefits in the following use cases:
 
 **Horizontal scaling of the backend**::
-Helps to avoid the complexity of managing shared or sticky sessions between multiple back-end servers.
+Helps to avoid the complexity of managing shared or sticky sessions between multiple backend servers.
 
 **Seamless deployment**::
-Back-end servers can be restarted without logging users out, and without the need for session persistence.
+Backend servers can be restarted without logging users out, and without the need for session persistence.
 
 **Offline logout for client-side applications**::
 Users can log off and have their authentication data destroyed on the client without requesting a logout from the server.

--- a/articles/lit/guides/security/vulnerabilities.adoc
+++ b/articles/lit/guides/security/vulnerabilities.adoc
@@ -9,10 +9,10 @@ order: 150
 
 == SQL Injections
 
-Since Hilla is a back-end-agnostic UI framework, it doesn't deal directly with back-end access.
-Instead, the choice of back-end framework (for example, Spring Data) is left to the developer.
+Since Hilla is a backend-agnostic UI framework, it doesn't deal directly with backend access.
+Instead, the choice of backend framework (for example, Spring Data) is left to the developer.
 Hilla doesn't provide mitigation for SQL injections.
-This is left to the back-end provider and developer.
+This is left to the backend provider and developer.
 
 // TODO what XSS section?
 However, SQL injections can be completely blocked in Hilla applications by following the data validation and escaping guidelines (see the XSS section), as well as standard secure database access practices.

--- a/articles/lit/guides/state-management.adoc
+++ b/articles/lit/guides/state-management.adoc
@@ -13,12 +13,12 @@ In such situations, it may become difficult to keep the application in a consist
 If you don't have a good state management strategy, it can be easy to introduce new bugs when changing application logic.
 
 This is where a state management library such as link:https://mobx.js.org/[MobX] can help to make the application easier to maintain and extend.
-Here, we focus on an approach to store all shared front-end state in a central MobX state store that acts as the single source of truth for the application state.
+Here, we focus on an approach to store all shared frontend state in a central MobX state store that acts as the single source of truth for the application state.
 It's then easy to display the state data, or anything derived from it, anywhere in the UI, so that the data is automatically updated everywhere it's displayed whenever the data is updated in the state store.
 
 == Using MobX in your Application
 
-Hilla recommends using the link:https://mobx.js.org/[MobX] library to manage front-end state in your applications.
+Hilla recommends using the link:https://mobx.js.org/[MobX] library to manage frontend state in your applications.
 When using Lit, you need to extend the [classname]`MobxLitElement` class, instead of [classname]`LitElement`.
 When your views are based on [classname]`MobxLitElement`, any MobX observables used in the [methodname]`render()` method are automatically tracked so that any change to those observables is automatically reflected in the view.
 

--- a/articles/lit/reference/endpoint-generator.adoc
+++ b/articles/lit/reference/endpoint-generator.adoc
@@ -29,7 +29,7 @@ The generator consists of three parts:
 The parser reads the Java bytecode and generates an OpenAPI scheme.
 
 *TypeScript Abstract Syntax Tree (AST) generator*::
-The AST generator reads the OpenAPI scheme and generates TypeScript endpoints that could be used in further front-end development.
+The AST generator reads the OpenAPI scheme and generates TypeScript endpoints that could be used in further frontend development.
 
 *Runtime controller*::
 The runtime controller provides runtime communication between the server and the client.

--- a/articles/lit/start/basics/index.adoc
+++ b/articles/lit/start/basics/index.adoc
@@ -101,10 +101,10 @@ The following lists the key folders and files in a Hilla application project:
 // See vaadin.com/docs/latest/configuration/source-control for an example in Vaadin docs
 
 `frontend`::
-The folder where your views and front-end code live.
+The folder where your views and frontend code live.
 
 `src`::
-The folder where your Java back-end code lives.
+The folder where your Java backend code lives.
 
 `pom.xml`::
 The project configuration file, which defines dependencies.
@@ -220,13 +220,13 @@ public interface TodoRepository extends JpaRepository<Todo, Integer> {
 }
 ----
 
-You now have all the necessary back-end code in place to start building a UI.
+You now have all the necessary backend code in place to start building a UI.
 
 Hilla can generate TypeScript versions of the Java files you created. To achieve this, run the project from the command line:
 
 include::{articles}/lit/start/quick.adoc[tag=run]
 
-**The first time you run the application, it may take up to a few minutes**, as Hilla downloads all the dependencies and builds a front-end bundle.
+**The first time you run the application, it may take up to a few minutes**, as Hilla downloads all the dependencies and builds a frontend bundle.
 Subsequent builds don't download dependencies, so that they are much faster.
 
 When the build has finished, you should see the application running on http://localhost:8080.
@@ -761,7 +761,7 @@ Run the project from the command line with the following command:
 include::{articles}/lit/start/quick.adoc[tag=run]
 
 [.secondary-text.small]
-The first time you run the application, it may take up to a few minutes, as Hilla downloads all the dependencies and builds a front-end bundle.
+The first time you run the application, it may take up to a few minutes, as Hilla downloads all the dependencies and builds a frontend bundle.
 Subsequent builds don't download dependencies, so that they are much faster.
 
 When the build has finished, you should see the application running on http://localhost:8080.

--- a/articles/lit/start/faq.adoc
+++ b/articles/lit/start/faq.adoc
@@ -33,7 +33,7 @@ Hilla simplifies the process of creating business applications. It:
 - gets you started quickly with a zero-configuration toolchain for building both your frontend and backend;
 
 == Who is Hilla made for?
-Hilla provides a simpler way to build complex business applications. A smaller team, or even a solo developer, can build the full stack, instead of having separate front-end and back-end teams synchronizing their work. Hilla is also made for those who value open-source transparency together with the option of first-party support for their business.
+Hilla provides a simpler way to build complex business applications. A smaller team, or even a solo developer, can build the full stack, instead of having separate frontend and backend teams synchronizing their work. Hilla is also made for those who value open-source transparency together with the option of first-party support for their business.
 
 == Who is behind Hilla?
 Hilla is made and maintained by https://vaadin.com[Vaadin], the company behind the top Java web framework and corresponding tools and components for over 20 years.
@@ -61,7 +61,7 @@ Yes, you can use any React components with Hilla, install them with npm and impo
 endif::react[]
 
 == How is Hilla different from Angular?
-Angular is a front-end framework for mobile and desktop applications with modules, dependency injection, and other features that enterprise application developers are used to.
+Angular is a frontend framework for mobile and desktop applications with modules, dependency injection, and other features that enterprise application developers are used to.
 
 ifdef::lit[]
 Hilla builds on web standards and includes a component model that uses the https://lit.dev/[Lit] library.
@@ -71,7 +71,7 @@ Hilla includes everything you need to build an application in one package: UI co
 You can get first-party support for using Hilla from Vaadin, the company that built it.
 
 == How is Hilla different from Vue?
-Vue.js is a lightweight front-end framework with a framework-specific component model.
+Vue.js is a lightweight frontend framework with a framework-specific component model.
 
 ifdef::lit[]
 Hilla builds on web standards and includes a component model that uses the https://lit.dev/[Lit] library.

--- a/articles/lit/start/gradle.adoc
+++ b/articles/lit/start/gradle.adoc
@@ -286,7 +286,7 @@ gradlew hillaGenerate
 pass:[<!-- vale Vale.Spelling = NO -->]
 
 `hillaInitApp`::
-  This task is not related to running a Hilla application and is therefore not mandatory. If you obtain a bare-bones Hilla project, for example, from https://start.spring.io/[Spring Initializr], it has no routes, no views, no endpoints, etc., and may therefore be a confusing starting point. This task scaffolds a sample Hello-World endpoint and view, and also required front-end dependencies and TypeScript configurations to boost development.
+  This task is not related to running a Hilla application and is therefore not mandatory. If you obtain a bare-bones Hilla project, for example, from https://start.spring.io/[Spring Initializr], it has no routes, no views, no endpoints, etc., and may therefore be a confusing starting point. This task scaffolds a sample Hello-World endpoint and view, and also required frontend dependencies and TypeScript configurations to boost development.
   `hillaInitApp` can be executed as a standard Gradle task, like this:
 
 [.example]

--- a/articles/lit/start/in-depth/crud-operations.adoc
+++ b/articles/lit/start/in-depth/crud-operations.adoc
@@ -24,7 +24,7 @@ When the store updates its internal state, the views automatically reflect the u
 
 The save and delete operations happen in two stages:
 First, the store calls the endpoint to update the backend.
-Next, if the back-end operation succeeds, it updates the local state that the views use.
+Next, if the backend operation succeeds, it updates the local state that the views use.
 
 === Saving & Deleting on Server
 

--- a/articles/lit/start/in-depth/index.adoc
+++ b/articles/lit/start/in-depth/index.adoc
@@ -12,7 +12,7 @@ The tutorial starts from an empty project and covers all the steps to build the 
 Once you have completed the tutorial, you are ready to turn your next application idea into reality.
 
 Hilla is a full-stack platform for building web applications with Java backends.
-It simplifies web application development by giving you everything you need in one package: UI components, tooling, frontend, and back-end frameworks.
+It simplifies web application development by giving you everything you need in one package: UI components, tooling, frontend, and backend frameworks.
 With fewer moving parts and less to configure, you can get started fast and stay productive throughout the entire project.
 
 == What You'll Learn
@@ -31,8 +31,8 @@ image::images/completed-app.png[A content management application with a side nav
 
 The technologies and concepts you learn are:
 
-* reactive front-end development with Lit and TypeScript
-* back-end development with Java and Spring Boot
+* reactive frontend development with Lit and TypeScript
+* backend development with Java and Spring Boot
 * application state management with MobX
 * PWA technologies for installation and offline usage
 * cloud deployment to Heroku.

--- a/articles/lit/start/in-depth/installing-and-offline-pwa.adoc
+++ b/articles/lit/start/in-depth/installing-and-offline-pwa.adoc
@@ -47,7 +47,7 @@ public class Application implements AppShellConfigurator {
 }
 ----
 
-By default, Hilla caches all your front-end views for offline use.
+By default, Hilla caches all your frontend views for offline use.
 You can specify additional resources to cache with the `offlineResources` array.
 
 You can simulate an offline situation using the browser developer tools.

--- a/articles/lit/start/in-depth/production-build-and-deployment.adoc
+++ b/articles/lit/start/in-depth/production-build-and-deployment.adoc
@@ -27,8 +27,8 @@ This chapter covers:
 
 == Preparing the Application for Production
 It's important to build a separate production-optimized version of the application before deploying it.
-In development mode, Hilla has a live-reload widget, debug logging, and uses a quick, but unoptimized, front-end build that includes source maps for easy debugging.
-Unoptimized front-end bundles can contain several megabytes of JavaScript.
+In development mode, Hilla has a live-reload widget, debug logging, and uses a quick, but unoptimized, frontend build that includes source maps for easy debugging.
+Unoptimized frontend bundles can contain several megabytes of JavaScript.
 
 The `pom.xml` build includes a `production` profile configuration that prepares an optimized build that's ready for production.
 

--- a/articles/lit/start/in-depth/project-setup.adoc
+++ b/articles/lit/start/in-depth/project-setup.adoc
@@ -66,12 +66,12 @@ image::images/project-structure.png[Hilla project structure containing frontend,
 
 The two main folders to be aware of are:
 
-* `frontend` - this is where your views and front-end code live.
-* `src` - this is where your Java back-end code lives.
+* `frontend` - this is where your views and frontend code live.
+* `src` - this is where your Java backend code lives.
 
 The key files in a Hilla application are:
 
-* [filename]`pom.xml` - the project configuration file, which defines back-end dependencies
+* [filename]`pom.xml` - the project configuration file, which defines backend dependencies
 * [filename]`frontend/index.html` - the bootstrap page
 * [filename]`frontend/index.ts` - the routing definition
 * [filename]`src/main/java/com/example/application/Application.java` - runs the Spring Boot application.
@@ -91,7 +91,7 @@ You can also run the application from the command line with the following comman
 ----
 
 The first startup may take a few minutes.
-Hilla downloads all the needed front-end and back-end dependencies and builds the application.
+Hilla downloads all the needed frontend and backend dependencies and builds the application.
 Hilla also installs Node and `npm`, if you don't already have them installed on your computer.
 
 When the build finishes, Hilla opens your default browser at http://localhost:8080.

--- a/articles/lit/start/in-depth/type-safe-server-access-with-endpoints.adoc
+++ b/articles/lit/start/in-depth/type-safe-server-access-with-endpoints.adoc
@@ -13,11 +13,11 @@ Instead of using REST and JSON, Hilla gives you type-safe asynchronous server ac
 Annotating a class with `@Endpoint` makes the methods available to the TypeScript frontend as async methods.
 Hilla generates TypeScript types based on the Java method parameters and return types, so you have type safety throughout your application.
 
-You can find the back-end code in the `src/main/java` directory.
+You can find the backend code in the `src/main/java` directory.
 
 This chapter covers:
 
-* the back-end architecture,
+* the backend architecture,
 * how to create an endpoint,
 * how to optimize communication by using data transfer objects (DTO).
 

--- a/articles/react/components/progress-bar/index.asciidoc
+++ b/articles/react/components/progress-bar/index.asciidoc
@@ -257,7 +257,7 @@ Use asynchronous processes whenever possible so as not to block the user from co
 
 === When to Use
 
-If a back-end process takes longer than 1 second, use a Progress Bar to show the user that something is happening, especially if it blocks the user's workflow.
+If a backend process takes longer than 1 second, use a Progress Bar to show the user that something is happening, especially if it blocks the user's workflow.
 
 === Placement
 

--- a/articles/react/guides/endpoints.adoc
+++ b/articles/react/guides/endpoints.adoc
@@ -1,6 +1,6 @@
 ---
 title: Endpoints
-description: A server-side Java endpoint is a back-end method that's exposed for calling from client-side TypeScript code.
+description: A server-side Java endpoint is a backend method that's exposed for calling from client-side TypeScript code.
 order: 30
 ---
 :react:

--- a/articles/react/guides/testing.adoc
+++ b/articles/react/guides/testing.adoc
@@ -191,7 +191,7 @@ Save the test so Vitest can run it in the browser, verifying that the interactio
 
 == Testing Backend Calls
 
-Views often need to interact with back-end services, which should be tested, as well. In this section, you'll create a back-end service to store todos and then verify that it's called correctly from the view. First, create a dummy service called, [filename]`TodoService.java` next to [filename]`Application.java`:
+Views often need to interact with backend services, which should be tested, as well. In this section, you'll create a backend service to store todos and then verify that it's called correctly from the view. First, create a dummy service called, [filename]`TodoService.java` next to [filename]`Application.java`:
 
 [source,java]
 ----


### PR DESCRIPTION
We've decided to change our policy about whether Back-End and Front-End should be hyphenated based on its use in a sentence. For now on, we'll write them as compound words -- regardless of the usage and context.