### PR TITLE
SampleTooltip in typescript extends LitElement, not LitTemplate

### DIFF
--- a/articles/flow/create-ui/creating-components/mixins.adoc
+++ b/articles/flow/create-ui/creating-components/mixins.adoc
@@ -56,7 +56,7 @@ public class Tooltip extends LitTemplate
 ----
 import { html, LitElement } from 'lit';
 
-class SampleTooltip extends LitTemplate {
+class SampleTooltip extends LitElement {
   render() {
     return html`
       <div part="content" theme="dark">


### PR DESCRIPTION
In the documentation about using Mixins there was an error in example code
SampleTooltip should extend LitElement, not  LitTemplate
