### PR TITLE
Fix broken link to Lumo Colors

### DIFF
--- a/articles/styling/lumo/lumo-variants.adoc
+++ b/articles/styling/lumo/lumo-variants.adoc
@@ -29,7 +29,7 @@ public class Application extends implements AppShellConfigurator {
 
 .Customize Dark Variant Colors
 [TIP]
-You can customize the colors for the dark theme variant as well. See link:/styling/lumo/lumo-style-properties/color[Lumo Colors] for details.
+You can customize the colors for the dark theme variant as well. See link:./lumo-style-properties/color[Lumo Colors] for details.
 
 The variant can also be applied only to certain parts of the UI, including individual components, through the ThemeList or Element API, depending on the component:
 

--- a/articles/styling/lumo/lumo-variants.adoc
+++ b/articles/styling/lumo/lumo-variants.adoc
@@ -29,7 +29,7 @@ public class Application extends implements AppShellConfigurator {
 
 .Customize Dark Variant Colors
 [TIP]
-You can customize the colors for the dark theme variant as well. See link:./lumo-style-properties/color[Lumo Colors] for details.
+You can customize the colors for the dark theme variant as well. See <<lumo-style-properties/color#,Lumo Colors>> for details.
 
 The variant can also be applied only to certain parts of the UI, including individual components, through the ThemeList or Element API, depending on the component:
 


### PR DESCRIPTION
The "Lumo Colors" link at https://vaadin.com/docs/latest/styling/lumo/lumo-variants redirects to https://vaadin.com/styling/lumo/lumo-style-properties/color which results in a 404 error. The corrected link now takes you to the correct page: https://vaadin.com/docs/latest/styling/lumo/lumo-style-properties/color


