### PR TITLE
docs: add date-picker and time-picker custom validator React example

### DIFF
--- a/frontend/demo/component/datepicker/react/date-picker-custom-validation.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-custom-validation.tsx
@@ -1,11 +1,32 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
+import React, { useEffect } from 'react';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
+import { useForm, useFormPart } from '@vaadin/hilla-react-form';
+import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
 
 function Example() {
   // tag::snippet[]
-  // This is a placeholder file. Binder support for React is not yet implemented. See https://github.com/vaadin/hilla/issues/587
-  return <DatePicker label="Meeting date" helperText="Mondays – Fridays only" />;
+  const { model, field } = useForm(AppointmentModel);
+  const dateField = useFormPart(model.startDate);
+
+  useEffect(() => {
+    dateField.addValidator({
+      message: 'Select a weekday',
+      validate: (startDate: string) => {
+        const date = new Date(startDate);
+        const isWeekday = date.getDay() >= 1 && date.getDay() <= 5;
+        return isWeekday;
+      },
+    });
+  }, []);
+
+  return (
+    <DatePicker
+      label="Meeting date"
+      helperText="Mondays – Fridays only"
+      {...field(model.startDate)}
+    />
+  );
   // end::snippet[]
 }
 

--- a/frontend/demo/component/timepicker/react/time-picker-custom-validation.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-custom-validation.tsx
@@ -1,20 +1,34 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
+import React, { useEffect } from 'react';
 import { TimePicker } from '@vaadin/react-components/TimePicker.js';
+import { useForm, useFormPart } from '@vaadin/hilla-react-form';
+import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
 
 function Example() {
-  // This is a placeholder file. Binder support for React is not yet implemented. See https://github.com/vaadin/hilla/issues/587
+  // tag::snippet[]
+  const { model, field } = useForm(AppointmentModel);
+  const timeField = useFormPart(model.startTime);
+
+  useEffect(() => {
+    timeField.addValidator({
+      message: 'The selected time is not available',
+      validate: (startTime: string) =>
+        (startTime >= '08:00' && startTime <= '12:00') ||
+        (startTime >= '13:00' && startTime <= '16:00'),
+    });
+  }, []);
+
   return (
-    // tag::snippet[]
     <TimePicker
       label="Appointment time"
       helperText="Open 8:00-12:00, 13:00-16:00"
       min="08:00"
       max="16:00"
       step={60 * 30}
+      {...field(model.startTime)}
     />
-    // end::snippet[]
   );
+  // end::snippet[]
 }
 
 export default reactExample(Example); // hidden-source-line


### PR DESCRIPTION
Part of #3212 

- [x] date-picker
- [x] time-picker
- [ ] date-time-picker

UPD: the `DateTimePicker` is currently blocked by https://github.com/vaadin/hilla/issues/2134