### PR TITLE
fix tooltip link in component overview

### DIFF
--- a/articles/components/index.asciidoc
+++ b/articles/components/index.asciidoc
@@ -560,7 +560,7 @@ image::{components-path-prefix}tooltip/tooltip.png["", opts=inline, role="banner
 include::tooltip/index.asciidoc[tag=description]
 
 [.sr-only]
-<<{components-path-prefix}spreadsheet#,See Spreadsheet>>
+<<{components-path-prefix}tooltip#,See Tooltip>>
 
 
 [.component-card]


### PR DESCRIPTION
Tooltip Component is linked to spreadsheet instead of tooltip details. had no test so please check if new link is correct. KR Martin


