### PR TITLE
chore: check tsx files, sort imports, Prettier fixes

### DIFF
--- a/frontend/demo/component/auto-crud/react/auto-crud-customized-grid.tsx
+++ b/frontend/demo/component/auto-crud/react/auto-crud-customized-grid.tsx
@@ -4,7 +4,7 @@ import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto
 import { AutoCrud } from '@vaadin/hilla-react-crud';
 import { EmployeeService } from 'Frontend/generated/endpoints';
 import EmployeeModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/EmployeeModel';
-import Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
+import type Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
 
 function Example() {
   // tag::snippet[]

--- a/frontend/demo/component/auto-form/react/auto-form-custom-renderer-alt.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-custom-renderer-alt.tsx
@@ -26,9 +26,7 @@ function GroupingLayoutRenderer({ children }: AutoFormLayoutRendererProps<Employ
         {fieldsMapping.get('active')}
       </HorizontalLayout>
       <h4>Other:</h4>
-      <HorizontalLayout theme="spacing">
-        {fieldsMapping.get('description')}
-      </HorizontalLayout>
+      <HorizontalLayout theme="spacing">{fieldsMapping.get('description')}</HorizontalLayout>
     </VerticalLayout>
   );
 }

--- a/frontend/demo/component/auto-form/react/auto-form-delete-after-delete.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-delete-after-delete.tsx
@@ -5,7 +5,7 @@ import { AutoForm } from '@vaadin/hilla-react-crud';
 import EmployeeModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/EmployeeModel';
 import { EmployeeService } from 'Frontend/generated/endpoints.js';
 import Gender from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee/Gender';
-import Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
+import type Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Button } from '@vaadin/react-components/Button.js';
@@ -38,7 +38,7 @@ function Example() {
 
   const handleDeleteSuccess = ({ item }: { item: Employee }) => {
     const json = JSON.stringify(item);
-    Notification.show('Item deleted: ' + json);
+    Notification.show(`Item deleted: ${json}`);
   };
 
   return (

--- a/frontend/demo/component/auto-form/react/auto-form-edit-new-modes.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-edit-new-modes.tsx
@@ -5,7 +5,7 @@ import { AutoForm } from '@vaadin/hilla-react-crud';
 import EmployeeModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/EmployeeModel';
 import { EmployeeService } from 'Frontend/generated/endpoints.js';
 import Gender from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee/Gender';
-import Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
+import type Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Button } from '@vaadin/react-components/Button.js';
@@ -38,7 +38,7 @@ function Example() {
 
   const handleSubmitSuccess = ({ item }: { item: Employee }) => {
     const json = JSON.stringify(item);
-    Notification.show('Form was submitted: ' + json);
+    Notification.show(`Form was submitted: ${json}`);
   };
 
   return (

--- a/frontend/demo/component/auto-form/react/auto-form-on-errors.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-on-errors.tsx
@@ -5,7 +5,7 @@ import { AutoForm } from '@vaadin/hilla-react-crud';
 import EmployeeModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/EmployeeModel';
 import { EmployeeService } from 'Frontend/generated/endpoints';
 import Gender from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee/Gender';
-import Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
+import type Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
 import { Notification } from '@vaadin/react-components/Notification.js';
 
 function Example() {
@@ -21,12 +21,12 @@ function Example() {
 
   const handleOnSubmitError = ({ error }: { error: unknown }) => {
     const json = JSON.stringify(error);
-    Notification.show('Error while submitting: ' + json);
+    Notification.show(`Error while submitting: ${json}`);
   };
 
   const handleOnDeleteError = ({ error }: { error: unknown }) => {
     const json = JSON.stringify(error);
-    Notification.show('Error while deleting: ' + json);
+    Notification.show(`Error while deleting: ${json}`);
   };
 
   return (

--- a/frontend/demo/component/auto-grid/react/auto-grid-column-options.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-column-options.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { AutoGrid } from '@vaadin/hilla-react-crud';
 import { ProductService } from 'Frontend/generated/endpoints';
 import ProductModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/ProductModel';
-import Product from 'Frontend/generated/com/vaadin/demo/fusion/crud/Product';
+import type Product from 'Frontend/generated/com/vaadin/demo/fusion/crud/Product';
 
 // tag::snippet[]
 function PriceRenderer({ item }: { item: Product }) {

--- a/frontend/demo/component/auto-grid/react/auto-grid-custom-columns.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-custom-columns.tsx
@@ -5,7 +5,7 @@ import { AutoGrid } from '@vaadin/hilla-react-crud';
 import { ProductService } from 'Frontend/generated/endpoints';
 import ProductModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/ProductModel';
 import { GridColumn } from '@vaadin/react-components/GridColumn';
-import Product from 'Frontend/generated/com/vaadin/demo/fusion/crud/Product';
+import type Product from 'Frontend/generated/com/vaadin/demo/fusion/crud/Product';
 
 function Example() {
   // tag::snippet[]

--- a/frontend/demo/component/auto-grid/react/auto-grid-filtering.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-filtering.tsx
@@ -6,9 +6,9 @@ import { ProductService } from 'Frontend/generated/endpoints';
 import ProductModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/ProductModel';
 import Matcher from 'Frontend/generated/com/vaadin/hilla/crud/filter/PropertyStringFilter/Matcher';
 import { TextField } from '@vaadin/react-components/TextField.js';
-import { Select, SelectItem } from '@vaadin/react-components/Select.js';
-import PropertyStringFilter from 'Frontend/generated/com/vaadin/hilla/crud/filter/PropertyStringFilter';
-import AndFilter from 'Frontend/generated/com/vaadin/hilla/crud/filter/AndFilter';
+import { Select, type SelectItem } from '@vaadin/react-components/Select.js';
+import type PropertyStringFilter from 'Frontend/generated/com/vaadin/hilla/crud/filter/PropertyStringFilter';
+import type AndFilter from 'Frontend/generated/com/vaadin/hilla/crud/filter/AndFilter';
 
 const categories: SelectItem[] = [
   { label: 'All', value: 'All' },
@@ -40,7 +40,7 @@ function Example() {
       children: [nameFilter, categoryFilter],
     };
 
-    return categoryFilterValue == 'All' ? nameFilter : andFilter;
+    return categoryFilterValue === 'All' ? nameFilter : andFilter;
   }, [categoryFilterValue, nameFilterValue]);
 
   return (

--- a/frontend/demo/component/auto-grid/react/auto-grid-selection.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-selection.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { AutoGrid } from '@vaadin/hilla-react-crud';
 import { ProductService } from 'Frontend/generated/endpoints';
 import ProductModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/ProductModel';
-import Product from 'Frontend/generated/com/vaadin/demo/fusion/crud/Product';
+import type Product from 'Frontend/generated/com/vaadin/demo/fusion/crud/Product';
 
 function Example() {
   // tag::snippet[]

--- a/frontend/demo/component/avatar/react/avatar-basic.tsx
+++ b/frontend/demo/component/avatar/react/avatar-basic.tsx
@@ -7,22 +7,21 @@ import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout';
 
 function Example() {
   const [person, setPerson] = useState<Person | undefined>(undefined);
+
   useEffect(() => {
     getPeople({ count: 1 }).then(({ people }) => setPerson(people[0]));
   }, []);
 
   return (
-    <>
-      <HorizontalLayout theme="spacing">
-        {/* tag::snippet[] */}
-        <Avatar />
+    <HorizontalLayout theme="spacing">
+      {/* tag::snippet[] */}
+      <Avatar />
 
-        <Avatar name={`${person?.firstName} ${person?.lastName}`} />
+      <Avatar name={`${person?.firstName} ${person?.lastName}`} />
 
-        <Avatar img={person?.pictureUrl} name={`${person?.firstName} ${person?.lastName}`} />
-        {/* end::snippet[] */}
-      </HorizontalLayout>
-    </>
+      <Avatar img={person?.pictureUrl} name={`${person?.firstName} ${person?.lastName}`} />
+      {/* end::snippet[] */}
+    </HorizontalLayout>
   );
 }
 

--- a/frontend/demo/component/badge/react/badge-size.tsx
+++ b/frontend/demo/component/badge/react/badge-size.tsx
@@ -4,16 +4,14 @@ import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 
 function Example() {
   return (
-    <>
-      <HorizontalLayout theme="spacing">
-        {/* tag::snippet[] */}
-        <span {...{ theme: 'badge small' }}>Pending</span>
-        <span {...{ theme: 'badge success small' }}>Confirmed</span>
-        <span {...{ theme: 'badge error small' }}>Denied</span>
-        <span {...{ theme: 'badge contrast small' }}>On hold</span>
-        {/* end::snippet[] */}
-      </HorizontalLayout>
-    </>
+    <HorizontalLayout theme="spacing">
+      {/* tag::snippet[] */}
+      <span {...{ theme: 'badge small' }}>Pending</span>
+      <span {...{ theme: 'badge success small' }}>Confirmed</span>
+      <span {...{ theme: 'badge error small' }}>Denied</span>
+      <span {...{ theme: 'badge contrast small' }}>On hold</span>
+      {/* end::snippet[] */}
+    </HorizontalLayout>
   );
 }
 

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
@@ -1,8 +1,8 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
+import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
-import React from 'react';
 
 function Example() {
   return (

--- a/frontend/demo/component/board/react/board-breakpoints.tsx
+++ b/frontend/demo/component/board/react/board-breakpoints.tsx
@@ -1,8 +1,8 @@
-import { Board } from '@vaadin/react-components/Board.js';
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
+import { Board } from '@vaadin/react-components/Board.js';
 import { BoardRow } from '@vaadin/react-components/BoardRow.js';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
-import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import boardStyles from './board-styles';
 
 function Example() {

--- a/frontend/demo/component/button/react/button-grid.tsx
+++ b/frontend/demo/component/button/react/button-grid.tsx
@@ -1,14 +1,13 @@
-import { Button } from '@vaadin/react-components/Button.js'; // hidden-source-line
-import React from 'react';
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React, { useEffect, useState } from 'react';
+import { Button } from '@vaadin/react-components/Button.js';
 import { Grid } from '@vaadin/react-components/Grid.js';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';
 import { GridSelectionColumn } from '@vaadin/react-components/GridSelectionColumn.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
-import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line        
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { useEffect, useState } from 'react';
 
 function Example() {
   // tag::snippet[]

--- a/frontend/demo/component/confirmdialog/react/confirm-dialog-basic.tsx
+++ b/frontend/demo/component/confirmdialog/react/confirm-dialog-basic.tsx
@@ -20,36 +20,34 @@ function Example() {
   }
 
   return (
-    <>
-      <HorizontalLayout style={{ alignItems: 'center', justifyContent: 'center' }} theme="spacing">
-        <Button onClick={() => setDialogOpened(true)}>Open confirm dialog</Button>
+    <HorizontalLayout style={{ alignItems: 'center', justifyContent: 'center' }} theme="spacing">
+      <Button onClick={() => setDialogOpened(true)}>Open confirm dialog</Button>
 
-        {/* tag::snippet[] */}
-        <ConfirmDialog
-          header="Unsaved changes"
-          cancelButtonVisible
-          rejectButtonVisible
-          rejectText="Discard"
-          confirmText="Save"
-          opened={dialogOpened}
-          onOpenedChanged={openedChanged}
-          onConfirm={() => {
-            setStatus('Saved');
-          }}
-          onCancel={() => {
-            setStatus('Canceled');
-          }}
-          onReject={() => {
-            setStatus('Discarded');
-          }}
-        >
-          There are unsaved changes. Do you want to discard or save them?
-        </ConfirmDialog>
-        {/* end::snippet[] */}
+      {/* tag::snippet[] */}
+      <ConfirmDialog
+        header="Unsaved changes"
+        cancelButtonVisible
+        rejectButtonVisible
+        rejectText="Discard"
+        confirmText="Save"
+        opened={dialogOpened}
+        onOpenedChanged={openedChanged}
+        onConfirm={() => {
+          setStatus('Saved');
+        }}
+        onCancel={() => {
+          setStatus('Canceled');
+        }}
+        onReject={() => {
+          setStatus('Discarded');
+        }}
+      >
+        There are unsaved changes. Do you want to discard or save them?
+      </ConfirmDialog>
+      {/* end::snippet[] */}
 
-        <span hidden={status === ''}>Status: {status}</span>
-      </HorizontalLayout>
-    </>
+      <span hidden={status === ''}>Status: {status}</span>
+    </HorizontalLayout>
   );
 }
 

--- a/frontend/demo/component/confirmdialog/react/confirm-dialog-cancel-button.tsx
+++ b/frontend/demo/component/confirmdialog/react/confirm-dialog-cancel-button.tsx
@@ -19,32 +19,30 @@ function Example() {
   };
 
   return (
-    <>
-      <HorizontalLayout style={{ alignItems: 'center', justifyContent: 'center' }} theme="spacing">
-        <Button onClick={() => setDialogOpened(true)}>Open confirm dialog</Button>
+    <HorizontalLayout style={{ alignItems: 'center', justifyContent: 'center' }} theme="spacing">
+      <Button onClick={() => setDialogOpened(true)}>Open confirm dialog</Button>
 
-        {/* tag::snippet[] */}
-        <ConfirmDialog
-          header='Delete "Report Q4"?'
-          cancelButtonVisible
-          confirmText="Delete"
-          confirmTheme="error primary"
-          opened={dialogOpened}
-          onOpenedChanged={openedChanged}
-          onCancel={() => {
-            setStatus('Canceled');
-          }}
-          onConfirm={() => {
-            setStatus('Deleted');
-          }}
-        >
-          Are you sure you want to permanently delete this item?
-        </ConfirmDialog>
-        {/* end::snippet[] */}
+      {/* tag::snippet[] */}
+      <ConfirmDialog
+        header='Delete "Report Q4"?'
+        cancelButtonVisible
+        confirmText="Delete"
+        confirmTheme="error primary"
+        opened={dialogOpened}
+        onOpenedChanged={openedChanged}
+        onCancel={() => {
+          setStatus('Canceled');
+        }}
+        onConfirm={() => {
+          setStatus('Deleted');
+        }}
+      >
+        Are you sure you want to permanently delete this item?
+      </ConfirmDialog>
+      {/* end::snippet[] */}
 
-        <span hidden={status === ''}>Status: {status}</span>
-      </HorizontalLayout>
-    </>
+      <span hidden={status === ''}>Status: {status}</span>
+    </HorizontalLayout>
   );
 }
 

--- a/frontend/demo/component/datepicker/react/date-picker-custom-functions.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-custom-functions.tsx
@@ -1,11 +1,10 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   DatePicker,
   type DatePickerElement,
   type DatePickerDate,
 } from '@vaadin/react-components/DatePicker.js';
-import { useState } from 'react';
 import dateFnsFormat from 'date-fns/format';
 import dateFnsParse from 'date-fns/parse';
 

--- a/frontend/demo/component/grid/react/grid-cell-focus.tsx
+++ b/frontend/demo/component/grid/react/grid-cell-focus.tsx
@@ -22,7 +22,7 @@ function Example() {
     }
     const eventContext = gridRef.current.getEventContext(event);
     const section = eventContext.section ?? 'Not available';
-    const row = eventContext.index != null ? eventContext.index : 'Not available';
+    const row = eventContext.index ?? 'Not available';
     const column = eventContext.column?.path ?? 'Not available';
     const person = eventContext.item;
     const fullName =

--- a/frontend/demo/component/grid/react/grid-column-borders.tsx
+++ b/frontend/demo/component/grid/react/grid-column-borders.tsx
@@ -19,12 +19,7 @@ function Example() {
     // tag::snippet[]
     <Grid items={items} theme="column-borders">
       <GridColumn header="Image" flexGrow={0} autoWidth>
-        {({ item }) => (
-          <Avatar
-            img={item.pictureUrl}
-            name={`${item.firstName} ${item.lastName}`}
-          />
-        )}
+        {({ item }) => <Avatar img={item.pictureUrl} name={`${item.firstName} ${item.lastName}`} />}
       </GridColumn>
       <GridColumn path="firstName" />
       <GridColumn path="lastName" />

--- a/frontend/demo/component/grid/react/grid-column-filtering.tsx
+++ b/frontend/demo/component/grid/react/grid-column-filtering.tsx
@@ -33,16 +33,14 @@ function Example() {
   }, []);
 
   return (
-    <>
-      <Grid items={items}>
-        <GridFilterColumn header="Name" path="displayName" flexGrow={0} width="230px">
-          {nameRenderer}
-        </GridFilterColumn>
+    <Grid items={items}>
+      <GridFilterColumn header="Name" path="displayName" flexGrow={0} width="230px">
+        {nameRenderer}
+      </GridFilterColumn>
 
-        <GridFilterColumn path="email" />
-        <GridFilterColumn path="profession" />
-      </Grid>
-    </>
+      <GridFilterColumn path="email" />
+      <GridFilterColumn path="profession" />
+    </Grid>
   );
 }
 

--- a/frontend/demo/component/grid/react/grid-column-freezing.tsx
+++ b/frontend/demo/component/grid/react/grid-column-freezing.tsx
@@ -22,31 +22,29 @@ function Example() {
   }, []);
 
   return (
-    <>
-      <Grid items={items} ref={gridRef}>
-        {/* tag::snippet1[] */}
-        <GridColumn frozen header="Name" autoWidth flexGrow={0}>
-          {({ item: person }) => (
-            <>
-              {person.firstName} {person.lastName}
-            </>
-          )}
-        </GridColumn>
-        {/* end::snippet1[] */}
+    <Grid items={items} ref={gridRef}>
+      {/* tag::snippet1[] */}
+      <GridColumn frozen header="Name" autoWidth flexGrow={0}>
+        {({ item: person }) => (
+          <>
+            {person.firstName} {person.lastName}
+          </>
+        )}
+      </GridColumn>
+      {/* end::snippet1[] */}
 
-        <GridColumn path="email" autoWidth />
-        <GridColumn path="address.phone" autoWidth />
-        <GridColumn path="profession" autoWidth />
-        <GridColumn path="address.street" autoWidth />
+      <GridColumn path="email" autoWidth />
+      <GridColumn path="address.phone" autoWidth />
+      <GridColumn path="profession" autoWidth />
+      <GridColumn path="address.street" autoWidth />
 
-        {/* tag::snippet2[] */}
+      {/* tag::snippet2[] */}
 
-        <GridColumn frozenToEnd autoWidth flexGrow={0}>
-          {() => <Button theme="tertiary-inline">Edit</Button>}
-        </GridColumn>
-        {/* end::snippet2[] */}
-      </Grid>
-    </>
+      <GridColumn frozenToEnd autoWidth flexGrow={0}>
+        {() => <Button theme="tertiary-inline">Edit</Button>}
+      </GridColumn>
+      {/* end::snippet2[] */}
+    </Grid>
   );
 }
 

--- a/frontend/demo/component/grid/react/grid-content.tsx
+++ b/frontend/demo/component/grid/react/grid-content.tsx
@@ -12,10 +12,7 @@ import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 // tag::snippet[]
 const employeeRenderer = (person: Person) => (
   <HorizontalLayout style={{ alignItems: 'center' }} theme="spacing">
-    <Avatar
-      img={person.pictureUrl}
-      name={`${person.firstName} ${person.lastName}`}
-    />
+    <Avatar img={person.pictureUrl} name={`${person.firstName} ${person.lastName}`} />
 
     <VerticalLayout style={{ lineHeight: 'var(--lumo-line-height-m)' }}>
       <span>
@@ -31,11 +28,7 @@ const employeeRenderer = (person: Person) => (
 );
 
 const statusRenderer = (person: Person) => (
-  <span
-    {...({
-      theme: `badge ${person.status === 'Available' ? 'success' : 'error'}`,
-    } satisfies object)}
-  >
+  <span {...{ theme: `badge ${person.status === 'Available' ? 'success' : 'error'}` }}>
     {person.status}
   </span>
 );

--- a/frontend/demo/component/grid/react/grid-external-filtering.tsx
+++ b/frontend/demo/component/grid/react/grid-external-filtering.tsx
@@ -39,37 +39,35 @@ function Example() {
   }, []);
 
   return (
-    <>
-      <VerticalLayout theme="spacing">
-        <TextField
-          placeholder="Search"
-          style={{ width: '50%' }}
-          onValueChanged={(e) => {
-            const searchTerm = (e.detail.value || '').trim().toLowerCase();
-            setFilteredItems(
-              items.filter(
-                ({ displayName, email, profession }) =>
-                  !searchTerm ||
-                  displayName.toLowerCase().includes(searchTerm) ||
-                  email.toLowerCase().includes(searchTerm) ||
-                  profession.toLowerCase().includes(searchTerm)
-              )
-            );
-          }}
-        >
-          <Icon slot="prefix" icon="vaadin:search"></Icon>
-        </TextField>
+    <VerticalLayout theme="spacing">
+      <TextField
+        placeholder="Search"
+        style={{ width: '50%' }}
+        onValueChanged={(e) => {
+          const searchTerm = (e.detail.value || '').trim().toLowerCase();
+          setFilteredItems(
+            items.filter(
+              ({ displayName, email, profession }) =>
+                !searchTerm ||
+                displayName.toLowerCase().includes(searchTerm) ||
+                email.toLowerCase().includes(searchTerm) ||
+                profession.toLowerCase().includes(searchTerm)
+            )
+          );
+        }}
+      >
+        <Icon slot="prefix" icon="vaadin:search"></Icon>
+      </TextField>
 
-        <Grid items={filteredItems}>
-          <GridColumn header="Name" flexGrow={0} width="230px">
-            {({ item }) => nameRenderer(item)}
-          </GridColumn>
+      <Grid items={filteredItems}>
+        <GridColumn header="Name" flexGrow={0} width="230px">
+          {({ item }) => nameRenderer(item)}
+        </GridColumn>
 
-          <GridColumn path="email"></GridColumn>
-          <GridColumn path="profession"></GridColumn>
-        </Grid>
-      </VerticalLayout>
-    </>
+        <GridColumn path="email"></GridColumn>
+        <GridColumn path="profession"></GridColumn>
+      </Grid>
+    </VerticalLayout>
   );
 }
 

--- a/frontend/demo/component/grid/react/grid-header-footer-styling.tsx
+++ b/frontend/demo/component/grid/react/grid-header-footer-styling.tsx
@@ -21,6 +21,7 @@ const ratingRenderer = (person: PersonWithRating) => (
 
 function Example() {
   const [items, setItems] = useState<PersonWithRating[]>([]);
+
   useEffect(() => {
     getPeople().then(({ people }) => {
       const peopleWithRating = people.map((person) => ({
@@ -41,7 +42,9 @@ function Example() {
         header-part-name="rating-header"
         footer-part-name="rating-footer"
         footerRenderer={() => <span>Avg rating: 5.32</span>}
-      >{({ item }) => ratingRenderer(item)}</GridColumn>
+      >
+        {({ item }) => ratingRenderer(item)}
+      </GridColumn>
     </Grid>
   );
 }

--- a/frontend/demo/component/grid/react/grid-no-border.tsx
+++ b/frontend/demo/component/grid/react/grid-no-border.tsx
@@ -17,12 +17,7 @@ function Example() {
     // tag::snippet[]
     <Grid items={items} theme="no-border">
       <GridColumn header="Image" flexGrow={0} autoWidth>
-        {({ item }) => (
-          <Avatar
-            img={item.pictureUrl}
-            name={`${item.firstName} ${item.lastName}`}
-          />
-        )}
+        {({ item }) => <Avatar img={item.pictureUrl} name={`${item.firstName} ${item.lastName}`} />}
       </GridColumn>
       <GridColumn path="firstName" />
       <GridColumn path="lastName" />

--- a/frontend/demo/component/grid/react/grid-no-row-border.tsx
+++ b/frontend/demo/component/grid/react/grid-no-row-border.tsx
@@ -8,6 +8,7 @@ import { Avatar } from '@vaadin/react-components/Avatar.js';
 
 function Example() {
   const [items, setItems] = useState<Person[]>([]);
+
   useEffect(() => {
     getPeople().then(({ people }) => setItems(people));
   }, []);
@@ -16,12 +17,7 @@ function Example() {
     // tag::snippet[]
     <Grid items={items} theme="no-row-borders">
       <GridColumn header="Image" flexGrow={0} autoWidth>
-        {({ item }) => (
-          <Avatar
-            img={item.pictureUrl}
-            name={`${item.firstName} ${item.lastName}`}
-          />
-        )}
+        {({ item }) => <Avatar img={item.pictureUrl} name={`${item.firstName} ${item.lastName}`} />}
       </GridColumn>
       <GridColumn path="firstName" />
       <GridColumn path="lastName" />

--- a/frontend/demo/component/grid/react/grid-rich-content-sorting.tsx
+++ b/frontend/demo/component/grid/react/grid-rich-content-sorting.tsx
@@ -13,10 +13,7 @@ import { format, parseISO } from 'date-fns';
 function employeeRenderer({ item: person }: { item: Person }) {
   return (
     <HorizontalLayout style={{ alignItems: 'center' }} theme="spacing">
-      <Avatar
-        img={person.pictureUrl}
-        name={`${person.firstName} ${person.lastName}`}
-      />
+      <Avatar img={person.pictureUrl} name={`${person.firstName} ${person.lastName}`} />
 
       <VerticalLayout style={{ lineHeight: 'var(--lumo-line-height-m)' }}>
         <span>

--- a/frontend/demo/component/grid/react/grid-row-reordering.tsx
+++ b/frontend/demo/component/grid/react/grid-row-reordering.tsx
@@ -49,10 +49,7 @@ function Example() {
     >
       <GridColumn header="Image" flexGrow={0} autoWidth>
         {({ item: person }) => (
-          <Avatar
-            img={person.pictureUrl}
-            name={`${person.firstName} ${person.lastName}`}
-          />
+          <Avatar img={person.pictureUrl} name={`${person.firstName} ${person.lastName}`} />
         )}
       </GridColumn>
 

--- a/frontend/demo/component/grid/react/grid-row-stripes.tsx
+++ b/frontend/demo/component/grid/react/grid-row-stripes.tsx
@@ -16,12 +16,7 @@ function Example() {
     // tag::snippet[]
     <Grid items={items} theme="row-stripes">
       <GridColumn header="Image" flexGrow={0} autoWidth>
-        {({ item }) => (
-          <Avatar
-            img={item.pictureUrl}
-            name={`${item.firstName} ${item.lastName}`}
-          />
-        )}
+        {({ item }) => <Avatar img={item.pictureUrl} name={`${item.firstName} ${item.lastName}`} />}
       </GridColumn>
       <GridColumn path="firstName" />
       <GridColumn path="lastName" />

--- a/frontend/demo/component/icons/iconset-generator.ts
+++ b/frontend/demo/component/icons/iconset-generator.ts
@@ -61,7 +61,9 @@ export class IconsetGenerator extends LitElement {
     }
 
     .drop:focus-within {
-      box-shadow: 0 0 0 2px var(--docs-surface-color-2), 0 0 0 4px var(--docs-link-color);
+      box-shadow:
+        0 0 0 2px var(--docs-surface-color-2),
+        0 0 0 4px var(--docs-link-color);
     }
 
     .drop:hover,

--- a/frontend/demo/component/icons/react/svg-sprites.tsx
+++ b/frontend/demo/component/icons/react/svg-sprites.tsx
@@ -1,7 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
-import React from 'react';
 import spriteIcons from '../../../../../src/main/resources/icons/solid.svg';
 
 function Example() {

--- a/frontend/demo/component/notification/react/notification-undo.tsx
+++ b/frontend/demo/component/notification/react/notification-undo.tsx
@@ -1,9 +1,9 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useState } from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { Notification } from '@vaadin/react-components/Notification.js';
-import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 
 function Example() {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "dspublisher:build": "node dspublisher/dspublisher-scripts.js --build",
     "dspublisher:clean": "node dspublisher/dspublisher-scripts.js --clean",
     "dspublisher:start": "node dspublisher/dspublisher-scripts.js --develop",
-    "lint": "eslint --ignore-path .gitignore ./frontend --ext .ts --ext .js",
+    "lint": "eslint --ignore-path .gitignore ./frontend --ext .ts --ext .js --ext .tsx",
     "prepare": "husky install"
   },
   "vaadin": {


### PR DESCRIPTION
- Sorted imports so that `import { reactExample }` comes first and then React imports
- Fixed some imports of generated entities in React examples to use `import type`
- Removed some not-needed fragments e.g. in `ConfirmDialog` React examples
- Did some Prettier formatting in React examples, especially some Grid demos