### PR TITLE
fix: fix interface name in navigation docs

### DIFF
--- a/articles/flow/routing/navigation.adoc
+++ b/articles/flow/routing/navigation.adoc
@@ -54,7 +54,7 @@ If deep linking is required, the target view must <<updating-url-parameters#,mai
 
 === Passing Data Using Route Parameters
 
-If your target view implements [interfacename]`HasRouteParameters`, you can submit trivial data to the target view as route parameters.
+If your target view implements [interfacename]`HasUrlParameter`, you can submit trivial data to the target view as route parameters.
 Compared to directly interacting with the target views Java API, this method automatically maintains the URL, which is beneficial for deep linking.
 However, you can't pass more complex objects as route parameters as such, and you always need to consider data safety parameters that end up in URLs.
 


### PR DESCRIPTION
HasRouteParameters interface does not exist, the correct name is HasUrlParameter.


