### PR TITLE
docs: use camel-case item properties in React example

### DIFF
--- a/frontend/demo/component/combobox/react/combo-box-basic.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-basic.tsx
@@ -12,7 +12,7 @@ function Example() {
 
   return (
     // tag::snippet[]
-    <ComboBox label="Country" item-label-path="name" item-value-path="id" items={items} />
+    <ComboBox label="Country" itemLabelPath="name" itemValuePath="id" items={items} />
     // end::snippet[]
   );
 }


### PR DESCRIPTION
For some reason this `tsx` file uses dash-case attributes while others use camel case. Updated it for consistency.