### PR TITLE
chore: advise importing icon collections client-side

### DIFF
--- a/articles/components/icons/index.adoc
+++ b/articles/components/icons/index.adoc
@@ -44,6 +44,12 @@ endif::[]
 Two icon collections are available through Vaadin dependencies: Vaadin Icons and Lumo Icons. The Flow API provides enumations for these collections that makes them easy to use.
 
 
+.Explicitly Import Icon Collections
+[NOTE]
+To use icons in client-side code (React / HTML), remember to import the necessary iconset explicitly.
+For Vaadin icons, use `import '@vaadin/icons';` etc.
+Failing to do so may result in icons being visible only in development mode but not in production.
+
 === Vaadin Icons
 
 Vaadin Icons is a collection of over six-hundred icons.


### PR DESCRIPTION
Add a note about importing icon collections explicitly when using the Web component or React icon.

Closes https://github.com/vaadin/react-components/issues/218

![Screenshot 2024-02-08 at 9 51 10](https://github.com/vaadin/docs/assets/1222264/bcf258d8-e35a-4127-abc9-021250dec584)
