### PR TITLE
docs: add Lit and React snippets to Lumo Variants page

### DIFF
--- a/articles/flow/styling/lumo/lumo-variants.adoc
+++ b/articles/flow/styling/lumo/lumo-variants.adoc
@@ -17,7 +17,12 @@ Lumo comes in two built-in color variants: the default light variant, and a dark
 
 image::../_images/lumo-light-and-dark.png[Lumo theme Light and Dark variants]
 
-The dark variant can be applied statically to the entire UI using the `@Theme` annotation on the class that implements the `AppShellConfigurator` interface:
+The dark variant can be applied statically to the entire UI. In Flow this can be done by using the
+`@Theme` annotation on the class that implements the `AppShellConfigurator` interface. In Hilla, the
+same can be achieved by setting `theme` attribute on the root `<html>` element:
+
+[.example]
+--
 
 [source,java]
 ----
@@ -27,14 +32,25 @@ public class Application extends implements AppShellConfigurator {
 }
 ----
 
+[source,typescript]
+----
+document.documentElement.setAttribute('theme', 'dark');
+----
+--
+
 .Customize Dark Variant Colors
 [TIP]
 You can customize the colors for the dark theme variant as well. See <<lumo-style-properties/color#,Lumo Colors>> for details.
 
-The variant can also be applied only to certain parts of the UI, including individual components, through the ThemeList or Element API, depending on the component:
+The variant can also be applied only to certain parts of the UI, including individual components. In
+Flow this can be done through the ThemeList or Element API, depending on the component.
+
+[.example]
+--
 
 [source,java]
 ----
+<source-info group="Java"></source-info>
 VerticalLayout layout = new VerticalLayout();
 layout.getThemeList().add(Lumo.DARK);
 
@@ -42,10 +58,31 @@ Div div = new Div();
 div.getElement().setAttribute("theme", Lumo.DARK);
 ----
 
-In addition to applying the dark variant statically, applications can allow the user to switch between the light and dark variants by dynamically applying them to the `UI` class:
+[source,html]
+----
+<source-info group="Lit"></source-info>
+<vaadin-vertical-layout theme="dark"></vaadin-vertical-layout>
+
+<div theme="dark"></div>
+----
+
+[source,tsx]
+----
+<source-info group="React"></source-info>
+<VerticalLayout {...{ theme: 'dark' }}></VerticalLayout>
+
+<div {...{ theme: 'dark' }}></div>
+----
+--
+
+In addition to applying the dark variant statically, applications can allow the user to switch between the light and dark variants by dynamically (in Flow by applying them to the `UI` class).
+
+[.example]
+--
 
 [source,java]
 ----
+<source-info group="Java"></source-info>
 @Route("")
 public class MainView extends VerticalLayout {
 
@@ -65,12 +102,51 @@ public class MainView extends VerticalLayout {
 }
 ----
 
+[source,ts]
+----
+<source-info group="Lit"></source-info>
+<vaadin-button
+  @click="${() => {
+    const root = document.documentElement;
+    if (root.getAttribute('theme') === 'dark') {
+      root.removeAttribute('theme');
+    } else {
+      root.setAttribute('theme', 'dark');
+    }
+  }}"
+>
+  Toggle theme variant
+</vaadin-button>
+----
+
+[source,tsx]
+----
+<source-info group="React"></source-info>
+<Button
+  onClick={() => {
+    const root = document.documentElement;
+    if (root.getAttribute('theme') === 'dark') {
+      root.removeAttribute('theme');
+    } else {
+      root.setAttribute('theme', 'dark');
+    }
+  }}
+>
+  Toggle theme variant
+</Button>
+----
+
+--
+
 The dark variant can also be https://cookbook.vaadin.com/os-light-dark-theme[applied automatically based on the operating system's light/dark mode setting]. It’s exposed to the browser through the `prefers-color-scheme` CSS feature.
 
 
 == Compact Preset
 
 Lumo also has a compact preset that applies reduced sizing to fonts and all Vaadin components. It is applied by loading an additional JavaScript module containing a modified set of Lumo sizing properties:
+
+[.example]
+--
 
 [source,java]
 ----
@@ -79,6 +155,12 @@ public class MainLayout extends VerticalLayout {
   ...
 }
 ----
+
+[source,typescript]
+----
+import '@vaadin/vaadin-lumo-styles/presets/compact.js';
+----
+--
 
 [discussion-id]`6edf45a5-74c9-4775-a0ad-48d822264ffe`
 

--- a/articles/flow/styling/lumo/lumo-variants.adoc
+++ b/articles/flow/styling/lumo/lumo-variants.adoc
@@ -19,7 +19,8 @@ image::../_images/lumo-light-and-dark.png[Lumo theme Light and Dark variants]
 
 The dark variant can be applied statically to the entire UI. In Flow this can be done by using the
 `@Theme` annotation on the class that implements the `AppShellConfigurator` interface. In Hilla, the
-same can be achieved by setting `theme` attribute on the root `<html>` element:
+same can be achieved by setting the `theme` attribute on the root `<html>` element:
+
 
 [.example]
 --
@@ -43,7 +44,8 @@ document.documentElement.setAttribute('theme', 'dark');
 You can customize the colors for the dark theme variant as well. See <<lumo-style-properties/color#,Lumo Colors>> for details.
 
 The variant can also be applied only to certain parts of the UI, including individual components. In
-Flow this can be done through the ThemeList or Element API, depending on the component.
+Flow this can be done through the `ThemeList` or `Element` API, depending on the component.
+
 
 [.example]
 --


### PR DESCRIPTION
Fixes #3215

Added Lit and React snippets for setting `theme` attribute and toggling it dynamically:

<img width="782" alt="Screenshot 2024-03-05 at 14 11 46" src="https://github.com/vaadin/docs/assets/10589913/e0ff4183-3766-42e7-8802-b1b1caa94018">

<img width="780" alt="Screenshot 2024-03-05 at 14 11 53" src="https://github.com/vaadin/docs/assets/10589913/453d791d-90fb-4f98-830e-645c4ef4404f">

For other code snippets (setting `dark` theme globally and `compact` preset) I only added single TypeScript snippet.