### PR TITLE
chore: add react-colorful dependency to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "proj4": "2.10.0",
         "promise-file-reader": "^1.0.3",
         "react": "18.2.0",
+        "react-colorful": "5.6.1",
         "react-dom": "18.2.0",
         "react-router-dom": "6.22.1",
         "vanilla-colorful": "^0.5.3"
@@ -10555,6 +10556,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -20937,6 +20947,12 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "requires": {}
     },
     "react-dom": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "proj4": "2.10.0",
     "promise-file-reader": "^1.0.3",
     "react": "18.2.0",
+    "react-colorful": "5.6.1",
     "react-dom": "18.2.0",
     "react-router-dom": "6.22.1",
     "vanilla-colorful": "^0.5.3"
@@ -133,7 +134,9 @@
     "react-router-dom": "$react-router-dom",
     "vanilla-colorful": "$vanilla-colorful",
     "@vaadin/hilla-lit-form": "$@vaadin/hilla-lit-form",
-    "@vaadin/hilla-react-signals": "$@vaadin/hilla-react-signals"
+    "@vaadin/hilla-react-signals": "$@vaadin/hilla-react-signals",
+    "@vaadin/hilla-file-router": "$@vaadin/hilla-file-router",
+    "react-colorful": "$react-colorful"
   },
   "private": true,
   "scripts": {
@@ -175,6 +178,7 @@
       "lit": "3.1.2",
       "proj4": "2.10.0",
       "react": "18.2.0",
+      "react-colorful": "5.6.1",
       "react-dom": "18.2.0",
       "react-router-dom": "6.22.1"
     },
@@ -208,6 +212,6 @@
       "workbox-core": "7.0.0",
       "workbox-precaching": "7.0.0"
     },
-    "hash": "39ef78f62909e59f32ef4c466ef3ef1e9e6610d3209fb6cfc9128423d6ab2f6d"
+    "hash": "0fb5eab6151fcc23b8ef53d7b9cf788a236be440c500d7241889dd16ef6cf776"
   }
 }


### PR DESCRIPTION
Follow-up to #3201.

In the React adapter guide, `react-colorful` dependency was added, but it's missing from `package.json`. This PR adds it.