### PR TITLE
docs: remove unsupported alt attribute from avatars

### DIFF
--- a/frontend/demo/component/grid/grid-column-borders.ts
+++ b/frontend/demo/component/grid/grid-column-borders.ts
@@ -49,7 +49,6 @@ export class Example extends LitElement {
     <vaadin-avatar
       img="${person.pictureUrl}"
       name="${person.firstName} ${person.lastName}"
-      alt="User avatar"
     ></vaadin-avatar>
   `;
 }

--- a/frontend/demo/component/grid/grid-content.ts
+++ b/frontend/demo/component/grid/grid-content.ts
@@ -57,7 +57,6 @@ export class Example extends LitElement {
       <vaadin-avatar
         img="${person.pictureUrl}"
         name="${person.firstName} ${person.lastName}"
-        alt="User avatar"
       ></vaadin-avatar>
       <vaadin-vertical-layout style="line-height: var(--lumo-line-height-m);">
         <span>${person.firstName} ${person.lastName}</span>

--- a/frontend/demo/component/grid/grid-no-border.ts
+++ b/frontend/demo/component/grid/grid-no-border.ts
@@ -49,7 +49,6 @@ export class Example extends LitElement {
     <vaadin-avatar
       img="${person.pictureUrl}"
       name="${person.firstName} ${person.lastName}"
-      alt="User avatar"
     ></vaadin-avatar>
   `;
 }

--- a/frontend/demo/component/grid/grid-no-row-border.ts
+++ b/frontend/demo/component/grid/grid-no-row-border.ts
@@ -49,7 +49,6 @@ export class Example extends LitElement {
     <vaadin-avatar
       img="${person.pictureUrl}"
       name="${person.firstName} ${person.lastName}"
-      alt="User avatar"
     ></vaadin-avatar>
   `;
 }

--- a/frontend/demo/component/grid/grid-rich-content-sorting.ts
+++ b/frontend/demo/component/grid/grid-rich-content-sorting.ts
@@ -53,7 +53,6 @@ export class Example extends LitElement {
       <vaadin-avatar
         img="${person.pictureUrl}"
         name="${person.firstName} ${person.lastName}"
-        alt="User avatar"
       ></vaadin-avatar>
       <vaadin-vertical-layout style="line-height: var(--lumo-line-height-m);">
         <span>${person.firstName} ${person.lastName}</span>

--- a/frontend/demo/component/grid/grid-row-reordering.ts
+++ b/frontend/demo/component/grid/grid-row-reordering.ts
@@ -79,7 +79,6 @@ export class Example extends LitElement {
     <vaadin-avatar
       img="${person.pictureUrl}"
       name="${person.firstName} ${person.lastName}"
-      alt="User avatar"
     ></vaadin-avatar>
   `;
 }

--- a/frontend/demo/component/grid/grid-row-stripes.ts
+++ b/frontend/demo/component/grid/grid-row-stripes.ts
@@ -49,7 +49,6 @@ export class Example extends LitElement {
     <vaadin-avatar
       img="${person.pictureUrl}"
       name="${person.firstName} ${person.lastName}"
-      alt="User avatar"
     ></vaadin-avatar>
   `;
 }

--- a/frontend/demo/component/grid/grid-wrap-cell-content.ts
+++ b/frontend/demo/component/grid/grid-wrap-cell-content.ts
@@ -51,7 +51,6 @@ export class Example extends LitElement {
     <vaadin-avatar
       img="${person.pictureUrl}"
       name="${person.firstName} ${person.lastName}"
-      alt="User avatar"
     ></vaadin-avatar>
   `;
 

--- a/frontend/demo/component/grid/react/grid-column-borders.tsx
+++ b/frontend/demo/component/grid/react/grid-column-borders.tsx
@@ -23,7 +23,6 @@ function Example() {
           <Avatar
             img={item.pictureUrl}
             name={`${item.firstName} ${item.lastName}`}
-            {...{ alt: 'User avatar' }}
           />
         )}
       </GridColumn>

--- a/frontend/demo/component/grid/react/grid-content.tsx
+++ b/frontend/demo/component/grid/react/grid-content.tsx
@@ -15,7 +15,6 @@ const employeeRenderer = (person: Person) => (
     <Avatar
       img={person.pictureUrl}
       name={`${person.firstName} ${person.lastName}`}
-      // alt="User avatar"
     />
 
     <VerticalLayout style={{ lineHeight: 'var(--lumo-line-height-m)' }}>

--- a/frontend/demo/component/grid/react/grid-no-border.tsx
+++ b/frontend/demo/component/grid/react/grid-no-border.tsx
@@ -21,7 +21,6 @@ function Example() {
           <Avatar
             img={item.pictureUrl}
             name={`${item.firstName} ${item.lastName}`}
-            {...{ alt: 'User avatar' }}
           />
         )}
       </GridColumn>

--- a/frontend/demo/component/grid/react/grid-no-row-border.tsx
+++ b/frontend/demo/component/grid/react/grid-no-row-border.tsx
@@ -20,7 +20,6 @@ function Example() {
           <Avatar
             img={item.pictureUrl}
             name={`${item.firstName} ${item.lastName}`}
-            {...{ alt: 'User avatar' }}
           />
         )}
       </GridColumn>

--- a/frontend/demo/component/grid/react/grid-rich-content-sorting.tsx
+++ b/frontend/demo/component/grid/react/grid-rich-content-sorting.tsx
@@ -16,7 +16,6 @@ function employeeRenderer({ item: person }: { item: Person }) {
       <Avatar
         img={person.pictureUrl}
         name={`${person.firstName} ${person.lastName}`}
-        {...{ alt: 'User avatar' }}
       />
 
       <VerticalLayout style={{ lineHeight: 'var(--lumo-line-height-m)' }}>

--- a/frontend/demo/component/grid/react/grid-row-reordering.tsx
+++ b/frontend/demo/component/grid/react/grid-row-reordering.tsx
@@ -52,7 +52,6 @@ function Example() {
           <Avatar
             img={person.pictureUrl}
             name={`${person.firstName} ${person.lastName}`}
-            {...{ alt: 'User avatar' }}
           />
         )}
       </GridColumn>

--- a/frontend/demo/component/grid/react/grid-row-stripes.tsx
+++ b/frontend/demo/component/grid/react/grid-row-stripes.tsx
@@ -20,7 +20,6 @@ function Example() {
           <Avatar
             img={item.pictureUrl}
             name={`${item.firstName} ${item.lastName}`}
-            {...{ alt: 'User avatar' }}
           />
         )}
       </GridColumn>


### PR DESCRIPTION
Original TS examples added in #411 were using `<img>` for rendering images in grid cells. Later on, they were replaced with `vaadin-avatar` in #631 but the `alt` attribute wasn't removed. This attribute is not supported by `vaadin-avatar`.