### PR TITLE
Made clear that RouteScopeOwner is a mandatory qualifier

### DIFF
--- a/articles/flow/integrations/cdi/contexts.adoc
+++ b/articles/flow/integrations/cdi/contexts.adoc
@@ -208,7 +208,9 @@ public class RouteService {
 
 [classname]`ParentView`, [classname]`ChildAView`, and [classname]`ChildBView` (paths: `/parent`, `/parent/child-a`, and `/parent/child-b`) use the same [classname]`RouteService` instance while you navigate between them. After navigating away from [classname]`ParentView`, the [classname]`RouteService` is also destroyed.
 
-Even though `@RouteScopeOwner` is redundant because it's a CDI qualifier, you need to define it on both the bean and on the injection point.
+Even though `@RouteScopeOwner` is a CDI qualifier, you need to define it on both the bean and on the injection point.
+Beans that are RouteScoped are in the RouteScope and for resolution are filtert for matching RouteScopeOwner qualifiers.
+E.g. querying for RouteScoped beans without a qualifier (thus implicit @Default) leads to no results. You must always provide a RouteScopeOwner.
 
 Route components can also be `@RouteScoped`. In this case, `@RouteScopeOwner` should point to a parent layout. If you omit it, the route itself becomes the owner.
 
@@ -229,6 +231,26 @@ public class ScopedView extends Div {
 ----
 
 The message is delivered to the `ScopedView` instance where the user already navigated. If on another view, there is no instance of this bean and the message isn't delivered to it.
+
+If you need to resolve RouteScoped beans programmatically, you need to instantiate the RouteScopeOwner qualifier on some matching Route.
+E.g. if you have an interface that lets controllers vote on a unsaved changes dialog:
+
+[source,java]
+----
+private static abstract class RouteScopeQualifier extends AnnotationLiteral<RouteScopeOwner> implements RouteScopeOwner {}
+
+public void voteOnRouteLeave(Class <? extends Component> currentRoute){
+       RouteScopeOwner routeScopeQualifier = new RouteScopeQualifier(){
+
+            @Override
+            public Class<? extends HasElement> value() {
+                return previousRoute;
+            }
+        };
+       Instance<RouteLeaveVoter> voters = CDI.current().select(RouteLeaveVoter.class, routeScopeQualifier);
+       boolean showDialog = voters.stream().map(RouteLeaveVoter::hasUnsavedChanges).anyMatch();
+}
+----
 
 
 === Preserving Beans during Browser Refresh

--- a/articles/flow/integrations/cdi/contexts.adoc
+++ b/articles/flow/integrations/cdi/contexts.adoc
@@ -208,9 +208,7 @@ public class RouteService {
 
 [classname]`ParentView`, [classname]`ChildAView`, and [classname]`ChildBView` (paths: `/parent`, `/parent/child-a`, and `/parent/child-b`) use the same [classname]`RouteService` instance while you navigate between them. After navigating away from [classname]`ParentView`, the [classname]`RouteService` is also destroyed.
 
-Even though `@RouteScopeOwner` is a CDI qualifier, you need to define it on both the bean and on the injection point.
-Beans that are RouteScoped are in the RouteScope and for resolution are filtert for matching RouteScopeOwner qualifiers.
-E.g. querying for RouteScoped beans without a qualifier (thus implicit @Default) leads to no results. You must always provide a RouteScopeOwner.
+Even though `@RouteScopeOwner` is a CDI qualifier, you need to define it on both the bean and on the injection point. Beans that are `RouteScoped` are in the `RouteScope`. For resolution they're filtered for matching RouteScopeOwner qualifiers. For example, querying for RouteScoped beans without a qualifier (i.e., implicit @Default) leads to no results. You must always provide a `RouteScopeOwner`.
 
 Route components can also be `@RouteScoped`. In this case, `@RouteScopeOwner` should point to a parent layout. If you omit it, the route itself becomes the owner.
 
@@ -232,8 +230,7 @@ public class ScopedView extends Div {
 
 The message is delivered to the `ScopedView` instance where the user already navigated. If on another view, there is no instance of this bean and the message isn't delivered to it.
 
-If you need to resolve RouteScoped beans programmatically, you need to instantiate the RouteScopeOwner qualifier on some matching Route.
-E.g. if you have an interface that lets controllers vote on a unsaved changes dialog:
+To resolve `RouteScoped` beans programmatically, you'll need to instantiate the `RouteScopeOwner` qualifier on some matching Route.  For example, if you have an interface that lets controllers vote on a unsaved changes dialog, you would do something like this:
 
 [source,java]
 ----

--- a/articles/flow/integrations/cdi/contexts.adoc
+++ b/articles/flow/integrations/cdi/contexts.adoc
@@ -16,7 +16,7 @@ Vaadin CDI contexts are conceptually similar to <<../spring/scopes#,Vaadin Sprin
 
 In CDI, most scopes are normal scopes. This means that most calls to managed beans are delegated by a client proxy to the active instance. The active instance is provided by the context.
 
-The https://vaadin.com/directory/component/vaadin-cdi/[Vaadin CDI] add-on introduces the `@VaadinServiceScoped`, `@VaadinSessionScoped`, `@NormalUIScoped`, and `@NormalRouteScoped` normal scopes.
+The https://vaadin.com/directory/component/vaadin-cdi/[Vaadin CDI] add-on introduces the [annotationname]`@VaadinServiceScoped`, [annotationname]`@VaadinSessionScoped`, [annotationname]`@NormalUIScoped`, and [annotationname]`@NormalRouteScoped` normal scopes.
 
 [NOTE]
 The Vaadin component hierarchy doesn't work with CDI client proxies. As a precaution, the `vaadin-cdi` add-on doesn't deploy if managed beans are found.
@@ -24,14 +24,14 @@ The Vaadin component hierarchy doesn't work with CDI client proxies. As a precau
 
 == Pseudo-Scopes
 
-Any scope that isn't a normal scope is called a pseudo-scope. The standard `@Dependent` and `@Singleton` are pseudo-scopes.
+Any scope that isn't a normal scope is called a pseudo-scope. The standard [annotationname]`@Dependent` and [annotationname]`@Singleton` are pseudo-scopes.
 
-The Vaadin add-on additionally introduces the `@UIScoped` and `@RouteScoped` pseudo-scopes.
+The Vaadin add-on additionally introduces the [annotationname]`@UIScoped` and [annotationname]`@RouteScoped` pseudo-scopes.
 
 Injection of a pseudo-scoped bean creates a direct reference to the object, but there are some limitations when not using proxies:
 
 - Circular referencing, for example injecting A to B and B to A, doesn't work.
-- Injecting into a larger scope binds the instance from the currently active smaller scope, and ignores changes in the smaller scope. For example, after being injected into a session scope, a `@UIScoped` bean points to the same instance (even if its [classname]`UI` is closed), regardless of the current [classname]`UI`.
+- Injecting into a larger scope binds the instance from the currently active smaller scope, and ignores changes in the smaller scope. For example, after being injected into a session scope, a [annotationname]`@UIScoped` bean points to the same instance (even if its [classname]`UI` is closed), regardless of the current [classname]`UI`.
 
 Pseudo-scopes aren't bean-defining annotations, so, in implicit bean archives, [annotationname]`@UIScoped` and [annotationname]`@RouteScoped` components need to be marked with the [annotationname]`@CdiComponent` stereotype annotation, which lets the container scan and manage the instances of the annotated types.
 
@@ -42,7 +42,7 @@ See https://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#normal_scope for more info
 
 Vaadin contexts are usable inside the [methodname]`UI.access()` method with any push transport.
 
-Certain default contexts from CDI, such as `RequestScoped` or `SessionScoped`, can be problematic. `HttpServletRequest` can't be resolved from a WebSocket connection in CDI, although this is needed for HTTP request, session, and conversation contexts. You should, therefore, use `WEBSOCKET_XHR` (the default), or `LONG_POLLING` transport mode, to avoid losing the standard contexts.
+Certain default contexts from CDI, such as `RequestScoped` or `SessionScoped`, can be problematic. [classname]`HttpServletRequest` can't be resolved from a WebSocket connection in CDI, although this is needed for HTTP request, session, and conversation contexts. You should, therefore, use `WEBSOCKET_XHR` (the default), or `LONG_POLLING` transport mode, to avoid losing the standard contexts.
 
 Background-thread contexts that depend on HTTP requests aren't active, regardless of push.
 
@@ -51,18 +51,18 @@ See <<../../advanced/server-push#push.access,Asynchronous Updates>> for more abo
 
 === @VaadinServiceScoped Context
 
-The `@VaadinServiceScoped` context manages the beans during the Vaadin service lifecycle. The lifecycle of the service is the same as the lifecycle of its Vaadin servlet. See <<../../advanced/application-lifecycle#vaadin-servlet-and-service,Vaadin Servlet and Service>> for more about the Vaadin service.
+The [annotationname]`@VaadinServiceScoped` context manages the beans during the Vaadin service lifecycle. The lifecycle of the service is the same as the lifecycle of its Vaadin servlet. See <<../../advanced/application-lifecycle#vaadin-servlet-and-service,Vaadin Servlet and Service>> for more about the Vaadin service.
 
-For beans that are automatically picked up by `VaadinService`, you need to use the `@VaadinServiceEnabled` annotation, together with the `@VaadinServiceScoped` annotation. See <<service-beans#,Vaadin Service Interfaces as CDI Beans>> for more.
+For beans that are automatically picked up by [classname]`VaadinService`, you need to use the [annotationname]`@VaadinServiceEnabled` annotation, together with the [annotationname]`@VaadinServiceScoped` annotation. See <<service-beans#,Vaadin Service Interfaces as CDI Beans>> for more.
 
 
 === @VaadinSessionScoped Context
 
-The `@VaadinSessionScoped` context manages the beans during the Vaadin session lifecycle. This means that the same bean instance is used within the whole Vaadin session.
+The [annotationname]`@VaadinSessionScoped` context manages the beans during the Vaadin session lifecycle. This means that the same bean instance is used within the whole Vaadin session.
 
 See <<../../advanced/application-lifecycle#user-session,User Session>> for more.
 
-The example below shows how to use the `@VaadinSessionScoped` annotation on route targets:
+The example below shows how to use the [annotationname]`@VaadinSessionScoped` annotation on route targets:
 
 [source,java]
 ----
@@ -99,11 +99,11 @@ If you open the root target in one tab and the `editor` target in another, the t
 
 == @UIScoped and @NormalUIScoped Contexts
 
-The `@UIScoped` and `@NormalUIScoped` contexts manage the beans during the [classname]`UI` lifecycle. Use `@UIScoped` for components and `@NormalUIScoped` for other beans.
+The [annotationname]`@UIScoped` and [annotationname]`@NormalUIScoped` contexts manage the beans during the [classname]`UI` lifecycle. Use [annotationname]`@UIScoped` for components and [annotationname]`@NormalUIScoped` for other beans.
 
 See <<../../advanced/application-lifecycle#loading-a-ui,Loading a UI>> for more about the [classname]`UI` lifecycle.
 
-The example below uses the `@NormalUIScoped` annotation on route targets:
+The example below uses the [annotationname]`@NormalUIScoped` annotation on route targets:
 
 [source,java]
 ----
@@ -153,13 +153,13 @@ In the same [classname]`UI` instance, the same bean instance is used with both `
 
 == @RouteScoped & @NormalRouteScoped Contexts
 
-`@RouteScoped` and `@NormalRouteScoped` manage the beans during the [classname]`Route` lifecycle. Use `@RouteScoped` for components and `@NormalRouteScoped` for other beans.
+[annotationname]`@RouteScoped` and [annotationname]`@NormalRouteScoped` manage the beans during the [classname]`Route` lifecycle. Use [annotationname]`@RouteScoped` for components and [annotationname]`@NormalRouteScoped` for other beans.
 
-Together with the `@RouteScopeOwner` annotation, both `@RouteScoped` and `@NormalRouteScoped` can be used to bind beans to router components (`@Route`, `RouteLayout`, `HasErrorParameter`). While the owner remains in the route chain, all the beans it owns remain in the scope.
+Together with the [annotationname]`@RouteScopeOwner` annotation, both [annotationname]`@RouteScoped` and [annotationname]`@NormalRouteScoped` can be used to bind beans to router components ([annotationname]`@Route`, [classname]`RouteLayout`, [classname]`HasErrorParameter`). While the owner remains in the route chain, all the beans it owns remain in the scope.
 
 See <<../../routing#,Defining Routes With @Route>> and <<../../routing/layout#,Router Layouts and Nested Router Targets>> for more about route targets, route layouts, and the route chain.
 
-Below uses the `@NormalRouteScoped` annotation on route targets:
+Below uses the [annotationname]`@NormalRouteScoped` annotation on route targets:
 
 [source,java]
 ----
@@ -208,11 +208,11 @@ public class RouteService {
 
 [classname]`ParentView`, [classname]`ChildAView`, and [classname]`ChildBView` (paths: `/parent`, `/parent/child-a`, and `/parent/child-b`) use the same [classname]`RouteService` instance while you navigate between them. After navigating away from [classname]`ParentView`, the [classname]`RouteService` is also destroyed.
 
-Even though `@RouteScopeOwner` is a CDI qualifier, you need to define it on both the bean and on the injection point. Beans that are `RouteScoped` are in the `RouteScope`. For resolution they're filtered for matching RouteScopeOwner qualifiers. For example, querying for RouteScoped beans without a qualifier (i.e., implicit @Default) leads to no results. You must always provide a `RouteScopeOwner`.
+[annotationname]`@RouteScopeOwner` is a CDI qualifier that you need to define on both the bean and on the injection point. [annotationname]`@RouteScoped` beans are resolved by filtering for matching [annotationname]`@RouteScopeOwner` qualifiers. For example, querying for [annotationname]`@RouteScoped` beans without the qualifier (i.e., implicit [annotationname]`@Default` qualifier) leads to no results.
 
-Route components can also be `@RouteScoped`. In this case, `@RouteScopeOwner` should point to a parent layout. If you omit it, the route itself becomes the owner.
+Route components can also be [annotationname]`@RouteScoped`. In this case, [annotationname]`@RouteScopeOwner` should point to a parent layout. If you omit it, the route itself becomes the owner.
 
-Here's how you might use the `@RouteScoped` annotation on an `@Route` component:
+Here's how you might use the [annotationname]`@RouteScoped` annotation on an `@Route` component:
 
 [source,java]
 ----
@@ -228,24 +228,22 @@ public class ScopedView extends Div {
 }
 ----
 
-The message is delivered to the `ScopedView` instance where the user already navigated. If on another view, there is no instance of this bean and the message isn't delivered to it.
+The message is delivered to the [classname]`ScopedView` instance where the user already navigated. If on another view, there is no instance of this bean and the message isn't delivered to it.
 
-To resolve `RouteScoped` beans programmatically, you'll need to instantiate the `RouteScopeOwner` qualifier on some matching Route.  For example, if you have an interface that lets controllers vote on a unsaved changes dialog, you would do something like this:
+If you need to programmatically lookup a [annotationname]`RouteScoped` bean, you'll need to instantiate the [annotationname]`RouteScopeOwner` qualifier, providing the owner class name.
 
 [source,java]
 ----
-private static abstract class RouteScopeQualifier extends AnnotationLiteral<RouteScopeOwner> implements RouteScopeOwner {}
+static abstract class RouteScopeOwnerLiteral extends AnnotationLiteral<RouteScopeOwner> implements RouteScopeOwner {}
 
-public void voteOnRouteLeave(Class <? extends Component> currentRoute){
-       RouteScopeOwner routeScopeQualifier = new RouteScopeQualifier(){
-
-            @Override
-            public Class<? extends HasElement> value() {
-                return previousRoute;
-            }
-        };
-       Instance<RouteLeaveVoter> voters = CDI.current().select(RouteLeaveVoter.class, routeScopeQualifier);
-       boolean showDialog = voters.stream().map(RouteLeaveVoter::hasUnsavedChanges).anyMatch();
+RouteService lookupRouteService() {
+    RouteScopeOwnerLiteral routeScopeQualifier = new RouteScopeOwnerLiteral() {
+        @Override
+        public Class<? extends HasElement> value() {
+            return ParentView.class;
+        }
+    };
+    return CDI.current().select(RouteService.class, routeScopeQualifier).get();
 }
 ----
 


### PR DESCRIPTION
Take over of #3120 rebased on `next` branch.
It should be back-ported to `latest`.
