### PR TITLE
chore: align usage of React hooks to use named exports

### DIFF
--- a/frontend/demo/component/contextmenu/react/context-menu-left-click.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-left-click.tsx
@@ -23,7 +23,7 @@ function Example() {
     }
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     getPeople({ count: 5 }).then(({ people }) => setGridItems(people));
   }, []);
 

--- a/frontend/demo/component/grid/react/grid-row-reordering.tsx
+++ b/frontend/demo/component/grid/react/grid-row-reordering.tsx
@@ -1,16 +1,20 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
-import { Grid, type GridDropEvent, type GridDragStartEvent } from '@vaadin/react-components/Grid.js';
+import React, { useEffect, useState } from 'react';
+import {
+  Grid,
+  type GridDropEvent,
+  type GridDragStartEvent,
+} from '@vaadin/react-components/Grid.js';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';
 import { Avatar } from '@vaadin/react-components/Avatar.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 function Example() {
-  const [items, setItems] = React.useState<Person[]>([]);
-  const [draggedItem, setDraggedItem] = React.useState<Person | undefined>(undefined);
+  const [items, setItems] = useState<Person[]>([]);
+  const [draggedItem, setDraggedItem] = useState<Person | undefined>(undefined);
 
-  React.useEffect(() => {
+  useEffect(() => {
     getPeople().then(({ people }) => setItems(people));
   }, []);
 

--- a/frontend/demo/component/gridpro/react/grid-pro-prevent-save.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-prevent-save.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { GridPro, type GridProItemPropertyChangedEvent } from '@vaadin/react-components/GridPro.js';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { Notification } from '@vaadin/notification';
@@ -7,9 +7,9 @@ import { GridProEditColumn } from '@vaadin/react-components/GridProEditColumn.js
 import { getPeople } from 'Frontend/demo/domain/DataService';
 
 function Example() {
-  const [items, setItems] = React.useState<Person[]>([]);
+  const [items, setItems] = useState<Person[]>([]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     getPeople().then(({ people }) => setItems(people));
   }, []);
 

--- a/frontend/demo/component/notification/react/notification-rich.tsx
+++ b/frontend/demo/component/notification/react/notification-rich.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
+import React, { useState } from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
@@ -8,7 +8,7 @@ import { Avatar } from '@vaadin/react-components/Avatar.js';
 import '@vaadin/icons';
 
 function Example() {
-  const [openedNotifications, setOpenedNotifications] = React.useState<number[]>([]);
+  const [openedNotifications, setOpenedNotifications] = useState<number[]>([]);
 
   function open(index: number) {
     setOpenedNotifications([...openedNotifications, index]);


### PR DESCRIPTION
Some of our examples use `React.useEffect` instead of `useEffect`. Updated these to align them. Also run Prettier.