### PR TITLE
Move Gradle guides under References

### DIFF
--- a/articles/lit/reference/gradle.adoc
+++ b/articles/lit/reference/gradle.adoc
@@ -2,7 +2,6 @@
 title: Gradle
 page-title: Using Gradle In Hilla Applications
 description: Building and running Hilla applications with Gradle.
-order: 40
 ---
 :lit:
 // tag::content[]

--- a/articles/react/reference/gradle.adoc
+++ b/articles/react/reference/gradle.adoc
@@ -2,7 +2,6 @@
 title: Gradle
 page-title: Using Gradle in Hilla applications
 description: Building and running a Hilla application using Gradle.
-order: 40
 ---
 :react:
-include::{root}/articles/lit/start/gradle.adoc[tag=content]
+include::{root}/articles/lit/reference/gradle.adoc[tag=content]


### PR DESCRIPTION
In its current position in the navigation, the docs can imply that Hilla is only Gradle-based. This PR moves the Gradle guide under the references heading.