### PR TITLE
docs: update indeterminate checkbox React example

### DIFF
--- a/frontend/demo/component/checkbox/react/checkbox-indeterminate.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-indeterminate.tsx
@@ -25,8 +25,7 @@ function Example() {
         checked={selectedIds.length === items.length}
         indeterminate={selectedIds.length > 0 && selectedIds.length < items.length}
         onChange={(e) => {
-          // TODO: This doesn't currently invoke. See https://github.com/vaadin/react-components/issues/133
-          setSelectedIds(e.currentTarget.checked ? items.map((person) => String(person.id)) : []);
+          setSelectedIds(e.target.checked ? items.map((person) => String(person.id)) : []);
         }}
       />
 


### PR DESCRIPTION
Removed TODO and updated the example to fix TS error after the `onChange` event addition to `Checkbox`:

```
frontend/demo/component/checkbox/react/checkbox-indeterminate.tsx:29:26 - error TS18047: 'e.currentTarget' is possibly 'null'.

29           setSelectedIds(e.currentTarget.checked ? items.map((person) => String(person.id)) : []);
                            ~~~~~~~~~~~~~~~

frontend/demo/component/checkbox/react/checkbox-indeterminate.tsx:29:42 - error TS2339: Property 'checked' does not exist on type 'EventTarget'.

29           setSelectedIds(e.currentTarget.checked ? items.map((person) => String(person.id)) : []);
```