### PR TITLE
docs: update accordion summary React example to use binder

### DIFF
--- a/frontend/demo/component/accordion/react/accordion-summary.tsx
+++ b/frontend/demo/component/accordion/react/accordion-summary.tsx
@@ -1,13 +1,19 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useEffect, useState } from 'react';
 import { Accordion, type AccordionOpenedChangedEvent } from '@vaadin/react-components/Accordion.js';
+import { AccordionHeading } from '@vaadin/react-components/AccordionHeading.js';
 import { AccordionPanel } from '@vaadin/react-components/AccordionPanel.js';
 import { FormLayout, type FormLayoutResponsiveStep } from '@vaadin/react-components/FormLayout.js';
 import { TextField } from '@vaadin/react-components/TextField.js';
 import { EmailField } from '@vaadin/react-components/EmailField.js';
 import { Button } from '@vaadin/react-components/Button.js';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';
+import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
+import { useForm } from '@vaadin/hilla-react-form';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import CardModel from 'Frontend/generated/com/vaadin/demo/domain/CardModel';
+import PersonModel from 'Frontend/generated/com/vaadin/demo/domain/PersonModel';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 
 const responsiveSteps: FormLayoutResponsiveStep[] = [
@@ -18,6 +24,9 @@ const responsiveSteps: FormLayoutResponsiveStep[] = [
 function Example() {
   const [countries, setCountries] = useState<Country[]>([]);
   const [openedPanelIndex, setOpenedPanelIndex] = useState<number | null>(0);
+
+  const person = useForm(PersonModel);
+  const card = useForm(CardModel);
 
   const handleAccordionPanelOpen = (event: AccordionOpenedChangedEvent) => {
     setOpenedPanelIndex(event.detail.value);
@@ -30,15 +39,38 @@ function Example() {
   // tag::snippet[]
   return (
     <Accordion opened={openedPanelIndex} onOpenedChanged={handleAccordionPanelOpen}>
-      <AccordionPanel summary="Customer details">
+      <AccordionPanel>
+        <AccordionHeading slot="summary">
+          <HorizontalLayout style={{ width: '100%', alignItems: 'center' }}>
+            Customer details
+            <VerticalLayout
+              hidden={openedPanelIndex === 0}
+              style={{ fontSize: 'var(--lumo-font-size-s)', marginLeft: 'auto' }}
+            >
+              <span>
+                {person.value.firstName} {person.value.lastName}
+              </span>
+              <span>{person.value.email}</span>
+              <span>{person.value.address?.phone}</span>
+            </VerticalLayout>
+          </HorizontalLayout>
+        </AccordionHeading>
         <FormLayout responsiveSteps={responsiveSteps}>
-          <TextField label="First name" />
+          <TextField label="First name" {...person.field(person.model.firstName)} />
 
-          <TextField label="Last name" />
+          <TextField label="Last name" {...person.field(person.model.lastName)} />
 
-          <EmailField label="Email address" {...{ colspan: 2 }} />
+          <EmailField
+            label="Email address"
+            data-colspan="2"
+            {...person.field(person.model.email)}
+          />
 
-          <TextField label="Phone number" {...{ colspan: 2 }} />
+          <TextField
+            label="Phone number"
+            data-colspan="2"
+            {...person.field(person.model.address.phone)}
+          />
         </FormLayout>
 
         <Button
@@ -51,15 +83,41 @@ function Example() {
         </Button>
       </AccordionPanel>
 
-      <AccordionPanel summary="Billing address">
+      <AccordionPanel>
+        <AccordionHeading slot="summary">
+          <HorizontalLayout style={{ width: '100%', alignItems: 'center' }}>
+            Billing address
+            <VerticalLayout
+              hidden={openedPanelIndex === 1}
+              style={{ fontSize: 'var(--lumo-font-size-s)', marginLeft: 'auto' }}
+            >
+              <span>{person.value.address?.street}</span>
+              <span>
+                {person.value.address?.zip} {person.value.address?.city}
+              </span>
+              <span>{person.value.address?.country}</span>
+            </VerticalLayout>
+          </HorizontalLayout>
+        </AccordionHeading>
+
         <FormLayout responsiveSteps={responsiveSteps}>
-          <TextField label="Address" {...{ colspan: 2 }} />
+          <TextField
+            label="Address"
+            data-colspan="2"
+            {...person.field(person.model.address.street)}
+          />
 
-          <TextField label="ZIP code" />
+          <TextField label="ZIP code" {...person.field(person.model.address.zip)} />
 
-          <TextField label="City" />
+          <TextField label="City" {...person.field(person.model.address.city)} />
 
-          <ComboBox label="Country" itemLabelPath="name" itemValuePath="id" items={countries} />
+          <ComboBox
+            label="Country"
+            itemLabelPath="name"
+            itemValuePath="name"
+            items={countries}
+            {...person.field(person.model.address.country)}
+          />
         </FormLayout>
 
         <Button
@@ -72,13 +130,30 @@ function Example() {
         </Button>
       </AccordionPanel>
 
-      <AccordionPanel summary="Payment">
+      <AccordionPanel>
+        <AccordionHeading slot="summary">
+          <HorizontalLayout style={{ width: '100%', alignItems: 'center' }}>
+            Payment
+            <VerticalLayout
+              hidden={openedPanelIndex === 2}
+              style={{ fontSize: 'var(--lumo-font-size-s)', marginLeft: 'auto' }}
+            >
+              <span>{card.value.accountNumber}</span>
+              <span>{card.value.expiryDate}</span>
+            </VerticalLayout>
+          </HorizontalLayout>
+        </AccordionHeading>
+
         <FormLayout responsiveSteps={responsiveSteps}>
-          <TextField label="Card number" {...{ colspan: 2 }} />
+          <TextField
+            label="Card number"
+            data-colspan="2"
+            {...card.field(card.model.accountNumber)}
+          />
 
-          <TextField label="Expiry date" />
+          <TextField label="Expiry date" {...card.field(card.model.expiryDate)} />
 
-          <TextField label="CVV" />
+          <TextField label="CVV" {...card.field(card.model.cvv)} />
         </FormLayout>
 
         <Button


### PR DESCRIPTION
Fixes #3210 

Aligned `accordion-summary.tsx` (React) with `accordion-summary.ts` (Lit), added `AccordionHeading` and binder.