### PR TITLE
docs: fix code snippets for new MSCB Java examples

### DIFF
--- a/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxAutoExpand.java
+++ b/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxAutoExpand.java
@@ -22,8 +22,8 @@ public class MultiSelectComboBoxAutoExpand extends Div {
         comboBox.select(countries.subList(0, 4));
         // tag::snippet[]
         comboBox.setAutoExpand(AutoExpandMode.BOTH);
-        add(comboBox);
         // end::snippet[]
+        add(comboBox);
     }
 
     public static class Exporter extends // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectedItemsOnTop.java
+++ b/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectedItemsOnTop.java
@@ -21,8 +21,8 @@ public class MultiSelectComboBoxSelectedItemsOnTop extends Div {
         comboBox.select(countries.subList(20, 23));
         // tag::snippet[]
         comboBox.setSelectedItemsOnTop(true);
-        add(comboBox);
         // end::snippet[]
+        add(comboBox);
     }
 
     public static class Exporter extends // hidden-source-line


### PR DESCRIPTION
Updated Java examples to not include `add(comboBox)` to the code snippet, as it's unnecessary.