### PR TITLE
Add navigation examples for hybrid apps (#3101) (CP: next)

### DIFF
--- a/articles/flow/integrations/hilla.adoc
+++ b/articles/flow/integrations/hilla.adoc
@@ -135,6 +135,12 @@ In `frontend/routes.tsx`, add the `serverSideRoutes` object to the `routes` arra
 
 Adding `serverSideRoutes` is required for React Router to be able to navigate to server-side (i.e., Vaadin Flow) routes. If this configuration is missed and the feature flag is enabled, Vaadin throws a runtime exception at build time.
 
+Use link:/docs/latest/components/side-nav[SideNav] or link:/docs/latest/routing/retrieving-routes#standard-navigation-targets[Anchor] components to navigate from a Flow view to a Hilla view:
+
+[source,java]
+----
+Anchor navigateToFlow = new Anchor("hilla", "Navigate to a Hilla view");
+----
 
 === Run the Application
 
@@ -254,6 +260,14 @@ Adding `serverSideRoutes` is required for React Router to be able to navigate to
 [NOTE]
 Vaadin creates [filename]`frontend/App.tsx` and [filename]`frontend/routes.tsx` files if they are missing, as well as the internal [filename]`Frontend/generated/flow/Flow.tsx` file. Also, React dependencies -- such as `react`, `react-dom` and `react-router-dom` -- are added to the [filename]`package.json` file and installed.
 
+Use Vaadin's https://hilla.dev/docs/react/components/side-nav[SideNav] or React's https://hilla.dev/docs/react/guides/routing#adding-routes[NavLink] / https://reactrouter.com/en/main/components/link[Link] components to navigate from a Hilla view to a Flow view:
+
+[source,javascript]
+----
+import { NavLink } from 'react-router-dom';
+
+<NavLink to="/flow-route">Navigate to a Flow View</NavLink>
+----
 
 [discussion-id]`9da82521-5074-42b6-82a5-88fc207987d0`
 


### PR DESCRIPTION
* Add navigation examples for hybrid apps

* Add a Link component

* First pass at editing.

---------

Cherry pick of the https://github.com/vaadin/docs/pull/3101


