### PR TITLE
docs: use dash-case aria label in React examples

### DIFF
--- a/frontend/demo/component/menubar/react/menu-bar-combo-buttons.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-combo-buttons.tsx
@@ -16,7 +16,7 @@ function Example() {
   const items = [
     { text: 'Save' },
     {
-      component: menuComponent(<Icon icon="vaadin:chevron-down" ariaLabel="Other save options" />),
+      component: menuComponent(<Icon icon="vaadin:chevron-down" aria-label="Other save options" />),
       children: [{ text: 'Save as draft' }, { text: 'Save as copy' }, { text: 'Save and publish' }],
     },
   ];

--- a/frontend/demo/component/menubar/react/menu-bar-icon-only.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-icon-only.tsx
@@ -12,7 +12,7 @@ function menuComponent(component: React.ReactNode) {
 }
 
 function createItem(iconName: string, ariaLabel: string) {
-  return menuComponent(<Icon icon={`vaadin:${iconName}`} ariaLabel={ariaLabel} />);
+  return menuComponent(<Icon icon={`vaadin:${iconName}`} aria-label={ariaLabel} />);
 }
 
 function Example() {

--- a/frontend/demo/component/menubar/react/menu-bar-icons.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-icons.tsx
@@ -26,7 +26,7 @@ function createItem(iconName: string, text: string, isChild = false) {
 
   return menuComponent(
     <>
-      <Icon icon={`vaadin:${iconName}`} style={iconStyle} ariaLabel={ariaLabel} />
+      <Icon icon={`vaadin:${iconName}`} style={iconStyle} aria-label={ariaLabel} />
       {text}
     </>
   );


### PR DESCRIPTION
The `aria-label` attribute from React's `AriaAttributes` should be used with React components instead of the `ariaLabel` -property from `ARIAMixin` derived from `HTMLElement`