### PR TITLE
docs: add notes about decorator usage

### DIFF
--- a/articles/lit/start/notes.adoc
+++ b/articles/lit/start/notes.adoc
@@ -32,9 +32,8 @@ First, you can keep using legacy decorators, they are still supported by Lit 3. 
 
 [source,diff]
 ----
--@state()
+@state()
 -private accessor value = 0;
-+@state()
 +private value = 0;
 ----
 

--- a/articles/lit/start/notes.adoc
+++ b/articles/lit/start/notes.adoc
@@ -1,0 +1,41 @@
+---
+title: Documentation Notes
+order: 100
+---
+:lit:
+
+= Documentation Notes
+
+== Standard vs. Legacy Decorators
+
+This documentation has been updated to use Lit 3, and as part of that uses standard decorators in Typescript examples. For reference, a property using a standard decorator looks like this:
+
+```ts
+@state()
+private accessor value = 0;
+```
+
+Whereas a property using a legacy decorator looks like this:
+
+```ts
+@state()
+private value = 0;
+```
+
+Depending on which Hilla version you are using you may need to either adapt the example code for it to work in your project.
+
+Starter projects since Hilla 2.5 are set up to use standard decorators, so if you have started developing your Hilla Lit project with Hilla 2.5, most likely you don't need to do anything and can use the code examples as is.
+
+If you started developing with a previous version of Hilla, your project is likely set up to not use standard decorators. That means the code examples shown in this documentation will not work out of the box.
+
+First, you can keep using legacy decorators, they are still supported by Lit 3. However, in order to use the code examples from this documentation you need to make some adjustments whenever a decorator is used by removing the `accessor` keyword:
+
+[source,diff]
+----
+-@state()
+-private accessor value = 0;
++@state()
++private value = 0;
+----
+
+For more information about decorator versions, please reference the https://lit.dev/docs/components/decorators/#decorator-versions[official Lit documentation].

--- a/articles/lit/start/notes.adoc
+++ b/articles/lit/start/notes.adoc
@@ -22,7 +22,7 @@ Whereas a property using a legacy decorator looks like this:
 private value = 0;
 ```
 
-Depending on which Hilla version you are using you may need to either adapt the example code for it to work in your project.
+Depending on which Hilla version you are using you may need to adapt the example code for it to work in your project.
 
 Starter projects since Hilla 2.5 are set up to use standard decorators, so if you have started developing your Hilla Lit project with Hilla 2.5, most likely you don't need to do anything and can use the code examples as is.
 


### PR DESCRIPTION
Adds a "Documentation Notes" page to the Hilla Lit docs that explains about the decorator usage in the documentation and explains how to adapt example code to use legacy decorators.