### PR TITLE
chore: use self-closing tags for React components in JSX

### DIFF
--- a/frontend/demo/component/app-layout/react/app-layout-basic.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-basic.tsx
@@ -27,7 +27,7 @@ function Example() {
   return (
     // tag::snippet[]
     <AppLayout>
-      <DrawerToggle slot="navbar"></DrawerToggle>
+      <DrawerToggle slot="navbar" />
       <h1 slot="navbar" style={h1Style}>
         MyApp
       </h1>

--- a/frontend/demo/component/avatar/react/avatar-abbreviation.tsx
+++ b/frontend/demo/component/avatar/react/avatar-abbreviation.tsx
@@ -7,9 +7,9 @@ function Example() {
   return (
     <HorizontalLayout theme="spacing">
       {/* tag::snippet[] */}
-      <Avatar name="Augusta Ada King"></Avatar>
+      <Avatar name="Augusta Ada King" />
 
-      <Avatar name="Augusta Ada King" abbr="AK"></Avatar>
+      <Avatar name="Augusta Ada King" abbr="AK" />
       {/* end::snippet[] */}
     </HorizontalLayout>
   );

--- a/frontend/demo/component/button/react/button-disable-long-action.tsx
+++ b/frontend/demo/component/button/react/button-disable-long-action.tsx
@@ -20,7 +20,7 @@ function Example() {
         Perform Action
       </Button>
 
-      <ProgressBar value={progress}></ProgressBar>
+      <ProgressBar value={progress} />
     </HorizontalLayout>
   );
   // end::snippet[]

--- a/frontend/demo/component/combobox/react/combo-box-auto-open.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-auto-open.tsx
@@ -19,7 +19,7 @@ function Example() {
       itemLabelPath="name"
       itemValuePath="id"
       items={items}
-    ></ComboBox>
+    />
     // end::snippet[]
   );
 }

--- a/frontend/demo/component/combobox/react/combo-box-custom-entry-1.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-custom-entry-1.tsx
@@ -12,7 +12,7 @@ function Example() {
       label="Browser"
       helperText="Select or type a browser"
       items={items}
-    ></ComboBox>
+    />
     // end::snippet[]
   );
 }

--- a/frontend/demo/component/combobox/react/combo-box-presentation.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-presentation.tsx
@@ -57,7 +57,7 @@ function Example() {
           </div>
         </div>
       )}
-    ></ComboBox>
+    />
     // end::snippet[]
   );
 }

--- a/frontend/demo/component/grid/react/grid-external-filtering.tsx
+++ b/frontend/demo/component/grid/react/grid-external-filtering.tsx
@@ -17,7 +17,7 @@ type PersonEnhanced = Person & { displayName: string };
 function nameRenderer(person: PersonEnhanced) {
   return (
     <HorizontalLayout style={{ alignItems: 'center' }} theme="spacing">
-      <Avatar img={person.pictureUrl} name={person.displayName}></Avatar>
+      <Avatar img={person.pictureUrl} name={person.displayName} />
       <span> {person.displayName} </span>
     </HorizontalLayout>
   );
@@ -56,7 +56,7 @@ function Example() {
           );
         }}
       >
-        <Icon slot="prefix" icon="vaadin:search"></Icon>
+        <Icon slot="prefix" icon="vaadin:search" />
       </TextField>
 
       <Grid items={filteredItems}>
@@ -64,8 +64,8 @@ function Example() {
           {({ item }) => nameRenderer(item)}
         </GridColumn>
 
-        <GridColumn path="email"></GridColumn>
-        <GridColumn path="profession"></GridColumn>
+        <GridColumn path="email" />
+        <GridColumn path="profession" />
       </Grid>
     </VerticalLayout>
   );

--- a/frontend/demo/component/gridpro/react/grid-pro-enter-next-row.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-enter-next-row.tsx
@@ -15,10 +15,10 @@ function Example() {
   return (
     // tag::snippet[]
     <GridPro items={items} enterNextRow>
-      <GridProEditColumn path="firstName"></GridProEditColumn>
-      <GridProEditColumn path="lastName"></GridProEditColumn>
-      <GridProEditColumn path="email"></GridProEditColumn>
-      <GridProEditColumn path="profession"></GridProEditColumn>
+      <GridProEditColumn path="firstName" />
+      <GridProEditColumn path="lastName" />
+      <GridProEditColumn path="email" />
+      <GridProEditColumn path="profession" />
     </GridPro>
     // end::snippet[]
   );

--- a/frontend/demo/component/scroller/react/scroller-mobile.tsx
+++ b/frontend/demo/component/scroller/react/scroller-mobile.tsx
@@ -25,19 +25,19 @@ function Example() {
       <Scroller scroll-direction="horizontal">
         <HorizontalLayout style={{ display: 'inline-flex' }} theme="padding spacing">
           <Button style={{ height: '100px' }}>
-            <Icon icon="vaadin:clipboard-check" slot="prefix"></Icon>
+            <Icon icon="vaadin:clipboard-check" slot="prefix" />
             Audit
           </Button>
           <Button style={{ height: '100px' }}>
-            <Icon icon="vaadin:book-dollar" slot="prefix"></Icon>
+            <Icon icon="vaadin:book-dollar" slot="prefix" />
             Report
           </Button>
           <Button style={{ height: '100px' }}>
-            <Icon icon="vaadin:line-chart" slot="prefix"></Icon>
+            <Icon icon="vaadin:line-chart" slot="prefix" />
             Dashboard
           </Button>
           <Button style={{ height: '100px' }}>
-            <Icon icon="vaadin:invoice" slot="prefix"></Icon>
+            <Icon icon="vaadin:invoice" slot="prefix" />
             Invoice
           </Button>
         </HorizontalLayout>

--- a/frontend/demo/component/side-nav/react/side-nav-labelled.tsx
+++ b/frontend/demo/component/side-nav/react/side-nav-labelled.tsx
@@ -25,26 +25,26 @@ const Example = () => {
         <SideNav style={{ width: '100%' }} ref={sideNavRef}>
           <span slot="label">Messages</span>
           <SideNavItem path="/inbox">
-            <Icon icon="vaadin:inbox" slot="prefix"></Icon>
+            <Icon icon="vaadin:inbox" slot="prefix" />
             Inbox
           </SideNavItem>
           <SideNavItem path="/sent">
-            <Icon icon="vaadin:paperplane" slot="prefix"></Icon>
+            <Icon icon="vaadin:paperplane" slot="prefix" />
             Sent
           </SideNavItem>
           <SideNavItem path="/trash">
-            <Icon icon="vaadin:trash" slot="prefix"></Icon>
+            <Icon icon="vaadin:trash" slot="prefix" />
             Trash
           </SideNavItem>
         </SideNav>
         <SideNav style={{ width: '100%' }} collapsible ref={secondSideNavRef}>
           <span slot="label">Admin</span>
           <SideNavItem path="/users">
-            <Icon icon="vaadin:group" slot="prefix"></Icon>
+            <Icon icon="vaadin:group" slot="prefix" />
             Users
           </SideNavItem>
           <SideNavItem path="/permissions">
-            <Icon icon="vaadin:key" slot="prefix"></Icon>
+            <Icon icon="vaadin:key" slot="prefix" />
             Permissions
           </SideNavItem>
         </SideNav>

--- a/frontend/demo/component/side-nav/react/side-nav-suffix.tsx
+++ b/frontend/demo/component/side-nav/react/side-nav-suffix.tsx
@@ -41,7 +41,7 @@ function Example() {
               style={{ padding: 'var(--lumo-space-xs)' }}
               aria-label="Upcoming appointment"
               slot="suffix"
-            ></Icon>
+            />
           </SideNavItem>
         </SideNav>
         {/* end::snippet[] */}

--- a/frontend/demo/component/tabs/react/tabsheet-prefix-suffix.tsx
+++ b/frontend/demo/component/tabs/react/tabsheet-prefix-suffix.tsx
@@ -12,7 +12,7 @@ function Example() {
       <Button slot="prefix">Close all</Button>
 
       <Button slot="suffix" theme="icon" aria-label="Add tab">
-        <Icon icon="vaadin:plus"></Icon>
+        <Icon icon="vaadin:plus" />
       </Button>
 
       <TabSheetTab label="Dashboard">

--- a/frontend/demo/component/textarea/react/text-area-helper.tsx
+++ b/frontend/demo/component/textarea/react/text-area-helper.tsx
@@ -16,7 +16,7 @@ function Example() {
       helperText={`${text.length}/${charLimit}`}
       onValueChanged={(event) => setText(event.detail.value)}
       style={{ width: '100%' }}
-    ></TextArea>
+    />
     // end::snippet[]
   );
 }

--- a/frontend/demo/component/upload/react/upload-clear-button.tsx
+++ b/frontend/demo/component/upload/react/upload-clear-button.tsx
@@ -15,7 +15,7 @@ function createFakeFiles() {
 }
 
 function Example() {
-  return <Upload files={createFakeFiles()}></Upload>;
+  return <Upload files={createFakeFiles()} />;
 }
 
 export default reactExample(Example); // hidden-source-line


### PR DESCRIPTION
Some React examples are using closing tags where it's not needed (as there are no children).
Updated these to keep the code cleaner and also to align with other React examples.