### PR TITLE
chore: remove use of standard decorators

### DIFF
--- a/dspublisher/config/default.json
+++ b/dspublisher/config/default.json
@@ -4,6 +4,5 @@
     "lit": true,
     "react": true
   },
-  "useStandardDecorators": true,
   "useEsbuild": true
 }

--- a/dspublisher/theme/init-browser.ts
+++ b/dspublisher/theme/init-browser.ts
@@ -70,7 +70,7 @@ class Footer extends LitElement {
   }
 
   @state()
-  private accessor documentTitle = document.title;
+  private documentTitle = document.title;
 
   private __titleObserver = new MutationObserver(() => {
     this.documentTitle = document.title;

--- a/frontend/demo/component/accordion/accordion-summary.ts
+++ b/frontend/demo/component/accordion/accordion-summary.ts
@@ -27,14 +27,14 @@ const responsiveSteps: FormLayoutResponsiveStep[] = [
 @customElement('accordion-summary')
 export class Example extends LitElement {
   @state()
-  private accessor countries: Country[] = [];
+  private countries: Country[] = [];
 
   private readonly personBinder = new Binder(this, PersonModel);
 
   private readonly cardBinder = new Binder(this, CardModel);
 
   @state()
-  private accessor openedPanelIndex: number | null = 0;
+  private openedPanelIndex: number | null = 0;
 
   protected override async firstUpdated() {
     this.countries = await getCountries();
@@ -117,9 +117,7 @@ export class Example extends LitElement {
                   ${this.personBinder.value.address?.zip} ${this.personBinder.value.address?.city}
                 </span>
 
-                <span>
-                  ${this.personBinder.value.address?.country}
-                </span>
+                <span> ${this.personBinder.value.address?.country} </span>
               </vaadin-vertical-layout>
             </vaadin-horizontal-layout>
           </vaadin-accordion-heading>

--- a/frontend/demo/component/app-layout/app-layout-height-auto.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-auto.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 20 });

--- a/frontend/demo/component/app-layout/app-layout-height-full.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-full.ts
@@ -28,7 +28,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/avatar/avatar-basic.ts
+++ b/frontend/demo/component/avatar/avatar-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/avatar/avatar-group-basic.ts
+++ b/frontend/demo/component/avatar/avatar-group-basic.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 3 });

--- a/frontend/demo/component/avatar/avatar-group-bg-color.ts
+++ b/frontend/demo/component/avatar/avatar-group-bg-color.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 6 });

--- a/frontend/demo/component/avatar/avatar-group-internationalisation.ts
+++ b/frontend/demo/component/avatar/avatar-group-internationalisation.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 2 });

--- a/frontend/demo/component/avatar/avatar-group-max-items.ts
+++ b/frontend/demo/component/avatar/avatar-group-max-items.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 6 });

--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/avatar/avatar-menu-bar.ts
+++ b/frontend/demo/component/avatar/avatar-menu-bar.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor menuBarItems: MenuBarItem[] = [];
+  private menuBarItems: MenuBarItem[] = [];
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   // tag::snippet[]
   protected override async firstUpdated() {

--- a/frontend/demo/component/avatar/avatar-name.ts
+++ b/frontend/demo/component/avatar/avatar-name.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor person: Person | undefined;
+  private person: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/badge/badge-highlight.ts
+++ b/frontend/demo/component/badge/badge-highlight.ts
@@ -18,7 +18,7 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 @customElement('badge-highlight')
 export class Example extends LitElement {
   @state()
-  private accessor items: readonly Report[] = [];
+  private items: readonly Report[] = [];
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -13,7 +13,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('badge-icons-only-table')
 export class Example extends LitElement {
   @state()
-  private accessor items: readonly UserPermissions[] = [];
+  private items: readonly UserPermissions[] = [];
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/badge/badge-interactive.ts
+++ b/frontend/demo/component/badge/badge-interactive.ts
@@ -19,10 +19,10 @@ type Profession = string;
 @customElement('badge-interactive')
 export class Example extends LitElement {
   @state()
-  private accessor items: readonly Profession[] = [];
+  private items: readonly Profession[] = [];
 
   @state()
-  private accessor selectedProfessions: readonly Profession[] = [];
+  private selectedProfessions: readonly Profession[] = [];
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor size = '0';
+  private size = '0';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'margin';
+  private theme = 'margin';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'padding';
+  private theme = 'padding';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor themeVariant = 'spacing-xl';
+  private themeVariant = 'spacing-xl';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'spacing';
+  private theme = 'spacing';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'margin';
+  private theme = 'margin';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'padding';
+  private theme = 'padding';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor themeVariant = 'spacing-xl';
+  private themeVariant = 'spacing-xl';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor theme = 'spacing';
+  private theme = 'spacing';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/board/example-chart.ts
+++ b/frontend/demo/component/board/example-chart.ts
@@ -36,7 +36,7 @@ export class Example extends LitElement {
   `;
 
   @state()
-  private accessor events: ViewEvent[] = [];
+  private events: ViewEvent[] = [];
 
   protected override async firstUpdated() {
     this.events = await getViewEvents();

--- a/frontend/demo/component/board/example-indicator.ts
+++ b/frontend/demo/component/board/example-indicator.ts
@@ -50,13 +50,13 @@ export class ExampleIndicator extends LitElement {
   `;
 
   @property()
-  accessor title = 'Unknown';
+  title = 'Unknown';
 
   @property()
-  accessor current = '0';
+  current = '0';
 
   @property({ type: Number })
-  accessor change = 0;
+  change = 0;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/board/example-statistics.ts
+++ b/frontend/demo/component/board/example-statistics.ts
@@ -78,7 +78,7 @@ export class ExampleStatistics extends LitElement {
   `;
 
   @state()
-  private accessor serviceHealth: ServiceHealth[] = [];
+  private serviceHealth: ServiceHealth[] = [];
 
   protected override async firstUpdated() {
     this.serviceHealth = await getServiceHealth();

--- a/frontend/demo/component/button/button-basic.ts
+++ b/frontend/demo/component/button/button-basic.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor counter = 0;
+  private counter = 0;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/button/button-disable-long-action.ts
+++ b/frontend/demo/component/button/button-disable-long-action.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor isDisabled = false;
+  private isDisabled = false;
 
   @query('fake-progress-bar')
-  private accessor fakeProgressBar!: FakeProgressBar;
+  private fakeProgressBar!: FakeProgressBar;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/button/button-grid.ts
+++ b/frontend/demo/component/button/button-grid.ts
@@ -23,10 +23,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor selectedItems: Person[] = [];
+  private selectedItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/button/button-labels.ts
+++ b/frontend/demo/component/button/button-labels.ts
@@ -25,10 +25,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor primaryEmail = 'foo@example.com';
+  private primaryEmail = 'foo@example.com';
 
   @state()
-  private accessor secondaryEmail = 'bar@example.com';
+  private secondaryEmail = 'bar@example.com';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/button/fake-progress-bar.ts
+++ b/frontend/demo/component/button/fake-progress-bar.ts
@@ -11,7 +11,7 @@ export class FakeProgressBar extends LitElement {
   `;
 
   @property({ type: Number })
-  accessor progress = 0;
+  progress = 0;
 
   simulateProgress() {
     this.progress = 0;

--- a/frontend/demo/component/charts/charts-overview.ts
+++ b/frontend/demo/component/charts/charts-overview.ts
@@ -44,7 +44,7 @@ export class Example extends LitElement {
   `;
 
   @state()
-  private accessor areaOptions: Options = {
+  private areaOptions: Options = {
     yAxis: { title: { text: '' } },
     xAxis: { visible: false },
     plotOptions: {
@@ -57,10 +57,10 @@ export class Example extends LitElement {
   };
 
   @state()
-  private accessor columnOptions: Options = { yAxis: { title: { text: '' } } };
+  private columnOptions: Options = { yAxis: { title: { text: '' } } };
 
   @state()
-  private accessor months = [
+  private months = [
     'Jan',
     'Feb',
     'Mar',
@@ -76,7 +76,7 @@ export class Example extends LitElement {
   ];
 
   @state()
-  private accessor pieOptions: Options = {
+  private pieOptions: Options = {
     tooltip: {
       pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>',
     },
@@ -90,7 +90,7 @@ export class Example extends LitElement {
   };
 
   @state()
-  private accessor pieValues: PointOptionsObject[] = [
+  private pieValues: PointOptionsObject[] = [
     { name: 'Chrome', y: 38 },
     { name: 'Firefox', y: 24 },
     { name: 'Edge', y: 15, sliced: true, selected: true },
@@ -98,7 +98,7 @@ export class Example extends LitElement {
   ];
 
   @state()
-  private accessor polarOptions: Options = {
+  private polarOptions: Options = {
     xAxis: {
       tickInterval: 45,
       min: 0,

--- a/frontend/demo/component/checkbox/checkbox-group-basic.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor value = ['0', '2'];
+  private value = ['0', '2'];
 
   protected override render() {
     return html`

--- a/frontend/demo/component/checkbox/checkbox-indeterminate.ts
+++ b/frontend/demo/component/checkbox/checkbox-indeterminate.ts
@@ -20,10 +20,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor selectedIds: string[] = [];
+  private selectedIds: string[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 3 });

--- a/frontend/demo/component/combobox/combo-box-auto-open.ts
+++ b/frontend/demo/component/combobox/combo-box-auto-open.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/combobox/combo-box-basic.ts
+++ b/frontend/demo/component/combobox/combo-box-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
+  private items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
 
   protected override render() {
     return html`

--- a/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
+  private items = ['Chrome', 'Edge', 'Firefox', 'Safari'];
 
   protected override render() {
     return html`

--- a/frontend/demo/component/combobox/combo-box-filtering-1.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-1.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/combobox/combo-box-filtering-2.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-2.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor allItems: Country[] = [];
+  private allItems: Country[] = [];
 
   @state()
-  private accessor filteredItems: Country[] = [];
+  private filteredItems: Country[] = [];
 
   protected override async firstUpdated() {
     const countries = await getCountries();

--- a/frontend/demo/component/combobox/combo-box-popup-width.ts
+++ b/frontend/demo/component/combobox/combo-box-popup-width.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -20,10 +20,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor allItems: Person[] = [];
+  private allItems: Person[] = [];
 
   @state()
-  private accessor filteredItems: Person[] = [];
+  private filteredItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
@@ -32,10 +32,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = true;
+  private dialogOpened = true;
 
   @state()
-  private accessor status = '';
+  private status = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor status = '';
+  private status = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor status = '';
+  private status = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor status = '';
+  private status = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/contextmenu/context-menu-basic.ts
+++ b/frontend/demo/component/contextmenu/context-menu-basic.ts
@@ -19,11 +19,11 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
+  private items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
   // end::snippet[]
 
   @state()
-  private accessor gridItems: Person[] = [];
+  private gridItems: Person[] = [];
 
   protected override async firstUpdated() {
     this.gridItems = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/contextmenu/context-menu-best-practices.ts
+++ b/frontend/demo/component/contextmenu/context-menu-best-practices.ts
@@ -24,11 +24,11 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
+  private items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
   // end::snippet[]
 
   @state()
-  private accessor gridItems: FileItem[] = [
+  private gridItems: FileItem[] = [
     { name: 'Annual Report.docx', size: '24 MB' },
     { name: 'Financials.xlsx', size: '42 MB' },
   ];

--- a/frontend/demo/component/contextmenu/context-menu-checkable.ts
+++ b/frontend/demo/component/contextmenu/context-menu-checkable.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: ContextMenuItem[] = [
+  private items: ContextMenuItem[] = [
     { text: 'Abigail Lewis', checked: true },
     { text: 'Allison Torres' },
     { text: 'Anna Myers' },

--- a/frontend/demo/component/contextmenu/context-menu-classname.ts
+++ b/frontend/demo/component/contextmenu/context-menu-classname.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: ContextMenuItem[] = [
+  private items: ContextMenuItem[] = [
     { text: 'Share' },
     { text: 'Duplicate' },
     { text: 'Delete', className: 'text-error' },

--- a/frontend/demo/component/contextmenu/context-menu-disabled.ts
+++ b/frontend/demo/component/contextmenu/context-menu-disabled.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'Preview' },
     { text: 'Edit' },
     { component: 'hr' },
@@ -41,7 +41,7 @@ export class Example extends LitElement {
   // end::snippet[]
 
   @state()
-  private accessor gridItems: FileItem[] = [
+  private gridItems: FileItem[] = [
     { name: 'Annual Report.pdf', size: '24 MB' },
     { name: 'Financials.pdf', size: '42 MB' },
   ];

--- a/frontend/demo/component/contextmenu/context-menu-dividers.ts
+++ b/frontend/demo/component/contextmenu/context-menu-dividers.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor gridItems: Person[] = [];
+  private gridItems: Person[] = [];
 
   protected override async firstUpdated() {
     this.gridItems = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
+++ b/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'Preview' },
     { text: 'Edit' },
     { component: 'hr' },
@@ -41,7 +41,7 @@ export class Example extends LitElement {
   // end::snippet[]
 
   @state()
-  private accessor gridItems: FileItem[] = [
+  private gridItems: FileItem[] = [
     { name: 'Annual Report.docx', size: '24 MB' },
     { name: 'Financials.xlsx', size: '42 MB' },
   ];

--- a/frontend/demo/component/contextmenu/context-menu-left-click.ts
+++ b/frontend/demo/component/contextmenu/context-menu-left-click.ts
@@ -20,11 +20,11 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
+  private items = [{ text: 'View' }, { text: 'Edit' }, { text: 'Delete' }];
   // end::snippet[]
 
   @state()
-  private accessor gridItems: Person[] = [];
+  private gridItems: Person[] = [];
 
   private contextMenuOpened?: boolean;
 

--- a/frontend/demo/component/contextmenu/context-menu-presentation.ts
+++ b/frontend/demo/component/contextmenu/context-menu-presentation.ts
@@ -25,10 +25,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor gridItems: Person[] = [];
+  private gridItems: Person[] = [];
 
   @state()
-  private accessor items: ContextMenuItem[] | undefined;
+  private items: ContextMenuItem[] | undefined;
 
   // tag::snippet[]
   protected override async firstUpdated() {

--- a/frontend/demo/component/crud/crud-basic.ts
+++ b/frontend/demo/component/crud/crud-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-columns.ts
+++ b/frontend/demo/component/crud/crud-columns.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-editor-aside.ts
+++ b/frontend/demo/component/crud/crud-editor-aside.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-editor-bottom.ts
+++ b/frontend/demo/component/crud/crud-editor-bottom.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-editor-content.ts
+++ b/frontend/demo/component/crud/crud-editor-content.ts
@@ -21,13 +21,13 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor professions: string[] = [];
+  private professions: string[] = [];
 
   @state()
-  private accessor responsiveSteps: FormLayoutResponsiveStep[] = [];
+  private responsiveSteps: FormLayoutResponsiveStep[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-grid-replacement.ts
+++ b/frontend/demo/component/crud/crud-grid-replacement.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-hidden-toolbar.ts
+++ b/frontend/demo/component/crud/crud-hidden-toolbar.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-item-initialization.ts
+++ b/frontend/demo/component/crud/crud-item-initialization.ts
@@ -18,10 +18,10 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-crud')
-  private accessor crud!: Crud<Partial<Person>>;
+  private crud!: Crud<Partial<Person>>;
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-localization.ts
+++ b/frontend/demo/component/crud/crud-localization.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @query('vaadin-crud')
-  private accessor crud!: Crud<Person>;
+  private crud!: Crud<Person>;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-open-editor.ts
+++ b/frontend/demo/component/crud/crud-open-editor.ts
@@ -18,10 +18,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor editedItem: Person | undefined;
+  private editedItem: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-sorting-filtering.ts
+++ b/frontend/demo/component/crud/crud-sorting-filtering.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/crud/crud-toolbar.ts
+++ b/frontend/demo/component/crud/crud-toolbar.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/custom-field/custom-field-basic.ts
+++ b/frontend/demo/component/custom-field/custom-field-basic.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @query('#start')
-  private accessor start!: DatePicker;
+  private start!: DatePicker;
 
   @query('#end')
-  private accessor end!: DatePicker;
+  private end!: DatePicker;
 
   private binder = new Binder(this, AppointmentModel);
 

--- a/frontend/demo/component/custom-field/custom-field-native-input.ts
+++ b/frontend/demo/component/custom-field/custom-field-native-input.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor customFieldValue = '';
+  private customFieldValue = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -19,13 +19,13 @@ export class Example extends LitElement {
   }
 
   @query('#amount')
-  private accessor amount!: TextField;
+  private amount!: TextField;
 
   @query('#currency')
-  private accessor currency!: Select;
+  private currency!: Select;
 
   @state()
-  private accessor currencies = [
+  private currencies = [
     { label: 'AUD', value: 'aud' },
     { label: 'CAD', value: 'cad' },
     { label: 'CHF', value: 'chf' },

--- a/frontend/demo/component/datepicker/date-picker-custom-functions.ts
+++ b/frontend/demo/component/datepicker/date-picker-custom-functions.ts
@@ -18,10 +18,10 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-date-picker')
-  private accessor datePicker!: DatePicker;
+  private datePicker!: DatePicker;
 
   @state()
-  private accessor selectedDateValue: string = dateFnsFormat(new Date(), 'yyyy-MM-dd');
+  private selectedDateValue: string = dateFnsFormat(new Date(), 'yyyy-MM-dd');
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/datepicker/date-picker-date-range.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-range.ts
@@ -17,10 +17,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor departureDate = '';
+  private departureDate = '';
 
   @state()
-  private accessor returnDate = '';
+  private returnDate = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
+++ b/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
@@ -36,16 +36,16 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  accessor selectedYear: number | undefined;
+  selectedYear: number | undefined;
 
   @state()
-  accessor selectedMonth: string | undefined;
+  selectedMonth: string | undefined;
 
   @state()
-  accessor selectedDay: number | undefined;
+  selectedDay: number | undefined;
 
   @state()
-  accessor selectableDays: number[] = [];
+  selectableDays: number[] = [];
 
   private handleYearChange(e: ComboBoxSelectedItemChangedEvent<number>) {
     this.selectedYear = e.detail.value!;

--- a/frontend/demo/component/datepicker/date-picker-internationalization.ts
+++ b/frontend/demo/component/datepicker/date-picker-internationalization.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-date-picker')
-  private accessor datePicker!: DatePicker;
+  private datePicker!: DatePicker;
 
   protected override firstUpdated() {
     this.datePicker.i18n = {

--- a/frontend/demo/component/datepicker/date-picker-min-max.ts
+++ b/frontend/demo/component/datepicker/date-picker-min-max.ts
@@ -18,13 +18,13 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor errorMessage = '';
+  private errorMessage = '';
 
   @state()
-  private accessor minDate = new Date();
+  private minDate = new Date();
 
   @state()
-  private accessor maxDate = addDays(new Date(), 60);
+  private maxDate = addDays(new Date(), 60);
 
   protected override render() {
     return html`

--- a/frontend/demo/component/datepicker/date-picker-week-numbers.ts
+++ b/frontend/demo/component/datepicker/date-picker-week-numbers.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-date-picker')
-  private accessor datePicker!: DatePicker;
+  private datePicker!: DatePicker;
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-date-time-picker')
-  private accessor dateTimePicker!: DateTimePicker;
+  private dateTimePicker!: DateTimePicker;
 
   protected override firstUpdated() {
     const _formatDate = (dateParts: DatePickerDate): string => {

--- a/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-date-time-picker')
-  private accessor dateTimePicker!: DateTimePicker;
+  private dateTimePicker!: DateTimePicker;
 
   protected override firstUpdated() {
     this.dateTimePicker.i18n = {

--- a/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts
@@ -12,16 +12,16 @@ const dateTimeFormat = `yyyy-MM-dd'T'HH:00:00`;
 @customElement('date-time-picker-min-max')
 export class Example extends LitElement {
   @state()
-  private accessor errorMessage = '';
+  private errorMessage = '';
 
   @state()
-  private accessor initialValue = addDays(new Date(), 7);
+  private initialValue = addDays(new Date(), 7);
 
   @state()
-  private accessor minDate = new Date();
+  private minDate = new Date();
 
   @state()
-  private accessor maxDate = addDays(new Date(), 60);
+  private maxDate = addDays(new Date(), 60);
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/datetimepicker/date-time-picker-range.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-range.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor startDateTime = initialStartValue;
+  private startDateTime = initialStartValue;
 
   @state()
-  private accessor endDateTime = initialEndValue;
+  private endDateTime = initialEndValue;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-date-time-picker')
-  private accessor dateTimePicker!: DateTimePicker;
+  private dateTimePicker!: DateTimePicker;
 
   protected override firstUpdated() {
     this.dateTimePicker.i18n = {

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -27,10 +27,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   @state()
-  private accessor responsiveSteps: FormLayoutResponsiveStep[] = [
+  private responsiveSteps: FormLayoutResponsiveStep[] = [
     { minWidth: 0, columns: 1 },
     { minWidth: '20em', columns: 2 },
   ];

--- a/frontend/demo/component/dialog/dialog-basic.ts
+++ b/frontend/demo/component/dialog/dialog-basic.ts
@@ -35,7 +35,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = true;
+  private dialogOpened = true;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/dialog/dialog-closing.ts
+++ b/frontend/demo/component/dialog/dialog-closing.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/dialog/dialog-draggable.ts
+++ b/frontend/demo/component/dialog/dialog-draggable.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/dialog/dialog-footer.ts
+++ b/frontend/demo/component/dialog/dialog-footer.ts
@@ -21,10 +21,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor user: Person | undefined;
+  private user: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/dialog/dialog-header.ts
+++ b/frontend/demo/component/dialog/dialog-header.ts
@@ -27,10 +27,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor user: Person | undefined;
+  private user: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/dialog/dialog-no-padding.ts
+++ b/frontend/demo/component/dialog/dialog-no-padding.ts
@@ -25,10 +25,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor people: Person[] | undefined;
+  private people: Person[] | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 50 });

--- a/frontend/demo/component/dialog/dialog-resizable.ts
+++ b/frontend/demo/component/dialog/dialog-resizable.ts
@@ -24,10 +24,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor dialogOpened = false;
+  private dialogOpened = false;
 
   @state()
-  private accessor people: Person[] | undefined;
+  private people: Person[] | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 50 });

--- a/frontend/demo/component/formlayout/form-layout-custom-field.ts
+++ b/frontend/demo/component/formlayout/form-layout-custom-field.ts
@@ -9,7 +9,7 @@ import '@vaadin/custom-field';
 import '@vaadin/horizontal-layout';
 
 import { applyTheme } from 'Frontend/generated/theme';
-import { Select } from '@vaadin/select';
+import type { Select } from '@vaadin/select';
 
 @customElement('form-layout-custom-field')
 export class Example extends LitElement {
@@ -22,16 +22,16 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('#month-field')
-  private accessor monthField!: Select;
+  private monthField!: Select;
 
   @query('#year-field')
-  private accessor yearField!: Select;
+  private yearField!: Select;
 
   @state()
-  private accessor months = Array.from({ length: 12 }, (_, i) => `${i + 1}`.padStart(2, '0'));
+  private months = Array.from({ length: 12 }, (_, i) => `${i + 1}`.padStart(2, '0'));
 
   @state()
-  private accessor years = Array.from({ length: 11 }, (_, i) => `${i + new Date().getFullYear()}`);
+  private years = Array.from({ length: 11 }, (_, i) => `${i + new Date().getFullYear()}`);
 
   protected override firstUpdated() {
     // Set title for screen readers
@@ -45,12 +45,9 @@ export class Example extends LitElement {
         <vaadin-form-item>
           <label slot="label">Expiration</label>
           <vaadin-custom-field
-            .parseValue="${(value: string) => {
-              return value ? value.split('/') : ['', ''];
-            }}"
-            .formatValue="${(values: unknown[]) => {
-              return values[0] && values[1] ? values.join('/') : '';
-            }}"
+            .parseValue="${(value: string) => (value ? value.split('/') : ['', ''])}"
+            .formatValue="${(values: unknown[]) =>
+              values[0] && values[1] ? values.join('/') : ''}"
           >
             <vaadin-horizontal-layout theme="spacing-xs">
               <vaadin-select

--- a/frontend/demo/component/grid/grid-basic.ts
+++ b/frontend/demo/component/grid/grid-basic.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -25,13 +25,13 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-grid')
-  private accessor grid!: Grid<Person>;
+  private grid!: Grid<Person>;
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor eventSummary = '';
+  private eventSummary = '';
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-alignment.ts
+++ b/frontend/demo/component/grid/grid-column-alignment.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-borders.ts
+++ b/frontend/demo/component/grid/grid-column-borders.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-filtering.ts
+++ b/frontend/demo/component/grid/grid-column-filtering.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: PersonEnhanced[] = [];
+  private items: PersonEnhanced[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-freezing.ts
+++ b/frontend/demo/component/grid/grid-column-freezing.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] | undefined;
+  private items: Person[] | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-grouping.ts
+++ b/frontend/demo/component/grid/grid-column-grouping.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-header-footer.ts
+++ b/frontend/demo/component/grid/grid-column-header-footer.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-reordering-resizing.ts
+++ b/frontend/demo/component/grid/grid-column-reordering-resizing.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-column-visibility.ts
+++ b/frontend/demo/component/grid/grid-column-visibility.ts
@@ -22,10 +22,10 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor contextMenuItems: Array<ContextMenuItem & { key: string }> = [
+  private contextMenuItems: Array<ContextMenuItem & { key: string }> = [
     { text: 'First name', checked: true, key: 'firstName', keepOpen: true },
     { text: 'Last name', checked: true, key: 'lastName', keepOpen: true },
     { text: 'Email', checked: true, key: 'email', keepOpen: true },

--- a/frontend/demo/component/grid/grid-column-width.ts
+++ b/frontend/demo/component/grid/grid-column-width.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-compact.ts
+++ b/frontend/demo/component/grid/grid-compact.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-content.ts
+++ b/frontend/demo/component/grid/grid-content.ts
@@ -25,7 +25,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] | undefined;
+  private items: Person[] | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-context-menu.ts
+++ b/frontend/demo/component/grid/grid-context-menu.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-data-provider.ts
+++ b/frontend/demo/component/grid/grid-data-provider.ts
@@ -76,10 +76,10 @@ export class Example extends LitElement {
 
   // tag::snippet2[]
   @state()
-  private accessor searchTerm = '';
+  private searchTerm = '';
 
   @query('#grid')
-  private accessor grid!: Grid;
+  private grid!: Grid;
 
   private dataProvider = async (
     params: GridDataProviderParams<Person>,

--- a/frontend/demo/component/grid/grid-drag-drop-filters.ts
+++ b/frontend/demo/component/grid/grid-drag-drop-filters.ts
@@ -28,19 +28,19 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-grid')
-  private accessor grid!: Grid<Person>;
+  private grid!: Grid<Person>;
 
   @state()
-  private accessor draggedItem: Person | undefined;
+  private draggedItem: Person | undefined;
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor managers: Person[] = [];
+  private managers: Person[] = [];
 
   @state()
-  private accessor expandedItems: Person[] = [];
+  private expandedItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -36,13 +36,13 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor draggedItem: Person | undefined;
+  private draggedItem: Person | undefined;
 
   @state()
-  private accessor grid1Items: Person[] = [];
+  private grid1Items: Person[] = [];
 
   @state()
-  private accessor grid2Items: Person[] = [];
+  private grid2Items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 10 });

--- a/frontend/demo/component/grid/grid-dynamic-height.ts
+++ b/frontend/demo/component/grid/grid-dynamic-height.ts
@@ -25,13 +25,13 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor invitedPeople: Person[] = [];
+  private invitedPeople: Person[] = [];
 
   @state()
-  private accessor selectedValue = '';
+  private selectedValue = '';
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-external-filtering.ts
+++ b/frontend/demo/component/grid/grid-external-filtering.ts
@@ -29,7 +29,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor filteredItems: PersonEnhanced[] = [];
+  private filteredItems: PersonEnhanced[] = [];
 
   private items: PersonEnhanced[] = [];
 

--- a/frontend/demo/component/grid/grid-header-footer-styling.ts
+++ b/frontend/demo/component/grid/grid-header-footer-styling.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: PersonWithRating[] = [];
+  private items: PersonWithRating[] = [];
 
   private ratingFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,

--- a/frontend/demo/component/grid/grid-item-details-toggle.ts
+++ b/frontend/demo/component/grid/grid-item-details-toggle.ts
@@ -21,10 +21,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor detailsOpenedItems: Person[] = [];
+  private detailsOpenedItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-item-details.ts
+++ b/frontend/demo/component/grid/grid-item-details.ts
@@ -22,10 +22,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor detailsOpenedItem: Person[] = [];
+  private detailsOpenedItem: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-lazy-column-rendering.ts
+++ b/frontend/demo/component/grid/grid-lazy-column-rendering.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();
@@ -32,16 +32,17 @@ export class Example extends LitElement {
         <!-- end::snippet[] -->
         <vaadin-grid-column frozen .renderer="${this.indexColumnRenderer}"></vaadin-grid-column>
 
-        ${[...Array(100).keys()].map((index) => {
-          // Generate 100 columns
-          return html`
-            <vaadin-grid-column
-              data-index="${index}"
-              .header="${`Col ${index}`}"
-              .renderer="${this.columnRenderer}"
-            ></vaadin-grid-column>
-          `;
-        })}
+        ${[...Array(100).keys()].map(
+          (index) =>
+            // Generate 100 columns
+            html`
+              <vaadin-grid-column
+                data-index="${index}"
+                .header="${`Col ${index}`}"
+                .renderer="${this.columnRenderer}"
+              ></vaadin-grid-column>
+            `
+        )}
       </vaadin-grid>
     `;
   }
@@ -51,6 +52,6 @@ export class Example extends LitElement {
   };
 
   private indexColumnRenderer: GridBodyRenderer<Person> = (root, _, { index }) => {
-    root.textContent = 'Row ' + index;
+    root.textContent = `Row ${index}`;
   };
 }

--- a/frontend/demo/component/grid/grid-multi-select-mode.ts
+++ b/frontend/demo/component/grid/grid-multi-select-mode.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-multisort.ts
+++ b/frontend/demo/component/grid/grid-multisort.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-no-border.ts
+++ b/frontend/demo/component/grid/grid-no-border.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-no-row-border.ts
+++ b/frontend/demo/component/grid/grid-no-row-border.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-rich-content-sorting.ts
+++ b/frontend/demo/component/grid/grid-rich-content-sorting.ts
@@ -25,7 +25,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-row-reordering.ts
+++ b/frontend/demo/component/grid/grid-row-reordering.ts
@@ -22,10 +22,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor draggedItem: Person | undefined;
+  private draggedItem: Person | undefined;
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-row-stripes.ts
+++ b/frontend/demo/component/grid/grid-row-stripes.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-single-selection-mode.ts
+++ b/frontend/demo/component/grid/grid-single-selection-mode.ts
@@ -19,10 +19,10 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   @state()
-  private accessor selectedItems: Person[] = [];
+  private selectedItems: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-sorting.ts
+++ b/frontend/demo/component/grid/grid-sorting.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-styling.ts
+++ b/frontend/demo/component/grid/grid-styling.ts
@@ -25,7 +25,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: PersonWithRating[] = [];
+  private items: PersonWithRating[] = [];
 
   private ratingFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,

--- a/frontend/demo/component/grid/grid-tooltip-generator.ts
+++ b/frontend/demo/component/grid/grid-tooltip-generator.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/grid/grid-wrap-cell-content.ts
+++ b/frontend/demo/component/grid/grid-wrap-cell-content.ts
@@ -21,7 +21,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-basic.ts
+++ b/frontend/demo/component/gridpro/grid-pro-basic.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-edit-column.ts
+++ b/frontend/demo/component/gridpro/grid-pro-edit-column.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-editors.ts
+++ b/frontend/demo/component/gridpro/grid-pro-editors.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
+++ b/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
+++ b/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   private showErrorNotification(msg: string) {
     const notification = Notification.show(msg, { position: 'bottom-center' });

--- a/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/gridpro/grid-pro-single-click.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-click.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();

--- a/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
+++ b/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
@@ -21,7 +21,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 5 });

--- a/frontend/demo/component/listbox/list-box-multi-selection.ts
+++ b/frontend/demo/component/listbox/list-box-multi-selection.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Person[] = [];
+  private items: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 20 });

--- a/frontend/demo/component/login/login-additional-information.ts
+++ b/frontend/demo/component/login/login-additional-information.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-login-overlay')
-  private accessor login!: LoginOverlay;
+  private login!: LoginOverlay;
 
   protected override firstUpdated() {
     this.login.i18n = {

--- a/frontend/demo/component/login/login-overlay-basic.ts
+++ b/frontend/demo/component/login/login-overlay-basic.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor loginOpened = false;
+  private loginOpened = false;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -76,16 +76,16 @@ export class LoginOverlayMockupElement extends LitElement {
   }
 
   @property({ type: String })
-  accessor headerTitle: string | undefined = 'App name';
+  headerTitle: string | undefined = 'App name';
 
   @property({ type: String })
-  accessor description: string | undefined = 'Application description';
+  description: string | undefined = 'Application description';
 
   @property({ type: Boolean })
-  accessor error = false;
+  error = false;
 
   @property({ type: Object })
-  accessor i18n: LoginI18n = {
+  i18n: LoginI18n = {
     form: {
       title: 'Log in',
       username: 'Username',

--- a/frontend/demo/component/login/react/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/react/login-overlay-mockup.ts
@@ -76,16 +76,16 @@ export class LoginOverlayMockupElement extends LitElement {
   }
 
   @property({ type: String })
-  accessor headerTitle: string | undefined = 'App name';
+  headerTitle: string | undefined = 'App name';
 
   @property({ type: String })
-  accessor description: string | undefined = 'Application description';
+  description: string | undefined = 'Application description';
 
   @property({ type: Boolean })
-  accessor error = false;
+  error = false;
 
   @property({ type: Object })
-  accessor i18n: LoginI18n = {
+  i18n: LoginI18n = {
     form: {
       title: 'Log in',
       username: 'Username',

--- a/frontend/demo/component/menubar/menu-bar-basic.ts
+++ b/frontend/demo/component/menubar/menu-bar-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {
@@ -39,7 +39,7 @@ export class Example extends LitElement {
   ];
 
   @state()
-  private accessor selectedItem: MenuBarItem | undefined;
+  private selectedItem: MenuBarItem | undefined;
   // end::snippet[]
 
   protected override render() {

--- a/frontend/demo/component/menubar/menu-bar-checkable.ts
+++ b/frontend/demo/component/menubar/menu-bar-checkable.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       text: 'Options',
       children: [{ text: 'Save automatically', checked: true }, { text: 'Notify watchers' }],

--- a/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
+++ b/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'Save' },
     {
       component: this.createItem(),

--- a/frontend/demo/component/menubar/menu-bar-custom-styling.ts
+++ b/frontend/demo/component/menubar/menu-bar-custom-styling.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View', className: 'bg-primary text-primary-contrast' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-disabled.ts
+++ b/frontend/demo/component/menubar/menu-bar-disabled.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit', disabled: true },
     {

--- a/frontend/demo/component/menubar/menu-bar-dividers.ts
+++ b/frontend/demo/component/menubar/menu-bar-dividers.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       text: 'Share',
       children: [

--- a/frontend/demo/component/menubar/menu-bar-drop-down.ts
+++ b/frontend/demo/component/menubar/menu-bar-drop-down.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       text: 'John Smith',
       children: [

--- a/frontend/demo/component/menubar/menu-bar-icon-only.ts
+++ b/frontend/demo/component/menubar/menu-bar-icon-only.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { component: this.createItem('eye', 'View') },
     { component: this.createItem('pencil', 'Edit') },
     {

--- a/frontend/demo/component/menubar/menu-bar-icons.ts
+++ b/frontend/demo/component/menubar/menu-bar-icons.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       component: this.createItem('share', 'Share'),
       children: [

--- a/frontend/demo/component/menubar/menu-bar-internationalization.ts
+++ b/frontend/demo/component/menubar/menu-bar-internationalization.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
+++ b/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-overflow.ts
+++ b/frontend/demo/component/menubar/menu-bar-overflow.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-right-aligned.ts
+++ b/frontend/demo/component/menubar/menu-bar-right-aligned.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/menu-bar-tooltip.ts
+++ b/frontend/demo/component/menubar/menu-bar-tooltip.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items = [
+  private items = [
     {
       component: this.createItem('eye'),
       tooltip: 'View',

--- a/frontend/demo/component/messages/message-basic.ts
+++ b/frontend/demo/component/messages/message-basic.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: MessageListItem[] = [];
+  private items: MessageListItem[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 1 });

--- a/frontend/demo/component/messages/message-input-component.ts
+++ b/frontend/demo/component/messages/message-input-component.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor message = '';
+  private message = '';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
@@ -24,7 +24,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();
@@ -28,7 +28,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor selectedCountries: Country[] = [];
+  private selectedCountries: Country[] = [];
 
   private get selectedCountriesText(): string {
     return this.selectedCountries.map((country) => country.name).join(', ');

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: Country[] = [];
+  private items: Country[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCountries();

--- a/frontend/demo/component/notification/notification-error.ts
+++ b/frontend/demo/component/notification/notification-error.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-error')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-keyboard-a11y.ts
+++ b/frontend/demo/component/notification/notification-keyboard-a11y.ts
@@ -12,10 +12,10 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-keyboard-a11y')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   @state()
-  private accessor isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(window.navigator.platform);
+  private isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(window.navigator.platform);
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-link.ts
+++ b/frontend/demo/component/notification/notification-link.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-link')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-retry.ts
+++ b/frontend/demo/component/notification/notification-retry.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-retry')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-undo.ts
+++ b/frontend/demo/component/notification/notification-undo.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-undo')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/notification/notification-warning.ts
+++ b/frontend/demo/component/notification/notification-warning.ts
@@ -14,7 +14,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('notification-warning')
 export class Example extends LitElement {
   @state()
-  private accessor notificationOpened = true;
+  private notificationOpened = true;
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
+++ b/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
@@ -26,10 +26,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor strengthText: PasswordStrength = 'weak';
+  private strengthText: PasswordStrength = 'weak';
 
   @state()
-  private accessor strengthColor = StrengthColor.weak;
+  private strengthColor = StrengthColor.weak;
 
   private pattern = '^(?=.*[0-9])(?=.*[a-zA-Z]).{8}.*$';
 

--- a/frontend/demo/component/radiobutton/radio-button-custom-option.ts
+++ b/frontend/demo/component/radiobutton/radio-button-custom-option.ts
@@ -21,10 +21,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor value: string | undefined;
+  private value: string | undefined;
 
   @state()
-  private accessor items: Card[] = [];
+  private items: Card[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCards();

--- a/frontend/demo/component/radiobutton/radio-button-presentation.ts
+++ b/frontend/demo/component/radiobutton/radio-button-presentation.ts
@@ -18,10 +18,10 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor value: string | undefined;
+  private value: string | undefined;
 
   @state()
-  private accessor items: Card[] = [];
+  private items: Card[] = [];
 
   protected override async firstUpdated() {
     this.items = await getCards();

--- a/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
@@ -22,13 +22,13 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor htmlValue = '';
+  private htmlValue = '';
 
   @state()
-  private accessor deltaValue = '';
+  private deltaValue = '';
 
   @query('vaadin-rich-text-editor')
-  private accessor richTextEditor!: RichTextEditor;
+  private richTextEditor!: RichTextEditor;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor richText = templates.richTextDelta;
+  private richText = templates.richTextDelta;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/select/select-basic-features.ts
+++ b/frontend/demo/component/select/select-basic-features.ts
@@ -34,7 +34,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/select/select-basic.ts
+++ b/frontend/demo/component/select/select-basic.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/select/select-complex-value-label.ts
+++ b/frontend/demo/component/select/select-complex-value-label.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items: SelectItem[] = [];
+  private items: SelectItem[] = [];
 
   protected override async firstUpdated() {
     const people = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -22,7 +22,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor people: Person[] = [];
+  private people: Person[] = [];
 
   protected override async firstUpdated() {
     this.people = (await getPeople({ count: 5 })).people;

--- a/frontend/demo/component/select/select-disabled.ts
+++ b/frontend/demo/component/select/select-disabled.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   @state()
   // tag::snippet[]
-  private accessor items = [
+  private items = [
     {
       label: 'XS (out of stock)',
       value: 'xs',

--- a/frontend/demo/component/select/select-dividers.ts
+++ b/frontend/demo/component/select/select-dividers.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
   @state()
   // tag::snippet[]
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/select/select-placeholder.ts
+++ b/frontend/demo/component/select/select-placeholder.ts
@@ -15,7 +15,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'XS',
       value: 'xs',

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor people: Person[] = [];
+  private people: Person[] = [];
 
   protected override async firstUpdated() {
     const { people } = await getPeople({ count: 4 });

--- a/frontend/demo/component/select/select-readonly-and-disabled.ts
+++ b/frontend/demo/component/select/select-readonly-and-disabled.ts
@@ -33,7 +33,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/select/select-styles.ts
+++ b/frontend/demo/component/select/select-styles.ts
@@ -30,7 +30,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor items = [
+  private items = [
     {
       label: 'Most recent first',
       value: 'recent',

--- a/frontend/demo/component/splitlayout/split-layout-toggle.ts
+++ b/frontend/demo/component/splitlayout/split-layout-toggle.ts
@@ -20,7 +20,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor sidebarCollapsed = false;
+  private sidebarCollapsed = false;
 
   protected override render() {
     const sidebarWidthPercentage = this.sidebarCollapsed ? 13 : 40;

--- a/frontend/demo/component/tabs/tabs-content.ts
+++ b/frontend/demo/component/tabs/tabs-content.ts
@@ -9,10 +9,10 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('tabs-content')
 export class Example extends LitElement {
   @state()
-  private accessor content = '';
+  private content = '';
 
   @state()
-  private accessor pages = ['Dashboard', 'Payment', 'Shipping'];
+  private pages = ['Dashboard', 'Payment', 'Shipping'];
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
+++ b/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor visitedTabs = new Set<number>();
+  private visitedTabs = new Set<number>();
 
   private selectedTabChanged(event: TabSheetSelectedChangedEvent) {
     this.visitedTabs = new Set([...this.visitedTabs, event.detail.value]);

--- a/frontend/demo/component/textarea/text-area-basic.ts
+++ b/frontend/demo/component/textarea/text-area-basic.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
   private charLimit = 140;
 
   @state()
-  private accessor text = 'Great job. This is excellent!';
+  private text = 'Great job. This is excellent!';
 
   protected override render() {
     return html`

--- a/frontend/demo/component/textarea/text-area-helper.ts
+++ b/frontend/demo/component/textarea/text-area-helper.ts
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   private charLimit = 600;
 
   @state()
-  private accessor text = templates.loremIpsum;
+  private text = templates.loremIpsum;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/timepicker/time-picker-min-max.ts
+++ b/frontend/demo/component/timepicker/time-picker-min-max.ts
@@ -9,7 +9,7 @@ import { applyTheme } from 'Frontend/generated/theme';
 @customElement('time-picker-min-max')
 export class Example extends LitElement {
   @state()
-  protected accessor errorMessage = '';
+  protected errorMessage = '';
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/tooltip/tooltip-manual.ts
+++ b/frontend/demo/component/tooltip/tooltip-manual.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor tooltipOpened = false;
+  private tooltipOpened = false;
 
   protected override render() {
     return html`

--- a/frontend/demo/component/tree-grid/tree-grid-column.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-column.ts
@@ -41,7 +41,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @state()
-  private accessor expandedItems: unknown[] = [];
+  private expandedItems: unknown[] = [];
 
   protected override render() {
     return html`

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -28,7 +28,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor expandedItems: Person[] = [];
+  private expandedItems: Person[] = [];
 
   async dataProvider(
     params: GridDataProviderParams<Person>,

--- a/frontend/demo/component/upload/upload-all-files.ts
+++ b/frontend/demo/component/upload/upload-all-files.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   // end::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/upload/upload-auto-upload-disabled.ts
+++ b/frontend/demo/component/upload/upload-auto-upload-disabled.ts
@@ -18,7 +18,7 @@ export class Example extends LitElement {
 
   // tag::snippet[]
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   protected override firstUpdated() {
     this.upload.i18n.addFiles.many = 'Select Files...';

--- a/frontend/demo/component/upload/upload-button-theme-variant.ts
+++ b/frontend/demo/component/upload/upload-button-theme-variant.ts
@@ -22,10 +22,10 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   @state()
-  private accessor maxFilesReached = false;
+  private maxFilesReached = false;
 
   protected override firstUpdated() {
     this.upload.i18n.dropFiles.one = 'Drop PDF here';

--- a/frontend/demo/component/upload/upload-error-messages.ts
+++ b/frontend/demo/component/upload/upload-error-messages.ts
@@ -23,10 +23,10 @@ export class Example extends LitElement {
   }
 
   @query('#upload-caution')
-  private accessor uploadCaution!: Upload;
+  private uploadCaution!: Upload;
 
   @query('#upload-recommended')
-  private accessor uploadRecommended!: Upload;
+  private uploadRecommended!: Upload;
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/upload/upload-file-count.ts
+++ b/frontend/demo/component/upload/upload-file-count.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   protected override firstUpdated() {
     this.upload.i18n.error.tooManyFiles = 'You may only upload a maximum of three files at once.';

--- a/frontend/demo/component/upload/upload-file-format.ts
+++ b/frontend/demo/component/upload/upload-file-format.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   protected override firstUpdated() {
     this.upload.i18n.addFiles.one = 'Upload Report...';

--- a/frontend/demo/component/upload/upload-file-size.ts
+++ b/frontend/demo/component/upload/upload-file-size.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   protected override firstUpdated() {
     this.upload.i18n.error.fileIsTooBig = 'The file exceeds the maximum allowed size of 10MB.';

--- a/frontend/demo/component/upload/upload-helper.ts
+++ b/frontend/demo/component/upload/upload-helper.ts
@@ -27,7 +27,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/upload/upload-labelling.ts
+++ b/frontend/demo/component/upload/upload-labelling.ts
@@ -17,7 +17,7 @@ export class Example extends LitElement {
   }
 
   @query('vaadin-upload')
-  private accessor upload!: Upload;
+  private upload!: Upload;
 
   // tag::snippet[]
   protected override firstUpdated() {

--- a/frontend/demo/component/virtuallist/virtual-list-basic.ts
+++ b/frontend/demo/component/virtuallist/virtual-list-basic.ts
@@ -32,7 +32,7 @@ export class Example extends LitElement {
   }
 
   @state()
-  private accessor people: Person[] | undefined;
+  private people: Person[] | undefined;
 
   private expandedPeople = new Set<Person>();
 

--- a/frontend/demo/flow/application/events/events-basic.ts
+++ b/frontend/demo/flow/application/events/events-basic.ts
@@ -7,10 +7,10 @@ import '@vaadin/horizontal-layout';
 // tag::snippet[]
 export class EventsBasic extends LitElement {
   @state()
-  private accessor caption = 'Click me!';
+  private caption = 'Click me!';
 
   @state()
-  private accessor count = 0;
+  private count = 0;
 
   protected override render() {
     return html`<vaadin-button @click="${this.onClick}">${this.caption}</vaadin-button>`;

--- a/frontend/demo/foundation/icons-preview.ts
+++ b/frontend/demo/foundation/icons-preview.ts
@@ -20,13 +20,13 @@ export type IconSetType = 'lumo' | 'vaadin';
 @customElement('icons-preview')
 export class IconsPreview extends LitElement {
   @state()
-  accessor iconNames: string[] | undefined;
+  iconNames: string[] | undefined;
 
   @property({ type: String, attribute: 'iconset-type' })
-  accessor iconsetType: IconSetType = 'vaadin';
+  iconsetType: IconSetType = 'vaadin';
 
   @query('input')
-  private accessor search!: HTMLInputElement;
+  private search!: HTMLInputElement;
 
   protected override createRenderRoot() {
     return this;

--- a/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
+++ b/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
@@ -22,10 +22,10 @@ export class DashboardGenerator extends LitElement {
   `;
 
   @state()
-  accessor accountId = '';
+  accountId = '';
 
   @state()
-  accessor json = '';
+  json = '';
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();


### PR DESCRIPTION
Remove the use of standard decorators in the component examples since they can't be used in Flow or Hilla apps.
See https://github.com/vaadin/docs-app/pull/407#issue-2043607860

I verified that both dev mode and build still work with these changes

