### PR TITLE
docs: Use Gradle toolchain to specify Java version in upgrade guide

### DIFF
--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -226,16 +226,30 @@ Java 17 or later is required. Below is an example of how to use this version:
     <maven.compiler.target>17</maven.compiler.target>
 </properties>
 ----
+[source,kotlin]
+----
+<source-info group="Gradle (Kotlin DSL)"></source-info>
+plugins {
+    java
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+----
 [source,groovy]
 ----
-<source-info group="Groovy"></source-info>
+<source-info group="Gradle (Groovy DSL)"></source-info>
 plugins {
     id 'java'
 }
 
 java {
-    sourceCompatibility = 17
-    targetCompatibility = 17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 ----
 --


### PR DESCRIPTION
Nowadays, it's common to use a [Java toolchain](https://docs.gradle.org/current/userguide/toolchains.html) instead of `sourceCompatibility` and `targetCompatibility`.