### PR TITLE
docs: replace title attribute usage with accessibleName

### DIFF
--- a/frontend/demo/component/custom-field/custom-field-basic.ts
+++ b/frontend/demo/component/custom-field/custom-field-basic.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement, query } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import '@vaadin/custom-field';
 import '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 import { Binder, field } from '@vaadin/hilla-lit-form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
 import { differenceInDays, parseISO, isAfter } from 'date-fns';
-import type { DatePicker } from '@vaadin/date-picker';
 
 @customElement('custom-field-basic')
 export class Example extends LitElement {
@@ -18,19 +17,9 @@ export class Example extends LitElement {
     return root;
   }
 
-  @query('#start')
-  private start!: DatePicker;
-
-  @query('#end')
-  private end!: DatePicker;
-
   private binder = new Binder(this, AppointmentModel);
 
   protected override firstUpdated() {
-    // Set title for screen readers
-    this.start.focusElement!.setAttribute('title', 'Start date');
-    this.end.focusElement!.setAttribute('title', 'End date');
-
     this.binder.for(this.binder.model.enrollmentPeriod).addValidator({
       message: 'Dates cannot be more than 30 days apart',
       validate: (enrollmentPeriod: string) => {
@@ -66,9 +55,12 @@ export class Example extends LitElement {
         required
         ${field(this.binder.model.enrollmentPeriod)}
       >
-        <vaadin-date-picker id="start" placeholder="Start date"></vaadin-date-picker>
+        <vaadin-date-picker
+          accessible-name="Start date"
+          placeholder="Start date"
+        ></vaadin-date-picker>
         &ndash;
-        <vaadin-date-picker id="end" placeholder="End date"></vaadin-date-picker>
+        <vaadin-date-picker accessible-name="End date" placeholder="End date"></vaadin-date-picker>
       </vaadin-custom-field>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -1,13 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/custom-field';
 import '@vaadin/horizontal-layout';
 import '@vaadin/select';
 import '@vaadin/text-field';
 import { applyTheme } from 'Frontend/generated/theme';
-import type { Select } from '@vaadin/select';
-import type { TextField } from '@vaadin/text-field';
 
 @customElement('custom-field-size-variants')
 export class Example extends LitElement {
@@ -17,12 +15,6 @@ export class Example extends LitElement {
     applyTheme(root);
     return root;
   }
-
-  @query('#amount')
-  private amount!: TextField;
-
-  @query('#currency')
-  private currency!: Select;
 
   @state()
   private currencies = [
@@ -35,20 +27,14 @@ export class Example extends LitElement {
     { label: 'USD', value: 'usd' },
   ];
 
-  protected override firstUpdated() {
-    // Set title for screen readers
-    this.amount.focusElement!.setAttribute('title', 'Amount');
-    this.currency.focusElement!.setAttribute('title', 'Currency');
-  }
-
   protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-custom-field label="Price" theme="small">
         <vaadin-horizontal-layout theme="spacing-s">
-          <vaadin-text-field id="amount" theme="small"></vaadin-text-field>
+          <vaadin-text-field accessible-name="Amount" theme="small"></vaadin-text-field>
           <vaadin-select
-            id="currency"
+            accessible-name="Currency"
             .items="${this.currencies}"
             theme="small"
             style="width: 6em;"

--- a/frontend/demo/component/custom-field/react/custom-field-basic.tsx
+++ b/frontend/demo/component/custom-field/react/custom-field-basic.tsx
@@ -37,9 +37,9 @@ function Example() {
       required
       onValueChanged={validate}
     >
-      <DatePicker placeholder="Start date"></DatePicker>
+      <DatePicker accessibleName="Start date" placeholder="Start date" />
       &ndash;
-      <DatePicker placeholder="End date"></DatePicker>
+      <DatePicker accessibleName="End date" placeholder="End date" />
     </CustomField>
     // end::snippet[]
   );

--- a/frontend/demo/component/custom-field/react/custom-field-size-variants.tsx
+++ b/frontend/demo/component/custom-field/react/custom-field-size-variants.tsx
@@ -1,26 +1,18 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { CustomField } from '@vaadin/react-components/CustomField.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
-import { Select, type SelectElement } from '@vaadin/react-components/Select.js';
-import { TextField, type TextFieldElement } from '@vaadin/react-components/TextField.js';
+import { Select } from '@vaadin/react-components/Select.js';
+import { TextField } from '@vaadin/react-components/TextField.js';
 
 function Example() {
-  const amountRef = useRef<TextFieldElement>(null);
-  const currencyRef = useRef<SelectElement>(null);
-
-  useEffect(() => {
-    amountRef.current?.focusElement?.setAttribute('title', 'Amount');
-    currencyRef.current?.focusElement?.setAttribute('title', 'Currency');
-  }, []);
-
   return (
     // tag::snippet[]
     <CustomField label="Price" theme="small">
       <HorizontalLayout theme="spacing-s">
-        <TextField ref={amountRef} theme="small" />
+        <TextField accessibleName="Amount" theme="small" />
         <Select
-          ref={currencyRef}
+          accessibleName="Currency"
           items={[
             { label: 'AUD', value: 'aud' },
             { label: 'CAD', value: 'cad' },

--- a/frontend/demo/component/formlayout/form-layout-custom-field.ts
+++ b/frontend/demo/component/formlayout/form-layout-custom-field.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
 
 import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/form-layout';
 import '@vaadin/form-layout/vaadin-form-item';
 import '@vaadin/select';
@@ -21,23 +21,11 @@ export class Example extends LitElement {
   }
 
   // tag::snippet[]
-  @query('#month-field')
-  private monthField!: Select;
-
-  @query('#year-field')
-  private yearField!: Select;
-
   @state()
   private months = Array.from({ length: 12 }, (_, i) => `${i + 1}`.padStart(2, '0'));
 
   @state()
   private years = Array.from({ length: 11 }, (_, i) => `${i + new Date().getFullYear()}`);
-
-  protected override firstUpdated() {
-    // Set title for screen readers
-    this.monthField.focusElement!.setAttribute('title', 'Month');
-    this.yearField.focusElement!.setAttribute('title', 'Year');
-  }
 
   render() {
     return html`
@@ -51,12 +39,12 @@ export class Example extends LitElement {
           >
             <vaadin-horizontal-layout theme="spacing-xs">
               <vaadin-select
-                id="month-field"
+                accessible-name="Month"
                 placeholder="Month"
                 .items="${this.months.map((month) => ({ label: month, value: month }))}"
               ></vaadin-select>
               <vaadin-select
-                id="year-field"
+                accessible-name="Year"
                 placeholder="Year"
                 .items="${this.years.map((year) => ({ label: year, value: year }))}"
               ></vaadin-select>

--- a/frontend/demo/component/formlayout/react/form-layout-custom-field.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-custom-field.tsx
@@ -1,22 +1,15 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';
 import { FormItem } from '@vaadin/react-components/FormItem.js';
-import { Select, type SelectElement } from '@vaadin/react-components/Select.js';
+import { Select } from '@vaadin/react-components/Select.js';
 import { CustomField } from '@vaadin/react-components/CustomField.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 
 function Example() {
   // tag::snippet[]
-  const monthFieldRef = useRef<SelectElement>(null);
-  const yearFieldRef = useRef<SelectElement>(null);
   const months = Array.from({ length: 12 }, (_, i) => `${i + 1}`.padStart(2, '0'));
   const years = Array.from({ length: 11 }, (_, i) => `${i + new Date().getFullYear()}`);
-
-  useEffect(() => {
-    monthFieldRef.current?.focusElement?.setAttribute('title', 'Month');
-    yearFieldRef.current?.focusElement?.setAttribute('title', 'Year');
-  }, []);
 
   return (
     <FormLayout>
@@ -28,12 +21,12 @@ function Example() {
         >
           <HorizontalLayout theme="spacing-xs">
             <Select
-              ref={monthFieldRef}
+              accessibleName="Month"
               placeholder="Month"
               items={months.map((month) => ({ label: month, value: month }))}
             />
             <Select
-              ref={yearFieldRef}
+              accessibleName="Year"
               placeholder="Year"
               items={years.map((year) => ({ label: year, value: year }))}
             />

--- a/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java
@@ -19,13 +19,11 @@ public class DateRangePicker extends CustomField<LocalDateRange> {
         start = new DatePicker();
         start.setPlaceholder("Start date");
         // Sets title for screen readers
-        start.getElement().executeJs(
-                "this.focusElement.setAttribute('title', 'Start date')");
+        start.setAriaLabel("Start date");
 
         end = new DatePicker();
         end.setPlaceholder("End date");
-        end.getElement().executeJs(
-                "this.focusElement.setAttribute('title', 'End date')");
+        end.setAriaLabel("End date");
 
         add(start, new Text(" – "), end);
     }

--- a/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
+++ b/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java
@@ -22,14 +22,12 @@ public class MoneyField extends CustomField<Money> {
     public MoneyField() {
         amount = new TextField();
         // Sets title for screen readers
-        amount.getElement()
-                .executeJs("this.focusElement.setAttribute('title', 'Amount')");
+        amount.setAriaLabel("Amount");
 
         currency = new Select<>();
         currency.setItems("AUD", "CAD", "CHF", "EUR", "GBP", "JPY", "USD");
         currency.setWidth("6em");
-        currency.getElement().executeJs(
-                "this.focusElement.setAttribute('title', 'Currency')");
+        currency.setAriaLabel("Currency");
 
         HorizontalLayout layout = new HorizontalLayout(amount, currency);
         // Removes default spacing

--- a/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutCustomField.java
+++ b/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutCustomField.java
@@ -38,14 +38,12 @@ public class FormLayoutCustomField extends Div {
             month.setItems(MONTHS);
             month.setPlaceholder("Month");
             // Set title for screen readers
-            month.getElement().executeJs(
-                    "this.focusElement.setAttribute('title', 'Month');");
+            month.setAriaLabel("Month");
             layout.add(month);
 
             year.setItems(YEARS);
             year.setPlaceholder("Year");
-            year.getElement().executeJs(
-                    "this.focusElement.setAttribute('title', 'Year');");
+            year.setAriaLabel("Year");
             layout.add(year);
 
             add(layout);


### PR DESCRIPTION
Replaced `title` attribute with `accessibleName` property and `setAriaLabel()` Java API added in 24.1.

This keeps the code cleaner, reduces usage of `executeJs` and directly accessing internal `focusElement`.
Also, `aria-label` is generally considered a better option for screen readers than the title attribute.