### PR TITLE
docs: update click shortcut chapter in shortcut article

### DIFF
--- a/articles/create-ui/shortcut.adoc
+++ b/articles/create-ui/shortcut.adoc
@@ -9,7 +9,7 @@ order: 30
 
 Shortcuts allow you to assign keyboard shortcuts to your components to improve end-user experience. You can add available shortcuts, create your own custom shortcuts, and configure the reaction when a shortcut is triggered.
 
-A shortcut key combination consists of one primary key and 0 to 4 key modifiers (i.e., kbd:[Alt], kbd:[Ctrl], kbd:[Meta], kbd:[Shift]).
+A shortcut key combination consists of one primary key, and zero to four key modifiers (i.e., kbd:[Alt], kbd:[Ctrl], kbd:[Meta], kbd:[Shift]).
 
 
 == Adding Click Shortcuts
@@ -83,7 +83,7 @@ All methods that allow you to add shortcuts return an instance of [classname]`Sh
 
 == Configuring Active Scope
 
-By default, shortcuts are registered to the global scope. This means that the shortcut is triggered when the user presses the correct keys, regardless of where their cursor is or which element is in focus on the screen.
+By default, shortcuts are registered to the global scope. This means that the shortcut is triggered when the user presses the correct keys, regardless of the location of their cursor, or which element is in focus on the screen.
 
 You can configure the availability of a shortcut (e.g., only when the user focuses on an element) using the [methodname]`addShortcutListener()` method made available by the fluent [classname]`ShortcutRegistration` API.
 
@@ -141,9 +141,7 @@ registration.remove(); // shortcut removed!
 [[lifecycle-owners]]
 == Shortcut Lifecycle Owners
 
-Shortcuts have a lifecycle that's controlled by an associated `Component`, called the `lifecycleOwner` component.
-
-When the component acting as a `lifecycleOwner` is both _attached_ and _visible_, the shortcut is active. If these conditions aren't both met, the shortcut can't be triggered.
+Shortcuts have a lifecycle that's controlled by an associated `Component`, called the `lifecycleOwner` component. When the component acting as a `lifecycleOwner` is both _attached_ and _visible_, the shortcut is active. If these conditions aren't both met, the shortcut can't be triggered.
 
 For focus and click shortcuts, the lifecycle owner is the component itself. It only makes sense for the click shortcut to be active when the button or input field is both in the layout and visible.
 
@@ -210,7 +208,7 @@ UI.getCurrent().addShortcutListener(listener,
 
 The `listener` handles events triggered by multiple shortcuts; both kbd:[Alt+G] and kbd:[Alt+J] invoke the listener. The [classname]`ShortcutEvent` provides the [methodname]`matches(Key, KeyModifier...)` method to determine which shortcut triggered the event. 
 
-For additional comparisons, you can use [methodname]`getSource()` (which returns the `listenOn` component) and [methodname]`getLifecycleOwner()` (which returns the `lifecycleOwner` component).
+For additional comparisons, you can use [methodname]`getSource()`, which returns the `listenOn` component. You can also use [methodname]`getLifecycleOwner()`, which returns the `lifecycleOwner` component.
 
 
 == Shorthands for Shortcut Modifiers
@@ -230,13 +228,13 @@ The focus shortcut here is triggered with kbd:[Alt+Shift+F].
 [classname]`ShortcutRegistration` also has the [methodname]`withModifiers(KeyModifiers...modifiers)` method, which can be used to configure simultaneously all modifiers -- or to remove all modifiers. Calling [methodname]`withModifiers(...)` without parameters removes all modifiers from the shortcut.
 
 
-== Shortcut Event Behavior on the Client Side
+== Shortcut Event Behavior on Client Side
 
 [classname]`ShortcutRegistration` provides methods to define the behavior of events on the client side. With browser DOM events, you can control whether an event should propagate upwards in the DOM tree (i.e., component hierarchy), and whether it should allow default browser behavior.
 
 By default, shortcuts consume the event. This means that events don't propagate upwards in the DOM tree (component hierarchy). Also, the default browser behavior is prevented. For example, the characters used in the shortcut aren't inserted into the input field, or clicking on a link prevents the browser from following the URL. See link:https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault[`Event.preventDefault()`] for more information.
 
-As an exception, click shortcuts created with the [methodname]`ClickNotifier::addClickShortcut(Key, KeyModifier...)` method allow default browser behavior by default.
+As an exception, click shortcuts created with the [methodname]`ClickNotifier::addClickShortcut(Key, KeyModifier...)` method allows default browser behavior.
 
 You can change the default behavior using the [methodname]`allowEventPropagation()` (fluent), [methodname]`allowBrowserDefault()` (fluent), [methodname]`setEventPropagationAllowed(boolean)`, and [methodname]`setBrowserDefaultAllowed(boolean)` methods.
 

--- a/articles/create-ui/shortcut.asciidoc
+++ b/articles/create-ui/shortcut.asciidoc
@@ -33,6 +33,8 @@ login.addClickShortcut(Key.ENTER);
 
 * Instead of clicking the button, the user can use the kbd:[Enter] key to perform the action tied to the button click.
 
+[NOTE]
+Since Vaadin 24.3, click shortcut resets focus on client side on an active element, e.g. `<input>`, by default before executing the shortcut action. This behavior can be disabled by calling https://vaadin.com/api/platform/com/vaadin/flow/component/ShortcutRegistration.html[[methodname]`setResetFocusOnActiveElement(boolean)`] on the shortcut registration.
 
 == Adding Focus Shortcuts
 

--- a/articles/create-ui/shortcut.asciidoc
+++ b/articles/create-ui/shortcut.asciidoc
@@ -34,7 +34,7 @@ login.addClickShortcut(Key.ENTER);
 * Instead of clicking the button, the user can use the kbd:[Enter] key to perform the action tied to the button click.
 
 [NOTE]
-Since Vaadin 24.3, click shortcut resets focus on client side on an active element, e.g. `<input>`, by default before executing the shortcut action. This behavior can be disabled by calling https://vaadin.com/api/platform/com/vaadin/flow/component/ShortcutRegistration.html[[methodname]`setResetFocusOnActiveElement(boolean)`] on the shortcut registration.
+Since Vaadin 24.3, click shortcut resets focus on client side on an active element, e.g. `<input>`, by default before executing the shortcut action, e.g. to properly submit the input's value when it's focused and shortcut is triggered. This behavior can be disabled by calling https://vaadin.com/api/platform/com/vaadin/flow/component/ShortcutRegistration.html[[methodname]`setResetFocusOnActiveElement(boolean)`] on the shortcut registration.
 
 == Adding Focus Shortcuts
 

--- a/articles/create-ui/shortcut.asciidoc
+++ b/articles/create-ui/shortcut.asciidoc
@@ -1,25 +1,22 @@
 ---
 title: Keyboard Shortcuts
-description: How to create keyboard shortcuts to components for a better user experience.
+description: Creating keyboard shortcuts to components for a better user experience.
 order: 30
 ---
 
 
 = Keyboard Shortcuts
 
-Shortcuts allow you to assign keyboard shortcuts to your components to improve end-user experience.
+Shortcuts allow you to assign keyboard shortcuts to your components to improve end-user experience. You can add available shortcuts, create your own custom shortcuts, and configure the reaction when a shortcut is triggered.
 
-You can add available shortcuts, create your own custom shortcuts, and configure the reaction when a shortcut is triggered.
+A shortcut key combination consists of one primary key and 0 to 4 key modifiers (i.e., kbd:[Alt], kbd:[Ctrl], kbd:[Meta], kbd:[Shift]).
 
-A shortcut key combination consists of one primary key and 0 to 4 key modifiers (kbd:[Alt], kbd:[Ctrl], kbd:[Meta], kbd:[Shift]).
 
 == Adding Click Shortcuts
 
-Click shortcuts define alternatives to the click action in components that implement the [interfacename]`ClickNotifier` interface.
+Click shortcuts define alternatives to the click action in components that implement the [interfacename]`ClickNotifier` interface. You can add a click shortcut using the [methodname]`addClickShortcut()` method.
 
-You can add a click shortcut using the [methodname]`addClickShortcut()` method.
-
-*Example*: Using the [methodname]`addClickShortcut()` method to add a click shortcut to a `Button` component.
+The example below uses the [methodname]`addClickShortcut()` method to add a click shortcut to a `Button` component:
 
 [source,java]
 ----
@@ -31,18 +28,17 @@ login.addClickListener(event -> this.login());
 login.addClickShortcut(Key.ENTER);
 ----
 
-* Instead of clicking the button, the user can use the kbd:[Enter] key to perform the action tied to the button click.
+Instead of clicking the button, the user can use the kbd:[Enter] key to perform the action tied to the button click.
 
 [NOTE]
-Since Vaadin 24.3, click shortcut resets focus on client side on an active element, e.g. `<input>`, by default before executing the shortcut action, e.g. to properly submit the input's value when it's focused and shortcut is triggered. This behavior can be disabled by calling https://vaadin.com/api/platform/com/vaadin/flow/component/ShortcutRegistration.html[[methodname]`setResetFocusOnActiveElement(boolean)`] on the shortcut registration.
+Since Vaadin 24.3, click shortcut resets client-side focus on an active element (e.g., `<input>`, by default) before executing the shortcut action. For example, it might submit properly the input's value when it's focused and the shortcut is triggered. This behavior can be disabled by calling https://vaadin.com/api/platform/com/vaadin/flow/component/ShortcutRegistration.html[[methodname]`setResetFocusOnActiveElement(boolean)`] on the shortcut registration.
+
 
 == Adding Focus Shortcuts
 
-Focus shortcuts place focus on a `Focusable` component, like an input field.
+Focus shortcuts place the focus on a `Focusable` component, like an input field. You can add a focus shortcut using the [methodname]`addFocusShortcut()` method.
 
-You can add a focus shortcut using the [methodname]`addFocusShortcut()` method.
-
-*Example*: Using the [methodname]`addFocusShortcut()` method to add a focus shortcut to a `TextTield`.
+The example here is using the [methodname]`addFocusShortcut()` method to add a focus shortcut to a `TextTield`:
 
 [source,java]
 ----
@@ -50,7 +46,8 @@ TextField textField = new TextField("Label");
 textField.addFocusShortcut(Key.KEY_F, KeyModifier.ALT);
 ----
 
-* The user can focus on the `Label` text field using the kbd:[Alt+F] keyboard shortcut.
+The user can focus on the `Label` text field using the kbd:[Alt+F] keyboard shortcut.
+
 
 == Adding Custom Shortcuts
 
@@ -58,7 +55,7 @@ You can use the [methodname]`addShortcutListener()` method to add a shortcut tha
 
 Assume you have a custom method, [methodname]`public void openCustomerCreation()`, that opens an input form in which users can enter new customer information.
 
-*Example*: Using the [methodname]`addShortcutListener()` method to add a custom shortcut that executes the [methodname]`openCustomerCreation()` method.
+The following example is using the [methodname]`addShortcutListener()` method to add a custom shortcut that executes the [methodname]`openCustomerCreation()` method:
 
 [source,java]
 ----
@@ -67,12 +64,11 @@ UI.getCurrent().addShortcutListener(
         KeyModifier.CONTROL, KeyModifier.ALT);
 ----
 
-* When the user presses kbd:[Ctrl+Alt+N], the form opens and the user can input the new customer information.
+When the user presses kbd:[Ctrl+Alt+N], the form opens. The user can then input the new customer information.
 
-You can configure a shortcut to run any code that complies with the [interfacename]`Command` functional interface.
-This interface has a single method called [methodname]`execute()`, which accepts zero arguments.
+You can configure a shortcut to run any code that complies with the [interfacename]`Command` functional interface. This interface has a single method called [methodname]`execute()`, which accepts zero arguments.
 
-*Example*: Using the [methodname]`addShortcutListener()` method to `show` a notification
+This example is using the [methodname]`addShortcutListener()` method to `show` a notification:
 
 [source,java]
 ----
@@ -84,14 +80,14 @@ UI.getCurrent().addShortcutListener(
 [NOTE]
 All methods that allow you to add shortcuts return an instance of [classname]`ShortcutRegistration`, which provides a fluent API that you can use to further configure your shortcuts.
 
-== Configuring the Active Scope of Shortcuts
 
-By default, shortcuts are registered to the global scope.
-This means that the shortcut is triggered when the user presses the correct keys, regardless of where their cursor is or which element is in focus on the screen.
+== Configuring Active Scope
 
-You can configure the availability of a shortcut (for example, only when the user focuses on an element) using the [methodname]`addShortcutListener()` method made available by the fluent [classname]`ShortcutRegistration` API.
+By default, shortcuts are registered to the global scope. This means that the shortcut is triggered when the user presses the correct keys, regardless of where their cursor is or which element is in focus on the screen.
 
-*Example*: Using the [methodname]`addShortcutListener()` method to define the component to which the listener attaches.
+You can configure the availability of a shortcut (e.g., only when the user focuses on an element) using the [methodname]`addShortcutListener()` method made available by the fluent [classname]`ShortcutRegistration` API.
+
+The example here is using the [methodname]`addShortcutListener()` method to define the component to which the listener attaches:
 
 [source,java]
 ----
@@ -118,20 +114,16 @@ public class Scope extends Div {
 }
 ----
 
-* The shortcut is tied to the parent component (`Scope`) of the input components.
-* If the user types input into either `TextField` and then presses kbd:[Esc], both input fields are cleared and focus is returned to the first field.
-* This is useful where the same action should be triggered by a shortcut configured on all fields contained inside the same scope, but not outside of the enveloping component.
-* The shortcut is created using the factory class [classname]`Shortcuts`, which offers the most generic method for creating shortcuts.
+The shortcut is tied to the parent component (`Scope`) of the input components. If the user types input into either `TextField` and then presses kbd:[Esc], both input fields are cleared and focus is returned to the first field. This is useful when the same action should be triggered by a shortcut configured on all fields contained inside the same scope, but not outside of the enveloping component.
 
-See <<lifecycle-owners>> below for more.
+The shortcut is created using the factory class [classname]`Shortcuts`, which offers the most generic method for creating shortcuts. See <<lifecycle-owners>> below for more.
+
 
 == Removing Shortcuts
 
-You can remove a registered shortcut using the [methodname]`Registration.remove()` method.
+You can remove a registered shortcut using the [methodname]`Registration.remove()` method. A method that adds or registers a shortcut returns either a [classname]`Registration` or [classname]`ShortcutRegistration` object.
 
-A method that adds or registers a shortcut returns either a [classname]`Registration` or [classname]`ShortcutRegistration` object.
-
-*Example*: Using the [methodname]`Registration.remove()` method to remove a shortcut.
+This example is using the [methodname]`Registration.remove()` method to remove a shortcut:
 
 [source,java]
 ----
@@ -145,23 +137,21 @@ ShortcutRegistration registration =
 registration.remove(); // shortcut removed!
 ----
 
+
 [[lifecycle-owners]]
 == Shortcut Lifecycle Owners
 
 Shortcuts have a lifecycle that's controlled by an associated `Component`, called the `lifecycleOwner` component.
 
-When the component acting as a `lifecycleOwner` is both *attached* and *visible*, the shortcut is active.
-If these conditions aren't both met, the shortcut can't be triggered.
+When the component acting as a `lifecycleOwner` is both _attached_ and _visible_, the shortcut is active. If these conditions aren't both met, the shortcut can't be triggered.
 
-* For focus and click shortcuts, the lifecycle owner is the component itself.
-It only makes sense for the click shortcut to be active when the button or input field is both in the layout and visible.
+For focus and click shortcuts, the lifecycle owner is the component itself. It only makes sense for the click shortcut to be active when the button or input field is both in the layout and visible.
 
-* For shortcuts registered through `UI`, the lifecycle owner is the `UI`.
-This means that the shortcut only stops functioning when it's <<Removing Shortcuts,removed>>.
+For shortcuts registered through `UI`, the lifecycle owner is the `UI`. This means that the shortcut only stops functioning when it's <<Removing Shortcuts,removed>>.
 
 You can use the [methodname]`Shortcuts.addShortcutListener(...)` method to create a shortcut with a lifecycle bound to a specific component.
 
-*Example*: Binding a shortcut to the lifecycle of the `Paragraph` component using the [methodname]`Shortcuts.addShortcutListener(...)` method.
+Binding a shortcut to the lifecycle of the `Paragraph` component using the [methodname]`Shortcuts.addShortcutListener(...)` method can be done like this:
 
 [source,java]
 ----
@@ -175,12 +165,11 @@ Shortcuts.addShortcutListener(paragraph,
 add(paragraph);
 ----
 
-* The first parameter of the [methodname]`Shortcuts.addShortcutListener(Component, Command, Key, KeyModifier...)` method is the `lifecycleOwner` component.
-* This code binds the kbd:[Alt+G] shortcut to the lifecycle of `paragraph` and is only active when the component is both attached and visible.
+The first parameter of the [methodname]`Shortcuts.addShortcutListener(Component, Command, Key, KeyModifier...)` method is the `lifecycleOwner` component. This code binds the kbd:[Alt+G] shortcut to the lifecycle of `paragraph` and is only active when the component is both attached and visible.
 
 You can also use the [methodname]`bindLifecycleTo()` method to reconfigure the `lifecycleOwner` component of shortcuts.
 
-*Example*: Binding the lifecycle of a click shortcut to another component using the [methodname]`bindLifecycleTo()` method.
+Binding the lifecycle of a click shortcut to another component using the [methodname]`bindLifecycleTo()` method would look like this:
 
 [source,java]
 ----
@@ -194,12 +183,12 @@ newUserButton.addClickShortcut(Key.KEY_N, KeyModifier.CONTROL)
 
 The keyboard shortcut for clicking the “Add user” button is active when the `usersList` component is visible on the page. Once the `usersList` component is detached or it becomes invisible, the shortcut is no longer active.
 
+
 == Listening for Shortcut Events
 
-The [methodname]`addShortcutListener()` method has an overload method that accepts a [classname]`ShortcutEventListener` instead of the <<Adding Custom Shortcuts,`Command`>> parameter.
-When the shortcut is detected, the event listener receives a [classname]`ShortcutEvent` that contains the `Key`, `KeyModifiers`, and both `listenOn` and `lifecycleOwner` components.
+The [methodname]`addShortcutListener()` method has an overload method that accepts a [classname]`ShortcutEventListener` instead of the <<Adding Custom Shortcuts,`Command`>> parameter. When the shortcut is detected, the event listener receives a [classname]`ShortcutEvent` that contains the `Key`, `KeyModifiers`, and both `listenOn` and `lifecycleOwner` components.
 
-*Example*: Registering a [classname]`ShortcutEventListener` and using it with the [methodname]`addShortcutListener()` overload method.
+Registering a [classname]`ShortcutEventListener` and using it with the [methodname]`addShortcutListener()` overload method is done like so:
 
 [source,java]
 ----
@@ -219,8 +208,8 @@ UI.getCurrent().addShortcutListener(listener,
         Key.KEY_J, KeyModifier.ALT);
 ----
 
-* The `listener` handles events triggered by multiple shortcuts; both kbd:[Alt+G] and kbd:[Alt+J] invoke the listener.
-* The [classname]`ShortcutEvent` provides the [methodname]`matches(Key, KeyModifier...)` method to determine which shortcut triggered the event.
+The `listener` handles events triggered by multiple shortcuts; both kbd:[Alt+G] and kbd:[Alt+J] invoke the listener. The [classname]`ShortcutEvent` provides the [methodname]`matches(Key, KeyModifier...)` method to determine which shortcut triggered the event. 
+
 For additional comparisons, you can use [methodname]`getSource()` (which returns the `listenOn` component) and [methodname]`getLifecycleOwner()` (which returns the `lifecycleOwner` component).
 
 
@@ -228,7 +217,7 @@ For additional comparisons, you can use [methodname]`getSource()` (which returns
 
 [classname]`ShortcutRegistration` includes shorthands for assigning key modifiers to a shortcut.
 
-*Example*: Using the [methodname]`withAlt()` and [methodname]`withShift()` key modifiers with the [methodname]`addFocusShortcut()` method.
+The example here is using the [methodname]`withAlt()` and [methodname]`withShift()` key modifiers with the [methodname]`addFocusShortcut()` method:
 
 [source,java]
 ----
@@ -236,27 +225,22 @@ Input input = new Input();
 input.addFocusShortcut(Key.KEY_F).withAlt().withShift();
 ----
 
-* The focus shortcut is triggered with kbd:[Alt+Shift+F].
+The focus shortcut here is triggered with kbd:[Alt+Shift+F].
 
-[classname]`ShortcutRegistration` also has the [methodname]`withModifiers(KeyModifiers...modifiers)` method, which can be used to configure all modifiers simultaneously, or to remove all modifiers.
-Calling [methodname]`withModifiers(...)` without parameters removes all modifiers from the shortcut.
+[classname]`ShortcutRegistration` also has the [methodname]`withModifiers(KeyModifiers...modifiers)` method, which can be used to configure simultaneously all modifiers -- or to remove all modifiers. Calling [methodname]`withModifiers(...)` without parameters removes all modifiers from the shortcut.
 
 
 == Shortcut Event Behavior on the Client Side
 
-[classname]`ShortcutRegistration` provides methods to define the behavior of events on the client side.
-With browser DOM events, you can control whether an event should propagate upwards in the DOM tree (component hierarchy), and whether it should allow default browser behavior.
+[classname]`ShortcutRegistration` provides methods to define the behavior of events on the client side. With browser DOM events, you can control whether an event should propagate upwards in the DOM tree (i.e., component hierarchy), and whether it should allow default browser behavior.
 
-By default, shortcuts consume the event, which means that:
-
-* events don't propagate upwards in the DOM tree (component hierarchy), and
-* the default browser behavior is prevented; for example, the characters used in the shortcut aren't inserted into the input field, or clicking on a link prevents the browser from following the URL. See link:https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault[`Event.preventDefault()`] for more information.
+By default, shortcuts consume the event. This means that events don't propagate upwards in the DOM tree (component hierarchy). Also, the default browser behavior is prevented. For example, the characters used in the shortcut aren't inserted into the input field, or clicking on a link prevents the browser from following the URL. See link:https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault[`Event.preventDefault()`] for more information.
 
 As an exception, click shortcuts created with the [methodname]`ClickNotifier::addClickShortcut(Key, KeyModifier...)` method allow default browser behavior by default.
 
 You can change the default behavior using the [methodname]`allowEventPropagation()` (fluent), [methodname]`allowBrowserDefault()` (fluent), [methodname]`setEventPropagationAllowed(boolean)`, and [methodname]`setBrowserDefaultAllowed(boolean)` methods.
 
-*Example*: Using the [methodname]`allowBrowserDefault()` method to change the default behavior of a focus shortcut.
+The example that follows is using the [methodname]`allowBrowserDefault()` method to change the default behavior of a focus shortcut:
 
 [source,java]
 ----
@@ -267,7 +251,7 @@ input.addFocusShortcut(Key.KEY_F)
         .allowBrowserDefault();
 ----
 
-*Example*: Using the [methodname]`allowEventPropagation()` method to react to a shortcut event and change the styles of a form.
+This next example is using the [methodname]`allowEventPropagation()` method to react to a shortcut event and change the styles of a form:
 
 [source,java]
 ----
@@ -292,11 +276,12 @@ Shortcuts.addShortcutListener(this,
 
 Once the "Name" field has focus and the shortcut is activated, the event is propagated higher in the component hierarchy and caught by the view component.
 
+
 == Checking Shortcut States
 
-[classname]`ShortcutRegistration` offers a variety of methods to check the internal state of a shortcut, and all configurable values that have corresponding getter methods.
+[classname]`ShortcutRegistration` offers a variety of methods to check the internal state of a shortcut, as well as all configurable values that have corresponding getter methods.
 
-In addition, you can use the boolean [methodname]`isShortcutActive()` method to check whether the shortcut is enabled on the client side.
+Additionally, you can use the boolean [methodname]`isShortcutActive()` method to check whether the shortcut is enabled on the client side.
 
 
 [discussion-id]`C949BD20-2809-4BD0-81FF-9A9A4E6F96E5`


### PR DESCRIPTION
Adds a note to point out how click notifier's `addClickShortcut` method's default behaviour has changed since 24.3.

Related-to: vaadin/flow#5959


