### PR TITLE
fix: remove "accessor" and disable Lit examples

### DIFF
--- a/articles/components/accordion/index.asciidoc
+++ b/articles/components/accordion/index.asciidoc
@@ -21,7 +21,7 @@ It reduces clutter and helps maintain the user's focus by showing only the relev
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -59,7 +59,7 @@ The summary supports rich content and can contain any component. This can be uti
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-summary.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-summary.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -89,7 +89,7 @@ This is the collapsible part of a panel. It can contain any component. When the 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-content.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -125,7 +125,7 @@ The `filled` theme variant makes the panel's boundaries visible. This helps tie 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-filled-panels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-filled-panels.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -154,7 +154,7 @@ Use the `small` theme variant for compact UIs.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-small-panels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-small-panels.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -183,7 +183,7 @@ The `reverse` theme variant places the toggle icon after the summary contents. T
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-reverse-panels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-reverse-panels.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -212,7 +212,7 @@ Accordion panels can be disabled to prevent them from being expanded or collapse
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-disabled-panels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-disabled-panels.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/app-layout/index.asciidoc
+++ b/articles/components/app-layout/index.asciidoc
@@ -23,7 +23,7 @@ include::{articles}/components/_shared.asciidoc[tag=scaled-examples-responsive]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-basic.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-basic.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -59,7 +59,7 @@ Application headers contain, for example, the application's name and branding, a
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-navbar-placement.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-navbar-placement.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -85,7 +85,7 @@ When placed to the side, the navbar is often seen as a view header, housing the 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -122,7 +122,7 @@ When the App Layout has an undefined/auto height, which is the default behavior,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-height-auto.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-height-auto.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -162,7 +162,7 @@ The full hierarchy of components from the App Layout to the `<body>` element nee
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-height-full.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-height-full.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -194,7 +194,7 @@ When the navbar is used for navigation, the *touch-optimized navbar* slot can be
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -226,7 +226,7 @@ The navbar is a good choice for a small number of items (3–5), as these can fi
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-navbar.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-navbar.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -253,7 +253,7 @@ Furthermore, a vertical list of items is easier for the user to scan.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-drawer.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-drawer.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -280,7 +280,7 @@ The secondary (and tertiary) navigation items can be placed in either the drawer
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/avatar/index.asciidoc
+++ b/articles/components/avatar/index.asciidoc
@@ -21,7 +21,7 @@ Avatar is a graphical representation of an object or entity, for example, a pers
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -73,7 +73,7 @@ pass:[<!-- vale Microsoft.Auto = YES -->]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-name.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-name.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -101,7 +101,7 @@ Abbreviations should be kept to a maximum of 2–3 characters.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-abbreviation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-abbreviation.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -131,7 +131,7 @@ Abbreviations aren't shown when images are used.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-image.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-image.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -160,7 +160,7 @@ It can be used, for example, to show that there are multiple users viewing the s
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-group-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-group-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -191,7 +191,7 @@ Clicking the overflow item displays the overflowing avatars and names in a list.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-group-max-items.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-group-max-items.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -220,7 +220,7 @@ The background color is set using a color index.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-group-bg-color.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-group-bg-color.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -299,7 +299,7 @@ The name of the focused Avatar is read aloud first.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-group-internationalisation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-group-internationalisation.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -328,7 +328,7 @@ Avatar has four available size variants:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-sizes.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-sizes.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -378,7 +378,7 @@ Avatar can be paired with Menu Bar to create a user account menu.
 ifdef::lit[]
 [source,javascript]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-menu-bar.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-menu-bar.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/badge/index.asciidoc
+++ b/articles/components/badge/index.asciidoc
@@ -19,7 +19,7 @@ They're used for labeling content, displaying metadata and/or highlighting infor
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -76,7 +76,7 @@ Icons can be placed on either side of the text.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-icons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-icons.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -116,7 +116,7 @@ For accessibility, a tooltip and `aria-label` attribute is recommended to ensure
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-icons-only.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-icons-only.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -147,7 +147,7 @@ Icon-only badges should primarily be used for common recurring content with high
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/badge/badge-icons-only-table.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-icons-only-table.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -186,7 +186,7 @@ Use the `small` theme variant to make a badge smaller, for example when space is
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-size.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-size.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -216,7 +216,7 @@ The color variants can be paired with the `primary` theme variant for additional
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-color.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-color.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -283,7 +283,7 @@ It can aid in making badges and buttons more distinct from one another.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-shape.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-shape.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -314,7 +314,7 @@ A typical use case for badges is to highlight an item's status, for example in a
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/badge/badge-highlight.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-highlight.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -350,7 +350,7 @@ For example, Badges that highlight active filters might contain a "Clear" Button
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/badge/badge-interactive.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-interactive.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -383,7 +383,7 @@ Badges can be used as counters, for example to show the number of unread/new mes
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-counter.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-counter.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/board/index.asciidoc
+++ b/articles/components/board/index.asciidoc
@@ -24,7 +24,7 @@ It reorders the components inside it on different screen sizes while maximizing 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/board/board-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]
@@ -99,7 +99,7 @@ Rows can be nested for finer-grained control of how certain areas of the layout 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/board/board-nested.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-nested.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]
@@ -167,7 +167,7 @@ Use the draggable split handle to resize the layout and see how the columns wrap
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/board/board-column-wrapping.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-column-wrapping.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -200,7 +200,7 @@ The possible combinations are shown below:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/board/board-column-span.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-column-span.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -259,7 +259,7 @@ Use the draggable split handle to resize the layout and see how the board stylin
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/board/board-breakpoints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-breakpoints.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,css]

--- a/articles/components/button/index.asciidoc
+++ b/articles/components/button/index.asciidoc
@@ -23,7 +23,7 @@ The Button component allows users to perform actions. It comes in several differ
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -53,7 +53,7 @@ The following variants can be used to distinguish between actions of different i
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -97,7 +97,7 @@ This is a style for distinguishing actions related to dangers, warnings, or erro
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-error.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-error.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -129,7 +129,7 @@ The following size variants are available for Button instances whose size needs 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-sizes.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-sizes.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -179,7 +179,7 @@ The *Tertiary Inline* variant omits all white space around the label. This can b
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-tertiary-inline.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-tertiary-inline.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -206,7 +206,7 @@ The *Success* and *Contrast* variants should provide additional color options fo
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-success.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-success.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -233,7 +233,7 @@ endif::[]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-contrast.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-contrast.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -271,7 +271,7 @@ Buttons can have icons instead of text, or they can have icons along with text.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-icons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-icons.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -312,7 +312,7 @@ Images on buttons can be used like icons. See the icon usage recommendations for
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-images.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-images.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -342,7 +342,7 @@ Buttons representing actions that aren't currently available to the user should 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -382,7 +382,7 @@ Buttons can be configured to be disabled when clicked. This can be useful especi
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-disable-long-action.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-disable-long-action.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -413,7 +413,7 @@ As with other components, the focus ring is only rendered when the button is foc
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-focus.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-focus.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -494,7 +494,7 @@ A button with a regular, visible label can also benefit from a separate `aria-la
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-labels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-labels.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -523,7 +523,7 @@ Buttons in forms should be placed below the form with which they're associated. 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-form.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-form.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -553,7 +553,7 @@ Buttons in dialogs should be placed at the bottom of the dialog and aligned righ
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-dialog.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-dialog.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -585,7 +585,7 @@ In the example below, the global _Add User_ action is separated from the selecti
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-grid.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-grid.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/charts/index.asciidoc
+++ b/articles/components/charts/index.asciidoc
@@ -25,7 +25,7 @@ include::{articles}/_commercial-banner.asciidoc[opts=optional]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/charts/charts-overview.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/charts/charts-overview.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/checkbox/index.asciidoc
+++ b/articles/components/checkbox/index.asciidoc
@@ -24,7 +24,7 @@ Checkbox Group is a group of related binary choices.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -49,7 +49,7 @@ endif::[]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-group-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-group-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ Disabling can be preferable to hiding an element to prevent changes in layout wh
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -120,7 +120,7 @@ The indeterminate state can be used for a parent checkbox to show that there is 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-indeterminate.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-indeterminate.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -150,7 +150,7 @@ The component's default orientation is horizontal. However, vertical orientation
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-vertical.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-vertical.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -177,7 +177,7 @@ In cases where vertical space needs to be conserved, horizontal orientation can 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-horizontal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-horizontal.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -206,7 +206,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-group-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-group-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -235,7 +235,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-group-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-group-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -266,7 +266,7 @@ Aim for short and descriptive labels using positive wording. Avoid negations.
 ifdef::lit[]
 [source,typescript, role=render-only]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-labeling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-labeling.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -286,7 +286,7 @@ It's important to provide labels for Checkbox Groups to distinguish clearly any 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/combo-box/index.asciidoc
+++ b/articles/components/combo-box/index.asciidoc
@@ -25,7 +25,7 @@ It supports lazy loading and can be configured to accept custom typed values.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]
@@ -67,7 +67,7 @@ Combo Box can be configured to allow entering custom values that aren't included
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-custom-entry-1.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-custom-entry-1.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -96,7 +96,7 @@ Custom values can also be stored and added to the list of options:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-custom-entry-2.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-custom-entry-2.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -127,7 +127,7 @@ Items can be customized to display more information than a single line of text.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-presentation.ts[render,tag=combobox,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-presentation.ts[tag=combobox,indent=0,group=TypeScript]
 
 ...
 
@@ -177,7 +177,7 @@ The overlay opens automatically when the field is focused using a pointer (i.e.,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-auto-open.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-auto-open.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]
@@ -218,7 +218,7 @@ The width of the popup is, by default, the same width as the input field. The po
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-popup-width.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-popup-width.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]
@@ -257,7 +257,7 @@ Combo Box's filtering, by default, is configured to show only items that contain
 ifdef::lit[]
 [source,html, role=render-only]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-filtering-1.ts[render,tags=snippet,indent=0]
+include::{root}/frontend/demo/component/combobox/combo-box-filtering-1.ts[tags=snippet,indent=0]
 ----
 endif::[]
 
@@ -277,7 +277,7 @@ Custom filtering is also possible. For example, if you only want to show items t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-filtering-2.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-filtering-2.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -306,7 +306,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -335,7 +335,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=constraint
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-constraints.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -364,7 +364,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -393,7 +393,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/confirm-dialog/index.asciidoc
+++ b/articles/components/confirm-dialog/index.asciidoc
@@ -21,7 +21,7 @@ Confirm Dialog is a modal Dialog used to confirm user actions.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts[render,frame,tags=*, indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts[frame,tags=*, indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -98,7 +98,7 @@ As the name suggests, its default label is “Confirm”, but it can and should 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts[render, tags=*, indent=0, group=TypeScript]
+include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts[ tags=*, indent=0, group=TypeScript]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ The “Cancel” button is used in situations where the user must be able to can
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts[render, tags=*, indent=0, group=TypeScript]
+include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts[ tags=*, indent=0, group=TypeScript]
 ----
 endif::[]
 
@@ -158,7 +158,7 @@ For example, if the user tries to leave a view containing unsaved changes, they 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts[render, tags=*, indent=0, group=TypeScript]
+include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts[ tags=*, indent=0, group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/context-menu/index.asciidoc
+++ b/articles/components/context-menu/index.asciidoc
@@ -27,7 +27,7 @@ Open the Context Menu by right-clicking (mouse) or long-pressing (touch) a Grid 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-basic.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-basic.ts[tag=snippet,indent=0,group=TypeScript]
 
 <!-- ... -->
 
@@ -63,7 +63,7 @@ include::index.asciidoc[tag=example-instructions]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-dividers.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-dividers.ts[tag=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -92,7 +92,7 @@ Checkable Menu Items can be used to toggle a setting on and off.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-checkable.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-checkable.ts[tag=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -128,7 +128,7 @@ include::index.asciidoc[tag=example-instructions]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-hierarchical.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-hierarchical.ts[tag=snippet,indent=0,group=TypeScript]
 
 // ...
 
@@ -163,7 +163,7 @@ include::index.asciidoc[tag=example-instructions]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-presentation.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-presentation.ts[tag=snippet,indent=0,group=TypeScript]
 
 ...
 
@@ -203,7 +203,7 @@ include::index.asciidoc[tag=example-instructions]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-disabled.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-disabled.ts[tag=snippet,indent=0,group=TypeScript]
 
 // ...
 
@@ -243,7 +243,7 @@ Open the Context Menu by clicking a Grid row.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-left-click.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-left-click.ts[tag=snippet,indent=0,group=TypeScript]
 
 // ...
 
@@ -281,7 +281,7 @@ Open the Context Menu by right-clicking (desktop) or long-pressing (mobile) a Gr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-best-practices.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-best-practices.ts[tag=snippet,indent=0,group=TypeScript]
 
 // ...
 

--- a/articles/components/cookie-consent/index.asciidoc
+++ b/articles/components/cookie-consent/index.asciidoc
@@ -28,7 +28,7 @@ include::{articles}/components/_shared.asciidoc[tag=scaled-examples]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/cookieconsent/cookie-consent-basic.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/cookieconsent/cookie-consent-basic.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -64,7 +64,7 @@ You can customize the message, the "Learn More" link, the "Dismiss" button, as w
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/cookieconsent/cookie-consent-localization.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/cookieconsent/cookie-consent-localization.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -116,7 +116,7 @@ Cookie Consent's theme is modified using CSS.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/cookieconsent/cookie-consent-theming.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/cookieconsent/cookie-consent-theming.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/crud/index.asciidoc
+++ b/articles/components/crud/index.asciidoc
@@ -25,7 +25,7 @@ CRUD is a component for managing a dataset. It allows for easy displaying, editi
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -59,7 +59,7 @@ CRUD automatically generates columns for each field in the provided dataset. You
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-columns.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-columns.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -94,7 +94,7 @@ Data is edited using CRUD's editor UI. By default, the editor is opened by click
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-open-editor.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-open-editor.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -138,7 +138,7 @@ The `aside` position displays the editor as an overlay next to the grid. Use thi
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-editor-aside.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-editor-aside.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -176,7 +176,7 @@ The bottom position can be useful when the user needs to see as many columns in 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-editor-bottom.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-editor-bottom.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -216,7 +216,7 @@ The editor's content is fully configurable, except for the header and footer.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-editor-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-editor-content.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -261,7 +261,7 @@ See <<../grid#,Grid documentation>> for details on configuring grids.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-grid-replacement.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-grid-replacement.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -303,7 +303,7 @@ Creating new items is done via the “New Item” Button in CRUD's toolbar. Both
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-toolbar.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-toolbar.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -337,7 +337,7 @@ The toolbar can be hidden if it isn't needed.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-hidden-toolbar.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-hidden-toolbar.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -371,7 +371,7 @@ Sorting and filtering can be disabled.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-sorting-filtering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-sorting-filtering.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -414,7 +414,7 @@ Newly created items can be initialized with data.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/crud/crud-item-initialization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-item-initialization.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -445,7 +445,7 @@ CRUD supports full localization through customizable labels for its buttons and 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/crud/crud-localization.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-localization.ts[tags=snippet;snippethtml,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/custom-field/index.asciidoc
+++ b/articles/components/custom-field/index.asciidoc
@@ -24,7 +24,7 @@ It provides standard input field features like label, helper, validation, and da
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/custom-field/custom-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/custom-field/custom-field-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -209,7 +209,7 @@ Custom Field works with native HTML elements. The `whitespace` variant can be us
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/custom-field/custom-field-native-input.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/custom-field/custom-field-native-input.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -249,7 +249,7 @@ The small theme variant can be used to make Custom Field's label, helper, and er
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/custom-field/custom-field-size-variants.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/custom-field/custom-field-size-variants.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/date-picker/index.asciidoc
+++ b/articles/components/date-picker/index.asciidoc
@@ -26,7 +26,7 @@ Try clicking the calendar icon. A calendar overlay appears, showing the current 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -200,7 +200,7 @@ When using the web component stand-alone, custom functions can be configured to 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-custom-functions.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-custom-functions.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -231,7 +231,7 @@ The valid input range of Date Picker can be restricted by defining `min` and `ma
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-min-max.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-min-max.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -261,7 +261,7 @@ Date Picker supports custom validation, such as limiting the options to Monday t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-custom-validation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-custom-validation.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -295,7 +295,7 @@ pass:[<!-- vale Vaadin.Abbr = YES --> ]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-week-numbers.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-week-numbers.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -327,7 +327,7 @@ Use this feature to minimize the need for unnecessary navigation or scrolling wh
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-initial-position.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-initial-position.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -357,7 +357,7 @@ The overlay automatically opens when the field is focused with a click or a tap,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-auto-open.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-auto-open.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -386,7 +386,7 @@ Date Picker allows localizing text and labels, such as month names and button la
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-internationalization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-internationalization.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -417,7 +417,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -446,7 +446,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -475,7 +475,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -507,7 +507,7 @@ You can create a date range picker using the Date Picker twice. Imagine the foll
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-date-range.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-date-range.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -545,7 +545,7 @@ Instead of a Date Picker, you can use individual input fields (i.e., day, month,
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -585,7 +585,7 @@ pass:[<!-- vale Google.DateFormat = YES -->]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/date-time-picker/index.asciidoc
+++ b/articles/components/date-time-picker/index.asciidoc
@@ -20,7 +20,7 @@ Date Time Picker is an input field for selecting both a date and a time.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -53,7 +53,7 @@ The default step is one hour (that is, `3600`). Unlike with <<../number-field#,N
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -83,7 +83,7 @@ The displayed time format changes based on the step.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -130,7 +130,7 @@ The overlay opens automatically when the field is focused using a pointer (i.e.,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -161,7 +161,7 @@ You can define a `min` and `max` value for Date Time Picker if you need to restr
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -190,7 +190,7 @@ If the `min` and `max` values aren't enough, you can also apply custom validatio
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -219,7 +219,7 @@ You can configure Date Time Picker to show week numbers in the date picker overl
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -250,7 +250,7 @@ Date Time Picker's initial position parameter defines which date is focused in t
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -279,7 +279,7 @@ Date Time Picker allows localizing texts and labels, such as month names and but
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -334,7 +334,7 @@ endif::[]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -363,7 +363,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -392,7 +392,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -423,7 +423,7 @@ You can accomplish a date time range picker using two Date Time Pickers.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-range.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-range.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -466,7 +466,7 @@ Use a helper text to show the expected date and time formats, and placeholders t
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/details/index.asciidoc
+++ b/articles/components/details/index.asciidoc
@@ -20,7 +20,7 @@ Details is an expandable panel for showing and hiding content from the user, to 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -56,7 +56,7 @@ The summary supports rich content and can contain any component. This can be use
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-summary.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-summary.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]
@@ -91,7 +91,7 @@ This is the collapsible part of Details. It can contain any component. When the 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-content.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ The `filled` theme variant makes the component's boundaries visible, which helps
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-filled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-filled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -155,7 +155,7 @@ Use the `small` theme variant for compact UIs.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-small.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-small.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -185,7 +185,7 @@ The reverse theme variant places the toggle icon after the summary contents, whi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-reverse.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-reverse.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -216,7 +216,7 @@ Details can be disabled to prevent them from being expanded or collapsed. Compon
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/dialog/index.asciidoc
+++ b/articles/components/dialog/index.asciidoc
@@ -23,7 +23,7 @@ ifdef::lit[]
 [source,html]
 ----
 
-include::{root}/frontend/demo/component/dialog/dialog-basic.ts[render,frame,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-basic.ts[frame,tags=*,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -65,7 +65,7 @@ The header contains an optional title element, and a slot next to it for custom 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-header.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-header.ts[tags=*,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -97,7 +97,7 @@ Components can be left-aligned by applying a margin:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-footer.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-footer.ts[tags=*,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ The content area's built-in padding can be removed by applying the `no-padding` 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-no-padding.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-no-padding.ts[tags=*,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -219,7 +219,7 @@ You can choose whether to make the component's content draggable as well, or onl
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-draggable.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-draggable.ts[tags=*,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -263,7 +263,7 @@ Dialogs that contain very little, or compact, information don't need to be resiz
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-resizable.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-resizable.ts[tags=*,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -298,7 +298,7 @@ Providing an explicit button for closing a Dialog is recommended.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-closing.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-closing.ts[tags=*,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/email-field/index.asciidoc
+++ b/articles/components/email-field/index.asciidoc
@@ -24,7 +24,7 @@ If the given address is invalid, the field is highlighted in red and an error me
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -55,7 +55,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -93,7 +93,7 @@ The example below uses the pattern `.+@example\.com` and only accepts addresses 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-constraints.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -122,7 +122,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -151,7 +151,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/form-layout/index.asciidoc
+++ b/articles/components/form-layout/index.asciidoc
@@ -20,7 +20,7 @@ Form Layout allows you to build responsive forms with multiple columns, and to p
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -56,7 +56,7 @@ Use the draggable split handle to resize Form Layout's available space and to te
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-custom-layout.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-custom-layout.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -92,7 +92,7 @@ For example, if you have a Form Layout with three columns and a component's `col
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-colspan.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-colspan.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -135,7 +135,7 @@ Labels positioned on the side are also often used when there is a need to compar
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-side.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-side.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -174,7 +174,7 @@ Form Item allows you to set a label for any type of component that you want to u
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-native-input.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-native-input.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -203,7 +203,7 @@ Form Item only supports placing a single field inside. Where you need to place m
 ifdef::lit[]
 [source,js]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-custom-field.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-custom-field.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/grid-pro/index.asciidoc
+++ b/articles/components/grid-pro/index.asciidoc
@@ -26,7 +26,7 @@ Grid Pro is an extension of the Grid component that provides inline editing with
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -75,7 +75,7 @@ Single Click Edit is a mode that enables the user to begin editing by single-cli
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-single-click.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-single-click.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -106,7 +106,7 @@ Single Cell Edit is a mode that makes tabbing from one cell to another exit from
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -137,7 +137,7 @@ kbd:[Enter] and kbd:[Shift+Enter] can be made to focus the editable cell in the 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -166,7 +166,7 @@ Editing is enabled on a per-column basis.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-edit-column.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-edit-column.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -212,7 +212,7 @@ Although Grid Pro can be configured to use any input field for editing, the buil
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-editors.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-editors.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -241,7 +241,7 @@ You can rollback changes when the entered input is incorrect or invalid.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-prevent-save.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-prevent-save.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -275,7 +275,7 @@ Editable cells can be highlighted by applying the `highlight-editable-cells` the
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -326,7 +326,7 @@ Read-only cells can be highlighted by applying the `highlight-read-only-cells` t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/grid/index.asciidoc
+++ b/articles/components/grid/index.asciidoc
@@ -30,7 +30,7 @@ pass:[<!-- vale Vaadin.Will = NO -->]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -70,7 +70,7 @@ Notice how much nicer and richer the grid content is rendered in the table below
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-content.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -133,7 +133,7 @@ Notice in the example here that the text in the _Address_ cells is wrapped. If y
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-wrap-cell-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-wrap-cell-content.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -169,7 +169,7 @@ Notice how the height of the rows in the earlier example adjusts because of the 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-dynamic-height.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-dynamic-height.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -204,7 +204,7 @@ In single-selection mode, the user can select and deselect rows by clicking anyw
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-single-selection-mode.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-single-selection-mode.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -234,7 +234,7 @@ In multi-select mode, the user can use a checkbox column to select and deselect 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-multi-select-mode.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-multi-select-mode.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -272,7 +272,7 @@ ifdef::lit[]
 [source,typescript]
 ----
 
-include::{root}/frontend/demo/component/grid/grid-column-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-alignment.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -304,7 +304,7 @@ In the example here, try scrolling the data to the right and back left. Notice t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-freezing.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-freezing.ts[tags=*,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -338,7 +338,7 @@ In the example below, the first and last names are grouped under _Name_. Whereas
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-grouping.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-grouping.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -368,7 +368,7 @@ Each column has a customizable header and footer. A basic column header shows th
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-header-footer.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-header-footer.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -404,7 +404,7 @@ In the example here, notice that the email address and telephone numbers are not
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-visibility.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-visibility.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -440,7 +440,7 @@ Instead of hiding columns as in the earlier example, in the example here the use
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-reordering-resizing.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-reordering-resizing.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -472,7 +472,7 @@ In the following example, the first and last columns have fixed widths. The seco
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-width.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-width.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -506,7 +506,7 @@ endif::[]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-sorting.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-sorting.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -538,7 +538,7 @@ In the example here, click on the _Profession_ column heading to set the first s
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-multisort.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-multisort.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -573,7 +573,7 @@ Columns with rich or custom content can be sorted by defining the property by wh
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-rich-content-sorting.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-rich-content-sorting.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -612,7 +612,7 @@ pass:[<!-- vale Vaadin.Spelling = YES -->]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-filtering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-filtering.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -643,7 +643,7 @@ Place filters outside the grid when the filter is based on multiple columns, or 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-external-filtering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-external-filtering.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -675,7 +675,7 @@ The following example works like the earlier example, but it uses a data provide
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-data-provider.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-data-provider.ts[tags=snippet,indent=0,group=TypeScript]
 
 ...
 
@@ -737,7 +737,7 @@ No Improvement If All Columns Visible:: The lazy column rendering mode can only 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-lazy-column-rendering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-lazy-column-rendering.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -767,7 +767,7 @@ Item details are expandable content areas that can be displayed below the regula
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-item-details.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-item-details.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -798,7 +798,7 @@ The default toggle behavior can be replaced by programmatically toggling the det
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-item-details-toggle.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-item-details-toggle.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -837,7 +837,7 @@ ifdef::lit[]
 [source,typescript]
 ----
 
-include::{root}/frontend/demo/component/grid/grid-context-menu.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-context-menu.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -873,7 +873,7 @@ In the example here, hold your mouse pointer over the birthday date for one of t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-tooltip-generator.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-tooltip-generator.ts[tag=snippet,indent=0,group=TypeScript]
 
 ...
 
@@ -935,7 +935,7 @@ You can drag rows to reorder them. This can be a useful and impressive feature f
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-row-reordering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-row-reordering.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -967,7 +967,7 @@ In the example here, there are two grids of data. Maybe they represent people to
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-drag-rows-between-grids.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-drag-rows-between-grids.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -998,7 +998,7 @@ Drag-and-drop filters determine which rows are draggable and which rows are vali
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-drag-drop-filters.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-drag-drop-filters.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -1089,7 +1089,7 @@ In the example below, bold font weight is applied to the [guilabel]*Rating* colu
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-styling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-styling.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -1131,7 +1131,7 @@ This is useful for displaying more information on-screen without having to scrol
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-compact.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-compact.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -1161,7 +1161,7 @@ The `no-border` theme variant removes the outer border of the grid. Compare the 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-no-border.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-no-border.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -1191,7 +1191,7 @@ This theme variant removes the horizontal row borders. This is best suited for s
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-no-row-border.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-no-row-border.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -1221,7 +1221,7 @@ You can add vertical borders between columns by using the `column-borders` theme
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-borders.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-borders.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -1251,7 +1251,7 @@ The `row-stripes` theme variant produces a background color for every other row.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-row-stripes.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-row-stripes.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -1306,7 +1306,7 @@ The cell focus event can be used to be notified when the user changes focus betw
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-cell-focus.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-cell-focus.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/horizontal-layout/index.asciidoc
+++ b/articles/components/horizontal-layout/index.asciidoc
@@ -22,7 +22,7 @@ See <<../vertical-layout#, Vertical Layout>> for placing components top-to-botto
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -55,7 +55,7 @@ You can position components at the top, middle, or bottom. You can also stretch 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -100,7 +100,7 @@ It's also possible to set a different vertical alignment for individual items by
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -130,7 +130,7 @@ Components in a Horizontal Layout can be left-aligned, centered or right-aligned
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -181,7 +181,7 @@ Spacing is used to create space among components in the same layout. Spacing can
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -208,7 +208,7 @@ Five different spacing theme variants are available:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -288,7 +288,7 @@ Padding is the space between the outer border and the content in a layout. Paddi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -318,7 +318,7 @@ Use margin to create space around a layout.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -348,7 +348,7 @@ Components can be made to expand and take up any excess space a layout may have.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/icons/index.asciidoc
+++ b/articles/components/icons/index.asciidoc
@@ -19,7 +19,7 @@ The icon component can render SVG and font icons. Two icon collections are avail
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icon-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icon-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -54,7 +54,7 @@ Vaadin Icons is a collection of over six-hundred icons.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/vaadin-icons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/vaadin-icons.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ Lumo Icons are used in the default Lumo theme for Vaadin components.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/lumo-icons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/lumo-icons.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ Standalone SVG images can be rendered as inline SVG icons using the icon compone
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/svg-standalone.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/svg-standalone.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -162,7 +162,7 @@ Using an image from an SVG sprite is similar to using a standalone SVG image -- 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/svg-sprites.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/svg-sprites.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -208,7 +208,7 @@ The desired icon can be specified in three different ways, depending on the font
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icon-fonts.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icon-fonts.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -320,7 +320,7 @@ The icon's fill color can be set to any CSS color value.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icons-color.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icons-color.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -350,7 +350,7 @@ The icon component has a property for setting the desired outer size of the icon
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icons-sizing.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icons-sizing.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -377,7 +377,7 @@ The internal padding of the icon can be adjusted to compensate for the lack of s
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icons-padding.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icons-padding.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -431,7 +431,7 @@ However, in most cases, there shouldn't be a need to make icons themselves scree
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icons-accessibility.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icons-accessibility.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/list-box/index.asciidoc
+++ b/articles/components/list-box/index.asciidoc
@@ -21,7 +21,7 @@ List Box allows the user to select one or more values from a scrollable list of 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -53,7 +53,7 @@ Use them sparingly to avoid creating unnecessary visual clutter.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-separators.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-separators.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -82,7 +82,7 @@ Disable items to show that they are currently unavailable for selection.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-disabled-items.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-disabled-items.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -120,7 +120,7 @@ Single selection allows the user to select only one item, whereas multiple selec
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-single-selection.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-single-selection.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -147,7 +147,7 @@ endif::[]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-multi-selection.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-multi-selection.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -181,7 +181,7 @@ pass:[<!-- vale Vaadin.TooWordy = YES -->]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-custom-item-presentation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-custom-item-presentation.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/login/index.asciidoc
+++ b/articles/components/login/index.asciidoc
@@ -39,7 +39,7 @@ It's compatible with password managers, supports internationalization, and works
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -71,7 +71,7 @@ You can customize the form's title and labels using internationalization.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/login/login-internationalization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-internationalization.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -98,7 +98,7 @@ The basic Login component can be used to create log-in pages featuring rich cont
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-rich-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-rich-content.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -140,7 +140,7 @@ The overlay can be opened programmatically or through user interaction (e.g., by
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-basic.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-basic.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -170,7 +170,7 @@ The overlay has a header and the log-in form. By default, the header contains pl
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-header.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-header.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -201,7 +201,7 @@ The overlay provides a custom form area for adding fields in addition to usernam
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-custom-form-area.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-custom-form-area.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -232,7 +232,7 @@ The footer area can be used for placing additional custom content, such as text,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-footer.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-footer.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -262,7 +262,7 @@ Login shows an error message when authentication fails. The error message includ
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-validation.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-validation.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -291,7 +291,7 @@ More information can be provided to the user, for example, by linking to a page 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/login/login-additional-information.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-additional-information.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -322,7 +322,7 @@ Login's titles, descriptions, labels, and messages are all customizable using in
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-internationalization.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-internationalization.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -24,7 +24,7 @@ Menu items can trigger an action, open a menu, or work as a toggle.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-basic.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-basic.ts[tags=snippet;snippethtml,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -56,7 +56,7 @@ The following variants are available to adjust the appearance of the component:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -104,7 +104,7 @@ Top-level items are aligned by default to the start of the Menu Bar. Use instead
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-right-aligned.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-right-aligned.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -135,7 +135,7 @@ The following example shows how to add a custom theme variant named `custom-them
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-custom-theme.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-custom-theme.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -172,7 +172,7 @@ Items that don't fit into the current width of the menu bar collapse automatical
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-overflow.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-overflow.ts[tags=snippet;snippethtml,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -212,7 +212,7 @@ Menu items can have icons in addition to text -- or instead of text.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-icons.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-icons.ts[tags=snippet;snippethtml,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -246,7 +246,7 @@ Icon-only menu buttons should be used primarily for common recurring actions wit
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-icon-only.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-icon-only.ts[tags=snippet;snippethtml,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -284,7 +284,7 @@ Menu items can be disabled to show that they are unavailable currently.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -314,7 +314,7 @@ Menu items in drop-down menus can be configured as checkable to toggle options o
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-checkable.ts[render,tags=snippet;snippethtml;snippetselected,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-checkable.ts[tags=snippet;snippethtml;snippetselected,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -350,7 +350,7 @@ You can use dividers to separate and group related content. However, use divider
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-dividers.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-dividers.ts[tags=snippet;snippethtml,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -386,7 +386,7 @@ A component can be configured to open drop-down menus on hover, instead of on cl
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-open-on-hover.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-open-on-hover.ts[tags=snippet;snippethtml,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -419,7 +419,7 @@ Tooltips can be configured on top-level items to provide additional information,
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-tooltip.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-tooltip.ts[tag=snippet,indent=0,group=TypeScript]
 
 ...
 
@@ -501,7 +501,7 @@ A Menu Bar with a single top-level item is essentially a drop-down button. This 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-drop-down.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-drop-down.ts[tags=snippet;snippethtml,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -529,7 +529,7 @@ So-called _combo buttons_ can be created in a similar way. For example, they can
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-combo-buttons.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-combo-buttons.ts[tags=snippet;snippethtml,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/message-input/index.asciidoc
+++ b/articles/components/message-input/index.asciidoc
@@ -22,7 +22,7 @@ Message Input allows users to author and send messages.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/messages/message-input-component.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/messages/message-input-component.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 ifdef::flow[]
@@ -52,7 +52,7 @@ Use the <<../message-list#,Message List>> component to show messages that users 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/messages/message-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/messages/message-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 ifdef::flow[]

--- a/articles/components/message-list/index.asciidoc
+++ b/articles/components/message-list/index.asciidoc
@@ -21,7 +21,7 @@ You can configure the text content, information about the sender, and the time o
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/messages/message-list-component.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/messages/message-list-component.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 ifdef::flow[]
@@ -57,7 +57,7 @@ include::{root}/frontend/themes/docs/message-list-theming.css[]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/messages/message-list-with-theme-component.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/messages/message-list-with-theme-component.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 ifdef::flow[]

--- a/articles/components/multi-select-combo-box/index.adoc
+++ b/articles/components/multi-select-combo-box/index.adoc
@@ -23,7 +23,7 @@ The component <<../combo-box#,supports the same features as the regular Combo Bo
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]
@@ -79,7 +79,7 @@ The component allows selecting multiple values, each of which is displayed as a 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]
@@ -124,7 +124,7 @@ Use the `selected-items-changed` event to react to the user changing the selecti
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]
@@ -167,7 +167,7 @@ The component can be set to read-only, which prevents the user from modifying it
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -198,7 +198,7 @@ The component can be configured to auto-expand in order to accommodate chips for
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -230,7 +230,7 @@ The component can be configured to group selected items at the top of the overla
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -289,7 +289,7 @@ The following example demonstrates how to localize the component's messages into
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/notification/index.asciidoc
+++ b/articles/components/notification/index.asciidoc
@@ -45,7 +45,7 @@ include::{articles}/components/_shared.asciidoc[tag=merge-examples]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-basic.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-basic.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -80,7 +80,7 @@ The `success` theme variant can be used to display success messages, such as whe
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-success.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-success.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -112,7 +112,7 @@ The `warning` theme variant can be used to display warnings.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-warning.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-warning.ts[frame,tags=snippet,indent=0,group=TypeScript]
 
 <!-- ... -->
 
@@ -148,7 +148,7 @@ The `error` theme variant can be used to display errors.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-error.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-error.ts[frame,tags=snippet,indent=0,group=TypeScript]
 
 <!-- ... -->
 
@@ -187,7 +187,7 @@ The `primary` theme variant can be used for important informational messages or 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-primary.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-primary.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -216,7 +216,7 @@ The contrast variant can improve legibility and distinguish the notification fro
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-contrast.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-contrast.ts[frame,tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -266,7 +266,7 @@ Use the `position` attribute in HTML templates (e.g., `<vaadin-notification posi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-position.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-position.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -329,7 +329,7 @@ For example, if an operation fails, the error notification could offer the user 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-retry.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-retry.ts[frame,tags=snippet,indent=0,group=TypeScript]
 
 <!-- ... -->
 
@@ -359,7 +359,7 @@ In situations where the user might want to revert an action, display an "Undo" b
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-undo.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-undo.ts[frame,tags=snippet,indent=0,group=TypeScript]
 
 <!-- ... -->
 
@@ -389,7 +389,7 @@ Notifications can also contain links to relevant information.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-link.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-link.ts[frame,tags=snippet,indent=0,group=TypeScript]
 
 <!-- ... -->
 
@@ -424,7 +424,7 @@ Make the notification persistent to prevent it from disappearing before the user
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-keyboard-a11y.ts[render,frame,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-keyboard-a11y.ts[frame,tags=*,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -466,7 +466,7 @@ include::{root}/frontend/demo/component/notification/notification-rich-preview.t
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-rich.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-rich.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -495,7 +495,7 @@ For simple, one-off notifications, it's convenient to use the static [methodname
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-static-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-static-helper.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -528,7 +528,7 @@ Less-urgent notifications can be provided through a link or a drop-down in the a
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-popup.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-popup.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/number-field/index.asciidoc
+++ b/articles/components/number-field/index.asciidoc
@@ -31,7 +31,7 @@ You can specify a unit as a prefix, or a suffix for the field.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ Step buttons allow the user to make small adjustments, quickly.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-step-buttons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-step-buttons.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -91,7 +91,7 @@ You can set the helper text to give information about the range.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-min-max.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-min-max.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -124,7 +124,7 @@ It also invalidates the field if the value entered doesn't align with the specif
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-step.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -155,7 +155,7 @@ To allow only integers to be entered, you can use the Integer Field like so:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-integer.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-integer.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -204,7 +204,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -233,7 +233,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -262,7 +262,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/password-field/index.asciidoc
+++ b/articles/components/password-field/index.asciidoc
@@ -22,7 +22,7 @@ The input is masked by default. On mobile devices, though, the last typed letter
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -50,7 +50,7 @@ The reveal button allows the user to disable masking and see the value they ente
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -79,7 +79,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -108,7 +108,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=constraint
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-constraints.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -137,7 +137,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -166,7 +166,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -195,7 +195,7 @@ Express clearly your password requirements to the user, so that they don't have 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-helper.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -221,7 +221,7 @@ Showing the strength of the entered password can also be a motivating factor for
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-advanced-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-advanced-helper.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/progress-bar/index.asciidoc
+++ b/articles/components/progress-bar/index.asciidoc
@@ -22,7 +22,7 @@ The progress can be determinate or indeterminate. Use Progress Bar to show an on
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -58,7 +58,7 @@ Use a determinate Progress Bar when progress can be computed.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-determinate.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-determinate.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ Use an indeterminate Progress Bar to show that progress is ongoing but can't be 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-indeterminate.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-indeterminate.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -115,7 +115,7 @@ These can be changed to any numeric values:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-custom-range.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-custom-range.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -143,7 +143,7 @@ Progress Bar comes with three theme variants: contrast, success, and error.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-theme-variants.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-theme-variants.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -195,7 +195,7 @@ Labels can also show the progress of a determinate progress bar in text in addit
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-label.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-label.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -228,7 +228,7 @@ If a process takes approximately 20 minutes, communicate that to the user.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-completion-time.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-completion-time.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/radio-button/index.asciidoc
+++ b/articles/components/radio-button/index.asciidoc
@@ -22,7 +22,7 @@ Radio Button Group allows users to select one value among multiple choices.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -54,7 +54,7 @@ Use read-only when content needs to be accessible but not editable. Read-only el
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-readonly.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-readonly.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -85,7 +85,7 @@ Disabling can be preferable to hiding an element to prevent changes in layout wh
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -115,7 +115,7 @@ The component's default orientation is horizontal. However, vertical orientation
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-vertical.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-vertical.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -142,7 +142,7 @@ In cases where vertical space needs to be conserved, horizontal orientation can 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-horizontal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-horizontal.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -175,7 +175,7 @@ Items can be customized to include more than a single line of text:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-presentation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-presentation.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -214,7 +214,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-group-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-group-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -243,7 +243,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-group-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-group-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -276,7 +276,7 @@ It's important to provide labels for Radio Button Groups to distinguish them fro
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-group-labels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-group-labels.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -306,7 +306,7 @@ To enable the user to enter a custom option instead of picking one from the list
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-custom-option.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-custom-option.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -340,7 +340,7 @@ In situations where the user isn't required to select a value, use a "blank" opt
 ifdef::lit[]
 [source,typescript,role=render-only]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-default-value.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-default-value.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -366,7 +366,7 @@ Two Radio Buttons can sometimes be a good alternative to a single Checkbox. If t
 ifdef::lit[]
 [source,typescript,role=render-only]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/rich-text-editor/index.asciidoc
+++ b/articles/components/rich-text-editor/index.asciidoc
@@ -26,7 +26,7 @@ It allows you to format and style your text using boldface, italics, headings, l
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -166,7 +166,7 @@ To prevent injecting malicious content, be sure to sanitize HTML strings before 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=htmlsnippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[tags=htmlsnippet,indent=0,group=TypeScript]
 
 ...
 
@@ -200,7 +200,7 @@ Setting the component to read-only hides the toolbar and makes the content non-e
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -234,7 +234,7 @@ The automatic resizing can be restricted to a minimum and maximum height.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -266,7 +266,7 @@ Apply the `compact` theme to make the toolbar more compact.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -296,7 +296,7 @@ Apply the `no-border` theme variant to remove Rich Text Editor’s border. An ex
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/scroller/index.asciidoc
+++ b/articles/components/scroller/index.asciidoc
@@ -21,7 +21,7 @@ Scroller is a component container for creating scrollable areas in the UI.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/scroller/scroller-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/scroller/scroller-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -74,7 +74,7 @@ It can also be used to conserve vertical space, for example in situations where 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/scroller/scroller-mobile.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/scroller/scroller-mobile.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -106,7 +106,7 @@ It can also be used as a fallback for a responsive layout that can't be guarante
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/scroller/scroller-both.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/scroller/scroller-both.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/select/index.asciidoc
+++ b/articles/components/select/index.asciidoc
@@ -21,7 +21,7 @@ Select allows users to choose a single value from a list of options presented in
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -54,7 +54,7 @@ Dividers can be used to group related options. Use dividers sparingly to avoid c
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-dividers.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-dividers.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ Items can be disabled. This prevents users from selecting them, while still show
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -119,7 +119,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -148,7 +148,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -177,7 +177,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -206,7 +206,7 @@ Use the placeholder feature to provide an inline text prompt for the field. Don'
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-placeholder.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-placeholder.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -277,7 +277,7 @@ When using complex values, a label can be set to represent the item value as pla
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/select/select-complex-value-label.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-complex-value-label.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 [source,typescript]
 ----
@@ -312,7 +312,7 @@ When using custom item renderers with rich content, a label can be set to repres
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/select/select-custom-renderer-label.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-custom-renderer-label.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 [source,typescript]
 ----
@@ -374,7 +374,7 @@ Items can be rendered with rich content instead of plain text. This can be usefu
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-presentation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-presentation.ts[tags=snippet,indent=0,group=TypeScript]
 
 ...
 

--- a/articles/components/side-nav/index.asciidoc
+++ b/articles/components/side-nav/index.asciidoc
@@ -27,7 +27,7 @@ For technical reasons, actual navigation is disabled in the examples on this pag
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ Interactive prefix and suffix elements aren't recommended since the entire item 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-suffix.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-suffix.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -91,7 +91,7 @@ Parent items can be links. Clicking them expands their sub-items in addition to 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-hierarchy.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-hierarchy.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -120,7 +120,7 @@ A label can be applied to the top of the navigation list. This can be useful for
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-labelled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-labelled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -175,7 +175,7 @@ Individual navigation items can be styled by applying a CSS class name to them.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-styling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-styling.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/split-layout/index.asciidoc
+++ b/articles/components/split-layout/index.asciidoc
@@ -21,7 +21,7 @@ Split Layout is a component with two content areas and a draggable split handle 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -54,7 +54,7 @@ The user can also be allowed to choose which orientation they want to use.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-orientation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-orientation.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -89,7 +89,7 @@ When using a percentage value, ensure that ancestors have an explicit height as 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -116,7 +116,7 @@ The splitter respects the minimum and maximum size of the content area component
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-min-max-size.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-min-max-size.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -144,7 +144,7 @@ This is useful when the user wants to toggle between certain positions.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-toggle.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-toggle.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -177,7 +177,7 @@ Split Layout has two theme variants: `small` and `minimal`.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-theme-small.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-theme-small.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -206,7 +206,7 @@ Both variants only show the split handle on hover and aren't ideal for touch dev
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/tabs/index.asciidoc
+++ b/articles/components/tabs/index.asciidoc
@@ -25,7 +25,7 @@ Below is a simple example of tabs with labels:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -57,7 +57,7 @@ Tabs are most conveniently used as part of a Tab Sheet that includes automatical
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabsheet-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabsheet-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ A Tab can be selected, unselected, or disabled.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-states.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-states.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -147,7 +147,7 @@ Horizontal tabs may be easier for users to understand and associate with the con
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-horizontal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-horizontal.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -174,7 +174,7 @@ In horizontal orientation, scroll buttons are displayed by default to aid scroll
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-hide-scroll-buttons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-hide-scroll-buttons.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -215,7 +215,7 @@ pass:[<!-- vale Vaadin.Wordiness = YES -->]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-vertical.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-vertical.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -249,7 +249,7 @@ Icons can be used to make tabs more prominent and easier to identify. They can b
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-icons-horizontal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-icons-horizontal.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -276,7 +276,7 @@ Vertical tabs work best with icons next to labels, as you can see here.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-icons-vertical.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-icons-vertical.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -308,7 +308,7 @@ Tabs can contain almost any UI elements. For instance, they can contain badges i
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-badges.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-badges.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -342,7 +342,7 @@ By default, tabs are left-aligned. They can be centered using the `centered` the
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-theme-centered.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-theme-centered.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -374,7 +374,7 @@ Apply the `equal-width-tabs` theme variant to make each tab share equally the av
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-theme-equal-width.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-theme-equal-width.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -406,7 +406,7 @@ The `minimal` theme variant reduces visual styles to a minimum.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-theme-minimal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-theme-minimal.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -438,7 +438,7 @@ The `small` theme variant can be used to make the Tabs smaller. This can be good
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-theme-small.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-theme-small.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -468,7 +468,7 @@ The `bordered` theme variant adds a border around the Tab Sheet component.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabsheet-theme-bordered.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabsheet-theme-bordered.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -499,7 +499,7 @@ Custom content can be placed before or after the tabs in a Tab Sheet by placing 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -528,7 +528,7 @@ Tab focus is rendered differently when focused by the keyboard. Once a tab is fo
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-focus-ring.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-focus-ring.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -556,7 +556,7 @@ Try clicking on each tab here. Notice how the text content changes depending on 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-content.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -585,7 +585,7 @@ Sometimes it can be desirable to initialize the contents for a tab, lazily. That
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/text-area/index.asciidoc
+++ b/articles/components/text-area/index.asciidoc
@@ -21,7 +21,7 @@ Text Area is an input field component that allows entry of multiple lines of tex
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -52,7 +52,7 @@ Unless set to a fixed height, Text Area adjusts its height automatically based o
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-auto-height.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-auto-height.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -81,7 +81,7 @@ The automatic resizing can be restricted to a minimum and maximum height like so
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-height.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-height.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -110,7 +110,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -139,7 +139,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=constraint
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-constraints.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -168,7 +168,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -197,7 +197,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -226,7 +226,7 @@ Longer free-form inputs are often capped at a certain character limit. The curre
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-helper.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/text-field/index.asciidoc
+++ b/articles/components/text-field/index.asciidoc
@@ -22,7 +22,7 @@ Prefix and suffix components, such as icons, are also supported.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -51,7 +51,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -80,7 +80,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=constraint
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-constraints.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -109,7 +109,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -138,7 +138,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/time-picker/index.asciidoc
+++ b/articles/components/time-picker/index.asciidoc
@@ -23,7 +23,7 @@ Time Picker is an input field for used entering or selecting a specific time.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -56,7 +56,7 @@ The default step is one hour (i.e., `3600` seconds). Unlike <<../number-field#,N
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-minutes-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-minutes-step.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ The displayed time format changes based on the step.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-seconds-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-seconds-step.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -135,7 +135,7 @@ The overlay opens automatically when the field is focused using a pointer (i.e.,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-auto-open.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-auto-open.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -167,7 +167,7 @@ You can define a minimum and maximum value for Time Picker if you need to restri
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-min-max.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-min-max.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -196,7 +196,7 @@ If the minimum and maximum values aren't sufficient for validation, you can also
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-custom-validation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-custom-validation.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -226,7 +226,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-basic-features.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -255,7 +255,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-readonly-and-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -284,7 +284,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-styles.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/tooltip/index.asciidoc
+++ b/articles/components/tooltip/index.asciidoc
@@ -21,7 +21,7 @@ A tooltip for an element becomes visible when the user hovers the mouse pointer 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tooltip/tooltip-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tooltip/tooltip-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -53,7 +53,7 @@ Tooltips can be displayed for UI elements that lack a dedicated tooltip API. Pro
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tooltip/tooltip-html-element.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tooltip/tooltip-html-element.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -85,7 +85,7 @@ The default positioning of the tooltip in relation to the target element can be 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tooltip/tooltip-positioning.ts[render,frame,tags=snippet,group=TypeScript]
+include::{root}/frontend/demo/component/tooltip/tooltip-positioning.ts[frame,tags=snippet,group=TypeScript]
 ----
 endif::[]
 
@@ -183,7 +183,7 @@ Tooltips can be configured not to appear automatically on hover or keyboard focu
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tooltip/tooltip-manual.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tooltip/tooltip-manual.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/tree-grid/index.asciidoc
+++ b/articles/components/tree-grid/index.asciidoc
@@ -21,7 +21,7 @@ Tree Grid is a component for displaying hierarchical tabular data grouped into e
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tree-grid/tree-grid-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tree-grid/tree-grid-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ The tree column is a column that contains the toggles for expanding and collapsi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tree-grid/tree-grid-column.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tree-grid/tree-grid-column.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -95,7 +95,7 @@ Like Grid, Tree Grid supports rich content.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tree-grid/tree-grid-rich-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tree-grid/tree-grid-rich-content.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/upload/index.asciidoc
+++ b/articles/components/upload/index.asciidoc
@@ -21,7 +21,7 @@ It shows the upload progress and the status of each file. Files can be uploaded 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -127,7 +127,7 @@ Upload allows the user to drag files onto the component to upload them. Multiple
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-drag-and-drop.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-drag-and-drop.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -156,7 +156,7 @@ By default, files are uploaded immediately, or at least they're added to the que
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-auto-upload-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-auto-upload-disabled.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -187,7 +187,7 @@ Uploads can be initiated programmatically when auto-upload is disabled. You migh
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-all-files.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-all-files.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -231,7 +231,7 @@ Upload can be configured to accept only files of specific formats. The acceptabl
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-file-format.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-file-format.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -279,7 +279,7 @@ When using a [classname]`Receiver` that doesn't implement the [interfacename]`Mu
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-file-count.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-file-count.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -313,7 +313,7 @@ Upload allows you to limit the file size by setting a maximum amount in bytes. B
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-file-size.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-file-size.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -423,7 +423,7 @@ All labels and messages in Upload are configurable. For a complete list of them,
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-internationalization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-internationalization.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -457,7 +457,7 @@ You can replace the default upload button. For example, if Upload needs a strong
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-button-theme-variant.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-button-theme-variant.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -489,7 +489,7 @@ You can also customize the drop label, as well as the icon.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-drop-label.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-drop-label.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -558,7 +558,7 @@ Choose labels that are informative and instructive. For example, if the user is 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-labelling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-labelling.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -589,7 +589,7 @@ Likewise, if the user is expected to upload a spreadsheet, but multiple file for
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-helper.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -625,7 +625,7 @@ A "Server Unavailable" message might suffice for tech-savvy users, but for some 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-error-messages.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-error-messages.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/vertical-layout/index.asciidoc
+++ b/articles/components/vertical-layout/index.asciidoc
@@ -22,7 +22,7 @@ See <<../horizontal-layout#, Horizontal Layout>> for information on placing comp
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -55,7 +55,7 @@ You can position components at the top, middle, or bottom. You can also position
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -109,7 +109,7 @@ Components in a Vertical Layout are left-aligned by default, but can be centered
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -154,7 +154,7 @@ It's also possible to align horizontally individual components by overriding the
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -185,7 +185,7 @@ Spacing is used to create space between components in the same layout. Spacing c
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -212,7 +212,7 @@ Five different spacing theme variants are available:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -295,7 +295,7 @@ Padding can help distinguish the content in a layout from its surrounding. Paddi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-padding.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-padding.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 
@@ -325,7 +325,7 @@ Margin is the space around a layout. This is different from Padding, which is ex
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-margin.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-margin.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 endif::[]
 

--- a/articles/components/virtual-list/index.asciidoc
+++ b/articles/components/virtual-list/index.asciidoc
@@ -22,7 +22,7 @@ To use this component, you need to assign it a set of data items and a _renderer
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/virtuallist/virtual-list-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/virtuallist/virtual-list-basic.ts[tags=snippet,indent=0,group=TypeScript]
 ----
 
 [source,typescript]

--- a/frontend/demo/component/accordion/accordion-summary.ts
+++ b/frontend/demo/component/accordion/accordion-summary.ts
@@ -27,14 +27,14 @@ const responsiveSteps: FormLayoutResponsiveStep[] = [
 @customElement('accordion-summary')
 export class Example extends LitElement {
   @state()
-  private accessor countries: Country[] = [];
+  private countries: Country[] = [];
 
   private readonly personBinder = new Binder(this, PersonModel);
 
   private readonly cardBinder = new Binder(this, CardModel);
 
   @state()
-  private accessor openedPanelIndex: number | null = 0;
+  private openedPanelIndex: number | null = 0;
 
   protected override async firstUpdated() {
     this.countries = await getCountries();

--- a/frontend/demo/component/app-layout/app-layout-height-auto.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-auto.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 20 });

--- a/frontend/demo/component/app-layout/app-layout-height-full.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-full.ts
@@ -28,7 +28,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/avatar/avatar-basic.ts
+++ b/frontend/demo/component/avatar/avatar-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/avatar/avatar-group-basic.ts
+++ b/frontend/demo/component/avatar/avatar-group-basic.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 3 });

--- a/frontend/demo/component/avatar/avatar-group-bg-color.ts
+++ b/frontend/demo/component/avatar/avatar-group-bg-color.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 6 });

--- a/frontend/demo/component/avatar/avatar-group-internationalisation.ts
+++ b/frontend/demo/component/avatar/avatar-group-internationalisation.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 2 });

--- a/frontend/demo/component/avatar/avatar-group-max-items.ts
+++ b/frontend/demo/component/avatar/avatar-group-max-items.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 6 });

--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/avatar/avatar-menu-bar.ts
+++ b/frontend/demo/component/avatar/avatar-menu-bar.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor menuBarItems: MenuBarItem[] = [];
+  private menuBarItems: MenuBarItem[] = [];
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   // tag::snippet[]
   protected override async firstUpdated() {

--- a/frontend/demo/component/avatar/avatar-name.ts
+++ b/frontend/demo/component/avatar/avatar-name.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/badge/badge-highlight.ts
+++ b/frontend/demo/component/badge/badge-highlight.ts
@@ -18,7 +18,7 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 @customElement('badge-highlight')
 export class Example extends LitElement {
   @state()
-  private accessor items: readonly Report[] = [];
+  private items: readonly Report[] = [];
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -13,7 +13,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('badge-icons-only-table')
 export class Example extends LitElement {
   @state()
-  private accessor items: readonly UserPermissions[] = [];
+  private items: readonly UserPermissions[] = [];
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/badge/badge-interactive.ts
+++ b/frontend/demo/component/badge/badge-interactive.ts
@@ -19,10 +19,10 @@ type Profession = string;
 @customElement('badge-interactive')
 export class Example extends LitElement {
   @state()
-  private accessor items: readonly Profession[] = [];
+  private items: readonly Profession[] = [];
 
   @state()
-  private accessor selectedProfessions: readonly Profession[] = [];
+  private selectedProfessions: readonly Profession[] = [];
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor size = '0';
+  private size = '0';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'margin';
+  private theme = 'margin';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'padding';
+  private theme = 'padding';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor themeVariant = 'spacing-xl';
+  private themeVariant = 'spacing-xl';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'spacing';
+  private theme = 'spacing';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'margin';
+  private theme = 'margin';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'padding';
+  private theme = 'padding';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor themeVariant = 'spacing-xl';
+  private themeVariant = 'spacing-xl';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'spacing';
+  private theme = 'spacing';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/board/example-chart.ts
+++ b/frontend/demo/component/board/example-chart.ts
@@ -36,7 +36,7 @@ export class Example extends LitElement {
   `;
 
   @state()
-  private accessor events: ViewEvent[] = [];
+  private events: ViewEvent[] = [];
 
   protected override async firstUpdated() {
     this.events = await getViewEvents();

--- a/frontend/demo/component/board/example-indicator.ts
+++ b/frontend/demo/component/board/example-indicator.ts
@@ -50,13 +50,13 @@ export class ExampleIndicator extends LitElement {
   `;
 
   @property()
-  accessor title = 'Unknown';
+  title = 'Unknown';
 
   @property()
-  accessor current = '0';
+  current = '0';
 
   @property({ type: Number })
-  accessor change = 0;
+  change = 0;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/board/example-statistics.ts
+++ b/frontend/demo/component/board/example-statistics.ts
@@ -78,7 +78,7 @@ export class ExampleStatistics extends LitElement {
   `;
 
   @state()
-  private accessor serviceHealth: ServiceHealth[] = [];
+  private serviceHealth: ServiceHealth[] = [];
 
   protected override async firstUpdated() {
     this.serviceHealth = await getServiceHealth();

--- a/frontend/demo/component/button/button-basic.ts
+++ b/frontend/demo/component/button/button-basic.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor counter = 0;
+  private counter = 0;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/button/button-disable-long-action.ts
+++ b/frontend/demo/component/button/button-disable-long-action.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor isDisabled = false;
+  private isDisabled = false;
 
   @query('fake-progress-bar')
-  private accessor fakeProgressBar!: FakeProgressBar;
+  private fakeProgressBar!: FakeProgressBar;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/button/button-grid.ts
+++ b/frontend/demo/component/button/button-grid.ts
@@ -23,10 +23,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor selectedItems: Person[] = [];
+  private selectedItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/button/button-labels.ts
+++ b/frontend/demo/component/button/button-labels.ts
@@ -25,10 +25,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor primaryEmail = 'foo@example.com';
+  private primaryEmail = 'foo@example.com';
 
   @state()
-  private accessor secondaryEmail = 'bar@example.com';
+  private secondaryEmail = 'bar@example.com';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/button/fake-progress-bar.ts
+++ b/frontend/demo/component/button/fake-progress-bar.ts
@@ -11,7 +11,7 @@ export class FakeProgressBar extends LitElement {
   `;
 
   @property({ type: Number })
-  accessor progress = 0;
+  progress = 0;
 
   simulateProgress() {
     this.progress = 0;

--- a/frontend/demo/component/charts/charts-overview.ts
+++ b/frontend/demo/component/charts/charts-overview.ts
@@ -44,7 +44,7 @@ export class Example extends LitElement {
   `;
 
   @state()
-  private accessor areaOptions: Options = {
+  private areaOptions: Options = {
     yAxis: { title: { text: '' } },
     xAxis: { visible: false },
     plotOptions: {
@@ -57,10 +57,10 @@ export class Example extends LitElement {
   };
 
   @state()
-  private accessor columnOptions: Options = { yAxis: { title: { text: '' } } };
+  private columnOptions: Options = { yAxis: { title: { text: '' } } };
 
   @state()
-  private accessor months = [
+  private months = [
     'Jan',
     'Feb',
     'Mar',
@@ -76,7 +76,7 @@ export class Example extends LitElement {
   ];
 
   @state()
-  private accessor pieOptions: Options = {
+  private pieOptions: Options = {
     tooltip: {
       pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>',
     },
@@ -90,7 +90,7 @@ export class Example extends LitElement {
   };
 
   @state()
-  private accessor pieValues: PointOptionsObject[] = [
+  private pieValues: PointOptionsObject[] = [
     { name: 'Chrome', y: 38 },
     { name: 'Firefox', y: 24 },
     { name: 'Edge', y: 15, sliced: true, selected: true },
@@ -98,7 +98,7 @@ export class Example extends LitElement {
   ];
 
   @state()
-  private accessor polarOptions: Options = {
+  private polarOptions: Options = {
     xAxis: {
       tickInterval: 45,
       min: 0,

--- a/frontend/demo/component/checkbox/checkbox-group-basic.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor value = ['0', '2'];
+  private value = ['0', '2'];
 
   protected override render() {
     return html`

--- a/frontend/demo/component/checkbox/checkbox-indeterminate.ts
+++ b/frontend/demo/component/checkbox/checkbox-indeterminate.ts
@@ -20,10 +20,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor selectedIds: string[] = [];
+  private selectedIds: string[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 3 });

--- a/frontend/demo/component/combobox/combo-box-auto-open.ts
+++ b/frontend/demo/component/combobox/combo-box-auto-open.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/combobox/combo-box-basic.ts
+++ b/frontend/demo/component/combobox/combo-box-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
+  private items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
 
   protected override render() {
     return html`

--- a/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
+  private items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
 
   protected override render() {
     return html`

--- a/frontend/demo/component/combobox/combo-box-filtering-1.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-1.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/combobox/combo-box-filtering-2.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-2.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor allItems: Country[] = [];
+  private allItems: Country[] = [];
 
   @state()
-  private accessor filteredItems: Country[] = [];
+  private filteredItems: Country[] = [];
 
   protected override async firstUpdated() {
     const countries = await getCountries();

--- a/frontend/demo/component/combobox/combo-box-popup-width.ts
+++ b/frontend/demo/component/combobox/combo-box-popup-width.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -20,10 +20,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor allItems: Person[] = [];
+  private allItems: Person[] = [];
 
   @state()
-  private accessor filteredItems: Person[] = [];
+  private filteredItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
@@ -32,10 +32,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = true;
+  private dialogOpened = true;
 
   @state()
-  private accessor status = '';
+  private status = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor status = '';
+  private status = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor status = '';
+  private status = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor status = '';
+  private status = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/contextmenu/context-menu-basic.ts
+++ b/frontend/demo/component/contextmenu/context-menu-basic.ts
@@ -19,11 +19,11 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
+  private items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
   // end::snippet[]
 
   @state()
-  private accessor gridItems: Person[] = [];
+  private gridItems: Person[] = [];
 
   protected override async firstUpdated() {
     this.gridItems = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/contextmenu/context-menu-best-practices.ts
+++ b/frontend/demo/component/contextmenu/context-menu-best-practices.ts
@@ -24,11 +24,11 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
+  private items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
   // end::snippet[]
 
   @state()
-  private accessor gridItems: FileItem[] = [
+  private gridItems: FileItem[] = [
     { name: 'Annual Report.docx', size: '24 MB' },
     { name: 'Financials.xlsx', size: '42 MB' },
   ];

--- a/frontend/demo/component/contextmenu/context-menu-checkable.ts
+++ b/frontend/demo/component/contextmenu/context-menu-checkable.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: ContextMenuItem[] = [
+  private items: ContextMenuItem[] = [
     { text: 'Abigail Lewis', checked: true },
     { text: 'Allison Torres' },
     { text: 'Anna Myers' },

--- a/frontend/demo/component/contextmenu/context-menu-disabled.ts
+++ b/frontend/demo/component/contextmenu/context-menu-disabled.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'Preview' },
     { text: 'Edit' },
     { component: 'hr' },
@@ -41,7 +41,7 @@ export class Example extends LitElement {
   // end::snippet[]
 
   @state()
-  private accessor gridItems: FileItem[] = [
+  private gridItems: FileItem[] = [
     { name: 'Annual Report.pdf', size: '24 MB' },
     { name: 'Financials.pdf', size: '42 MB' },
   ];

--- a/frontend/demo/component/contextmenu/context-menu-dividers.ts
+++ b/frontend/demo/component/contextmenu/context-menu-dividers.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor gridItems: Person[] = [];
+  private gridItems: Person[] = [];
 
   protected override async firstUpdated() {
     this.gridItems = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
+++ b/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'Preview' },
     { text: 'Edit' },
     { component: 'hr' },
@@ -41,7 +41,7 @@ export class Example extends LitElement {
   // end::snippet[]
 
   @state()
-  private accessor gridItems: FileItem[] = [
+  private gridItems: FileItem[] = [
     { name: 'Annual Report.docx', size: '24 MB' },
     { name: 'Financials.xlsx', size: '42 MB' },
   ];

--- a/frontend/demo/component/contextmenu/context-menu-left-click.ts
+++ b/frontend/demo/component/contextmenu/context-menu-left-click.ts
@@ -20,11 +20,11 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
+  private items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
   // end::snippet[]
 
   @state()
-  private accessor gridItems: Person[] = [];
+  private gridItems: Person[] = [];
 
   private contextMenuOpened?: boolean;
 

--- a/frontend/demo/component/contextmenu/context-menu-presentation.ts
+++ b/frontend/demo/component/contextmenu/context-menu-presentation.ts
@@ -25,10 +25,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor gridItems: Person[] = [];
+  private gridItems: Person[] = [];
 
   @state()
-  private accessor items: ContextMenuItem[] | undefined;
+  private items: ContextMenuItem[] | undefined;
 
   // tag::snippet[]
   protected override async firstUpdated() {

--- a/frontend/demo/component/crud/crud-basic.ts
+++ b/frontend/demo/component/crud/crud-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-columns.ts
+++ b/frontend/demo/component/crud/crud-columns.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-editor-aside.ts
+++ b/frontend/demo/component/crud/crud-editor-aside.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-editor-bottom.ts
+++ b/frontend/demo/component/crud/crud-editor-bottom.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-editor-content.ts
+++ b/frontend/demo/component/crud/crud-editor-content.ts
@@ -21,13 +21,13 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor professions: string[] = [];
+  private professions: string[] = [];
 
   @state()
-  private accessor responsiveSteps: FormLayoutResponsiveStep[] = [];
+  private responsiveSteps: FormLayoutResponsiveStep[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-grid-replacement.ts
+++ b/frontend/demo/component/crud/crud-grid-replacement.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-hidden-toolbar.ts
+++ b/frontend/demo/component/crud/crud-hidden-toolbar.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-item-initialization.ts
+++ b/frontend/demo/component/crud/crud-item-initialization.ts
@@ -18,10 +18,10 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-crud')
-  private accessor crud!: Crud<Partial<Person>>;
+  private crud!: Crud<Partial<Person>>;
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-localization.ts
+++ b/frontend/demo/component/crud/crud-localization.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @query('vaadin-crud')
-  private accessor crud!: Crud<Person>;
+  private crud!: Crud<Person>;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-open-editor.ts
+++ b/frontend/demo/component/crud/crud-open-editor.ts
@@ -18,10 +18,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor editedItem: Person | undefined;
+  private editedItem: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-sorting-filtering.ts
+++ b/frontend/demo/component/crud/crud-sorting-filtering.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-toolbar.ts
+++ b/frontend/demo/component/crud/crud-toolbar.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/custom-field/custom-field-basic.ts
+++ b/frontend/demo/component/custom-field/custom-field-basic.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @query('#start')
-  private accessor start!: DatePicker;
+  private start!: DatePicker;
 
   @query('#end')
-  private accessor end!: DatePicker;
+  private end!: DatePicker;
 
   private binder = new Binder(this, AppointmentModel);
 

--- a/frontend/demo/component/custom-field/custom-field-native-input.ts
+++ b/frontend/demo/component/custom-field/custom-field-native-input.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor customFieldValue = '';
+  private customFieldValue = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -19,13 +19,13 @@ export class Example extends LitElement {
   }
 
   @query('#amount')
-  private accessor amount!: TextField;
+  private amount!: TextField;
 
   @query('#currency')
-  private accessor currency!: Select;
+  private currency!: Select;
 
   @state()
-  private accessor currencies = [
+  private currencies = [
     { label: 'AUD', value: 'aud' },
     { label: 'CAD', value: 'cad' },
     { label: 'CHF', value: 'chf' },

--- a/frontend/demo/component/datepicker/date-picker-custom-functions.ts
+++ b/frontend/demo/component/datepicker/date-picker-custom-functions.ts
@@ -18,10 +18,10 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-date-picker')
-  private accessor datePicker!: DatePicker;
+  private datePicker!: DatePicker;
 
   @state()
-  private accessor selectedDateValue: string = dateFnsFormat(new Date(), 'yyyy-MM-dd');
+  private selectedDateValue: string = dateFnsFormat(new Date(), 'yyyy-MM-dd');
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/datepicker/date-picker-date-range.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-range.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor departureDate = '';
+  private departureDate = '';
 
   @state()
-  private accessor returnDate = '';
+  private returnDate = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
+++ b/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
@@ -36,16 +36,16 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  accessor selectedYear: number | undefined;
+  selectedYear: number | undefined;
 
   @state()
-  accessor selectedMonth: string | undefined;
+  selectedMonth: string | undefined;
 
   @state()
-  accessor selectedDay: number | undefined;
+  selectedDay: number | undefined;
 
   @state()
-  accessor selectableDays: number[] = [];
+  selectableDays: number[] = [];
 
   private handleYearChange(e: ComboBoxSelectedItemChangedEvent<number>) {
     this.selectedYear = e.detail.value!;

--- a/frontend/demo/component/datepicker/date-picker-internationalization.ts
+++ b/frontend/demo/component/datepicker/date-picker-internationalization.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-date-picker')
-  private accessor datePicker!: DatePicker;
+  private datePicker!: DatePicker;
 
   protected override firstUpdated() {
     this.datePicker.i18n = {

--- a/frontend/demo/component/datepicker/date-picker-min-max.ts
+++ b/frontend/demo/component/datepicker/date-picker-min-max.ts
@@ -18,13 +18,13 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor errorMessage = '';
+  private errorMessage = '';
 
   @state()
-  private accessor minDate = new Date();
+  private minDate = new Date();
 
   @state()
-  private accessor maxDate = addDays(new Date(), 60);
+  private maxDate = addDays(new Date(), 60);
 
   protected override render() {
     return html`

--- a/frontend/demo/component/datepicker/date-picker-week-numbers.ts
+++ b/frontend/demo/component/datepicker/date-picker-week-numbers.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-date-picker')
-  private accessor datePicker!: DatePicker;
+  private datePicker!: DatePicker;
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-date-time-picker')
-  private accessor dateTimePicker!: DateTimePicker;
+  private dateTimePicker!: DateTimePicker;
 
   protected override firstUpdated() {
     const _formatDate = (dateParts: DatePickerDate): string => {

--- a/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-date-time-picker')
-  private accessor dateTimePicker!: DateTimePicker;
+  private dateTimePicker!: DateTimePicker;
 
   protected override firstUpdated() {
     this.dateTimePicker.i18n = {

--- a/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts
@@ -12,16 +12,16 @@ const dateTimeFormat = `yyyy-MM-dd'T'HH:00:00`;
 @customElement('date-time-picker-min-max')
 export class Example extends LitElement {
   @state()
-  private accessor errorMessage = '';
+  private errorMessage = '';
 
   @state()
-  private accessor initialValue = addDays(new Date(), 7);
+  private initialValue = addDays(new Date(), 7);
 
   @state()
-  private accessor minDate = new Date();
+  private minDate = new Date();
 
   @state()
-  private accessor maxDate = addDays(new Date(), 60);
+  private maxDate = addDays(new Date(), 60);
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/datetimepicker/date-time-picker-range.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-range.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor startDateTime = initialStartValue;
+  private startDateTime = initialStartValue;
 
   @state()
-  private accessor endDateTime = initialEndValue;
+  private endDateTime = initialEndValue;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-date-time-picker')
-  private accessor dateTimePicker!: DateTimePicker;
+  private dateTimePicker!: DateTimePicker;
 
   protected override firstUpdated() {
     this.dateTimePicker.i18n = {

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -27,10 +27,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   @state()
-  private accessor responsiveSteps: FormLayoutResponsiveStep[] = [
+  private responsiveSteps: FormLayoutResponsiveStep[] = [
     { minWidth: 0, columns: 1 },
     { minWidth: '20em', columns: 2 },
   ];

--- a/frontend/demo/component/dialog/dialog-basic.ts
+++ b/frontend/demo/component/dialog/dialog-basic.ts
@@ -35,7 +35,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = true;
+  private dialogOpened = true;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/dialog/dialog-closing.ts
+++ b/frontend/demo/component/dialog/dialog-closing.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/dialog/dialog-draggable.ts
+++ b/frontend/demo/component/dialog/dialog-draggable.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/dialog/dialog-footer.ts
+++ b/frontend/demo/component/dialog/dialog-footer.ts
@@ -21,10 +21,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor user: Person | undefined;
+  private user: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/dialog/dialog-header.ts
+++ b/frontend/demo/component/dialog/dialog-header.ts
@@ -27,10 +27,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor user: Person | undefined;
+  private user: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/dialog/dialog-no-padding.ts
+++ b/frontend/demo/component/dialog/dialog-no-padding.ts
@@ -25,10 +25,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor people: Person[] | undefined;
+  private people: Person[] | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 50 });

--- a/frontend/demo/component/dialog/dialog-resizable.ts
+++ b/frontend/demo/component/dialog/dialog-resizable.ts
@@ -24,10 +24,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor people: Person[] | undefined;
+  private people: Person[] | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 50 });

--- a/frontend/demo/component/formlayout/form-layout-custom-field.ts
+++ b/frontend/demo/component/formlayout/form-layout-custom-field.ts
@@ -22,16 +22,16 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('#month-field')
-  private accessor monthField!: Select;
+  private monthField!: Select;
 
   @query('#year-field')
-  private accessor yearField!: Select;
+  private yearField!: Select;
 
   @state()
-  private accessor months = Array.from({ length: 12 }, (_, i) => `${i + 1}`.padStart(2, '0'));
+  private months = Array.from({ length: 12 }, (_, i) => `${i + 1}`.padStart(2, '0'));
 
   @state()
-  private accessor years = Array.from({ length: 11 }, (_, i) => `${i + new Date().getFullYear()}`);
+  private years = Array.from({ length: 11 }, (_, i) => `${i + new Date().getFullYear()}`);
 
   protected override firstUpdated() {
     // Set title for screen readers

--- a/frontend/demo/component/grid/grid-basic.ts
+++ b/frontend/demo/component/grid/grid-basic.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -25,13 +25,13 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-grid')
-  private accessor grid!: Grid<Person>;
+  private grid!: Grid<Person>;
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor eventSummary = '';
+  private eventSummary = '';
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-alignment.ts
+++ b/frontend/demo/component/grid/grid-column-alignment.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-borders.ts
+++ b/frontend/demo/component/grid/grid-column-borders.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-filtering.ts
+++ b/frontend/demo/component/grid/grid-column-filtering.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: PersonEnhanced[] = [];
+  private items: PersonEnhanced[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-freezing.ts
+++ b/frontend/demo/component/grid/grid-column-freezing.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] | undefined;
+  private items: Person[] | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-grouping.ts
+++ b/frontend/demo/component/grid/grid-column-grouping.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-header-footer.ts
+++ b/frontend/demo/component/grid/grid-column-header-footer.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-reordering-resizing.ts
+++ b/frontend/demo/component/grid/grid-column-reordering-resizing.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-visibility.ts
+++ b/frontend/demo/component/grid/grid-column-visibility.ts
@@ -22,10 +22,10 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor contextMenuItems: Array<ContextMenuItem & { key: string }> = [
+  private contextMenuItems: Array<ContextMenuItem & { key: string }> = [
     { text: 'First name', checked: true, key: 'firstName', keepOpen: true },
     { text: 'Last name', checked: true, key: 'lastName', keepOpen: true },
     { text: 'Email', checked: true, key: 'email', keepOpen: true },

--- a/frontend/demo/component/grid/grid-column-width.ts
+++ b/frontend/demo/component/grid/grid-column-width.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-compact.ts
+++ b/frontend/demo/component/grid/grid-compact.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-content.ts
+++ b/frontend/demo/component/grid/grid-content.ts
@@ -25,7 +25,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] | undefined;
+  private items: Person[] | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-context-menu.ts
+++ b/frontend/demo/component/grid/grid-context-menu.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-data-provider.ts
+++ b/frontend/demo/component/grid/grid-data-provider.ts
@@ -76,10 +76,10 @@ export class Example extends LitElement {
 
   // tag::snippet2[]
   @state()
-  private accessor searchTerm = '';
+  private searchTerm = '';
 
   @query('#grid')
-  private accessor grid!: Grid;
+  private grid!: Grid;
 
   private dataProvider = async (
     params: GridDataProviderParams<Person>,

--- a/frontend/demo/component/grid/grid-drag-drop-filters.ts
+++ b/frontend/demo/component/grid/grid-drag-drop-filters.ts
@@ -28,19 +28,19 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-grid')
-  private accessor grid!: Grid<Person>;
+  private grid!: Grid<Person>;
 
   @state()
-  private accessor draggedItem: Person | undefined;
+  private draggedItem: Person | undefined;
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor managers: Person[] = [];
+  private managers: Person[] = [];
 
   @state()
-  private accessor expandedItems: Person[] = [];
+  private expandedItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -36,13 +36,13 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor draggedItem: Person | undefined;
+  private draggedItem: Person | undefined;
 
   @state()
-  private accessor grid1Items: Person[] = [];
+  private grid1Items: Person[] = [];
 
   @state()
-  private accessor grid2Items: Person[] = [];
+  private grid2Items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 10 });

--- a/frontend/demo/component/grid/grid-dynamic-height.ts
+++ b/frontend/demo/component/grid/grid-dynamic-height.ts
@@ -25,13 +25,13 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor invitedPeople: Person[] = [];
+  private invitedPeople: Person[] = [];
 
   @state()
-  private accessor selectedValue = '';
+  private selectedValue = '';
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-external-filtering.ts
+++ b/frontend/demo/component/grid/grid-external-filtering.ts
@@ -29,7 +29,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor filteredItems: PersonEnhanced[] = [];
+  private filteredItems: PersonEnhanced[] = [];
 
   private items: PersonEnhanced[] = [];
 

--- a/frontend/demo/component/grid/grid-item-details-toggle.ts
+++ b/frontend/demo/component/grid/grid-item-details-toggle.ts
@@ -21,10 +21,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor detailsOpenedItems: Person[] = [];
+  private detailsOpenedItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-item-details.ts
+++ b/frontend/demo/component/grid/grid-item-details.ts
@@ -22,10 +22,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor detailsOpenedItem: Person[] = [];
+  private detailsOpenedItem: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-lazy-column-rendering.ts
+++ b/frontend/demo/component/grid/grid-lazy-column-rendering.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-multi-select-mode.ts
+++ b/frontend/demo/component/grid/grid-multi-select-mode.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-multisort.ts
+++ b/frontend/demo/component/grid/grid-multisort.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-no-border.ts
+++ b/frontend/demo/component/grid/grid-no-border.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-no-row-border.ts
+++ b/frontend/demo/component/grid/grid-no-row-border.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-rich-content-sorting.ts
+++ b/frontend/demo/component/grid/grid-rich-content-sorting.ts
@@ -25,7 +25,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-row-reordering.ts
+++ b/frontend/demo/component/grid/grid-row-reordering.ts
@@ -22,10 +22,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor draggedItem: Person | undefined;
+  private draggedItem: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-row-stripes.ts
+++ b/frontend/demo/component/grid/grid-row-stripes.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-single-selection-mode.ts
+++ b/frontend/demo/component/grid/grid-single-selection-mode.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor selectedItems: Person[] = [];
+  private selectedItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-sorting.ts
+++ b/frontend/demo/component/grid/grid-sorting.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-styling.ts
+++ b/frontend/demo/component/grid/grid-styling.ts
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: PersonWithRating[] = [];
+  private items: PersonWithRating[] = [];
 
   private ratingFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,

--- a/frontend/demo/component/grid/grid-tooltip-generator.ts
+++ b/frontend/demo/component/grid/grid-tooltip-generator.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-wrap-cell-content.ts
+++ b/frontend/demo/component/grid/grid-wrap-cell-content.ts
@@ -21,7 +21,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-basic.ts
+++ b/frontend/demo/component/gridpro/grid-pro-basic.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-edit-column.ts
+++ b/frontend/demo/component/gridpro/grid-pro-edit-column.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-editors.ts
+++ b/frontend/demo/component/gridpro/grid-pro-editors.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
+++ b/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
+++ b/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   private showErrorNotification(msg: string) {
     const notification = Notification.show(msg, { position: 'bottom-center' });

--- a/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-single-click.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-click.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
+++ b/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
@@ -21,7 +21,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 5 });

--- a/frontend/demo/component/listbox/list-box-multi-selection.ts
+++ b/frontend/demo/component/listbox/list-box-multi-selection.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 20 });

--- a/frontend/demo/component/login/login-additional-information.ts
+++ b/frontend/demo/component/login/login-additional-information.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-login-overlay')
-  private accessor login!: LoginOverlay;
+  private login!: LoginOverlay;
 
   protected override firstUpdated() {
     this.login.i18n = {

--- a/frontend/demo/component/login/login-overlay-basic.ts
+++ b/frontend/demo/component/login/login-overlay-basic.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor loginOpened = false;
+  private loginOpened = false;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -76,16 +76,16 @@ export class LoginOverlayMockupElement extends LitElement {
   }
 
   @property({ type: String })
-  accessor headerTitle: string | undefined = 'App name';
+  headerTitle: string | undefined = 'App name';
 
   @property({ type: String })
-  accessor description: string | undefined = 'Application description';
+  description: string | undefined = 'Application description';
 
   @property({ type: Boolean })
-  accessor error = false;
+  error = false;
 
   @property({ type: Object })
-  accessor i18n: LoginI18n = {
+  i18n: LoginI18n = {
     form: {
       title: 'Log in',
       username: 'Username',

--- a/frontend/demo/component/login/react/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/react/login-overlay-mockup.ts
@@ -76,16 +76,16 @@ export class LoginOverlayMockupElement extends LitElement {
   }
 
   @property({ type: String })
-  accessor headerTitle: string | undefined = 'App name';
+  headerTitle: string | undefined = 'App name';
 
   @property({ type: String })
-  accessor description: string | undefined = 'Application description';
+  description: string | undefined = 'Application description';
 
   @property({ type: Boolean })
-  accessor error = false;
+  error = false;
 
   @property({ type: Object })
-  accessor i18n: LoginI18n = {
+  i18n: LoginI18n = {
     form: {
       title: 'Log in',
       username: 'Username',

--- a/frontend/demo/component/menubar/menu-bar-basic.ts
+++ b/frontend/demo/component/menubar/menu-bar-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {
@@ -39,7 +39,7 @@ export class Example extends LitElement {
   ];
 
   @state()
-  private accessor selectedItem: MenuBarItem | undefined;
+  private selectedItem: MenuBarItem | undefined;
   // end::snippet[]
 
   protected override render() {

--- a/frontend/demo/component/menubar/menu-bar-checkable.ts
+++ b/frontend/demo/component/menubar/menu-bar-checkable.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       text: 'Options',
       children: [{ text: 'Save automatically', checked: true }, { text: 'Notify watchers' }],

--- a/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
+++ b/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'Save' },
     {
       component: this.createItem(),

--- a/frontend/demo/component/menubar/menu-bar-custom-theme.ts
+++ b/frontend/demo/component/menubar/menu-bar-custom-theme.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View', theme: 'custom-theme' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-disabled.ts
+++ b/frontend/demo/component/menubar/menu-bar-disabled.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit', disabled: true },
     {

--- a/frontend/demo/component/menubar/menu-bar-dividers.ts
+++ b/frontend/demo/component/menubar/menu-bar-dividers.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       text: 'Share',
       children: [

--- a/frontend/demo/component/menubar/menu-bar-drop-down.ts
+++ b/frontend/demo/component/menubar/menu-bar-drop-down.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       text: 'John Smith',
       children: [

--- a/frontend/demo/component/menubar/menu-bar-icon-only.ts
+++ b/frontend/demo/component/menubar/menu-bar-icon-only.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { component: this.createItem('eye', 'View') },
     { component: this.createItem('pencil', 'Edit') },
     {

--- a/frontend/demo/component/menubar/menu-bar-icons.ts
+++ b/frontend/demo/component/menubar/menu-bar-icons.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       component: this.createItem('share', 'Share'),
       children: [

--- a/frontend/demo/component/menubar/menu-bar-internationalization.ts
+++ b/frontend/demo/component/menubar/menu-bar-internationalization.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
+++ b/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-overflow.ts
+++ b/frontend/demo/component/menubar/menu-bar-overflow.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-right-aligned.ts
+++ b/frontend/demo/component/menubar/menu-bar-right-aligned.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-tooltip.ts
+++ b/frontend/demo/component/menubar/menu-bar-tooltip.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       component: this.createItem('eye'),
       tooltip: 'View',

--- a/frontend/demo/component/messages/message-basic.ts
+++ b/frontend/demo/component/messages/message-basic.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: MessageListItem[] = [];
+  private items: MessageListItem[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/messages/message-input-component.ts
+++ b/frontend/demo/component/messages/message-input-component.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor message = '';
+  private message = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();
@@ -28,7 +28,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor selectedCountries: Country[] = [];
+  private selectedCountries: Country[] = [];
 
   private get selectedCountriesText(): string {
     return this.selectedCountries.map((country) => country.name).join(', ');

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/notification/notification-error.ts
+++ b/frontend/demo/component/notification/notification-error.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-error')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-keyboard-a11y.ts
+++ b/frontend/demo/component/notification/notification-keyboard-a11y.ts
@@ -12,10 +12,10 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-keyboard-a11y')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   @state()
-  private accessor isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(window.navigator.platform);
+  private isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(window.navigator.platform);
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-link.ts
+++ b/frontend/demo/component/notification/notification-link.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-link')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-retry.ts
+++ b/frontend/demo/component/notification/notification-retry.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-retry')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-undo.ts
+++ b/frontend/demo/component/notification/notification-undo.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-undo')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-warning.ts
+++ b/frontend/demo/component/notification/notification-warning.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-warning')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
+++ b/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
@@ -26,10 +26,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor strengthText: PasswordStrength = 'weak';
+  private strengthText: PasswordStrength = 'weak';
 
   @state()
-  private accessor strengthColor = StrengthColor.weak;
+  private strengthColor = StrengthColor.weak;
 
   private pattern = '^(?=.*[0-9])(?=.*[a-zA-Z]).{8}.*$';
 

--- a/frontend/demo/component/radiobutton/radio-button-custom-option.ts
+++ b/frontend/demo/component/radiobutton/radio-button-custom-option.ts
@@ -21,10 +21,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor value: string | undefined;
+  private value: string | undefined;
 
   @state()
-  private accessor items: Card[] = [];
+  private items: Card[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCards();

--- a/frontend/demo/component/radiobutton/radio-button-presentation.ts
+++ b/frontend/demo/component/radiobutton/radio-button-presentation.ts
@@ -18,10 +18,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor value: string | undefined;
+  private value: string | undefined;
 
   @state()
-  private accessor items: Card[] = [];
+  private items: Card[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCards();

--- a/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
@@ -22,13 +22,13 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor htmlValue = '';
+  private htmlValue = '';
 
   @state()
-  private accessor deltaValue = '';
+  private deltaValue = '';
 
   @query('vaadin-rich-text-editor')
-  private accessor richTextEditor!: RichTextEditor;
+  private richTextEditor!: RichTextEditor;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/select/select-basic-features.ts
+++ b/frontend/demo/component/select/select-basic-features.ts
@@ -34,7 +34,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/select/select-basic.ts
+++ b/frontend/demo/component/select/select-basic.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/select/select-complex-value-label.ts
+++ b/frontend/demo/component/select/select-complex-value-label.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: SelectItem[] = [];
+  private items: SelectItem[] = [];
 
   protected override async firstUpdated() {
     const people = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor people: Person[] = [];
+  private people: Person[] = [];
 
   protected override async firstUpdated() {
     this.people = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/select/select-disabled.ts
+++ b/frontend/demo/component/select/select-disabled.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   @state()
   // tag::snippet[]
-  private accessor items = [
+  private items = [
     {
       label: 'XS (out of stock)',
       value: 'xs',

--- a/frontend/demo/component/select/select-dividers.ts
+++ b/frontend/demo/component/select/select-dividers.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   @state()
   // tag::snippet[]
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/select/select-placeholder.ts
+++ b/frontend/demo/component/select/select-placeholder.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'XS',
       value: 'xs',

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor people: Person[] = [];
+  private people: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 4 });

--- a/frontend/demo/component/select/select-readonly-and-disabled.ts
+++ b/frontend/demo/component/select/select-readonly-and-disabled.ts
@@ -33,7 +33,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/select/select-styles.ts
+++ b/frontend/demo/component/select/select-styles.ts
@@ -30,7 +30,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/splitlayout/split-layout-toggle.ts
+++ b/frontend/demo/component/splitlayout/split-layout-toggle.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor sidebarCollapsed = false;
+  private sidebarCollapsed = false;
 
   protected override render() {
     const sidebarWidthPercentage = this.sidebarCollapsed ? 13 : 40;

--- a/frontend/demo/component/tabs/tabs-content.ts
+++ b/frontend/demo/component/tabs/tabs-content.ts
@@ -9,10 +9,10 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('tabs-content')
 export class Example extends LitElement {
   @state()
-  private accessor content = '';
+  private content = '';
 
   @state()
-  private accessor pages = ['Dashboard', 'Payment', 'Shipping'];
+  private pages = ['Dashboard', 'Payment', 'Shipping'];
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
+++ b/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor visitedTabs = new Set<number>();
+  private visitedTabs = new Set<number>();
 
   private selectedTabChanged(event: TabSheetSelectedChangedEvent) {
     this.visitedTabs = new Set([...this.visitedTabs, event.detail.value]);

--- a/frontend/demo/component/textarea/text-area-basic.ts
+++ b/frontend/demo/component/textarea/text-area-basic.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   private charLimit = 140;
 
   @state()
-  private accessor text = 'Great job. This is excellent!';
+  private text = 'Great job. This is excellent!';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/textarea/text-area-helper.ts
+++ b/frontend/demo/component/textarea/text-area-helper.ts
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   private charLimit = 600;
 
   @state()
-  private accessor text = templates.loremIpsum;
+  private text = templates.loremIpsum;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/timepicker/time-picker-min-max.ts
+++ b/frontend/demo/component/timepicker/time-picker-min-max.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('time-picker-min-max')
 export class Example extends LitElement {
   @state()
-  protected accessor errorMessage = '';
+  protected errorMessage = '';
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/tooltip/tooltip-manual.ts
+++ b/frontend/demo/component/tooltip/tooltip-manual.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor tooltipOpened = false;
+  private tooltipOpened = false;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/tree-grid/tree-grid-column.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-column.ts
@@ -41,7 +41,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor expandedItems: unknown[] = [];
+  private expandedItems: unknown[] = [];
 
   protected override render() {
     return html`

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -28,7 +28,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor expandedItems: Person[] = [];
+  private expandedItems: Person[] = [];
 
   async dataProvider(
     params: GridDataProviderParams<Person>,

--- a/frontend/demo/component/upload/upload-all-files.ts
+++ b/frontend/demo/component/upload/upload-all-files.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   // end::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/upload/upload-auto-upload-disabled.ts
+++ b/frontend/demo/component/upload/upload-auto-upload-disabled.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   protected override firstUpdated() {
     this.upload.i18n.addFiles.many = 'Select Files...';

--- a/frontend/demo/component/upload/upload-button-theme-variant.ts
+++ b/frontend/demo/component/upload/upload-button-theme-variant.ts
@@ -22,10 +22,10 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   @state()
-  private accessor maxFilesReached = false;
+  private maxFilesReached = false;
 
   protected override firstUpdated() {
     this.upload.i18n.dropFiles.one = 'Drop PDF here';

--- a/frontend/demo/component/upload/upload-error-messages.ts
+++ b/frontend/demo/component/upload/upload-error-messages.ts
@@ -23,10 +23,10 @@ export class Example extends LitElement {
   }
 
   @query('#upload-caution')
-  private accessor uploadCaution!: Upload;
+  private uploadCaution!: Upload;
 
   @query('#upload-recommended')
-  private accessor uploadRecommended!: Upload;
+  private uploadRecommended!: Upload;
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/upload/upload-file-count.ts
+++ b/frontend/demo/component/upload/upload-file-count.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   protected override firstUpdated() {
     this.upload.i18n.error.tooManyFiles = 'You may only upload a maximum of three files at once.';

--- a/frontend/demo/component/upload/upload-file-format.ts
+++ b/frontend/demo/component/upload/upload-file-format.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   protected override firstUpdated() {
     this.upload.i18n.addFiles.one = 'Upload Report...';

--- a/frontend/demo/component/upload/upload-file-size.ts
+++ b/frontend/demo/component/upload/upload-file-size.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   protected override firstUpdated() {
     this.upload.i18n.error.fileIsTooBig = 'The file exceeds the maximum allowed size of 10MB.';

--- a/frontend/demo/component/upload/upload-helper.ts
+++ b/frontend/demo/component/upload/upload-helper.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/upload/upload-labelling.ts
+++ b/frontend/demo/component/upload/upload-labelling.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/virtuallist/virtual-list-basic.ts
+++ b/frontend/demo/component/virtuallist/virtual-list-basic.ts
@@ -32,7 +32,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor people: Person[] | undefined;
+  private people: Person[] | undefined;
 
   private expandedPeople = new Set<Person>();
 

--- a/frontend/demo/flow/application/events/events-basic.ts
+++ b/frontend/demo/flow/application/events/events-basic.ts
@@ -7,10 +7,10 @@ import '@vaadin/horizontal-layout';
 // tag::snippet[]
 export class EventsBasic extends LitElement {
   @state()
-  private accessor caption = 'Click me!';
+  private caption = 'Click me!';
 
   @state()
-  private accessor count = 0;
+  private count = 0;
 
   protected override render() {
     return html`<vaadin-button @click="${this.onClick}">${this.caption}</vaadin-button>`;

--- a/frontend/demo/foundation/icons-preview.ts
+++ b/frontend/demo/foundation/icons-preview.ts
@@ -20,13 +20,13 @@ export type IconSetType = 'lumo' | 'vaadin';
 @customElement('icons-preview')
 export class IconsPreview extends LitElement {
   @state()
-  accessor iconNames: string[] | undefined;
+  iconNames: string[] | undefined;
 
   @property({ type: String, attribute: 'iconset-type' })
-  accessor iconsetType: IconSetType = 'vaadin';
+  iconsetType: IconSetType = 'vaadin';
 
   @query('input')
-  private accessor search!: HTMLInputElement;
+  private search!: HTMLInputElement;
 
   protected override createRenderRoot() {
     return this;

--- a/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
+++ b/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
@@ -22,10 +22,10 @@ export class DashboardGenerator extends LitElement {
   `;
 
   @state()
-  accessor accountId = '';
+  accountId = '';
 
   @state()
-  accessor json = '';
+  json = '';
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();


### PR DESCRIPTION
This PR temporary disables rendering Lit examples to avoid issues with standard/legacy decorators