### PR TITLE
bugfix: Removed invalid card elements from css selectors

### DIFF
--- a/articles/create-ui/dnd/drag-source.asciidoc
+++ b/articles/create-ui/dnd/drag-source.asciidoc
@@ -32,7 +32,7 @@ When a component is set draggable on the server side, the `draggable` attribute 
 
 [source,css]
 ----
-.v-dragged.card {
+.v-dragged {
     outline: 1px dotted hotpink;
     opacity: 0.5;
 }

--- a/articles/create-ui/dnd/drop-target.asciidoc
+++ b/articles/create-ui/dnd/drop-target.asciidoc
@@ -105,7 +105,7 @@ The class name is removed when:
 
 [source,css]
 ----
-.v-drag-over-target.card {
+.v-drag-over-target {
     outline: 1px solid lightgreen;
 }
 ----


### PR DESCRIPTION
Not used in the examples and most there is not an element like card in the user code either.


