### PR TITLE
fix: use static hosting for product data download

### DIFF
--- a/articles/react/guides/data-grids.adoc
+++ b/articles/react/guides/data-grids.adoc
@@ -157,7 +157,7 @@ In order to have some example product data, download this SQL script and put it 
 <p>
 <a
 class="button primary water"
-href="https://hilla.dev/docs/connect/_download?file=product-data.sql"
+href="../../static/product-data/data.sql"
 style="color:#FFFFFF"
  >Download product data</a>
 </p>

--- a/dspublisher/dspublisher-scripts.js
+++ b/dspublisher/dspublisher-scripts.js
@@ -222,6 +222,13 @@ const SCRIPTS = {
             path.resolve(__dirname, '..', 'target', jarFile),
             path.resolve(__dirname, 'out', 'docs.jar')
           );
+
+          // Copy other static resources
+          fs.mkdirSync(path.resolve(__dirname, 'out', 'public', 'static', 'product-data'));
+          fs.copyFileSync(
+            path.resolve(__dirname, '..', 'src', 'main', 'resources', 'files', 'product-data.sql'),
+            path.resolve(__dirname, 'out', 'public', 'static', 'product-data', 'data.sql')
+          );
         },
         phases: [
           {


### PR DESCRIPTION
Updates the DS Publisher build script to copy product data file into the static content hosted by nginx, so that it can be downloaded from there.