### PR TITLE
chore: remove grid auto-width workarounds from React examples

### DIFF
--- a/frontend/demo/component/grid/react/grid-column-freezing.tsx
+++ b/frontend/demo/component/grid/react/grid-column-freezing.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useState, useRef } from 'react';
-import { Grid, type GridElement } from '@vaadin/react-components/Grid.js';
+import React, { useEffect, useState } from 'react';
+import { Grid } from '@vaadin/react-components/Grid.js';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { getPeople } from 'Frontend/demo/domain/DataService';
@@ -8,21 +8,13 @@ import { Button } from '@vaadin/react-components/Button.js';
 
 function Example() {
   const [items, setItems] = useState<Person[]>([]);
-  const gridRef = useRef<GridElement>(null);
 
   useEffect(() => {
     getPeople().then(({ people }) => setItems(people));
-
-    // Workaround for https://github.com/vaadin/react-components/issues/129
-    setTimeout(() => {
-      gridRef.current?.recalculateColumnWidths();
-      gridRef.current?.scrollToIndex(1);
-      gridRef.current?.scrollToIndex(0);
-    }, 100);
   }, []);
 
   return (
-    <Grid items={items} ref={gridRef}>
+    <Grid items={items}>
       {/* tag::snippet1[] */}
       <GridColumn frozen header="Name" autoWidth flexGrow={0}>
         {({ item: person }) => (

--- a/frontend/demo/component/grid/react/grid-content.tsx
+++ b/frontend/demo/component/grid/react/grid-content.tsx
@@ -34,19 +34,14 @@ const statusRenderer = (person: Person) => (
 );
 
 function Example() {
-  const gridRef = React.useRef<any>(null);
   const [items, setItems] = useState<Person[]>([]);
+
   useEffect(() => {
     getPeople().then(({ people }) => setItems(people));
-
-    // Workaround for https://github.com/vaadin/react-components/issues/129
-    setTimeout(() => {
-      gridRef.current?.recalculateColumnWidths();
-    }, 100);
   }, []);
 
   return (
-    <Grid items={items} ref={gridRef}>
+    <Grid items={items}>
       <GridSelectionColumn />
 
       <GridColumn header="Employee" flexGrow={0} autoWidth>


### PR DESCRIPTION
Remove workarounds related to https://github.com/vaadin/react-components/issues/129 since the issue has now been fixed