### PR TITLE
fix: set i18n header before modifying for login java example

### DIFF
--- a/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java
@@ -13,10 +13,10 @@ public class LoginOverlayInternationalization extends Div {
         // tag::snippet[]
         LoginI18n i18n = LoginI18n.createDefault();
 
-        i18n.setHeader(new LoginI18n.Header());
-        LoginI18n.Header i18nHeader = i18n.getHeader();
+        LoginI18n.Header i18nHeader = new LoginI18n.Header();
         i18nHeader.setTitle("Sovelluksen nimi");
         i18nHeader.setDescription("Sovelluksen kuvaus");
+        i18n.setHeader(i18nHeader);
 
         LoginI18n.Form i18nForm = i18n.getForm();
         i18nForm.setTitle("Kirjaudu sisään");

--- a/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java
@@ -13,6 +13,7 @@ public class LoginOverlayInternationalization extends Div {
         // tag::snippet[]
         LoginI18n i18n = LoginI18n.createDefault();
 
+        i18n.setHeader(new LoginI18n.Header());
         LoginI18n.Header i18nHeader = i18n.getHeader();
         i18nHeader.setTitle("Sovelluksen nimi");
         i18nHeader.setDescription("Sovelluksen kuvaus");


### PR DESCRIPTION
The Login internationalization Java example is broken because the header was never set. This is required because there is no default for Header. It is also broken in v23, but is masked by the unified preview example.

This PR initializes the i18n Header.

Fixes #[5903](https://github.com/vaadin/flow-components/issues/5903)