### PR TITLE
fix: Show Error View for RPC calls by default

### DIFF
--- a/articles/advanced/custom-error-handler.asciidoc
+++ b/articles/advanced/custom-error-handler.asciidoc
@@ -55,7 +55,7 @@ Button button = new Button("Click me", event -> {
 [role="since:com.vaadin:vaadin@V24.3"]
 == Show Error Parameter Views for Non-Navigation Exceptions
 
-In the [classname]`DefaultErrorHandler`, it's possible to enable transitioning to an [interfacename]`HasErrorParameter<T extends Exception>` error view on exceptions. This is done by setting the `enableErrorHandlerRedirect` parameter to `true`. See <<{articles}/routing/exceptions#, Error Resolving>> for more information on the [interfacename]`HasErrorParameter`.
+In the [classname]`DefaultErrorHandler`, it's possible to enable transitioning to an [interfacename]`HasErrorParameter<T extends Exception>` error view on exceptions. See <<{articles}/routing/exceptions#, Error Resolving>> for more information on the [interfacename]`HasErrorParameter`.
 
 For a customized error handler, the same can be done by using the [classname]`ErrorHandlerUtil` method, [methodname]`handleErrorByRedirectingToErrorView` like so:
 

--- a/articles/routing/exceptions.asciidoc
+++ b/articles/routing/exceptions.asciidoc
@@ -241,12 +241,13 @@ public class FaultyBlogPostHandler extends Component
 [role="since:com.vaadin:vaadin@V24.3"]
 == Show Error View for Exception during RPC Call
 
-To use registered error views outside routing and rerouting, the application can set the `enableErrorHandlerRedirect` parameter to `true`.
+Vaadin shows the registered error views if an exception occurs outside routing and rerouting, e.g. during remote procedure call (RPC) on a server when a button click event is fired.
 
 This enables updating the current view content to a registered [interfacename]`HasErrorParameter<T extends Exception>` that handles the exact exception thrown for RPC events.
 
 If you're using a custom [interfacename]`ErrorHandler`, see the  <<{articles}/advanced/custom-error-handler#, Showing Error Parameter Views For Non-Navigation Exceptions>> page on this feature.
 
+If this redirection isn't desired, you can provide a custom error handler implementation without a redirect to error view, see the <<{articles}/advanced/custom-error-handler#, Custom Error Handling>>.
 
 [discussion-id]`F4039D66-C9C5-4CEE-B49A-F1224B46C5E8`
 


### PR DESCRIPTION
Removes "enableErrorHandlerRedirect" parameter as now the feature is available by default and this parameter has been removed.

Related to https://github.com/vaadin/flow/issues/4715
