### PR TITLE
fix: Note about access control annotation for HasUrlParameter

### DIFF
--- a/articles/security/enabling-security.adoc
+++ b/articles/security/enabling-security.adoc
@@ -411,6 +411,7 @@ public class CustomAccessDeniedError extends RouteAccessDeniedError {
 [source,java]
 ----
 @Tag(Tag.DIV)
+@AnonymousAllowed
 public static class CustomAccessDeniedError extends Component
         implements HasErrorParameter<AccessDeniedException> {
     @Override
@@ -422,6 +423,8 @@ public static class CustomAccessDeniedError extends Component
 }
 ----
 
+[interfacename]`HasErrorParameter` error view needs an access control annotation, so that Vaadin allows the navigation to it.
+Example above uses [annotationname]`@AnonymousAllowed`, but it can be also [annotationname]`@PermitAll`.
 
 === Reroute to Different Error Type
 


### PR DESCRIPTION
Adds an access control annotation to the example code and a note that this is needed to allow navigation.

Related to https://github.com/vaadin/docs/pull/2956