### PR TITLE
Docs/rename ts to lit

### DIFF
--- a/articles/components/_input-field-common-features.adoc
+++ b/articles/components/_input-field-common-features.adoc
@@ -114,7 +114,7 @@ Visible labels are strongly recommended for all input fields. In situations wher
 --
 [source,html,subs=attributes+]
 ----
-include::_shared-code-snippets.adoc[tags=aria-label-typescript,indent=0,group=TypeScript]
+include::_shared-code-snippets.adoc[tags=aria-label-typescript,indent=0,group=Lit]
 ----
 
 [source,java]

--- a/articles/components/_input-field-common-features.adoc
+++ b/articles/components/_input-field-common-features.adoc
@@ -119,7 +119,7 @@ include::_shared-code-snippets.adoc[tags=aria-label-typescript,indent=0,group=Li
 
 [source,java]
 ----
-include::_shared-code-snippets.adoc[tags=aria-label-java,indent=0,group=Java]
+include::_shared-code-snippets.adoc[tags=aria-label-java,indent=0,group=Flow]
 ----
 --
 ====

--- a/articles/components/accordion/index.adoc
+++ b/articles/components/accordion/index.adoc
@@ -21,7 +21,7 @@ It reduces clutter and helps maintain the user's focus by showing only the relev
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -59,7 +59,7 @@ The summary supports rich content and can contain any component. This can be uti
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-summary.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-summary.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -89,7 +89,7 @@ This is the collapsible part of a panel. It can contain any component. When the 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-content.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -125,7 +125,7 @@ The `filled` theme variant makes the panel's boundaries visible. This helps tie 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-filled-panels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-filled-panels.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -154,7 +154,7 @@ Use the `small` theme variant for compact UIs.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-small-panels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-small-panels.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -183,7 +183,7 @@ The `reverse` theme variant places the toggle icon after the summary contents. T
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-reverse-panels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-reverse-panels.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -212,7 +212,7 @@ Accordion panels can be disabled to prevent them from being expanded or collapse
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/accordion/accordion-disabled-panels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/accordion/accordion-disabled-panels.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/accordion/index.adoc
+++ b/articles/components/accordion/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -66,7 +66,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionSummary.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionSummary.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -96,7 +96,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionContent.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionContent.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -132,7 +132,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionFilledPanels.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionFilledPanels.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -161,7 +161,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionSmallPanels.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionSmallPanels.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -190,7 +190,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionReversePanels.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionReversePanels.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -219,7 +219,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionDisabledPanels.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/accordion/AccordionDisabledPanels.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/app-layout/index.adoc
+++ b/articles/components/app-layout/index.adoc
@@ -23,7 +23,7 @@ include::{articles}/components/_shared.adoc[tag=scaled-examples-responsive]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-basic.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-basic.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -59,7 +59,7 @@ Application headers contain, for example, the application's name and branding, a
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-navbar-placement.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-navbar-placement.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -85,7 +85,7 @@ When placed to the side, the navbar is often seen as a view header, housing the 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -122,7 +122,7 @@ When the App Layout has an undefined/auto height, which is the default behavior,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-height-auto.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-height-auto.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -162,7 +162,7 @@ The full hierarchy of components from the App Layout to the `<body>` element nee
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-height-full.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-height-full.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -194,7 +194,7 @@ When the navbar is used for navigation, the *touch-optimized navbar* slot can be
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -226,7 +226,7 @@ The navbar is a good choice for a small number of items (3–5), as these can fi
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-navbar.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-navbar.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -253,7 +253,7 @@ Furthermore, a vertical list of items is easier for the user to scan.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-drawer.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-drawer.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -280,7 +280,7 @@ The secondary (and tertiary) navigation items can be placed in either the drawer
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/app-layout/index.adoc
+++ b/articles/components/app-layout/index.adoc
@@ -30,7 +30,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -66,7 +66,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -92,7 +92,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -129,7 +129,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightAuto.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightAuto.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -169,7 +169,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightFull.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightFull.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -201,7 +201,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBottomNavbar.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBottomNavbar.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -233,7 +233,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbar.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbar.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -260,7 +260,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -287,7 +287,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/avatar/index.adoc
+++ b/articles/components/avatar/index.adoc
@@ -21,7 +21,7 @@ Avatar is a graphical representation of an object or entity, for example, a pers
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -73,7 +73,7 @@ pass:[<!-- vale Microsoft.Auto = YES -->]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-name.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-name.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -101,7 +101,7 @@ Abbreviations should be kept to a maximum of 2–3 characters.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-abbreviation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-abbreviation.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -131,7 +131,7 @@ Abbreviations aren't shown when images are used.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-image.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-image.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -160,7 +160,7 @@ It can be used, for example, to show that there are multiple users viewing the s
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-group-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-group-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -191,7 +191,7 @@ Clicking the overflow item displays the overflowing avatars and names in a list.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-group-max-items.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-group-max-items.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -220,7 +220,7 @@ The background color is set using a color index.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-group-bg-color.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-group-bg-color.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -299,7 +299,7 @@ The name of the focused Avatar is read aloud first.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-group-internationalisation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-group-internationalisation.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -328,7 +328,7 @@ Avatar has four available size variants:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-sizes.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-sizes.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -378,7 +378,7 @@ Avatar can be paired with Menu Bar to create a user account menu.
 ifdef::lit[]
 [source,javascript]
 ----
-include::{root}/frontend/demo/component/avatar/avatar-menu-bar.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/avatar/avatar-menu-bar.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/avatar/index.adoc
+++ b/articles/components/avatar/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -80,7 +80,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarName.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarName.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -108,7 +108,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarAbbreviation.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarAbbreviation.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -138,7 +138,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarImage.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarImage.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -167,7 +167,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -198,7 +198,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupMaxItems.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupMaxItems.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -227,7 +227,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupBgColor.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupBgColor.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -306,7 +306,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupInternationalisation.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarGroupInternationalisation.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -335,7 +335,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarSizes.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarSizes.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -385,7 +385,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarMenuBar.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/avatar/AvatarMenuBar.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/badge/index.adoc
+++ b/articles/components/badge/index.adoc
@@ -26,7 +26,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -83,13 +83,13 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java[render,tags=snippet1,indent=0,group=Flow]
 
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java[render,tags=snippet2,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java[render,tags=snippet3,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java[render,tags=snippet3,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -123,11 +123,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIconsOnly.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIconsOnly.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIconsOnly.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIconsOnly.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -154,11 +154,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIconsOnlyTable.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIconsOnlyTable.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIconsOnlyTable.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeIconsOnlyTable.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -193,7 +193,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeSize.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeSize.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -223,9 +223,9 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeColor.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeColor.java[render,tags=snippet1,indent=0,group=Flow]
 
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeColor.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeColor.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -290,7 +290,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeShape.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeShape.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -321,11 +321,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeHighlight.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeHighlight.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeHighlight.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeHighlight.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -357,11 +357,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeInteractive.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeInteractive.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeInteractive.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeInteractive.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -390,11 +390,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeCounter.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeCounter.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeCounter.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/badge/BadgeCounter.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/badge/index.adoc
+++ b/articles/components/badge/index.adoc
@@ -19,7 +19,7 @@ They're used for labeling content, displaying metadata and/or highlighting infor
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -76,7 +76,7 @@ Icons can be placed on either side of the text.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-icons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-icons.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -116,7 +116,7 @@ For accessibility, a tooltip and `aria-label` attribute is recommended to ensure
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-icons-only.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-icons-only.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -147,7 +147,7 @@ Icon-only badges should primarily be used for common recurring content with high
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/badge/badge-icons-only-table.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-icons-only-table.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -186,7 +186,7 @@ Use the `small` theme variant to make a badge smaller, for example when space is
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-size.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-size.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -216,7 +216,7 @@ The color variants can be paired with the `primary` theme variant for additional
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-color.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-color.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -283,7 +283,7 @@ It can aid in making badges and buttons more distinct from one another.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-shape.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-shape.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -314,7 +314,7 @@ A typical use case for badges is to highlight an item's status, for example in a
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/badge/badge-highlight.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-highlight.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -350,7 +350,7 @@ For example, Badges that highlight active filters might contain a "Clear" Button
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/badge/badge-interactive.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-interactive.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -383,7 +383,7 @@ Badges can be used as counters, for example to show the number of unread/new mes
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/badge/badge-counter.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/badge/badge-counter.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/board/index.adoc
+++ b/articles/components/board/index.adoc
@@ -41,17 +41,17 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/board/BoardBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/BoardBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/board/ExampleIndicator.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/ExampleIndicator.java[group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/board/ExampleChart.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/ExampleChart.java[group=Flow]
 ----
 endif::[]
 
@@ -116,17 +116,17 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/board/BoardNested.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/BoardNested.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/board/ExampleIndicator.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/ExampleIndicator.java[group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/board/ExampleStatistics.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/ExampleStatistics.java[group=Flow]
 ----
 endif::[]
 
@@ -174,7 +174,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/board/BoardColumnWrapping.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/BoardColumnWrapping.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -207,11 +207,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/board/BoardColumnSpan.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/BoardColumnSpan.java[render,tags=snippet,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/board/BoardColumnSpan.java[render,tags=createBoard,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/BoardColumnSpan.java[render,tags=createBoard,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -271,12 +271,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/board/BoardBreakpoints.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/board/BoardBreakpoints.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,css]
 ----
-include::{root}/frontend/themes/docs/board.css[tags=breakpoint,indent=0,group=Java]
+include::{root}/frontend/themes/docs/board.css[tags=breakpoint,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/board/index.adoc
+++ b/articles/components/board/index.adoc
@@ -24,17 +24,17 @@ It reorders the components inside it on different screen sizes while maximizing 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/board/board-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/board/example-indicator.ts[group=TypeScript]
+include::{root}/frontend/demo/component/board/example-indicator.ts[group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/board/example-chart.ts[group=TypeScript]
+include::{root}/frontend/demo/component/board/example-chart.ts[group=Lit]
 ----
 endif::[]
 
@@ -99,17 +99,17 @@ Rows can be nested for finer-grained control of how certain areas of the layout 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/board/board-nested.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-nested.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/board/example-indicator.ts[group=TypeScript]
+include::{root}/frontend/demo/component/board/example-indicator.ts[group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/board/example-statistics.ts[group=TypeScript]
+include::{root}/frontend/demo/component/board/example-statistics.ts[group=Lit]
 ----
 endif::[]
 
@@ -167,7 +167,7 @@ Use the draggable split handle to resize the layout and see how the columns wrap
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/board/board-column-wrapping.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-column-wrapping.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -200,7 +200,7 @@ The possible combinations are shown below:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/board/board-column-span.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-column-span.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -259,12 +259,12 @@ Use the draggable split handle to resize the layout and see how the board stylin
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/board/board-breakpoints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/board/board-breakpoints.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,css]
 ----
-include::{root}/frontend/themes/docs/board.css[tags=breakpoint,indent=0,group=TypeScript]
+include::{root}/frontend/themes/docs/board.css[tags=breakpoint,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/button/index.adoc
+++ b/articles/components/button/index.adoc
@@ -30,7 +30,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -104,7 +104,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonError.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonError.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -136,7 +136,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonSizes.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -186,7 +186,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonTertiaryInline.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonTertiaryInline.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -213,7 +213,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonSuccess.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonSuccess.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -240,7 +240,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonContrast.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonContrast.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -278,7 +278,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonIcons.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonIcons.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -319,7 +319,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonImages.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonImages.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -349,7 +349,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -389,7 +389,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonDisableLongAction.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonDisableLongAction.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -501,7 +501,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonLabels.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonLabels.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -530,7 +530,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonForm.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonForm.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -560,7 +560,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonDialog.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonDialog.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -592,7 +592,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonGrid.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/button/ButtonGrid.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/button/index.adoc
+++ b/articles/components/button/index.adoc
@@ -23,7 +23,7 @@ The Button component allows users to perform actions. It comes in several differ
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -53,7 +53,7 @@ The following variants can be used to distinguish between actions of different i
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -97,7 +97,7 @@ This is a style for distinguishing actions related to dangers, warnings, or erro
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-error.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-error.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -129,7 +129,7 @@ The following size variants are available for Button instances whose size needs 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-sizes.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-sizes.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -179,7 +179,7 @@ The *Tertiary Inline* variant omits all white space around the label. This can b
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-tertiary-inline.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-tertiary-inline.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -206,7 +206,7 @@ The *Success* and *Contrast* variants should provide additional color options fo
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-success.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-success.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -233,7 +233,7 @@ endif::[]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-contrast.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-contrast.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -271,7 +271,7 @@ Buttons can have icons instead of text, or they can have icons along with text.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-icons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-icons.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -312,7 +312,7 @@ Images on buttons can be used like icons. See the icon usage recommendations for
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-images.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-images.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -342,7 +342,7 @@ Buttons representing actions that aren't currently available to the user should 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -382,7 +382,7 @@ Buttons can be configured to be disabled when clicked. This can be useful especi
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-disable-long-action.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-disable-long-action.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -413,7 +413,7 @@ As with other components, the focus ring is only rendered when the button is foc
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-focus.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-focus.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -494,7 +494,7 @@ A button with a regular, visible label can also benefit from a separate `aria-la
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-labels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-labels.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -523,7 +523,7 @@ Buttons in forms should be placed below the form with which they're associated. 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-form.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-form.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -553,7 +553,7 @@ Buttons in dialogs should be placed at the bottom of the dialog and aligned righ
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-dialog.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-dialog.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -585,7 +585,7 @@ In the example below, the global _Add User_ action is separated from the selecti
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/button/button-grid.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/button/button-grid.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/charts/charttypes.adoc
+++ b/articles/components/charts/charttypes.adoc
@@ -80,7 +80,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeLine.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeLine.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -98,7 +98,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeSpline.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeSpline.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -149,7 +149,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeArea.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeArea.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -166,7 +166,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSpline.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSpline.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -184,7 +184,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaRange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaRange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -202,7 +202,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSplineRange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSplineRange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -245,7 +245,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumn.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumn.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -263,7 +263,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumnRange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumnRange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -281,7 +281,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBar.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBar.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -356,7 +356,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeErrorBar.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeErrorBar.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -441,7 +441,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBoxPlot.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBoxPlot.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -508,7 +508,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeScatter.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeScatter.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -623,7 +623,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBubble.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBubble.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -697,7 +697,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBullet.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBullet.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -833,7 +833,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeOrganization.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeOrganization.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -921,7 +921,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePie.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePie.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1093,7 +1093,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeGauge.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeGauge.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1245,7 +1245,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeSolidGauge.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeSolidGauge.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1299,7 +1299,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaRange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaRange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1317,7 +1317,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumnRange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumnRange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1424,7 +1424,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePolar.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePolar.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1519,7 +1519,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeFunnel.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeFunnel.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1537,7 +1537,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePyramid.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePyramid.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1691,7 +1691,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeWaterfall.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeWaterfall.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1813,7 +1813,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeTimeline.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeTimeline.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1897,7 +1897,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeXrange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeXrange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -1993,7 +1993,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeHeatMap.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeHeatMap.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -2172,7 +2172,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeTreeMap.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeTreeMap.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -2258,7 +2258,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePolygon.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePolygon.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -2361,7 +2361,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeFlags.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeFlags.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -2481,7 +2481,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeOhlc.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeOhlc.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -2499,7 +2499,7 @@ include::{root}/frontend/demo/component/charts/charttypes/chart-type-libraries.t
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeCandlestick.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeCandlestick.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --

--- a/articles/components/charts/index.adoc
+++ b/articles/components/charts/index.adoc
@@ -25,7 +25,7 @@ include::{articles}/flow/_commercial-banner.adoc[opts=optional]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/charts/charts-overview.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/charts/charts-overview.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/checkbox/index.adoc
+++ b/articles/components/checkbox/index.adoc
@@ -24,7 +24,7 @@ Checkbox Group is a group of related binary choices.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -49,7 +49,7 @@ endif::[]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-group-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-group-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ Disabling can be preferable to hiding an element to prevent changes in layout wh
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -120,7 +120,7 @@ The indeterminate state can be used for a parent checkbox to show that there is 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-indeterminate.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-indeterminate.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -150,7 +150,7 @@ The component's default orientation is horizontal. However, vertical orientation
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-vertical.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-vertical.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -177,7 +177,7 @@ In cases where vertical space needs to be conserved, horizontal orientation can 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-horizontal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-horizontal.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -206,7 +206,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-group-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-group-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -235,7 +235,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-group-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-group-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -266,7 +266,7 @@ Aim for short and descriptive labels using positive wording. Avoid negations.
 ifdef::lit[]
 [source,typescript, role=render-only]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-labeling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-labeling.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -286,7 +286,7 @@ It's important to provide labels for Checkbox Groups to distinguish clearly any 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/checkbox/index.adoc
+++ b/articles/components/checkbox/index.adoc
@@ -31,7 +31,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -56,7 +56,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -93,7 +93,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -127,7 +127,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxIndeterminate.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxIndeterminate.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -157,7 +157,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxVertical.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxVertical.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -184,7 +184,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxHorizontal.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxHorizontal.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -213,7 +213,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -242,7 +242,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -293,7 +293,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxAdjacentGroups.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxAdjacentGroups.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/combo-box/index.adoc
+++ b/articles/components/combo-box/index.adoc
@@ -25,12 +25,12 @@ It supports lazy loading and can be configured to accept custom typed values.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=Lit]
 ----
 endif::[]
 
@@ -67,7 +67,7 @@ Combo Box can be configured to allow entering custom values that aren't included
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-custom-entry-1.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-custom-entry-1.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -96,7 +96,7 @@ Custom values can also be stored and added to the list of options:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-custom-entry-2.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-custom-entry-2.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -127,16 +127,16 @@ Items can be customized to display more information than a single line of text.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-presentation.ts[render,tag=combobox,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-presentation.ts[render,tag=combobox,indent=0,group=Lit]
 
 ...
 
-include::{root}/frontend/demo/component/combobox/combo-box-presentation.ts[render,tag=renderer,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-presentation.ts[render,tag=renderer,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=Lit]
 ----
 endif::[]
 
@@ -177,12 +177,12 @@ The overlay opens automatically when the field is focused using a pointer (i.e.,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-auto-open.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-auto-open.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=Lit]
 ----
 endif::[]
 
@@ -218,12 +218,12 @@ The width of the popup is, by default, the same width as the input field. The po
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-popup-width.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-popup-width.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=Lit]
 ----
 endif::[]
 
@@ -277,7 +277,7 @@ Custom filtering is also possible. For example, if you only want to show items t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-filtering-2.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-filtering-2.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -306,7 +306,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -335,7 +335,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=constraint
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-constraints.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -364,7 +364,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -393,7 +393,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/combobox/combo-box-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/combobox/combo-box-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/combo-box/index.adoc
+++ b/articles/components/combo-box/index.adoc
@@ -37,12 +37,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 
@@ -74,7 +74,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomEntry1.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomEntry1.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -103,7 +103,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomEntry2.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxCustomEntry2.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -143,16 +143,16 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java[render,tag=combobox,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java[render,tag=combobox,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java[render,tag=renderer,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java[render,tag=renderer,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 
@@ -189,12 +189,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxAutoOpen.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxAutoOpen.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 
@@ -230,12 +230,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPopupWidth.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPopupWidth.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 
@@ -284,7 +284,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxFiltering2.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxFiltering2.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -313,7 +313,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -342,7 +342,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxConstraints.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxConstraints.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -371,7 +371,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -400,7 +400,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/confirm-dialog/index.adoc
+++ b/articles/components/confirm-dialog/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogBasic.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogBasic.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -105,7 +105,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogConfirmButton.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogConfirmButton.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -133,7 +133,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogCancelButton.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogCancelButton.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -165,7 +165,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogRejectButton.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/confirmdialog/ConfirmDialogRejectButton.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/confirm-dialog/index.adoc
+++ b/articles/components/confirm-dialog/index.adoc
@@ -21,7 +21,7 @@ Confirm Dialog is a modal Dialog used to confirm user actions.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts[render,frame,tags=*, indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts[render,frame,tags=*, indent=0,group=Lit]
 ----
 endif::[]
 
@@ -98,7 +98,7 @@ As the name suggests, its default label is “Confirm”, but it can and should 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts[render, tags=*, indent=0, group=TypeScript]
+include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts[render, tags=*, indent=0, group=Lit]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ The “Cancel” button is used in situations where the user must be able to can
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts[render, tags=*, indent=0, group=TypeScript]
+include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts[render, tags=*, indent=0, group=Lit]
 ----
 endif::[]
 
@@ -158,7 +158,7 @@ For example, if the user tries to leave a view containing unsaved changes, they 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts[render, tags=*, indent=0, group=TypeScript]
+include::{root}/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts[render, tags=*, indent=0, group=Lit]
 ----
 endif::[]
 

--- a/articles/components/context-menu/index.adoc
+++ b/articles/components/context-menu/index.adoc
@@ -38,7 +38,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -70,7 +70,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDividers.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDividers.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -99,11 +99,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuCheckable.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuCheckable.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuCheckable.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuCheckable.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -139,7 +139,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuHierarchical.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuHierarchical.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -174,12 +174,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java[render,tags=snippet1,indent=0,group=Java]
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java[render,tags=snippet1,indent=0,group=Flow]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java[render,tags=snippet2,indent=0,group=Flow]
 
 // ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java[render,tags=snippet3,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java[render,tags=snippet3,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -208,7 +208,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuClassname.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuClassname.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -247,11 +247,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java[render,tags=snippet1,indent=0,group=Flow]
 
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java[render,tags=snippet2,indent=0,group=Flow]
 
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java[render,tags=snippet3,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuDisabled.java[render,tags=snippet3,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -287,7 +287,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuLeftClick.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuLeftClick.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -325,7 +325,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBestPractices.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuBestPractices.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/context-menu/index.adoc
+++ b/articles/components/context-menu/index.adoc
@@ -27,11 +27,11 @@ Open the Context Menu by right-clicking (mouse) or long-pressing (touch) a Grid 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-basic.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-basic.ts[render,tag=snippet,indent=0,group=Lit]
 
 <!-- ... -->
 
-include::{root}/frontend/demo/component/contextmenu/context-menu-basic.ts[render,tag=snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-basic.ts[render,tag=snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -63,7 +63,7 @@ include::index.adoc[tag=example-instructions]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-dividers.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-dividers.ts[render,tag=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -92,7 +92,7 @@ Checkable Menu Items can be used to toggle a setting on and off.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-checkable.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-checkable.ts[render,tag=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -128,11 +128,11 @@ include::index.adoc[tag=example-instructions]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-hierarchical.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-hierarchical.ts[render,tag=snippet,indent=0,group=Lit]
 
 // ...
 
-include::{root}/frontend/demo/component/contextmenu/context-menu-hierarchical.ts[render,tag=snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-hierarchical.ts[render,tag=snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -163,11 +163,11 @@ include::index.adoc[tag=example-instructions]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-presentation.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-presentation.ts[render,tag=snippet,indent=0,group=Lit]
 
 ...
 
-include::{root}/frontend/demo/component/contextmenu/context-menu-presentation.ts[render,tag=snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-presentation.ts[render,tag=snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -201,7 +201,7 @@ Individual menu items can be styled by [since:com.vaadin:vaadin@V24.3]#applying 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-classname.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-classname.ts[render,tag=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -236,11 +236,11 @@ include::index.adoc[tag=example-instructions]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-disabled.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-disabled.ts[render,tag=snippet,indent=0,group=Lit]
 
 // ...
 
-include::{root}/frontend/demo/component/contextmenu/context-menu-disabled.ts[render,tag=snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-disabled.ts[render,tag=snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -276,11 +276,11 @@ Open the Context Menu by clicking a Grid row.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-left-click.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-left-click.ts[render,tag=snippet,indent=0,group=Lit]
 
 // ...
 
-include::{root}/frontend/demo/component/contextmenu/context-menu-left-click.ts[render,tag=snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-left-click.ts[render,tag=snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -314,11 +314,11 @@ Open the Context Menu by right-clicking (desktop) or long-pressing (mobile) a Gr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/contextmenu/context-menu-best-practices.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-best-practices.ts[render,tag=snippet,indent=0,group=Lit]
 
 // ...
 
-include::{root}/frontend/demo/component/contextmenu/context-menu-best-practices.ts[render,tag=snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/contextmenu/context-menu-best-practices.ts[render,tag=snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/cookie-consent/index.adoc
+++ b/articles/components/cookie-consent/index.adoc
@@ -28,7 +28,7 @@ include::{articles}/components/_shared.adoc[tag=scaled-examples]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/cookieconsent/cookie-consent-basic.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/cookieconsent/cookie-consent-basic.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -62,7 +62,7 @@ You can customize the message, the "Learn More" link, the "Dismiss" button, as w
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/cookieconsent/cookie-consent-localization.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/cookieconsent/cookie-consent-localization.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -113,7 +113,7 @@ Cookie Consent's theme is modified using CSS.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/cookieconsent/cookie-consent-theming.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/cookieconsent/cookie-consent-theming.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/cookie-consent/index.adoc
+++ b/articles/components/cookie-consent/index.adoc
@@ -35,7 +35,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentBasic.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentBasic.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -69,7 +69,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentLocalization.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentLocalization.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -125,7 +125,7 @@ include::{root}/frontend/themes/docs/cookie-consent-theming.css[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentTheming.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/cookieconsent/CookieConsentTheming.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/crud/index.adoc
+++ b/articles/components/crud/index.adoc
@@ -32,11 +32,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -66,11 +66,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudColumns.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudColumns.java[render,tags=snippet,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -101,11 +101,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudOpenEditor.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudOpenEditor.java[render,tags=snippet,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -145,11 +145,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudEditorAside.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudEditorAside.java[render,tags=snippet,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -183,11 +183,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudEditorBottom.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudEditorBottom.java[render,tags=snippet,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -223,15 +223,15 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudEditorContent.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudEditorContent.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudEditorContent.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudEditorContent.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -268,15 +268,15 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudGridReplacement.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudGridReplacement.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudGridReplacement.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudGridReplacement.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -310,11 +310,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudToolbar.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudToolbar.java[render,tags=snippet,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -344,7 +344,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudHiddenToolbar.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudHiddenToolbar.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -378,19 +378,19 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudSortingFiltering.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudSortingFiltering.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudSortingFiltering.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudSortingFiltering.java[render,tags=snippet2,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudSortingFiltering.java[render,tags=snippet3,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudSortingFiltering.java[render,tags=snippet3,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -421,7 +421,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudItemInitialization.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudItemInitialization.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -452,11 +452,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudLocalization.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/CrudLocalization.java[render,tags=snippet,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/crud/PersonDataProvider.java[render,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/crud/index.adoc
+++ b/articles/components/crud/index.adoc
@@ -25,7 +25,7 @@ CRUD is a component for managing a dataset. It allows for easy displaying, editi
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -59,7 +59,7 @@ CRUD automatically generates columns for each field in the provided dataset. You
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-columns.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-columns.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -94,7 +94,7 @@ Data is edited using CRUD's editor UI. By default, the editor is opened by click
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-open-editor.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-open-editor.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -138,7 +138,7 @@ The `aside` position displays the editor as an overlay next to the grid. Use thi
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-editor-aside.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-editor-aside.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -176,7 +176,7 @@ The bottom position can be useful when the user needs to see as many columns in 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-editor-bottom.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-editor-bottom.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -216,7 +216,7 @@ The editor's content is fully configurable, except for the header and footer.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-editor-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-editor-content.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -261,7 +261,7 @@ See <<../grid#,Grid documentation>> for details on configuring grids.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-grid-replacement.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-grid-replacement.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -303,7 +303,7 @@ Creating new items is done via the “New Item” Button in CRUD's toolbar. Both
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-toolbar.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-toolbar.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -337,7 +337,7 @@ The toolbar can be hidden if it isn't needed.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-hidden-toolbar.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-hidden-toolbar.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -371,7 +371,7 @@ Sorting and filtering can be disabled.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/crud/crud-sorting-filtering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-sorting-filtering.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -414,7 +414,7 @@ Newly created items can be initialized with data.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/crud/crud-item-initialization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-item-initialization.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -445,7 +445,7 @@ CRUD supports full localization through customizable labels for its buttons and 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/crud/crud-localization.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/crud/crud-localization.ts[render,tags=snippet;snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/custom-field/index.adoc
+++ b/articles/components/custom-field/index.adoc
@@ -24,7 +24,7 @@ It provides standard input field features like label, helper, validation, and da
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/custom-field/custom-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/custom-field/custom-field-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -197,7 +197,7 @@ Custom Field works with native HTML elements. The `whitespace` variant can be us
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/custom-field/custom-field-native-input.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/custom-field/custom-field-native-input.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -237,7 +237,7 @@ The small theme variant can be used to make Custom Field's label, helper, and er
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/custom-field/custom-field-size-variants.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/custom-field/custom-field-size-variants.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/custom-field/index.adoc
+++ b/articles/components/custom-field/index.adoc
@@ -31,22 +31,22 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java[tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/customfield/DateRangePicker.java[tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/customfield/CustomFieldBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/customfield/CustomFieldBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/customfield/LocalDateRange.java[tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/customfield/LocalDateRange.java[tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Appointment.java[tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/domain/Appointment.java[tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -204,17 +204,17 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/customfield/PaymentInformationField.java[tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/customfield/PaymentInformationField.java[tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/customfield/CustomFieldNativeInput.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/customfield/CustomFieldNativeInput.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/customfield/PaymentInformation.java[tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/customfield/PaymentInformation.java[tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -244,17 +244,17 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java[tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/customfield/MoneyField.java[tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/customfield/CustomFieldSizeVariants.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/customfield/CustomFieldSizeVariants.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/customfield/Money.java[tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/customfield/Money.java[tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/date-picker/index.adoc
+++ b/articles/components/date-picker/index.adoc
@@ -33,7 +33,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -238,7 +238,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerMinMax.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerMinMax.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -268,7 +268,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerCustomValidation.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerCustomValidation.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -302,7 +302,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerWeekNumbers.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerWeekNumbers.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -334,7 +334,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInitialPosition.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInitialPosition.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -364,7 +364,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerAutoOpen.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerAutoOpen.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -393,7 +393,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInternationalization.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerInternationalization.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -424,7 +424,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -453,7 +453,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -482,7 +482,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -514,7 +514,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDateRange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDateRange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -552,7 +552,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerIndividualInputFields.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerIndividualInputFields.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -592,7 +592,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDateFormatIndicator.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDateFormatIndicator.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/date-picker/index.adoc
+++ b/articles/components/date-picker/index.adoc
@@ -26,7 +26,7 @@ Try clicking the calendar icon. A calendar overlay appears, showing the current 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -200,7 +200,7 @@ When using the web component stand-alone, custom functions can be configured to 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-custom-functions.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-custom-functions.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -231,7 +231,7 @@ The valid input range of Date Picker can be restricted by defining `min` and `ma
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-min-max.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-min-max.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -261,7 +261,7 @@ Date Picker supports custom validation, such as limiting the options to Monday t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-custom-validation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-custom-validation.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -295,7 +295,7 @@ pass:[<!-- vale Vaadin.Abbr = YES --> ]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-week-numbers.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-week-numbers.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -327,7 +327,7 @@ Use this feature to minimize the need for unnecessary navigation or scrolling wh
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-initial-position.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-initial-position.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -357,7 +357,7 @@ The overlay automatically opens when the field is focused with a click or a tap,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-auto-open.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-auto-open.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -386,7 +386,7 @@ Date Picker allows localizing text and labels, such as month names and button la
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-internationalization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-internationalization.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -417,7 +417,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -446,7 +446,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -475,7 +475,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -507,7 +507,7 @@ You can create a date range picker using the Date Picker twice. Imagine the foll
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-date-range.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-date-range.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -545,7 +545,7 @@ Instead of a Date Picker, you can use individual input fields (i.e., day, month,
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -585,7 +585,7 @@ pass:[<!-- vale Google.DateFormat = YES -->]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/date-time-picker/index.adoc
+++ b/articles/components/date-time-picker/index.adoc
@@ -27,7 +27,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinutesStep.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinutesStep.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -90,7 +90,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerSecondsStep.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerSecondsStep.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -137,7 +137,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerAutoOpen.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerAutoOpen.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -168,7 +168,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinMax.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerMinMax.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -197,7 +197,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerCustomValidation.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerCustomValidation.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -226,7 +226,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerWeekNumbers.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerWeekNumbers.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -257,7 +257,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInitialPosition.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInitialPosition.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -286,7 +286,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInternationalization.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInternationalization.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -323,7 +323,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{articles}/components/_shared-code-snippets.adoc[tags=aria-label-dtp-java,indent=0,group=Java]
+include::{articles}/components/_shared-code-snippets.adoc[tags=aria-label-dtp-java,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -341,7 +341,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -370,7 +370,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -399,7 +399,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -430,7 +430,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerRange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerRange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -473,7 +473,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInputFormat.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerInputFormat.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/date-time-picker/index.adoc
+++ b/articles/components/date-time-picker/index.adoc
@@ -20,7 +20,7 @@ Date Time Picker is an input field for selecting both a date and a time.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -53,7 +53,7 @@ The default step is one hour (that is, `3600`). Unlike with <<../number-field#,N
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -83,7 +83,7 @@ The displayed time format changes based on the step.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -130,7 +130,7 @@ The overlay opens automatically when the field is focused using a pointer (i.e.,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -161,7 +161,7 @@ You can define a `min` and `max` value for Date Time Picker if you need to restr
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-min-max.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -190,7 +190,7 @@ If the `min` and `max` values aren't enough, you can also apply custom validatio
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -219,7 +219,7 @@ You can configure Date Time Picker to show week numbers in the date picker overl
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -250,7 +250,7 @@ Date Time Picker's initial position parameter defines which date is focused in t
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -279,7 +279,7 @@ Date Time Picker allows localizing texts and labels, such as month names and but
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -316,7 +316,7 @@ If the built-in label cannot be used, an invisible label should be provided for 
 ifdef::lit[]
 [source,html]
 ----
-include::{articles}/components/_shared-code-snippets.adoc[tags=aria-label-dtp-typescript,indent=0,group=TypeScript]
+include::{articles}/components/_shared-code-snippets.adoc[tags=aria-label-dtp-typescript,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -334,7 +334,7 @@ endif::[]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -363,7 +363,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -392,7 +392,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -423,7 +423,7 @@ You can accomplish a date time range picker using two Date Time Pickers.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-range.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-range.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -466,7 +466,7 @@ Use a helper text to show the expected date and time formats, and placeholders t
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/details/index.adoc
+++ b/articles/components/details/index.adoc
@@ -20,7 +20,7 @@ Details is an expandable panel for showing and hiding content from the user, to 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -56,12 +56,12 @@ The summary supports rich content and can contain any component. This can be use
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-summary.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-summary.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=Lit]
 ----
 endif::[]
 
@@ -91,7 +91,7 @@ This is the collapsible part of Details. It can contain any component. When the 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-content.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ The `filled` theme variant makes the component's boundaries visible, which helps
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-filled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-filled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -155,7 +155,7 @@ Use the `small` theme variant for compact UIs.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-small.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-small.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -185,7 +185,7 @@ The reverse theme variant places the toggle icon after the summary contents, whi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-reverse.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-reverse.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -216,7 +216,7 @@ Details can be disabled to prevent them from being expanded or collapsed. Compon
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/details/details-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/details/details-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/details/index.adoc
+++ b/articles/components/details/index.adoc
@@ -27,7 +27,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -68,7 +68,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsSummary.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsSummary.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -98,7 +98,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsContent.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsContent.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -133,7 +133,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsFilled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsFilled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -162,7 +162,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsSmall.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsSmall.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -192,7 +192,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsReverse.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsReverse.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -223,7 +223,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/details/DetailsDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -23,7 +23,7 @@ ifdef::lit[]
 [source,html]
 ----
 
-include::{root}/frontend/demo/component/dialog/dialog-basic.ts[render,frame,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-basic.ts[render,frame,tags=*,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -65,7 +65,7 @@ The header contains an optional title element, and a slot next to it for custom 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-header.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-header.ts[render,tags=*,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -97,7 +97,7 @@ Components can be left-aligned by applying a margin:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-footer.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-footer.ts[render,tags=*,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ The content area's built-in padding can be removed by applying the `no-padding` 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-no-padding.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-no-padding.ts[render,tags=*,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -219,7 +219,7 @@ You can choose whether to make the component's content draggable as well, or onl
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-draggable.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-draggable.ts[render,tags=*,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -263,7 +263,7 @@ Dialogs that contain very little, or compact, information don't need to be resiz
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-resizable.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-resizable.ts[render,tags=*,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -298,7 +298,7 @@ Providing an explicit button for closing a Dialog is recommended.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/dialog/dialog-closing.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/dialog/dialog-closing.ts[render,tags=*,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -30,7 +30,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogBasic.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogBasic.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -72,7 +72,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogHeader.java[render,tags=*,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogHeader.java[render,tags=*,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -104,7 +104,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogFooter.java[render,tags=*,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogFooter.java[render,tags=*,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -133,7 +133,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogNoPadding.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogNoPadding.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -226,11 +226,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogDraggable.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogDraggable.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogDraggable.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogDraggable.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -270,7 +270,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogResizable.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogResizable.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -305,7 +305,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogClosing.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/dialog/DialogClosing.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/email-field/index.adoc
+++ b/articles/components/email-field/index.adoc
@@ -24,7 +24,7 @@ If the given address is invalid, the field is highlighted in red and an error me
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -55,7 +55,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -93,7 +93,7 @@ The example below uses the pattern `.+@example\.com` and only accepts addresses 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-constraints.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -122,7 +122,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -151,7 +151,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/emailfield/email-field-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/emailfield/email-field-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/email-field/index.adoc
+++ b/articles/components/email-field/index.adoc
@@ -31,7 +31,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -62,7 +62,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -100,7 +100,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldConstraints.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldConstraints.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -129,7 +129,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -158,7 +158,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/form-layout/index.adoc
+++ b/articles/components/form-layout/index.adoc
@@ -27,7 +27,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -63,7 +63,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutCustomLayout.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutCustomLayout.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -99,7 +99,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutColspan.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutColspan.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -142,7 +142,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutSide.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutSide.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -181,7 +181,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutNativeInput.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutNativeInput.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -210,7 +210,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutCustomField.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/formlayout/FormLayoutCustomField.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/form-layout/index.adoc
+++ b/articles/components/form-layout/index.adoc
@@ -20,7 +20,7 @@ Form Layout allows you to build responsive forms with multiple columns, and to p
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -56,7 +56,7 @@ Use the draggable split handle to resize Form Layout's available space and to te
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-custom-layout.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-custom-layout.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -92,7 +92,7 @@ For example, if you have a Form Layout with three columns and a component's `col
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-colspan.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-colspan.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -135,7 +135,7 @@ Labels positioned on the side are also often used when there is a need to compar
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-side.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-side.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -174,7 +174,7 @@ Form Item allows you to set a label for any type of component that you want to u
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-native-input.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-native-input.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -203,7 +203,7 @@ Form Item only supports placing a single field inside. Where you need to place m
 ifdef::lit[]
 [source,js]
 ----
-include::{root}/frontend/demo/component/formlayout/form-layout-custom-field.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/formlayout/form-layout-custom-field.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/grid-pro/index.adoc
+++ b/articles/components/grid-pro/index.adoc
@@ -26,7 +26,7 @@ Grid Pro is an extension of the Grid component that provides inline editing with
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -75,7 +75,7 @@ Single Click Edit is a mode that enables the user to begin editing by single-cli
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-single-click.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-single-click.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -106,7 +106,7 @@ Single Cell Edit is a mode that makes tabbing from one cell to another exit from
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -137,7 +137,7 @@ kbd:[Enter] and kbd:[Shift+Enter] can be made to focus the editable cell in the 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -166,7 +166,7 @@ Editing is enabled on a per-column basis.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-edit-column.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-edit-column.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -212,7 +212,7 @@ Although Grid Pro can be configured to use any input field for editing, the buil
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-editors.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-editors.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -241,7 +241,7 @@ You can rollback changes when the entered input is incorrect or invalid.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-prevent-save.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-prevent-save.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -275,7 +275,7 @@ Editable cells can be highlighted by applying the `highlight-editable-cells` the
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -326,7 +326,7 @@ Read-only cells can be highlighted by applying the `highlight-read-only-cells` t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/grid-pro/index.adoc
+++ b/articles/components/grid-pro/index.adoc
@@ -33,7 +33,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -82,7 +82,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProSingleClick.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProSingleClick.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -113,7 +113,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProSingleCellEdit.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProSingleCellEdit.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -144,7 +144,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProEnterNextRow.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProEnterNextRow.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -173,7 +173,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProEditColumn.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProEditColumn.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -219,7 +219,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProEditor.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProEditor.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -248,7 +248,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProPreventSave.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProPreventSave.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -282,7 +282,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightEditableCells.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightEditableCells.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -333,7 +333,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightReadOnlyCells.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProThemeHighlightReadOnlyCells.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/grid/index.adoc
+++ b/articles/components/grid/index.adoc
@@ -37,12 +37,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=snippet]
+include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Flow,tags=snippet]
 ----
 endif::[]
 
@@ -77,11 +77,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContent.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContent.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContent.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContent.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -140,7 +140,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridWrapCellContent.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridWrapCellContent.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -176,7 +176,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDynamicHeight.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDynamicHeight.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -211,7 +211,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridSingleSelectionMode.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridSingleSelectionMode.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -241,7 +241,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridMultiSelectionMode.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridMultiSelectionMode.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -279,7 +279,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnAlignment.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnAlignment.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -311,7 +311,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnFreezing.java[render,tags=*,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnFreezing.java[render,tags=*,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -345,7 +345,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnGrouping.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnGrouping.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -375,11 +375,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnHeaderFooter.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnHeaderFooter.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnHeaderFooter.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnHeaderFooter.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -411,11 +411,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnVisibility.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnVisibility.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnVisibility.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnVisibility.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -447,7 +447,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnReorderingResizing.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnReorderingResizing.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -479,7 +479,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnWidth.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnWidth.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -513,7 +513,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridSorting.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridSorting.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -545,7 +545,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridMultiSort.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridMultiSort.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -580,7 +580,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridRichContentSorting.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridRichContentSorting.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -619,11 +619,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnFiltering.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnFiltering.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnFiltering.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnFiltering.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -650,7 +650,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridExternalFiltering.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridExternalFiltering.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -686,17 +686,17 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDataProvider.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDataProvider.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/PersonDataProvider.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/PersonDataProvider.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/PersonFilter.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/PersonFilter.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -744,7 +744,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridLazyColumnRendering.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridLazyColumnRendering.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -774,11 +774,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridItemDetails.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridItemDetails.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridItemDetails.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridItemDetails.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -805,11 +805,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridItemDetailsToggle.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridItemDetailsToggle.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridItemDetailsToggle.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridItemDetailsToggle.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -844,11 +844,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContextMenuExample.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContextMenuExample.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContextMenuExample.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridContextMenuExample.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -884,7 +884,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridTooltipGenerator.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridTooltipGenerator.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -942,7 +942,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridRowReordering.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridRowReordering.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -974,7 +974,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDragRowsBetweenGrids.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDragRowsBetweenGrids.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -1005,7 +1005,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -1037,12 +1037,12 @@ include::{root}/frontend/demo/component/grid/grid-buffered-inline-editor.ts[prei
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridBufferedInlineEditor.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridBufferedInlineEditor.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/ValidationMessage.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/ValidationMessage.java[group=Flow]
 ----
 endif::[]
 --
@@ -1062,12 +1062,12 @@ include::{root}/frontend/demo/component/grid/grid-unbuffered-inline-editor.ts[pr
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridUnbufferedInlineEditor.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridUnbufferedInlineEditor.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/ValidationMessage.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/ValidationMessage.java[group=Flow]
 ----
 endif::[]
 --
@@ -1096,7 +1096,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridStyling.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridStyling.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -1132,7 +1132,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridHeaderFooterStyling.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridHeaderFooterStyling.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -1174,7 +1174,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridCompact.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridCompact.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -1204,7 +1204,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridNoBorder.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridNoBorder.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -1234,7 +1234,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridNoRowBorder.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridNoRowBorder.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -1264,7 +1264,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnBorders.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridColumnBorders.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -1294,7 +1294,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridRowStripes.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridRowStripes.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -1349,7 +1349,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/grid/GridCellFocus.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/grid/GridCellFocus.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/grid/index.adoc
+++ b/articles/components/grid/index.adoc
@@ -30,7 +30,7 @@ pass:[<!-- vale Vaadin.Will = NO -->]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -70,7 +70,7 @@ Notice how much nicer and richer the grid content is rendered in the table below
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-content.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -133,7 +133,7 @@ Notice in the example here that the text in the _Address_ cells is wrapped. If y
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-wrap-cell-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-wrap-cell-content.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -169,7 +169,7 @@ Notice how the height of the rows in the earlier example adjusts because of the 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-dynamic-height.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-dynamic-height.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -204,7 +204,7 @@ In single-selection mode, the user can select and deselect rows by clicking anyw
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-single-selection-mode.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-single-selection-mode.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -234,7 +234,7 @@ In multi-select mode, the user can use a checkbox column to select and deselect 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-multi-select-mode.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-multi-select-mode.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -272,7 +272,7 @@ ifdef::lit[]
 [source,typescript]
 ----
 
-include::{root}/frontend/demo/component/grid/grid-column-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-alignment.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -304,7 +304,7 @@ In the example here, try scrolling the data to the right and back left. Notice t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-freezing.ts[render,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-freezing.ts[render,tags=*,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -338,7 +338,7 @@ In the example below, the first and last names are grouped under _Name_. Whereas
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-grouping.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-grouping.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -368,7 +368,7 @@ Each column has a customizable header and footer. A basic column header shows th
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-header-footer.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-header-footer.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -404,7 +404,7 @@ In the example here, notice that the email address and telephone numbers are not
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-visibility.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-visibility.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -440,7 +440,7 @@ Instead of hiding columns as in the earlier example, in the example here the use
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-reordering-resizing.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-reordering-resizing.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -472,7 +472,7 @@ In the following example, the first and last columns have fixed widths. The seco
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-width.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-width.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -506,7 +506,7 @@ endif::[]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-sorting.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-sorting.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -538,7 +538,7 @@ In the example here, click on the _Profession_ column heading to set the first s
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-multisort.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-multisort.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -573,7 +573,7 @@ Columns with rich or custom content can be sorted by defining the property by wh
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-rich-content-sorting.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-rich-content-sorting.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -612,7 +612,7 @@ pass:[<!-- vale Vaadin.Spelling = YES -->]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-filtering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-filtering.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -643,7 +643,7 @@ Place filters outside the grid when the filter is based on multiple columns, or 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-external-filtering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-external-filtering.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -675,11 +675,11 @@ The following example works like the earlier example, but it uses a data provide
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-data-provider.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-data-provider.ts[render,tags=snippet,indent=0,group=Lit]
 
 ...
 
-include::{root}/frontend/demo/component/grid/grid-data-provider.ts[render,tags=snippet2,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-data-provider.ts[render,tags=snippet2,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -737,7 +737,7 @@ No Improvement If All Columns Visible:: The lazy column rendering mode can only 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-lazy-column-rendering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-lazy-column-rendering.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -767,7 +767,7 @@ Item details are expandable content areas that can be displayed below the regula
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-item-details.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-item-details.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -798,7 +798,7 @@ The default toggle behavior can be replaced by programmatically toggling the det
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-item-details-toggle.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-item-details-toggle.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -837,7 +837,7 @@ ifdef::lit[]
 [source,typescript]
 ----
 
-include::{root}/frontend/demo/component/grid/grid-context-menu.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-context-menu.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -873,11 +873,11 @@ In the example here, hold your mouse pointer over the birthday date for one of t
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-tooltip-generator.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-tooltip-generator.ts[render,tag=snippet,indent=0,group=Lit]
 
 ...
 
-include::{root}/frontend/demo/component/grid/grid-tooltip-generator.ts[render,tag=snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-tooltip-generator.ts[render,tag=snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -935,7 +935,7 @@ You can drag rows to reorder them. This can be a useful and impressive feature f
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-row-reordering.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-row-reordering.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -967,7 +967,7 @@ In the example here, there are two grids of data. Maybe they represent people to
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-drag-rows-between-grids.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-drag-rows-between-grids.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -998,7 +998,7 @@ Drag-and-drop filters determine which rows are draggable and which rows are vali
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-drag-drop-filters.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-drag-drop-filters.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -1089,7 +1089,7 @@ In the example below, bold font weight is applied to the [guilabel]*Rating* colu
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-styling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-styling.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -1125,7 +1125,7 @@ Header and footer cells can be similarly styled through their own custom part na
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-header-footer-styling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-header-footer-styling.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -1167,7 +1167,7 @@ This is useful for displaying more information on-screen without having to scrol
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-compact.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-compact.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -1197,7 +1197,7 @@ The `no-border` theme variant removes the outer border of the grid. Compare the 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-no-border.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-no-border.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -1227,7 +1227,7 @@ This theme variant removes the horizontal row borders. This is best suited for s
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-no-row-border.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-no-row-border.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -1257,7 +1257,7 @@ You can add vertical borders between columns by using the `column-borders` theme
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-column-borders.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-column-borders.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -1287,7 +1287,7 @@ The `row-stripes` theme variant produces a background color for every other row.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-row-stripes.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-row-stripes.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -1342,7 +1342,7 @@ The cell focus event can be used to be notified when the user changes focus betw
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/grid/grid-cell-focus.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/grid/grid-cell-focus.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/horizontal-layout/index.adoc
+++ b/articles/components/horizontal-layout/index.adoc
@@ -29,7 +29,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayout.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayout.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -62,7 +62,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutVerticalAlignment.java[render,tags=layout,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutVerticalAlignment.java[render,tags=layout,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -107,7 +107,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutIndividualAlignment.java[render,tags=layout,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutIndividualAlignment.java[render,tags=layout,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -137,7 +137,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutHorizontalAlignment.java[render,tags=layout,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutHorizontalAlignment.java[render,tags=layout,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -188,7 +188,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacing.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacing.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -215,7 +215,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacingVariants.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacingVariants.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -295,7 +295,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutPadding.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutPadding.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -325,7 +325,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutMargin.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutMargin.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -355,7 +355,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsExpandingItems.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsExpandingItems.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/horizontal-layout/index.adoc
+++ b/articles/components/horizontal-layout/index.adoc
@@ -22,7 +22,7 @@ See <<../vertical-layout#, Vertical Layout>> for placing components top-to-botto
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -55,7 +55,7 @@ You can position components at the top, middle, or bottom. You can also stretch 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -100,7 +100,7 @@ It's also possible to set a different vertical alignment for individual items by
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -130,7 +130,7 @@ Components in a Horizontal Layout can be left-aligned, centered or right-aligned
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -181,7 +181,7 @@ Spacing is used to create space among components in the same layout. Spacing can
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -208,7 +208,7 @@ Five different spacing theme variants are available:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -288,7 +288,7 @@ Padding is the space between the outer border and the content in a layout. Paddi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -318,7 +318,7 @@ Use margin to create space around a layout.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -348,7 +348,7 @@ Components can be made to expand and take up any excess space a layout may have.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/icons/index.adoc
+++ b/articles/components/icons/index.adoc
@@ -19,7 +19,7 @@ The icon component can render SVG and font icons. Two icon collections are avail
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icon-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icon-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ Vaadin Icons is a collection of over six-hundred icons.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/vaadin-icons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/vaadin-icons.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -92,7 +92,7 @@ Lumo Icons are used in the default Lumo theme for Vaadin components.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/lumo-icons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/lumo-icons.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -132,7 +132,7 @@ Standalone SVG images can be rendered as inline SVG icons using the icon compone
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/svg-standalone.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/svg-standalone.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -168,7 +168,7 @@ Using an image from an SVG sprite is similar to using a standalone SVG image -- 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/svg-sprites.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/svg-sprites.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -214,7 +214,7 @@ The desired icon can be specified in three different ways, depending on the font
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icon-fonts.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icon-fonts.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -326,7 +326,7 @@ The icon's fill color can be set to any CSS color value.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icons-color.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icons-color.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -356,7 +356,7 @@ The icon component has a property for setting the desired outer size of the icon
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icons-sizing.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icons-sizing.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -383,7 +383,7 @@ The internal padding of the icon can be adjusted to compensate for the lack of s
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icons-padding.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icons-padding.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -437,7 +437,7 @@ However, in most cases, there shouldn't be a need to make icons themselves scree
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/icons/icons-accessibility.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/icons/icons-accessibility.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/icons/index.adoc
+++ b/articles/components/icons/index.adoc
@@ -26,7 +26,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/IconBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/IconBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -67,7 +67,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/VaadinIcons.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/VaadinIcons.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -99,7 +99,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/LumoIcons.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/LumoIcons.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -139,7 +139,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/SvgStandalone.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/SvgStandalone.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -175,7 +175,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/SvgSprites.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/SvgSprites.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -221,7 +221,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/IconFonts.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/IconFonts.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -333,7 +333,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/IconsColor.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/IconsColor.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -363,7 +363,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/IconsSizing.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/IconsSizing.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -390,7 +390,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/IconsPadding.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/IconsPadding.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -444,7 +444,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/icons/IconsAccessibility.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/icons/IconsAccessibility.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/list-box/index.adoc
+++ b/articles/components/list-box/index.adoc
@@ -21,7 +21,7 @@ List Box allows the user to select one or more values from a scrollable list of 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -53,7 +53,7 @@ Use them sparingly to avoid creating unnecessary visual clutter.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-separators.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-separators.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -82,7 +82,7 @@ Disable items to show that they are currently unavailable for selection.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-disabled-items.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-disabled-items.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -120,7 +120,7 @@ Single selection allows the user to select only one item, whereas multiple selec
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-single-selection.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-single-selection.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -147,7 +147,7 @@ endif::[]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-multi-selection.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-multi-selection.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -181,7 +181,7 @@ pass:[<!-- vale Vaadin.TooWordy = YES -->]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/listbox/list-box-custom-item-presentation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/listbox/list-box-custom-item-presentation.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/list-box/index.adoc
+++ b/articles/components/list-box/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxSeparators.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxSeparators.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -89,7 +89,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxDisabledItems.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxDisabledItems.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -127,7 +127,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxSingleSelection.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxSingleSelection.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -154,7 +154,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxMultiSelection.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxMultiSelection.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -188,7 +188,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxCustomItemPresentation.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/listbox/ListBoxCustomItemPresentation.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/login/index.adoc
+++ b/articles/components/login/index.adoc
@@ -39,7 +39,7 @@ It's compatible with password managers, supports internationalization, and works
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -71,7 +71,7 @@ You can customize the form's title and labels using internationalization.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/login/login-internationalization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-internationalization.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -98,7 +98,7 @@ The basic Login component can be used to create log-in pages featuring rich cont
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-rich-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-rich-content.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -140,7 +140,7 @@ The overlay can be opened programmatically or through user interaction (e.g., by
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-basic.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-basic.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -170,7 +170,7 @@ The overlay has a header and the log-in form. By default, the header contains pl
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-header.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-header.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -201,7 +201,7 @@ The overlay provides a custom form area for adding fields in addition to usernam
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-custom-form-area.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-custom-form-area.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -232,7 +232,7 @@ The footer area can be used for placing additional custom content, such as text,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-footer.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-footer.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -262,7 +262,7 @@ Login shows an error message when authentication fails. The error message includ
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/login/login-validation.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-validation.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -291,7 +291,7 @@ More information can be provided to the user, for example, by linking to a page 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/login/login-additional-information.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-additional-information.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -322,7 +322,7 @@ Login's titles, descriptions, labels, and messages are all customizable using in
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/login/login-overlay-internationalization.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/login/login-overlay-internationalization.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/login/index.adoc
+++ b/articles/components/login/index.adoc
@@ -46,7 +46,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -78,7 +78,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -110,7 +110,7 @@ include::{root}/frontend/themes/docs/login-rich-content.css[render,indent=0]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginRichContent.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginRichContent.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -147,7 +147,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayBasic.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayBasic.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -177,7 +177,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayHeader.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayHeader.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -208,7 +208,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayCustomFormArea.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayCustomFormArea.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -239,7 +239,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayFooter.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayFooter.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -269,7 +269,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginValidation.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginValidation.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -298,7 +298,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginAdditionalInformation.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginAdditionalInformation.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -329,7 +329,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/map/index.adoc
+++ b/articles/components/map/index.adoc
@@ -28,7 +28,7 @@ include::{root}/frontend/demo/component/map/map-basic.ts[preimport,hidden]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -72,11 +72,11 @@ include::{root}/frontend/demo/component/map/map-viewport.ts[preimport,hidden]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapViewport.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapViewport.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapViewport.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapViewport.java[render,tags=snippet2,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -146,7 +146,7 @@ include::{root}/frontend/demo/component/map/map-sources.ts[preimport,hidden]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapSources.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapSources.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -177,20 +177,20 @@ include::{root}/frontend/demo/component/map/map-layers.ts[preimport,hidden]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapLayers.java[render,tags=snippet1,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapLayers.java[render,tags=snippet1,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapLayers.java[render,tags=snippet2,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapLayers.java[render,tags=snippet2,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapLayers.java[render,tags=snippet3,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapLayers.java[render,tags=snippet3,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/LayerOption.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/LayerOption.java[group=Flow]
 ----
 endif::[]
 --
@@ -215,7 +215,7 @@ include::{root}/frontend/demo/component/map/map-markers.ts[preimport,hidden]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapMarkers.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapMarkers.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -244,7 +244,7 @@ include::{root}/frontend/demo/component/map/map-marker-text.ts[preimport,hidden]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapMarkerText.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapMarkerText.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -268,7 +268,7 @@ include::{root}/frontend/demo/component/map/map-marker-drag-drop.ts[preimport,hi
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapMarkerDragDrop.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapMarkerDragDrop.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -315,7 +315,7 @@ include::{root}/frontend/demo/component/map/map-events.ts[preimport,hidden]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapEvents.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapEvents.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -458,7 +458,7 @@ include::{root}/frontend/demo/component/map/map-theme-borderless.ts[preimport,hi
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/map/MapThemeBorderless.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -24,7 +24,7 @@ Menu items can trigger an action, open a menu, or work as a toggle.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-basic.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-basic.ts[render,tags=snippet;snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -56,7 +56,7 @@ The following variants are available to adjust the appearance of the component:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -104,7 +104,7 @@ Top-level items are aligned by default to the start of the Menu Bar. Use instead
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-right-aligned.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-right-aligned.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -134,7 +134,7 @@ Individual menu items can be styled by [since:com.vaadin:vaadin@V24.3]##applying
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-custom-styling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-custom-styling.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -172,7 +172,7 @@ By default, collapsed items are removed from the end of the menu bar, but the co
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-overflow.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-overflow.ts[render,tags=snippet;snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -208,7 +208,7 @@ Menu items can have icons in addition to text -- or instead of text.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-icons.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-icons.ts[render,tags=snippet;snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -242,7 +242,7 @@ Icon-only menu buttons should be used primarily for common recurring actions wit
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-icon-only.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-icon-only.ts[render,tags=snippet;snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -280,7 +280,7 @@ Menu items can be disabled to show that they are unavailable currently.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -311,7 +311,7 @@ Menu items in drop-down menus can be configured as checkable to toggle options o
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-checkable.ts[render,tags=snippet;snippethtml;snippetselected,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-checkable.ts[render,tags=snippet;snippethtml;snippetselected,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -346,7 +346,7 @@ You can use dividers to separate and group related content. However, use divider
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-dividers.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-dividers.ts[render,tags=snippet;snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -381,7 +381,7 @@ A component can be configured to open drop-down menus on hover, instead of on cl
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-open-on-hover.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-open-on-hover.ts[render,tags=snippet;snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -412,11 +412,11 @@ Tooltips can be configured on top-level items to provide additional information,
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-tooltip.ts[render,tag=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-tooltip.ts[render,tag=snippet,indent=0,group=Lit]
 
 ...
 
-include::{root}/frontend/demo/component/menubar/menu-bar-tooltip.ts[render,tag=snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-tooltip.ts[render,tag=snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -493,7 +493,7 @@ A Menu Bar with a single top-level item is essentially a drop-down button. This 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-drop-down.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-drop-down.ts[render,tags=snippet;snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -521,7 +521,7 @@ So-called _combo buttons_ can be created in a similar way. For example, they can
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-combo-buttons.ts[render,tags=snippet;snippethtml,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-combo-buttons.ts[render,tags=snippet;snippethtml,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -551,7 +551,7 @@ Menu Bar provides an API for localization. Currently, only the accessible label 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/menubar/menu-bar-internationalization.ts[tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/menubar/menu-bar-internationalization.ts[tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -31,7 +31,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -63,7 +63,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -111,7 +111,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarRightAligned.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarRightAligned.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -141,7 +141,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarCustomStyling.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarCustomStyling.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -179,7 +179,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarOverflow.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarOverflow.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -215,11 +215,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarIcons.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarIcons.java[render,tags=snippet,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarIcons.java[render,tags=createIcon,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarIcons.java[render,tags=createIcon,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -249,11 +249,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarIconOnly.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarIconOnly.java[render,tags=snippet,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarIconOnly.java[render,tags=createIcon,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarIconOnly.java[render,tags=createIcon,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -287,7 +287,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -318,7 +318,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarCheckable.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarCheckable.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -353,7 +353,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarDividers.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarDividers.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -388,7 +388,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarOpenOnHover.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarOpenOnHover.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -423,11 +423,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarTooltip.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarTooltip.java[render,tags=snippet,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarTooltip.java[render,tags=createIcon,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarTooltip.java[render,tags=createIcon,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -500,7 +500,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarDropDown.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarDropDown.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -528,7 +528,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarComboButtons.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarComboButtons.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -558,7 +558,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarInternationalization.java[tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/menubar/MenuBarInternationalization.java[tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/message-input/index.adoc
+++ b/articles/components/message-input/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/messages/MessageInputComponent.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/messages/MessageInputComponent.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -58,7 +58,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/messages/MessagesBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/messages/MessagesBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/message-input/index.adoc
+++ b/articles/components/message-input/index.adoc
@@ -22,7 +22,7 @@ Message Input allows users to author and send messages.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/messages/message-input-component.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/messages/message-input-component.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 ifdef::flow[]
@@ -52,7 +52,7 @@ Use the <<../message-list#,Message List>> component to show messages that users 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/messages/message-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/messages/message-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 ifdef::flow[]

--- a/articles/components/message-list/index.adoc
+++ b/articles/components/message-list/index.adoc
@@ -27,7 +27,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/messages/MessageListComponent.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/messages/MessageListComponent.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -61,7 +61,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/messages/MessageListWithThemeComponent.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/messages/MessageListWithThemeComponent.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/message-list/index.adoc
+++ b/articles/components/message-list/index.adoc
@@ -21,7 +21,7 @@ You can configure the text content, information about the sender, and the time o
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/messages/message-list-component.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/messages/message-list-component.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 ifdef::flow[]
@@ -55,7 +55,7 @@ include::{root}/frontend/themes/docs/message-list-theming.css[]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/messages/message-list-with-theme-component.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/messages/message-list-with-theme-component.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 ifdef::flow[]

--- a/articles/components/multi-select-combo-box/index.adoc
+++ b/articles/components/multi-select-combo-box/index.adoc
@@ -36,12 +36,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 
@@ -91,12 +91,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelection.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelection.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 
@@ -138,12 +138,12 @@ Use [methodname]`addValueChangeListener()` to be notified about the user changin
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectionChange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectionChange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Country.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 
@@ -174,7 +174,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxReadOnly.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxReadOnly.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -206,7 +206,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxAutoExpand.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxAutoExpand.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -238,7 +238,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectedItemsOnTop.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxSelectedItemsOnTop.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -296,7 +296,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxI18nDemo.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/multiselectcombobox/MultiSelectComboBoxI18nDemo.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/multi-select-combo-box/index.adoc
+++ b/articles/components/multi-select-combo-box/index.adoc
@@ -23,12 +23,12 @@ The component <<../combo-box#,supports the same features as the regular Combo Bo
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=Lit]
 ----
 endif::[]
 
@@ -79,12 +79,12 @@ The component allows selecting multiple values, each of which is displayed as a 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=Lit]
 ----
 endif::[]
 
@@ -124,12 +124,12 @@ Use the `selected-items-changed` event to react to the user changing the selecti
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Country.ts[group=Lit]
 ----
 endif::[]
 
@@ -167,7 +167,7 @@ The component can be set to read-only, which prevents the user from modifying it
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -199,7 +199,7 @@ The component can be configured to auto-expand so as to accommodate chips for se
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -231,7 +231,7 @@ The component can be configured to group selected items at the top of the overla
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -289,7 +289,7 @@ The following example demonstrates how to localize the component's messages into
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/notification/index.adoc
+++ b/articles/components/notification/index.adoc
@@ -52,7 +52,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationBasic.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationBasic.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -87,7 +87,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationSuccess.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationSuccess.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -123,7 +123,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationWarning.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationWarning.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -159,7 +159,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationError.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationError.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -194,7 +194,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPrimary.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPrimary.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -223,7 +223,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationContrast.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationContrast.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -273,15 +273,15 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java[render,tags=snippet,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java[render,tags=createButton,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java[render,tags=createButton,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java[render,tags=show,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java[render,tags=show,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -340,7 +340,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationRetry.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationRetry.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -370,7 +370,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationUndo.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationUndo.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -400,7 +400,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationLink.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationLink.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -431,11 +431,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java[render,frame,tags=snippet,indent=0,group=Flow]
 
 // ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java[tags=setupUndoShortcut,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java[tags=setupUndoShortcut,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -473,7 +473,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationRich.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationRich.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -502,7 +502,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -535,7 +535,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPopup.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/notification/NotificationPopup.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/notification/index.adoc
+++ b/articles/components/notification/index.adoc
@@ -45,7 +45,7 @@ include::{articles}/components/_shared.adoc[tag=merge-examples]
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-basic.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-basic.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -80,7 +80,7 @@ The `success` theme variant can be used to display success messages, such as whe
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-success.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-success.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -112,11 +112,11 @@ The `warning` theme variant can be used to display warnings.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-warning.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-warning.ts[render,frame,tags=snippet,indent=0,group=Lit]
 
 <!-- ... -->
 
-include::{root}/frontend/demo/component/notification/notification-warning.ts[tags=renderer,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-warning.ts[tags=renderer,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -148,11 +148,11 @@ The `error` theme variant can be used to display errors.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-error.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-error.ts[render,frame,tags=snippet,indent=0,group=Lit]
 
 <!-- ... -->
 
-include::{root}/frontend/demo/component/notification/notification-error.ts[tags=renderer,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-error.ts[tags=renderer,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -187,7 +187,7 @@ The `primary` theme variant can be used for important informational messages or 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-primary.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-primary.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -216,7 +216,7 @@ The contrast variant can improve legibility and distinguish the notification fro
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-contrast.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-contrast.ts[render,frame,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -266,7 +266,7 @@ Use the `position` attribute in HTML templates (e.g., `<vaadin-notification posi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-position.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-position.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -329,11 +329,11 @@ For example, if an operation fails, the error notification could offer the user 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-retry.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-retry.ts[render,frame,tags=snippet,indent=0,group=Lit]
 
 <!-- ... -->
 
-include::{root}/frontend/demo/component/notification/notification-retry.ts[tags=renderer,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-retry.ts[tags=renderer,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -359,11 +359,11 @@ In situations where the user might want to revert an action, display an "Undo" b
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-undo.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-undo.ts[render,frame,tags=snippet,indent=0,group=Lit]
 
 <!-- ... -->
 
-include::{root}/frontend/demo/component/notification/notification-undo.ts[tags=renderer,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-undo.ts[tags=renderer,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -389,11 +389,11 @@ Notifications can also contain links to relevant information.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-link.ts[render,frame,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-link.ts[render,frame,tags=snippet,indent=0,group=Lit]
 
 <!-- ... -->
 
-include::{root}/frontend/demo/component/notification/notification-link.ts[tags=renderer,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-link.ts[tags=renderer,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -424,7 +424,7 @@ Make the notification persistent to prevent it from disappearing before the user
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-keyboard-a11y.ts[render,frame,tags=*,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-keyboard-a11y.ts[render,frame,tags=*,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -466,7 +466,7 @@ include::{root}/frontend/demo/component/notification/notification-rich-preview.t
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/notification/notification-rich.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-rich.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -495,7 +495,7 @@ For simple, one-off notifications, it's convenient to use the static [methodname
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-static-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-static-helper.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -528,7 +528,7 @@ Less-urgent notifications can be provided through a link or a drop-down in the a
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/notification/notification-popup.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/notification/notification-popup.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/number-field/index.adoc
+++ b/articles/components/number-field/index.adoc
@@ -33,7 +33,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -62,7 +62,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStepButtons.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStepButtons.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -93,7 +93,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldMinMax.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldMinMax.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStep.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStep.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -157,7 +157,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldInteger.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldInteger.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -184,7 +184,7 @@ include::{root}/frontend/demo/component/numberfield/number-field-big-decimal.ts[
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldBigDecimal.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldBigDecimal.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -206,7 +206,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -235,7 +235,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -264,7 +264,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/number-field/index.adoc
+++ b/articles/components/number-field/index.adoc
@@ -26,7 +26,7 @@ You can specify a unit as a prefix, or a suffix for the field.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -55,7 +55,7 @@ Step buttons allow the user to make small adjustments, quickly.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-step-buttons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-step-buttons.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ You can set the helper text to give information about the range.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-min-max.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-min-max.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -119,7 +119,7 @@ It also invalidates the field if the value entered doesn't align with the specif
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-step.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -150,7 +150,7 @@ To allow only integers to be entered, you can use the Integer Field like so:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-integer.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-integer.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -199,7 +199,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -228,7 +228,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -257,7 +257,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/numberfield/number-field-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/numberfield/number-field-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/password-field/index.adoc
+++ b/articles/components/password-field/index.adoc
@@ -22,7 +22,7 @@ The input is masked by default. On mobile devices, though, the last typed letter
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -50,7 +50,7 @@ The reveal button allows the user to disable masking and see the value they ente
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -79,7 +79,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -108,7 +108,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=constraint
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-constraints.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -137,7 +137,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -166,7 +166,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -195,7 +195,7 @@ Express clearly your password requirements to the user, so that they don't have 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-helper.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -221,7 +221,7 @@ Showing the strength of the entered password can also be a motivating factor for
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/passwordfield/password-field-advanced-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/passwordfield/password-field-advanced-helper.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/password-field/index.adoc
+++ b/articles/components/password-field/index.adoc
@@ -29,7 +29,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -57,7 +57,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldRevealButtonHidden.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldRevealButtonHidden.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -115,7 +115,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldConstraints.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldConstraints.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -144,7 +144,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -173,7 +173,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -202,7 +202,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldHelper.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldHelper.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -228,7 +228,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldAdvancedHelper.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldAdvancedHelper.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/progress-bar/index.adoc
+++ b/articles/components/progress-bar/index.adoc
@@ -29,7 +29,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -65,7 +65,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarDeterminate.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarDeterminate.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -93,7 +93,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarIndeterminate.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarIndeterminate.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -122,7 +122,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarCustomRange.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarCustomRange.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -150,7 +150,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarThemeVariants.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarThemeVariants.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -202,7 +202,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarLabel.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarLabel.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -235,7 +235,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarCompletionTime.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/progressbar/ProgressBarCompletionTime.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/progress-bar/index.adoc
+++ b/articles/components/progress-bar/index.adoc
@@ -22,7 +22,7 @@ The progress can be determinate or indeterminate. Use Progress Bar to show an on
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -58,7 +58,7 @@ Use a determinate Progress Bar when progress can be computed.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-determinate.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-determinate.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ Use an indeterminate Progress Bar to show that progress is ongoing but can't be 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-indeterminate.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-indeterminate.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -115,7 +115,7 @@ These can be changed to any numeric values:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-custom-range.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-custom-range.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -143,7 +143,7 @@ Progress Bar comes with three theme variants: contrast, success, and error.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-theme-variants.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-theme-variants.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -195,7 +195,7 @@ Labels can also show the progress of a determinate progress bar in text in addit
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-label.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-label.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -228,7 +228,7 @@ If a process takes approximately 20 minutes, communicate that to the user.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/progressbar/progress-bar-completion-time.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/progressbar/progress-bar-completion-time.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/radio-button/index.adoc
+++ b/articles/components/radio-button/index.adoc
@@ -22,7 +22,7 @@ Radio Button Group allows users to select one value among multiple choices.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -54,7 +54,7 @@ Use read-only when content needs to be accessible but not editable. Read-only el
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-readonly.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-readonly.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -85,7 +85,7 @@ Disabling can be preferable to hiding an element to prevent changes in layout wh
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -115,7 +115,7 @@ The component's default orientation is horizontal. However, vertical orientation
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-vertical.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-vertical.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -142,7 +142,7 @@ In cases where vertical space needs to be conserved, horizontal orientation can 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-horizontal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-horizontal.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -175,7 +175,7 @@ Items can be customized to include more than a single line of text:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-presentation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-presentation.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -214,7 +214,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-group-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-group-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -243,7 +243,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-group-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-group-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -276,7 +276,7 @@ It's important to provide labels for Radio Button Groups to distinguish them fro
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-group-labels.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-group-labels.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -306,7 +306,7 @@ To enable the user to enter a custom option instead of picking one from the list
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-custom-option.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-custom-option.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -340,7 +340,7 @@ In situations where the user isn't required to select a value, use a "blank" opt
 ifdef::lit[]
 [source,typescript,role=render-only]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-default-value.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-default-value.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -366,7 +366,7 @@ Two Radio Buttons can sometimes be a good alternative to a single Checkbox. If t
 ifdef::lit[]
 [source,typescript,role=render-only]
 ----
-include::{root}/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/radio-button/index.adoc
+++ b/articles/components/radio-button/index.adoc
@@ -29,7 +29,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -61,7 +61,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonReadonly.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonReadonly.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -92,7 +92,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -122,7 +122,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonVertical.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonVertical.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -149,7 +149,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonHorizontal.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonHorizontal.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -182,17 +182,17 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonPresentation.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonPresentation.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Card.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/domain/Card.java[group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/DataService.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/domain/DataService.java[group=Flow]
 ----
 endif::[]
 
@@ -221,7 +221,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -250,7 +250,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -283,7 +283,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupLabels.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupLabels.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -313,7 +313,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonCustomOption.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonCustomOption.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/rich-text-editor/index.adoc
+++ b/articles/components/rich-text-editor/index.adoc
@@ -33,7 +33,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -177,7 +177,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorSetGetValue.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -207,7 +207,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorReadonly.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorReadonly.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -241,7 +241,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorMinMaxHeight.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorMinMaxHeight.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -273,7 +273,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeCompact.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeCompact.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -303,7 +303,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeNoBorder.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/richtexteditor/RichTextEditorThemeNoBorder.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/rich-text-editor/index.adoc
+++ b/articles/components/rich-text-editor/index.adoc
@@ -26,7 +26,7 @@ It allows you to format and style your text using boldface, italics, headings, l
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -166,11 +166,11 @@ To prevent injecting malicious content, be sure to sanitize HTML strings before 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=htmlsnippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=htmlsnippet,indent=0,group=Lit]
 
 ...
 
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -200,7 +200,7 @@ Setting the component to read-only hides the toolbar and makes the content non-e
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -234,7 +234,7 @@ The automatic resizing can be restricted to a minimum and maximum height.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -266,7 +266,7 @@ Apply the `compact` theme to make the toolbar more compact.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -296,7 +296,7 @@ Apply the `no-border` theme variant to remove Rich Text Editor’s border. An ex
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/scroller/index.adoc
+++ b/articles/components/scroller/index.adoc
@@ -21,7 +21,7 @@ Scroller is a component container for creating scrollable areas in the UI.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/scroller/scroller-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/scroller/scroller-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -74,7 +74,7 @@ It can also be used to conserve vertical space, for example in situations where 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/scroller/scroller-mobile.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/scroller/scroller-mobile.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -106,7 +106,7 @@ It can also be used as a fallback for a responsive layout that can't be guarante
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/scroller/scroller-both.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/scroller/scroller-both.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/scroller/index.adoc
+++ b/articles/components/scroller/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/scroller/ScrollerBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/scroller/ScrollerBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -81,7 +81,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/scroller/ScrollerMobile.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/scroller/ScrollerMobile.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -113,7 +113,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/scroller/ScrollerBoth.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/scroller/ScrollerBoth.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/select/index.adoc
+++ b/articles/components/select/index.adoc
@@ -21,7 +21,7 @@ Select allows users to choose a single value from a list of options presented in
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -54,7 +54,7 @@ Dividers can be used to group related options. Use dividers sparingly to avoid c
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-dividers.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-dividers.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ Items can be disabled. This prevents users from selecting them, while still show
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -119,7 +119,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -148,7 +148,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -177,7 +177,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -206,7 +206,7 @@ Use the placeholder feature to provide an inline text prompt for the field. Don'
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-placeholder.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-placeholder.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -277,11 +277,11 @@ When using complex values, a label can be set to represent the item value as pla
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/select/select-complex-value-label.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-complex-value-label.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=Lit]
 ----
 endif::[]
 
@@ -312,11 +312,11 @@ When using custom item renderers with rich content, a label can be set to repres
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/select/select-custom-renderer-label.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-custom-renderer-label.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=Lit]
 ----
 endif::[]
 
@@ -374,7 +374,7 @@ Items can be rendered with rich content instead of plain text. This can be usefu
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/select/select-presentation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/select/select-presentation.ts[render,tags=snippet,indent=0,group=Lit]
 
 ...
 

--- a/articles/components/select/index.adoc
+++ b/articles/components/select/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -61,7 +61,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectDividers.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectDividers.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -93,7 +93,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -155,7 +155,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -184,7 +184,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -213,7 +213,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectPlaceholder.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectPlaceholder.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -241,7 +241,7 @@ include::{root}/frontend/demo/component/select/select-empty-selection.ts[preimpo
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectEmptySelection.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectEmptySelection.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -261,7 +261,7 @@ include::{root}/frontend/demo/component/select/select-empty-selection-caption.ts
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectEmptySelectionCaption.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectEmptySelectionCaption.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --
@@ -288,11 +288,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectComplexValueLabel.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectComplexValueLabel.java[render,tags=snippet,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 
@@ -323,11 +323,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java[render,tags=snippet,indent=0,group=Flow]
 ----
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 
@@ -385,7 +385,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/side-nav/index.adoc
+++ b/articles/components/side-nav/index.adoc
@@ -34,7 +34,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -67,7 +67,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavSuffix.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavSuffix.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -98,7 +98,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavHierarchy.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavHierarchy.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -127,7 +127,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavLabelled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavLabelled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -182,7 +182,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavStyling.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/sidenav/SideNavStyling.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/side-nav/index.adoc
+++ b/articles/components/side-nav/index.adoc
@@ -27,7 +27,7 @@ For technical reasons, actual navigation is disabled in the examples on this pag
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ Interactive prefix and suffix elements aren't recommended since the entire item 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-suffix.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-suffix.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -91,7 +91,7 @@ Parent items can be links. Clicking them expands their sub-items in addition to 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-hierarchy.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-hierarchy.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -120,7 +120,7 @@ A label can be applied to the top of the navigation list. This can be useful for
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-labelled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-labelled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -175,7 +175,7 @@ Individual navigation items can be styled by applying a CSS class name to them.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/side-nav/side-nav-styling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/side-nav/side-nav-styling.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/split-layout/index.adoc
+++ b/articles/components/split-layout/index.adoc
@@ -21,7 +21,7 @@ Split Layout is a component with two content areas and a draggable split handle 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -54,7 +54,7 @@ The user can also be allowed to choose which orientation they want to use.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-orientation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-orientation.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -89,7 +89,7 @@ When using a percentage value, ensure that ancestors have an explicit height as 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -116,7 +116,7 @@ The splitter respects the minimum and maximum size of the content area component
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-min-max-size.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-min-max-size.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -144,7 +144,7 @@ This is useful when the user wants to toggle between certain positions.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-toggle.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-toggle.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -177,7 +177,7 @@ Split Layout has two theme variants: `small` and `minimal`.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-theme-small.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-theme-small.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -206,7 +206,7 @@ Both variants only show the split handle on hover and aren't ideal for touch dev
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/split-layout/index.adoc
+++ b/articles/components/split-layout/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -61,7 +61,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutOrientation.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutOrientation.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -96,7 +96,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutInitialSplitterPosition.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutInitialSplitterPosition.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -123,7 +123,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutMinMaxSize.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutMinMaxSize.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -151,11 +151,11 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutToggle.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutToggle.java[render,tags=snippet,indent=0,group=Flow]
 
 ...
 
-include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutToggle.java[render,tags=setstyles,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutToggle.java[render,tags=setstyles,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -184,7 +184,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutThemeVariants.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutThemeVariants.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -213,7 +213,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutMinimalThemeVariants.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutMinimalThemeVariants.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/spreadsheet/index.adoc
+++ b/articles/components/spreadsheet/index.adoc
@@ -224,7 +224,7 @@ include::{root}/frontend/demo/component/spreadsheet/spreadsheet-imports.ts[preim
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/spreadsheet/SpreadsheetComponents.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/spreadsheet/SpreadsheetComponents.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 --

--- a/articles/components/tabs/index.adoc
+++ b/articles/components/tabs/index.adoc
@@ -25,7 +25,7 @@ Below is a simple example of tabs with labels:
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -57,7 +57,7 @@ Tabs are most conveniently used as part of a Tab Sheet that includes automatical
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabsheet-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabsheet-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ A Tab can be selected, unselected, or disabled.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-states.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-states.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -147,7 +147,7 @@ Horizontal tabs may be easier for users to understand and associate with the con
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-horizontal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-horizontal.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -174,7 +174,7 @@ In horizontal orientation, scroll buttons are displayed by default to aid scroll
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-hide-scroll-buttons.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-hide-scroll-buttons.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -215,7 +215,7 @@ pass:[<!-- vale Vaadin.Wordiness = YES -->]
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-vertical.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-vertical.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -249,7 +249,7 @@ Icons can be used to make tabs more prominent and easier to identify. They can b
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-icons-horizontal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-icons-horizontal.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -276,7 +276,7 @@ Vertical tabs work best with icons next to labels, as you can see here.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-icons-vertical.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-icons-vertical.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -308,7 +308,7 @@ Tabs can contain almost any UI elements. For instance, they can contain badges i
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-badges.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-badges.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -342,7 +342,7 @@ By default, tabs are left-aligned. They can be centered using the `centered` the
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-theme-centered.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-theme-centered.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -374,7 +374,7 @@ Apply the `equal-width-tabs` theme variant to make each tab share equally the av
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-theme-equal-width.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-theme-equal-width.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -406,7 +406,7 @@ The `minimal` theme variant reduces visual styles to a minimum.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-theme-minimal.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-theme-minimal.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -438,7 +438,7 @@ The `small` theme variant can be used to make the Tabs smaller. This can be good
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-theme-small.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-theme-small.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -468,7 +468,7 @@ The `bordered` theme variant adds a border around the Tab Sheet component.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabsheet-theme-bordered.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabsheet-theme-bordered.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -499,7 +499,7 @@ Custom content can be placed before or after the tabs in a Tab Sheet by placing 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -528,7 +528,7 @@ Tab focus is rendered differently when focused by the keyboard. Once a tab is fo
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-focus-ring.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-focus-ring.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -556,7 +556,7 @@ Try clicking on each tab here. Notice how the text content changes depending on 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tabs/tabs-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabs-content.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -585,7 +585,7 @@ Sometimes it can be desirable to initialize the contents for a tab, lazily. That
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/tabs/index.adoc
+++ b/articles/components/tabs/index.adoc
@@ -32,7 +32,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -64,7 +64,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabSheetBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabSheetBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -93,7 +93,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsStates.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsStates.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -154,7 +154,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsHorizontal.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsHorizontal.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -181,7 +181,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsHideScrollButtons.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsHideScrollButtons.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -222,7 +222,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsVertical.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsVertical.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -256,7 +256,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsIconsHorizontal.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsIconsHorizontal.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -283,7 +283,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsIconsVertical.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsIconsVertical.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -315,7 +315,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsBadges.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsBadges.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -349,7 +349,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsThemeCentered.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsThemeCentered.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -381,7 +381,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsThemeEqualWidth.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsThemeEqualWidth.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -413,7 +413,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsThemeMinimal.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsThemeMinimal.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -445,7 +445,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsThemeSmall.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsThemeSmall.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -475,7 +475,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabSheetThemeBordered.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabSheetThemeBordered.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -506,7 +506,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabSheetPrefixSuffix.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabSheetPrefixSuffix.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -563,7 +563,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsContent.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabsContent.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -592,7 +592,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabSheetLazyInitialization.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tabs/TabSheetLazyInitialization.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/text-area/index.adoc
+++ b/articles/components/text-area/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -59,7 +59,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaAutoHeight.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaAutoHeight.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -88,7 +88,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaHeight.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaHeight.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -117,7 +117,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -146,7 +146,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaConstraints.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaConstraints.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -175,7 +175,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -204,7 +204,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -233,7 +233,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaHelper.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaHelper.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/text-area/index.adoc
+++ b/articles/components/text-area/index.adoc
@@ -21,7 +21,7 @@ Text Area is an input field component that allows entry of multiple lines of tex
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -52,7 +52,7 @@ Unless set to a fixed height, Text Area adjusts its height automatically based o
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-auto-height.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-auto-height.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -81,7 +81,7 @@ The automatic resizing can be restricted to a minimum and maximum height like so
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-height.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-height.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -110,7 +110,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -139,7 +139,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=constraint
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-constraints.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -168,7 +168,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -197,7 +197,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -226,7 +226,7 @@ Longer free-form inputs are often capped at a certain character limit. The curre
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textarea/text-area-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textarea/text-area-helper.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/text-field/index.adoc
+++ b/articles/components/text-field/index.adoc
@@ -29,7 +29,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -58,7 +58,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -87,7 +87,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldConstraints.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldConstraints.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -116,7 +116,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -145,7 +145,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/text-field/index.adoc
+++ b/articles/components/text-field/index.adoc
@@ -22,7 +22,7 @@ Prefix and suffix components, such as icons, are also supported.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -51,7 +51,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -80,7 +80,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=constraint
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-constraints.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-constraints.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -109,7 +109,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -138,7 +138,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/textfield/text-field-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/textfield/text-field-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/time-picker/index.adoc
+++ b/articles/components/time-picker/index.adoc
@@ -23,7 +23,7 @@ Time Picker is an input field for used entering or selecting a specific time.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -56,7 +56,7 @@ The default step is one hour (i.e., `3600` seconds). Unlike <<../number-field#,N
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-minutes-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-minutes-step.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ The displayed time format changes based on the step.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-seconds-step.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-seconds-step.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -135,7 +135,7 @@ The overlay opens automatically when the field is focused using a pointer (i.e.,
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-auto-open.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-auto-open.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -167,7 +167,7 @@ You can define a minimum and maximum value for Time Picker if you need to restri
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-min-max.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-min-max.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -196,7 +196,7 @@ If the minimum and maximum values aren't sufficient for validation, you can also
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-custom-validation.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-custom-validation.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -226,7 +226,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=basic-intr
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-basic-features.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -255,7 +255,7 @@ include::{articles}/components/_input-field-common-features.adoc[tag=readonly-an
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -284,7 +284,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-int
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/timepicker/time-picker-styles.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/timepicker/time-picker-styles.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/time-picker/index.adoc
+++ b/articles/components/time-picker/index.adoc
@@ -30,7 +30,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -63,7 +63,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerMinutesStep.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerMinutesStep.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -93,7 +93,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerSecondsStep.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerSecondsStep.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -142,7 +142,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerAutoOpen.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerAutoOpen.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -174,7 +174,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerMinMax.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerMinMax.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -203,7 +203,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerCustomValidation.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerCustomValidation.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -233,7 +233,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerBasicFeatures.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -262,7 +262,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -291,7 +291,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerStyles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/timepicker/TimePickerStyles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/tooltip/index.adoc
+++ b/articles/components/tooltip/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tooltip/TooltipBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tooltip/TooltipBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tooltip/TooltipHtmlElement.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tooltip/TooltipHtmlElement.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -92,7 +92,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tooltip/TooltipPositioning.java[render,frame,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tooltip/TooltipPositioning.java[render,frame,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -190,7 +190,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/tooltip/TooltipManual.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/tooltip/TooltipManual.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/tooltip/index.adoc
+++ b/articles/components/tooltip/index.adoc
@@ -21,7 +21,7 @@ A tooltip for an element becomes visible when the user hovers the mouse pointer 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tooltip/tooltip-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tooltip/tooltip-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -53,7 +53,7 @@ Tooltips can be displayed for UI elements that lack a dedicated tooltip API. Pro
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tooltip/tooltip-html-element.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tooltip/tooltip-html-element.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -85,7 +85,7 @@ The default positioning of the tooltip in relation to the target element can be 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tooltip/tooltip-positioning.ts[render,frame,tags=snippet,group=TypeScript]
+include::{root}/frontend/demo/component/tooltip/tooltip-positioning.ts[render,frame,tags=snippet,group=Lit]
 ----
 endif::[]
 
@@ -183,7 +183,7 @@ Tooltips can be configured not to appear automatically on hover or keyboard focu
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/tooltip/tooltip-manual.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tooltip/tooltip-manual.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/tree-grid/index.adoc
+++ b/articles/components/tree-grid/index.adoc
@@ -28,12 +28,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/treegrid/TreeGridBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/treegrid/TreeGridBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=snippet]
+include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Flow,tags=snippet]
 ----
 endif::[]
 
@@ -67,12 +67,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/treegrid/TreeGridColumn.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/treegrid/TreeGridColumn.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=snippet]
+include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Flow,tags=snippet]
 ----
 endif::[]
 
@@ -102,12 +102,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=snippet]
+include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Flow,tags=snippet]
 ----
 endif::[]
 

--- a/articles/components/tree-grid/index.adoc
+++ b/articles/components/tree-grid/index.adoc
@@ -21,7 +21,7 @@ Tree Grid is a component for displaying hierarchical tabular data grouped into e
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tree-grid/tree-grid-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tree-grid/tree-grid-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -60,7 +60,7 @@ The tree column is a column that contains the toggles for expanding and collapsi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tree-grid/tree-grid-column.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tree-grid/tree-grid-column.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -95,7 +95,7 @@ Like Grid, Tree Grid supports rich content.
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/tree-grid/tree-grid-rich-content.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/tree-grid/tree-grid-rich-content.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/upload/index.adoc
+++ b/articles/components/upload/index.adoc
@@ -21,7 +21,7 @@ It shows the upload progress and the status of each file. Files can be uploaded 
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -126,7 +126,7 @@ Upload allows the user to drag files onto the component to upload them. Multiple
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-drag-and-drop.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-drag-and-drop.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -155,7 +155,7 @@ By default, files are uploaded immediately -- or at least they're added to the q
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-auto-upload-disabled.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-auto-upload-disabled.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -186,7 +186,7 @@ Uploads can be initiated programmatically when auto-upload is disabled. You migh
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-all-files.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-all-files.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -229,7 +229,7 @@ Upload can be configured to accept only files of specific formats. The acceptabl
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-file-format.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-file-format.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -283,7 +283,7 @@ When using a [classname]`Receiver` that doesn't implement the [interfacename]`Mu
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-file-count.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-file-count.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -317,7 +317,7 @@ Upload allows you to limit the file size by setting a maximum amount in bytes. B
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-file-size.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-file-size.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -419,7 +419,7 @@ All labels and messages in Upload are configurable. For a complete list of them,
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-internationalization.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-internationalization.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -453,7 +453,7 @@ You can replace the default upload button. You might do this if Upload needs a s
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-button-theme-variant.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-button-theme-variant.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -484,7 +484,7 @@ You can also customize the drop label, as well as the icon.
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/upload/upload-drop-label.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-drop-label.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -549,7 +549,7 @@ Choose labels that are informative and instructive. For example, if the user is 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-labelling.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-labelling.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -580,7 +580,7 @@ Likewise, if the user is expected to upload a spreadsheet, but multiple file for
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-helper.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-helper.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -616,7 +616,7 @@ A "Server Unavailable" message might suffice for tech-savvy users, but for some 
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/upload/upload-error-messages.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/upload/upload-error-messages.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/upload/index.adoc
+++ b/articles/components/upload/index.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -133,7 +133,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadDragAndDrop.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadDragAndDrop.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -162,12 +162,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadAutoUploadDisabled.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadAutoUploadDisabled.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Flow]
 ----
 endif::[]
 
@@ -193,12 +193,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadAllFiles.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadAllFiles.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Flow]
 ----
 endif::[]
 
@@ -236,12 +236,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadFileFormat.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadFileFormat.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Flow]
 ----
 endif::[]
 
@@ -290,12 +290,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadFileCount.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadFileCount.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Flow]
 ----
 endif::[]
 
@@ -324,12 +324,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadFileSize.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadFileSize.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Flow]
 ----
 endif::[]
 
@@ -426,12 +426,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadInternationalization.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadInternationalization.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadFinnishI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadFinnishI18N.java[group=Flow]
 ----
 endif::[]
 
@@ -460,12 +460,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadButtonThemeVariant.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadButtonThemeVariant.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Flow]
 ----
 endif::[]
 
@@ -491,7 +491,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadDropLabel.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadDropLabel.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -556,12 +556,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadLabelling.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadLabelling.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Flow]
 ----
 endif::[]
 
@@ -587,12 +587,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadHelper.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadHelper.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Flow]
 ----
 endif::[]
 
@@ -623,12 +623,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadErrorMessages.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadErrorMessages.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18N.java[group=Flow]
 ----
 endif::[]
 

--- a/articles/components/vertical-layout/index.adoc
+++ b/articles/components/vertical-layout/index.adoc
@@ -29,7 +29,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayout.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayout.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -62,7 +62,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutVerticalAlignment.java[render,tags=layout,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutVerticalAlignment.java[render,tags=layout,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -116,7 +116,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutHorizontalAlignment.java[render,tags=layout,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutHorizontalAlignment.java[render,tags=layout,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -161,7 +161,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutIndividualAlignment.java[render,tags=layout,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutIndividualAlignment.java[render,tags=layout,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -192,7 +192,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsSpacing.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsSpacing.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -219,7 +219,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsSpacingVariants.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsSpacingVariants.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -302,7 +302,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsPadding.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsPadding.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 
@@ -332,7 +332,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsMargin.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsMargin.java[render,tags=snippet,indent=0,group=Flow]
 ----
 endif::[]
 

--- a/articles/components/vertical-layout/index.adoc
+++ b/articles/components/vertical-layout/index.adoc
@@ -22,7 +22,7 @@ See <<../horizontal-layout#, Horizontal Layout>> for information on placing comp
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -55,7 +55,7 @@ You can position components at the top, middle, or bottom. You can also position
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -109,7 +109,7 @@ Components in a Vertical Layout are left-aligned by default, but can be centered
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -154,7 +154,7 @@ It's also possible to align horizontally individual components by overriding the
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -185,7 +185,7 @@ Spacing is used to create space between components in the same layout. Spacing c
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -212,7 +212,7 @@ Five different spacing theme variants are available:
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -295,7 +295,7 @@ Padding can help distinguish the content in a layout from its surrounding. Paddi
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-padding.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-padding.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 
@@ -325,7 +325,7 @@ Margin is the space around a layout. This is different from Padding, which is ex
 ifdef::lit[]
 [source,typescript]
 ----
-include::{root}/frontend/demo/component/basiclayouts/basic-layouts-margin.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/basiclayouts/basic-layouts-margin.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 endif::[]
 

--- a/articles/components/virtual-list/index.adoc
+++ b/articles/components/virtual-list/index.adoc
@@ -22,12 +22,12 @@ To use this component, you need to assign it a set of data items and a _renderer
 ifdef::lit[]
 [source,html]
 ----
-include::{root}/frontend/demo/component/virtuallist/virtual-list-basic.ts[render,tags=snippet,indent=0,group=TypeScript]
+include::{root}/frontend/demo/component/virtuallist/virtual-list-basic.ts[render,tags=snippet,indent=0,group=Lit]
 ----
 
 [source,typescript]
 ----
-include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=TypeScript]
+include::{root}/frontend/generated/com/vaadin/demo/domain/Person.ts[group=Lit]
 ----
 endif::[]
 

--- a/articles/components/virtual-list/index.adoc
+++ b/articles/components/virtual-list/index.adoc
@@ -34,12 +34,12 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/component/virtuallist/VirtualListBasic.java[render,tags=snippet,indent=0,group=Java]
+include::{root}/src/main/java/com/vaadin/demo/component/virtuallist/VirtualListBasic.java[render,tags=snippet,indent=0,group=Flow]
 ----
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Java,tags=*,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/domain/Person.java[group=Flow,tags=*,indent=0]
 ----
 endif::[]
 


### PR DESCRIPTION
- Renamed "TypeScript" tabs in Components examples to "Lit"
- Renamed "Java" tabs in Components examples to "Flow"