### PR TITLE
docs: remove not needed fragments and Icon workaround

### DIFF
--- a/frontend/demo/component/badge/react/badge-basic.tsx
+++ b/frontend/demo/component/badge/react/badge-basic.tsx
@@ -5,18 +5,16 @@ import { HorizontalLayout } from '@hilla/react-components/HorizontalLayout';
 
 function Example() {
   return (
-    <>
-      <HorizontalLayout theme="spacing">
-        {/* tag::snippet[] */}
-        {/* Since a native span element does not know about the theme attribute, as a workaround, you
+    <HorizontalLayout theme="spacing">
+      {/* tag::snippet[] */}
+      {/* Since a native span element does not know about the theme attribute, as a workaround, you
         can use the spread operator to pass the theme attribute to the span element. */}
-        <span {...{ theme: 'badge' }}>Pending</span>
-        <span {...{ theme: 'badge success' }}>Confirmed</span>
-        <span {...{ theme: 'badge error' }}>Denied</span>
-        <span {...{ theme: 'badge contrast' }}>On hold</span>
-        {/* end::snippet[] */}
-      </HorizontalLayout>
-    </>
+      <span {...{ theme: 'badge' }}>Pending</span>
+      <span {...{ theme: 'badge success' }}>Confirmed</span>
+      <span {...{ theme: 'badge error' }}>Denied</span>
+      <span {...{ theme: 'badge contrast' }}>On hold</span>
+      {/* end::snippet[] */}
+    </HorizontalLayout>
   );
 }
 

--- a/frontend/demo/component/badge/react/badge-icons-only.tsx
+++ b/frontend/demo/component/badge/react/badge-icons-only.tsx
@@ -1,46 +1,30 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Icon } from '@hilla/react-components/Icon.js';
-import {
-  HorizontalLayout,
-  type HorizontalLayoutElement,
-} from '@hilla/react-components/HorizontalLayout.js';
+import { HorizontalLayout } from '@hilla/react-components/HorizontalLayout.js';
 import '@vaadin/icons';
 
 function Example() {
-  const layoutRef = useRef<HorizontalLayoutElement>(null);
-
-  useEffect(() => {
-    if (!layoutRef.current) {
-      return;
-    }
-    // Workaround for https://github.com/vaadin/web-components/issues/6301
-    const icons = layoutRef.current.querySelectorAll('vaadin-icon');
-    icons.forEach((icon) => icon.setAttribute('icon', icon.icon ?? ''));
-  });
-
   return (
-    <>
-      <HorizontalLayout theme="spacing" ref={layoutRef}>
-        {/* tag::snippet[] */}
-        <Icon
-          aria-label="Confirmed"
-          icon="vaadin:check"
-          style={{ padding: 'var(--lumo-space-xs)' }}
-          theme="badge success"
-          title="Confirmed"
-        />
+    <HorizontalLayout theme="spacing">
+      {/* tag::snippet[] */}
+      <Icon
+        aria-label="Confirmed"
+        icon="vaadin:check"
+        style={{ padding: 'var(--lumo-space-xs)' }}
+        theme="badge success"
+        title="Confirmed"
+      />
 
-        <Icon
-          aria-label="Cancelled"
-          icon="vaadin:close-small"
-          style={{ padding: 'var(--lumo-space-xs)' }}
-          theme="badge error"
-          title="Cancelled"
-        />
-        {/* end::snippet[] */}
-      </HorizontalLayout>
-    </>
+      <Icon
+        aria-label="Cancelled"
+        icon="vaadin:close-small"
+        style={{ padding: 'var(--lumo-space-xs)' }}
+        theme="badge error"
+        title="Cancelled"
+      />
+      {/* end::snippet[] */}
+    </HorizontalLayout>
   );
 }
 


### PR DESCRIPTION
The workaround is no longer needed as https://github.com/vaadin/web-components/issues/6301 has been fixed.
Also, removed some extra fragments around layout components in badge examples.