### PR TITLE
refactor: grid drag drop example should set parent correctly

### DIFF
--- a/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java
@@ -61,8 +61,7 @@ public class GridDragDropFilters extends Div {
                 return;
 
             draggedItem.setManagerId(newManager.getId());
-            treeData.removeItem(draggedItem);
-            treeData.addItem(newManager, draggedItem);
+            treeData.setParent(draggedItem, newManager);
 
             treeDataProvider.refreshAll();
         });


### PR DESCRIPTION
Follow-up from a Flow component [issue](https://github.com/vaadin/flow-components/issues/5530).

The example removes the item on drop before adding it under a parent again. This makes the item to lose its children, which is the way `TreeData.remove` works. To update the parent of an item in the tree, `TreeData.setParent` should be used instead. 

This PR updates the example to set the parent correctly.