### PR TITLE
docs: add TypeScript snippet to runtime theme switching

### DIFF
--- a/articles/flow/styling/advanced/runtime-theme-switching.adoc
+++ b/articles/flow/styling/advanced/runtime-theme-switching.adoc
@@ -78,12 +78,12 @@ function switchTheme(newTheme: string) {
 ----
 --
 
-The theme switching method above could be executed based on the user’s domain in a multi-tenant application, user preferences stored in a database, or by an event listener on a component that allows the user to choose a theme.
+The theme switching method above could be executed based on the user's domain in a multi-tenant application, calling user preferences stored in a database, or by an event listener on a component that allows the user to choose a theme.
 
 
 == Dark/Light Colors per OS/Browser Settings
 
-Themes with custom dark and light variants can apply them based on the user’s OS or browser settings, so that users with dark or light mode set in their system get the corresponding variant without having to switch to it in the application. This is done through a CSS media query:
+Themes with custom dark and light variants can apply them based on the user's operating system or browser settings. This allows users with dark or light mode set in their system to get the corresponding variant without having to switch to it in the application. This is done through a CSS media query like so:
 
 [source,css]
 ----
@@ -101,7 +101,7 @@ html {
 }
 ----
 
-There's also a way to https://cookbook.vaadin.com/os-light-dark-theme[apply the built-in Lumo dark theme automatically] based on the same OS/browser setting.
+There's also a way to apply the built-in Lumo dark theme based on the same OS/browser setting. See https://cookbook.vaadin.com/os-light-dark-theme[OS Light & Dark] page.
 
 [discussion-id]`e6a9898b-960b-468f-a83a-a6dbcba182fa`
 


### PR DESCRIPTION
Fixes #3216

Note: the original issue mentions Lit and React, but I only added a single TypeScript code snippet since the code is about toggling class on `<body>`. Here is what the resulting snippet looks like:

<img width="460" alt="Screenshot 2024-03-04 at 16 11 04" src="https://github.com/vaadin/docs/assets/10589913/b79baf5c-2ea6-4b1e-ab02-9ad80846aba1">
