### PR TITLE
docs: updated shortcut.adoc for resetFocusOnActiveElement

### DIFF
--- a/articles/create-ui/shortcut.adoc
+++ b/articles/create-ui/shortcut.adoc
@@ -272,16 +272,16 @@ Shortcuts.addShortcutListener(this,
 Once the "Name" field has focus and the shortcut is activated, the event is propagated higher in the component hierarchy and caught by the view component.
 
 
-== Resetting focus on active focused element before shortcut is triggered
+== Submitting Change Events Before Shortcut Activation
 
-[classname]`ShortcutRegistration` has a [methodname]`resetFocusOnActiveElement()` (fluent) and [methodname]`setResetFocusOnActiveElement(boolean)` to make the active focused element lose focus (i.e., it's blurred) and receive focus again before a shortcut is triggered. For example, this ensures any pending input value change events are submitted before a shortcut is triggered.
+[classname]`ShortcutRegistration` has a [methodname]`resetFocusOnActiveElement()` and [methodname]`setResetFocusOnActiveElement(boolean)` to make the active focused element lose focus (i.e., it's blurred) and receive focus again before a shortcut is triggered. This ensures any pending input value change events for that focused element are submitted before a shortcut is activated.
 
-The example below uses the [methodname]`addClickShortcut()` method to add a click shortcut to a `Button` component with a keyboard shortcut for saving text field value:
+The following example adds a keyboard shortcut for the [guilabel]*Save* button. The `resetFocusOnActiveElement()` method is used to ensure that any changes made to the `description` field are submitted to the server before the keyboard shortcut is handled.
 
 [source,java]
 ----
 TextField description = new TextField("Description");
-// ON_CHANGE is default mode, but we set it explicitly here for clarity
+// ON_CHANGE is the default mode, but we explicitly set it here for clarity
 description.setValueChangeMode(ValueChangeMode.ON_CHANGE);
 
 Button save = new Button("Save");

--- a/articles/create-ui/shortcut.adoc
+++ b/articles/create-ui/shortcut.adoc
@@ -30,10 +30,6 @@ login.addClickShortcut(Key.ENTER);
 
 Instead of clicking the button, the user can use the kbd:[Enter] key to perform the action tied to the button click.
 
-.The active focused element loses focus (i.e., it's blurred) and receives focus again before a shortcut is triggered.
-[NOTE]
-For example, this ensures any pending input value change events are submitted before a shortcut is triggered. This behavior can be disabled by calling https://vaadin.com/api/platform/com/vaadin/flow/component/ShortcutRegistration.html[[methodname]`setResetFocusOnActiveElement(boolean)`] on the shortcut registration. 
-
 
 == Adding Focus Shortcuts
 
@@ -274,6 +270,24 @@ Shortcuts.addShortcutListener(this,
 ----
 
 Once the "Name" field has focus and the shortcut is activated, the event is propagated higher in the component hierarchy and caught by the view component.
+
+
+== Resetting focus on active focused element before shortcut is triggered
+
+[classname]`ShortcutRegistration` has a [methodname]`resetFocusOnActiveElement()` (fluent) and [methodname]`setResetFocusOnActiveElement(boolean)` to make the active focused element lose focus (i.e., it's blurred) and receive focus again before a shortcut is triggered. For example, this ensures any pending input value change events are submitted before a shortcut is triggered.
+
+The example below uses the [methodname]`addClickShortcut()` method to add a click shortcut to a `Button` component with a keyboard shortcut for saving text field value:
+
+[source,java]
+----
+TextField description = new TextField("Description");
+// ON_CHANGE is default mode, but we set it explicitly here for clarity
+description.setValueChangeMode(ValueChangeMode.ON_CHANGE);
+
+Button save = new Button("Save");
+save.addClickListener(event -> this.save());
+save.addClickShortcut(Key.ENTER, KeyModifier.CONTROL).resetFocusOnActiveElement();
+----
 
 
 == Checking Shortcut States


### PR DESCRIPTION
Reverted earlier changes from https://github.com/vaadin/docs/pull/2954. Default behaviour of `addClickShortcut` is now reverted back to old one due to side effects. Added new chapter about resetFocusOnActiveElement, merged with previously added text, added example code.


