### PR TITLE
Kubernetes Kit: Update the Redis host path

### DIFF
--- a/articles/tools/kubernetes/configuration.asciidoc
+++ b/articles/tools/kubernetes/configuration.asciidoc
@@ -71,7 +71,7 @@ This property defines the name of the Redis service deployment within a cluster.
 .application.properties
 [source,properties]
 ----
-spring.redis.host: redis-service
+spring.data.redis.host: redis-service
 ----
 
 .application.yaml


### PR DESCRIPTION
Updates the configuration entry for Redis, see https://github.com/vaadin/kubernetes-kit/issues/91