### PR TITLE
docs: add Spring Events article

### DIFF
--- a/articles/flow/advanced/service-init-listener.adoc
+++ b/articles/flow/advanced/service-init-listener.adoc
@@ -4,12 +4,28 @@ description: Using VaadinServiceInitListener to configure RequestHandler, IndexH
 order: 100
 ---
 
-
 = Service Init Listener
 
-[classname]`VaadinServiceInitListener` can be used to configure [classname]`RequestHandler`, [classname]`IndexHtmlRequestListener` and <<dependency-filter#,DependencyFilter>> objects. You can also use it to <<{articles}/flow/routing/dynamic#application.startup,dynamically register routes>> during application startup, and to <<{articles}/flow/advanced/session-and-ui-init-listener#, register session and UI listeners>>.
+The [classname]`ServiceInitEvent` is fired when your Vaadin application starts. It is a good place to configure [classname]`RequestHandler`, [classname]`IndexHtmlRequestListener` and <<dependency-filter#,DependencyFilter>> objects. You can also use it to <<{articles}/flow/routing/dynamic#application.startup,dynamically register routes>> during application startup, and to <<{articles}/flow/advanced/session-and-ui-init-listener#, register session and UI listeners>>.
 
-The listener gets a [classname]`ServiceInitEvent`, which is sent when a Vaadin service is initialized.
+In Spring and CDI apps the [classname]`ServiceInitEvent` is fired as applications event, so it is enought to annotate your bean method accepting [classname]`ServiceInitEvent` as a parameter with https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/event/EventListener.html[@EventListener] (Spring) or https://jakarta.ee/specifications/cdi/4.0/apidocs/jakarta.cdi/jakarta/enterprise/event/observes[@Observes] (CDI) annotation.
+
+[source,java]
+----
+@Component
+public class MyBean {
+
+    @EventListener
+    public void logSessionInits(ServiceInitEvent event) {
+        event.getSource().addSessionInitListener(
+                sessionInitEvent -> LoggerFactory.getLogger(getClass())
+                        .info("A new Session has been initialized!"));
+    }
+
+}
+----
+
+Alternatively you can implement [classname]`VaadinServiceInitListener` interface and register it.
 
 [source,java]
 ----
@@ -37,7 +53,8 @@ public class ApplicationServiceInitListener
 }
 ----
 
-In a Spring Boot project, it's sufficient to register this listener by adding the `@Component` annotation on the class.
+In Spring and CDI project, all beans implementing the interface are automatically registered.
+
 In plain Java projects, the listener should be registered as a provider via the Java Service Provider Interface (SPI) loading facility.
 To do this, you should create the [filename]`META-INF/services` resource directory and a provider configuration file with the name [filename]`com.vaadin.flow.server.VaadinServiceInitListener`.
 This is a text file and should contain the fully qualified name of the [classname]`ApplicationServiceInitListener` class on its own line.

--- a/articles/flow/advanced/service-init-listener.adoc
+++ b/articles/flow/advanced/service-init-listener.adoc
@@ -4,6 +4,7 @@ description: Using VaadinServiceInitListener to configure RequestHandler, IndexH
 order: 100
 ---
 
+
 = Service Init Listener
 
 The [classname]`ServiceInitEvent` is fired when your Vaadin application starts. It's a good place to configure the [classname]`RequestHandler`, [classname]`IndexHtmlRequestListener` and <<dependency-filter#,`DependencyFilter`>> objects. You can also use it to <</flow/routing/dynamic#application.startup,dynamically register routes>> during application startup, and to <<session-and-ui-init-listener#, register session and UI listeners>>.

--- a/articles/flow/advanced/service-init-listener.adoc
+++ b/articles/flow/advanced/service-init-listener.adoc
@@ -6,9 +6,9 @@ order: 100
 
 = Service Init Listener
 
-The [classname]`ServiceInitEvent` is fired when your Vaadin application starts. It is a good place to configure [classname]`RequestHandler`, [classname]`IndexHtmlRequestListener` and <<dependency-filter#,DependencyFilter>> objects. You can also use it to <<{articles}/flow/routing/dynamic#application.startup,dynamically register routes>> during application startup, and to <<{articles}/flow/advanced/session-and-ui-init-listener#, register session and UI listeners>>.
+The [classname]`ServiceInitEvent` is fired when your Vaadin application starts. It's a good place to configure the [classname]`RequestHandler`, [classname]`IndexHtmlRequestListener` and <<dependency-filter#,`DependencyFilter`>> objects. You can also use it to <</flow/routing/dynamic#application.startup,dynamically register routes>> during application startup, and to <<session-and-ui-init-listener#, register session and UI listeners>>.
 
-In Spring and CDI apps the [classname]`ServiceInitEvent` is fired as applications event, so it is enought to annotate your bean method accepting [classname]`ServiceInitEvent` as a parameter with https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/event/EventListener.html[@EventListener] (Spring) or https://jakarta.ee/specifications/cdi/4.0/apidocs/jakarta.cdi/jakarta/enterprise/event/observes[@Observes] (CDI) annotation.
+In Spring and CDI applications, the [classname]`ServiceInitEvent` is fired as an application event. It's enough to annotate your bean method accepting [classname]`ServiceInitEvent` as a parameter with the https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/event/EventListener.html[`@EventListener`] (Spring) or https://jakarta.ee/specifications/cdi/4.0/apidocs/jakarta.cdi/jakarta/enterprise/event/observes[`@Observes`] (CDI) annotation. The following shows an example of this:
 
 [source,java]
 ----
@@ -25,7 +25,7 @@ public class MyBean {
 }
 ----
 
-Alternatively you can implement [classname]`VaadinServiceInitListener` interface and register it.
+Alternatively, you can implement the [interfacename]`VaadinServiceInitListener` interface and register it, like shown in the following example:
 
 [source,java]
 ----
@@ -53,23 +53,22 @@ public class ApplicationServiceInitListener
 }
 ----
 
-In Spring and CDI project, all beans implementing the interface are automatically registered.
+In a Spring or CDI project, all beans implementing the [interfacename]`VaadinServiceInitListener` interface are registered automatically.
 
-In plain Java projects, the listener should be registered as a provider via the Java Service Provider Interface (SPI) loading facility.
-To do this, you should create the [filename]`META-INF/services` resource directory and a provider configuration file with the name [filename]`com.vaadin.flow.server.VaadinServiceInitListener`.
-This is a text file and should contain the fully qualified name of the [classname]`ApplicationServiceInitListener` class on its own line.
-It allows the application to discover the [classname]`ApplicationServiceInitListener` class, instantiate it and register it as a service init listener for the application.
+In plain Java projects, the listener should be registered as a provider via the Java Service Provider Interface (SPI) loading facility. To do this, you should create the [filename]`META-INF/services` resource directory and a provider configuration file with the name [filename]`com.vaadin.flow.server.VaadinServiceInitListener`. This is a text file and should contain the fully qualified name of the [classname]`ApplicationServiceInitListener` class on its own line. It allows the application to discover the [classname]`ApplicationServiceInitListener` class, instantiate it and register it as a service init listener for the application.
 
-image:images/service-init-listener.png[The location of the configuration file]
+.Location of the Configuration File
+image::images/service-init-listener.png[A screenshot showing the file and folder structure of a Vaadin project, where the VaadinServiceInitListener configuration file is selected in the file tree]
 
-The content of the file should look like this:
-[source,text]
+The content of the configuration file should look like this, as an example (replace `com.mycompany` with the package name of your implementation):
 ----
 com.mycompany.ApplicationServiceInitListener
 ----
 
-[TIP]
-See https://docs.oracle.com/javase/tutorial/ext/basics/spi.html#register-service-providers and https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html for details of Java SPI loading.
+The following pages offer more details about Java SPI loading:
+
+- https://docs.oracle.com/javase/tutorial/ext/basics/spi.html#register-service-providers
+- https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html
 
 
 [discussion-id]`EA8B92C9-D967-4C55-B760-FEBEEA964D72`

--- a/articles/flow/integrations/spring/events.adoc
+++ b/articles/flow/integrations/spring/events.adoc
@@ -1,0 +1,44 @@
+---
+title: Spring Events
+description: List of published events to Spring.
+order: 70
+---
+
+
+= Spring Events
+
+The Spring integration publishes events to application context.
+
+It isn't necessary to register a listener. It's sufficient to handle these events using only an EventListener.
+
+Events published to Spring application context include:
+
+- `ServiceInitEvent` See <<../../advanced/service-init-listener#,VaadinServiceInitListener>>
+for more.
+
+The example here uses the `@EventListener` annotation to listen to `ServiceInitEvent`:
+
+[source,java]
+----
+@SpringComponent
+public class BootstrapCustomizer {
+
+    @EventListener
+    private void onServiceInit(ServiceInitEvent serviceInitEvent) {
+        serviceInitEvent.addIndexHtmlRequestListener(
+                this::modifyBootstrapPage);
+    }
+
+    private void modifyBootstrapPage(
+            IndexHtmlResponse response) {
+        response.getDocument().body().append(
+                "<p>By Spring EventListener</p>");
+    }
+}
+----
+
+++++
+<style>
+[class^=PageHeader-module--descriptionContainer] {display: none;}
+</style>
+++++

--- a/articles/flow/integrations/spring/events.adoc
+++ b/articles/flow/integrations/spring/events.adoc
@@ -1,22 +1,20 @@
 ---
 title: Spring Events
-description: List of published events to Spring.
+description: List of events published to the Spring context.
 order: 70
 ---
 
 
 = Spring Events
 
-The Spring integration publishes events to application context.
+The Spring integration publishes events to the application context. You don't need to register a listener. It's sufficient to handle these events using only the `@EventListener` annotation.
 
-It isn't necessary to register a listener. It's sufficient to handle these events using only an EventListener.
+Events published to the Spring application context include:
 
-Events published to Spring application context include:
+`ServiceInitEvent`::
+See <</flow/advanced/service-init-listener#,VaadinServiceInitListener>> for details.
 
-- `ServiceInitEvent` See <<../../advanced/service-init-listener#,VaadinServiceInitListener>>
-for more.
-
-The example here uses the `@EventListener` annotation to listen to `ServiceInitEvent`:
+The example here uses the `@EventListener` annotation to listen to the `ServiceInitEvent` event:
 
 [source,java]
 ----


### PR DESCRIPTION
Adds a similar page for events as for CDI integration. A list of events that are published automatically and can be listened to.

Related-to: vaadin/flow#14086


