### PR TITLE
docs: Add .flow-node-tasks.lock to .gitignore example

### DIFF
--- a/articles/configuration/source-control.adoc
+++ b/articles/configuration/source-control.adoc
@@ -78,6 +78,7 @@ pnpmfile.js
 .npmrc
 webpack.generated.js
 vite.generated.ts
+.flow-node-tasks.lock
 
 # Browser drivers for local integration tests
 drivers/


### PR DESCRIPTION
Since v24, `vaadinBuildFrontend` is generating a `.flow-node-tasks.lock`.