### PR TITLE
chore: add missing hidden-source-line, align React imports

### DIFF
--- a/frontend/demo/component/accordion/react/accordion-summary.tsx
+++ b/frontend/demo/component/accordion/react/accordion-summary.tsx
@@ -1,4 +1,4 @@
-import { reactExample } from 'Frontend/demo/react-example';
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useEffect, useState } from 'react';
 import { Accordion, type AccordionOpenedChangedEvent } from '@hilla/react-components/Accordion.js';
 import { AccordionPanel } from '@hilla/react-components/AccordionPanel.js';
@@ -95,4 +95,4 @@ function Example() {
   // end::snippet[]
 }
 
-export default reactExample(Example);
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/badge/react/badge-basic.tsx
+++ b/frontend/demo/component/badge/react/badge-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-
 import React from 'react';
 import { HorizontalLayout } from '@hilla/react-components/HorizontalLayout';
 

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
@@ -1,8 +1,8 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
+import React from 'react';
 import { Button } from '@hilla/react-components/Button.js';
 import { HorizontalLayout } from '@hilla/react-components/HorizontalLayout.js';
-import React from 'react';
 
 function Example() {
   return (

--- a/frontend/demo/component/board/react/board-breakpoints.tsx
+++ b/frontend/demo/component/board/react/board-breakpoints.tsx
@@ -1,8 +1,8 @@
-import { Board } from '@hilla/react-components/Board.js';
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
+import { Board } from '@hilla/react-components/Board.js';
 import { BoardRow } from '@hilla/react-components/BoardRow.js';
 import { SplitLayout } from '@hilla/react-components/SplitLayout.js';
-import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import boardStyles from './board-styles';
 
 function Example() {

--- a/frontend/demo/component/button/react/button-grid.tsx
+++ b/frontend/demo/component/button/react/button-grid.tsx
@@ -1,12 +1,12 @@
-import { Button } from '@hilla/react-components/Button.js'; // hidden-source-line
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
+import { Button } from '@hilla/react-components/Button.js';
 import { Grid } from '@hilla/react-components/Grid.js';
 import { GridColumn } from '@hilla/react-components/GridColumn.js';
 import { GridSelectionColumn } from '@hilla/react-components/GridSelectionColumn.js';
 import { HorizontalLayout } from '@hilla/react-components/HorizontalLayout.js';
 import { VerticalLayout } from '@hilla/react-components/VerticalLayout.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import { reactExample } from 'Frontend/demo/react-example';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { useEffect, useState } from 'react';
 

--- a/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
@@ -1,4 +1,4 @@
-import { reactExample } from 'Frontend/demo/react-example';
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useEffect, useRef, useState } from 'react';
 import { ContextMenu, type ContextMenuItem } from '@hilla/react-components/ContextMenu.js';
 import { Grid, type GridElement } from '@hilla/react-components/Grid.js';
@@ -108,4 +108,4 @@ function Example() {
   // end::snippet[]
 }
 
-export default reactExample(Example);
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/crud/react/crud-localization.tsx
+++ b/frontend/demo/component/crud/react/crud-localization.tsx
@@ -1,11 +1,11 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React, { useEffect, useState } from 'react';
 import { Crud, crudPath } from '@hilla/react-components/Crud.js';
 import { Grid } from '@hilla/react-components/Grid.js';
 import { GridColumn } from '@hilla/react-components/GridColumn.js';
 import { TextField } from '@hilla/react-components/TextField.js';
 import { EmailField } from '@hilla/react-components/EmailField.js';
 import { ComboBox } from '@hilla/react-components/ComboBox.js';
-import React, { useEffect, useState } from 'react';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { CrudEditColumn } from '@hilla/react-components/CrudEditColumn.js';

--- a/frontend/demo/component/grid/react/grid-item-details.tsx
+++ b/frontend/demo/component/grid/react/grid-item-details.tsx
@@ -1,4 +1,4 @@
-import { reactExample } from 'Frontend/demo/react-example';
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useEffect, useState } from 'react';
 import { Grid } from '@hilla/react-components/Grid.js';
 import { GridColumn } from '@hilla/react-components/GridColumn.js';
@@ -60,4 +60,4 @@ function Example() {
   // end::snippet[]
 }
 
-export default reactExample(Example);
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/icons/react/svg-sprites.tsx
+++ b/frontend/demo/component/icons/react/svg-sprites.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React from 'react';
 import { Icon } from '@hilla/react-components/Icon.js';
 import { HorizontalLayout } from '@hilla/react-components/HorizontalLayout.js';
 import spriteIcons from '../../../../../src/main/resources/icons/solid.svg';

--- a/frontend/demo/component/menubar/react/menu-bar-combo-buttons.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-combo-buttons.tsx
@@ -1,4 +1,4 @@
-import { reactExample } from 'Frontend/demo/react-example';
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { MenuBar } from '@hilla/react-components/MenuBar.js';
 import { Icon } from '@hilla/react-components/Icon.js';
@@ -18,4 +18,4 @@ function Example() {
   // end::snippet[]
 }
 
-export default reactExample(Example);
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/messages/react/message-list-component.tsx
+++ b/frontend/demo/component/messages/react/message-list-component.tsx
@@ -1,4 +1,4 @@
-import { reactExample } from 'Frontend/demo/react-example';
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useEffect, useState } from 'react';
 import { format, subDays, subMinutes } from 'date-fns';
 import { MessageList } from '@hilla/react-components/MessageList.js';
@@ -36,4 +36,4 @@ function Example() {
   // end::snippet[]
 }
 
-export default reactExample(Example);
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/notification/react/notification-primary.tsx
+++ b/frontend/demo/component/notification/react/notification-primary.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React from 'react';
 import { Notification } from '@hilla/react-components/Notification.js';
 
 function Example() {

--- a/frontend/demo/component/radiobutton/react/radio-button-checkbox-alternative.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-checkbox-alternative.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-
 import React from 'react';
 import { Checkbox } from '@hilla/react-components/Checkbox.js';
 import { RadioGroup } from '@hilla/react-components/RadioGroup.js';

--- a/frontend/demo/component/tabs/react/tabsheet-lazy-initialization.tsx
+++ b/frontend/demo/component/tabs/react/tabsheet-lazy-initialization.tsx
@@ -1,4 +1,4 @@
-import { reactExample } from 'Frontend/demo/react-example';
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useState } from 'react';
 import { TabSheet, type TabSheetSelectedChangedEvent } from '@hilla/react-components/TabSheet.js';
 import { Tabs } from '@hilla/react-components/Tabs.js';
@@ -32,4 +32,4 @@ function Example() {
   // end::snippet[]
 }
 
-export default reactExample(Example);
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/upload/react/upload-labelling.tsx
+++ b/frontend/demo/component/upload/react/upload-labelling.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import { Notification } from '@hilla/react-components/Notification.js';
 import React, { useEffect, useRef } from 'react';
+import { Notification } from '@hilla/react-components/Notification.js';
 import { Upload } from '@hilla/react-components/Upload.js';
 import type { UploadFileRejectEvent } from '@hilla/react-components/Upload.js';
 


### PR DESCRIPTION
- Added missing `// hidden-source-line` comments to a few React examples
- Sorted imports so that `import React from 'react'` would be the topmost