### PR TITLE
chore: reset loading rows background in grid styling example

### DIFF
--- a/frontend/demo/component/grid/grid-styling.ts
+++ b/frontend/demo/component/grid/grid-styling.ts
@@ -39,7 +39,11 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-grid .items="${this.items}" .cellPartNameGenerator="${this.cellPartNameGenerator}">
+      <vaadin-grid
+        .items="${this.items}"
+        .cellPartNameGenerator="${this.cellPartNameGenerator}"
+        class="styling"
+      >
         <vaadin-grid-column path="firstName"></vaadin-grid-column>
         <vaadin-grid-column path="lastName"></vaadin-grid-column>
         <vaadin-grid-column path="profession"></vaadin-grid-column>

--- a/frontend/demo/component/grid/react/grid-styling.tsx
+++ b/frontend/demo/component/grid/react/grid-styling.tsx
@@ -49,7 +49,7 @@ function Example() {
   }, []);
 
   return (
-    <Grid items={items} cellPartNameGenerator={cellPartNameGenerator}>
+    <Grid items={items} cellPartNameGenerator={cellPartNameGenerator} className="styling">
       <GridColumn path="firstName" />
       <GridColumn path="lastName" />
       <GridColumn path="profession" />

--- a/frontend/themes/docs/grid-styling.css
+++ b/frontend/themes/docs/grid-styling.css
@@ -1,14 +1,18 @@
 /* Add this to your global CSS, for example in: */
 /* frontend/theme/[my-theme]/styles.css */
 
-vaadin-grid::part(high-rating) {
+vaadin-grid.styling::part(high-rating) {
     background-color: var(--lumo-success-color-10pct);
 }
 
-vaadin-grid::part(low-rating) {
+vaadin-grid.styling::part(low-rating) {
     background-color: var(--lumo-error-color-10pct);
 }
 
-vaadin-grid::part(font-weight-bold) {
+vaadin-grid.styling::part(loading-row-cell) {
+    background-color: var(--lumo-base-color);
+}
+
+vaadin-grid.styling::part(font-weight-bold) {
     font-weight: bold;
 }

--- a/src/main/java/com/vaadin/demo/component/grid/GridStyling.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridStyling.java
@@ -15,6 +15,7 @@ public class GridStyling extends Div {
     public GridStyling() {
         // tag::snippet[]
         Grid<PersonWithRating> grid = new Grid<>(PersonWithRating.class, false);
+        grid.addClassName("styling");
         grid.addColumn(PersonWithRating::getFirstName).setHeader("First name");
         grid.addColumn(PersonWithRating::getLastName).setHeader("Last name");
         grid.addColumn(PersonWithRating::getProfession).setHeader("Profession");


### PR DESCRIPTION
Reset the background color of loading rows in the Grid styling example. Couldn't find a way to achieve this by modifying the existing selectors (instead of overriding with a new selector).

Before:

https://github.com/vaadin/docs/assets/1222264/63379269-e40c-43e1-b13c-670fff64cdbe

After:

https://github.com/vaadin/docs/assets/1222264/c26cc390-92a3-4874-ba5b-a6618db4b3cb

