### PR TITLE
docs: removed unnecessary 'before 24.3 note'

### DIFF
--- a/articles/security/enabling-security.adoc
+++ b/articles/security/enabling-security.adoc
@@ -377,8 +377,6 @@ If the user is already authenticated and tries to navigate to a view for which t
 
 In development mode, Vaadin shows the [classname]`RouteAccessDeniedError` view, which shows an _Access denied_ message with a list of available routes. In production mode, Vaadin shows the [classname]`RouteAccessDeniedError` view, which shows a _Could not navigate to 'RequestedRouteName'_ message by default. For security reasons, the message doesn't say whether the navigation target exists.
 
-Before Vaadin 24.3, Vaadin shows the [classname]`RouteNotFoundError` view instead of the [classname]`RouteAccessDeniedError` view. Both views look the same since they extend the [classname]`AbstractRouteNotFoundError` class.
-
 [role="since:com.vaadin:vaadin@V24.3"]
 == Customizing Error Messages for Unauthorized Views
 


### PR DESCRIPTION
24.3 is improved to not change the previous behavior. default `RouteAccessDeniedError` reroutes to `RouteNotFoundError` now, it doesn't extend `AbstractRouteNotFoundError`. No need to mention anything here anymore.

Related-to: vaadin/flow#18082


