### PR TITLE
chore: fix hidden-source-line usage for navigation helper

### DIFF
--- a/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
@@ -23,12 +23,9 @@ export class Example extends LitElement {
     } /* hidden-source-line */
   `;
 
-  /* prettier-ignore */ protected firstUpdated() {
-    /* hidden-source-line */
-    patchAppLayoutNavigation(
-      this.shadowRoot!.querySelector('vaadin-horizontal-layout')!
-    ); /* hidden-source-line */
-  } /* hidden-source-line */
+  /* prettier-ignore */ protected firstUpdated() { // hidden-source-line
+    patchAppLayoutNavigation(this.shadowRoot!.querySelector('vaadin-horizontal-layout')!); // hidden-source-line
+  } // hidden-source-line
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();

--- a/frontend/demo/component/app-layout/app-layout-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar.ts
@@ -7,7 +7,7 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
-import { patchAppLayoutNavigation } from './app-layout-helper';
+import { patchAppLayoutNavigation } from './app-layout-helper'; // hidden-source-line
 
 @customElement('app-layout-navbar')
 export class Example extends LitElement {

--- a/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
+++ b/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
@@ -11,7 +11,7 @@ import '@vaadin/side-nav';
 import '@vaadin/vertical-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { patchAppLayoutNavigation } from './app-layout-helper';
+import { patchAppLayoutNavigation } from './app-layout-helper'; // hidden-source-line
 
 @customElement('app-layout-secondary-navigation')
 export class Example extends LitElement {
@@ -35,8 +35,7 @@ export class Example extends LitElement {
     return root;
   }
 
-  /* prettier-ignore */ protected firstUpdated() {
-    // hidden-source-line
+  /* prettier-ignore */ protected firstUpdated() { // hidden-source-line
     patchSideNavNavigation(this.shadowRoot!.querySelector('vaadin-side-nav')!); // hidden-source-line
     patchAppLayoutNavigation(this.shadowRoot!.querySelector('#navigation')!); // hidden-source-line
   } // hidden-source-line


### PR DESCRIPTION
Fixed some Lit TS examples to hide imports of `patchAppLayoutNavigation` and correctly apply `hidden-source-line` comments. Currently, some of the demos are rendered incorrectly due to those comments on wrong lines:

<img width="450" alt="Screenshot 2024-03-07 at 14 04 02" src="https://github.com/vaadin/docs/assets/10589913/d7876931-8487-4970-bb6f-83aca73c774b">


<img width="561" alt="Screenshot 2024-03-07 at 14 09 02" src="https://github.com/vaadin/docs/assets/10589913/1cbc9ab7-6902-4eb8-86a8-a288777ae377">
