### PR TITLE
docs: note about eagerServerLoad property in exceptions article

### DIFF
--- a/articles/routing/exceptions.asciidoc
+++ b/articles/routing/exceptions.asciidoc
@@ -45,9 +45,9 @@ Exceptions are matched in the order below:
 
 The `404` [classname]`RouteNotFoundError` (for [classname]`NotFoundException`), and `500` [classname]`InternalServerError` (for [classname]`java.lang.Exception`) are implemented by default.
 
-By default, the initial request loads the client-side bootstrapping first with a HTTP 200 response and an error page is rendered later. The HTTP 404 response from [classname]`RouteNotFoundError` is only processed in the server side and never returned to the browser.
+By default, the initial request loads the client-side bootstrapping first with a HTTP 200 response and an error page is rendered later in another request which returns initial JSON data fragment including the error page. The HTTP 404 response from [classname]`RouteNotFoundError` is only processed in the server side and never returned to the browser as a HTTP code of the response.
 
-If you enable the <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>,[classname]`RouteNotFoundError` returns a HTTP 404 response for the navigation request. 
+If you enable the <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>, then the initial JSON data fragment is already included in the first request's response, and it includes the [classname]`RouteNotFoundError` page with a HTTP 404 code.
 
 == Custom Exception Handlers
 

--- a/articles/routing/exceptions.asciidoc
+++ b/articles/routing/exceptions.asciidoc
@@ -45,9 +45,10 @@ Exceptions are matched in the order below:
 
 The `404` [classname]`RouteNotFoundError` (for [classname]`NotFoundException`), and `500` [classname]`InternalServerError` (for [classname]`java.lang.Exception`) are implemented by default.
 
-By default, the initial request loads the client-side bootstrapping first with a HTTP 200 response and an error page is rendered later in another request which returns initial JSON data fragment including the error page. The HTTP 404 response from [classname]`RouteNotFoundError` is only processed in the server side and never returned to the browser as a HTTP code of the response.
+By default, the initial request first loads the client-side bootstrapping with a HTTP 200 response. An error page is rendered later in another request which returns an initial JSON data fragment, including the error page. The HTTP 404 response from [classname]`RouteNotFoundError` is only processed in the server side. It isn't returned to the browser as an HTTP code of the response.
 
-If you enable the <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>, then the initial JSON data fragment is already included in the first request's response, and it includes the [classname]`RouteNotFoundError` page with a HTTP 404 code.
+If you enable the <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>, the initial JSON data fragment is part of the first request's response. It includes the [classname]`RouteNotFoundError` page with am HTTP 404 code.
+
 
 == Custom Exception Handlers
 

--- a/articles/routing/exceptions.asciidoc
+++ b/articles/routing/exceptions.asciidoc
@@ -45,14 +45,9 @@ Exceptions are matched in the order below:
 
 The `404` [classname]`RouteNotFoundError` (for [classname]`NotFoundException`), and `500` [classname]`InternalServerError` (for [classname]`java.lang.Exception`) are implemented by default.
 
-[NOTE]
-====
-Activate <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>
-to make [classname]`RouteNotFoundError` return `404` HTTP response for the navigation request in the browser.
-By default, initial request loads client-side bootsrapping first with `200` HTTP response
-and error page is rendered later. `404` HTTP response from [classname]`RouteNotFoundError`
-is only processed in the server side and never returned to the browser.
-====
+By default, the initial request loads the client-side bootstrapping first with a HTTP 200 response and an error page is rendered later. The HTTP 404 response from [classname]`RouteNotFoundError` is only processed in the server side and never returned to the browser.
+
+If you enable the <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>,[classname]`RouteNotFoundError` returns a HTTP 404 response for the navigation request. 
 
 == Custom Exception Handlers
 

--- a/articles/routing/exceptions.asciidoc
+++ b/articles/routing/exceptions.asciidoc
@@ -3,21 +3,21 @@ title: Router Exception Handling
 order: 70
 ---
 
+
 = Router Exception Handling
 
-[classname]`Router` provides special support for navigation target exceptions.
-When an unhandled exception is thrown during navigation, an error view is shown.
+[classname]`Router` provides special support for navigation target exceptions. When an unhandled exception is thrown during navigation, an error view is shown.
 
 Exception targets work in the same way as regular navigation targets, except that they don't typically have a specific `@Route`, because they are shown for arbitrary URLs.
+
 
 == Error Resolving
 
 Errors in navigation are resolved to a target that's based on the exception type thrown during navigation.
 
-At startup, all classes implementing the [interfacename]`HasErrorParameter<T extends Exception>` interface are collected for use as exception targets during navigation.
-An example of such a class is [classname]`RouteNotFoundError`, which is included by default in the framework and is used to resolve errors related to the router's `NotFoundException`.
+At startup, all classes implementing the [interfacename]`HasErrorParameter<T extends Exception>` interface are collected for use as exception targets during navigation. An example of such a class is [classname]`RouteNotFoundError`, which is included by default in the framework and is used to resolve errors related to the router's `NotFoundException`.
 
-*Example*: [classname]`RouteNotFoundError` defines the default target for the [classname]`NotFoundException` that's shown when there is no target for the given URL.
+In the example here, [classname]`RouteNotFoundError` defines the default target for the [classname]`NotFoundException` that's shown when there is no target for the given URL:
 
 [source,java]
 ----
@@ -36,12 +36,9 @@ public class RouteNotFoundError extends Component
 }
 ----
 
-* This returns a `404` HTTP response and displays the text specified in the parameter to [methodname]`setText()`.
+This returns a `404` HTTP response and displays the text specified in the parameter to [methodname]`setText()`.
 
-Exceptions are matched in the order below:
-
-. By exception cause.
-. By exception super type.
+Exceptions are matched first by exception cause, then by exception super type.
 
 The `404` [classname]`RouteNotFoundError` (for [classname]`NotFoundException`), and `500` [classname]`InternalServerError` (for [classname]`java.lang.Exception`) are implemented by default.
 
@@ -71,18 +68,14 @@ public class CustomNotFoundTarget
 }
 ----
 
-Note:
+[Note]
+Only extending instances are allowed. Exception targets may define [classname]`ParentLayouts`.
+[classname]`BeforeNavigationEvent` and [classname]`AfterNavigationEvent` are still sent, as in normal navigation. One exception may only have one exception handler.
 
-* Only extending instances are allowed.
-* Exception targets may define [classname]`ParentLayouts`.
-[classname]`BeforeNavigationEvent` and [classname]`AfterNavigationEvent` are still sent, as in normal navigation.
-
-* One exception may only have one exception handler.
 
 === Advanced Exception Handling Example
 
-The following example assumes an application `Dashboard` that collects and shows widgets to users.
-Only authenticated users are allowed to see protected widgets.
+The following example assumes an application `Dashboard` that collects and shows widgets to users. Only authenticated users are allowed to see protected widgets.
 
 If the collection instantiates a [classname]`ProtectedWidget` in error, the widget itself checks authentication on creation and throw an [classname]`AccessDeniedException`.
 
@@ -150,14 +143,15 @@ public class AccessDeniedExceptionHandler
 }
 ----
 
-== Rerouting to an Error View
+
+== Rerouting to Error View
 
 It's possible to reroute from the [classname]`BeforeEnterEvent` and [classname]`BeforeLeaveEvent` to an error view registered for an exception.
 
-You can use one of the [methodname]`rerouteToError()` method overloads.
-All you need to add is the exception class to target, and a custom error message, where necessary.
+You can use one of the [methodname]`rerouteToError()` method overloads. All you need to add is the exception class to target, and a custom error message, where necessary.
 
-*Example*: Reroute to error view
+The example below shows how to reroute to an error view:
+
 [source,java]
 ----
 public class AuthenticationHandler
@@ -181,7 +175,7 @@ public class AuthenticationHandler
 
 If the rerouting method catches an exception, you can use the [methodname]`rerouteToError(Exception, String)` method to set a custom message.
 
-*Example*: Blog sample error view with a custom message
+This example is of a blog sample error view with a custom message:
 
 [source,java]
 ----

--- a/articles/routing/exceptions.asciidoc
+++ b/articles/routing/exceptions.asciidoc
@@ -43,9 +43,9 @@ Exceptions are matched first by exception cause, then by exception super type.
 
 The `404` [classname]`RouteNotFoundError` for [classname]`NotFoundException`, and `500` [classname]`InternalServerError` for [classname]`java.lang.Exception` are implemented by default.
 
-By default, the initial request first loads the client-side bootstrapping with a HTTP 200 response. An error page is rendered later in another request which returns an initial JSON data fragment, including the error page. The HTTP 404 response from [classname]`RouteNotFoundError` is only processed in the server side. It isn't returned to the browser as an HTTP code of the response.
+Also by default, the initial request first loads the client-side bootstrapping with an HTTP 200 response. An error page is rendered later in another request which returns an initial JSON data fragment, including the error page. The HTTP 404 response from [classname]`RouteNotFoundError` is only processed in the server side. It isn't returned to the browser as an HTTP code of the response.
 
-If you enable the <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>, the initial JSON data fragment is part of the first request's response. It includes the [classname]`RouteNotFoundError` page with a HTTP 404 response.
+If you enable the <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>, the initial JSON data fragment is part of the first request's response. It includes the [classname]`RouteNotFoundError` page with an HTTP 404 response.
 
 
 == Custom Exception Handlers
@@ -151,7 +151,7 @@ It's possible to reroute from the [classname]`BeforeEnterEvent` and [classname]`
 
 You can use one of the [methodname]`rerouteToError()` method overloads. You need only to add the exception class to the target, and a custom error message, where necessary.
 
-This example shows how to reroute to error view:
+This example shows how to reroute to an error view:
 
 [source,java]
 ----

--- a/articles/routing/exceptions.asciidoc
+++ b/articles/routing/exceptions.asciidoc
@@ -47,7 +47,7 @@ The `404` [classname]`RouteNotFoundError` (for [classname]`NotFoundException`), 
 
 By default, the initial request first loads the client-side bootstrapping with a HTTP 200 response. An error page is rendered later in another request which returns an initial JSON data fragment, including the error page. The HTTP 404 response from [classname]`RouteNotFoundError` is only processed in the server side. It isn't returned to the browser as an HTTP code of the response.
 
-If you enable the <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>, the initial JSON data fragment is part of the first request's response. It includes the [classname]`RouteNotFoundError` page with am HTTP 404 code.
+If you enable the <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>, the initial JSON data fragment is part of the first request's response. It includes the [classname]`RouteNotFoundError` page with a HTTP 404 response.
 
 
 == Custom Exception Handlers

--- a/articles/routing/exceptions.asciidoc
+++ b/articles/routing/exceptions.asciidoc
@@ -45,6 +45,14 @@ Exceptions are matched in the order below:
 
 The `404` [classname]`RouteNotFoundError` (for [classname]`NotFoundException`), and `500` [classname]`InternalServerError` (for [classname]`java.lang.Exception`) are implemented by default.
 
+[NOTE]
+====
+Activate <<{articles}/configuration/properties/#properties,`eagerServerLoad` property>>
+to make [classname]`RouteNotFoundError` return `404` HTTP response for the navigation request in the browser.
+By default, initial request loads client-side bootsrapping first with `200` HTTP response
+and error page is rendered later. `404` HTTP response from [classname]`RouteNotFoundError`
+is only processed in the server side and never returned to the browser.
+====
 
 == Custom Exception Handlers
 


### PR DESCRIPTION
Adds a description about `eagerServerLoad` property for Flow, which is needed in cases when HTTP code response from `RouteNotFoundError` has to go to the browser.

Fixes: #1521


