### PR TITLE
chore: show react examples in production

### DIFF
--- a/dspublisher/config/production.json
+++ b/dspublisher/config/production.json
@@ -2,7 +2,7 @@
   "asciidocAttributes": {
     "flow": true,
     "lit": true,
-    "react": false
+    "react": true
   },
   "useStandardDecorators": true,
   "useEsbuild": true


### PR DESCRIPTION
Enable showing the React examples in production on `next`. Currently, they are only visible in development mode.