### PR TITLE
docs: swap logout instructions

### DIFF
--- a/articles/security/advanced-topics/securing-plain-java-app.adoc
+++ b/articles/security/advanced-topics/securing-plain-java-app.adoc
@@ -73,8 +73,8 @@ public class SecurityUtils {
     }
 
     public static void logout() {
-        VaadinSession.getCurrent().getSession().invalidate();
         UI.getCurrent().getPage().setLocation(LOGOUT_SUCCESS_URL);
+        VaadinSession.getCurrent().getSession().invalidate();
     }
 }
 ----

--- a/articles/tools/mpr/configuration/session.asciidoc
+++ b/articles/tools/mpr/configuration/session.asciidoc
@@ -18,8 +18,8 @@ Below is an example of this:
 [source,java]
 ----
 Button close = new Button("Close session", event -> {
-    VaadinSession.getCurrent().getSession().invalidate();
     UI.getCurrent().getPage().reload();
+    VaadinSession.getCurrent().getSession().invalidate();
 });
 ----
 


### PR DESCRIPTION
Invalidating the session before accessing UI.getCurrent() may cause null pointer exceptions on some servlet container (for example Tomcat).

Fixes vaadin/flow#18284


