### PR TITLE
[UI Unit Testing] Use the correct query form in the scoped example

### DIFF
--- a/articles/testing/ui-unit/component-query.adoc
+++ b/articles/testing/ui-unit/component-query.adoc
@@ -35,7 +35,7 @@ You can also restrict search scope to the children of the current view by using 
 TextField nameField = $view(TextField.class).first();
 
 // Get the first TextField nested in a container
-TextField nameField = $view(TextField.class, view.formLayout).first();
+TextField nameField = $(TextField.class, view.formLayout).first();
 ----
 
 The query object has many filtering utilities that can be used to refine the search. For example, you can filter by component `id`, by a property value, or using custom predicates on potential candidates.


### PR DESCRIPTION
The code example for a scoped query in the UI Unit Testing section uses `$view(class, parent)` for a nested query, however it should be `$(class, parent)`.