### PR TITLE
Remove duplicated text

### DIFF
--- a/articles/tools/observability/index.asciidoc
+++ b/articles/tools/observability/index.asciidoc
@@ -17,7 +17,7 @@ At its core, Observability Kit is a custom Java agent that runs together with a 
 
 .New in Vaadin 24.1.
 [TIP]
-You can now use Observability Kit <<{articles}/tools/observability/configuration/#frontend-observability-configuration,to observe the frontend>> to observe the frontend of your application
+You can now use Observability Kit <<{articles}/tools/observability/configuration/#frontend-observability-configuration,to observe the frontend>> of your application
 
 == Topics
 


### PR DESCRIPTION
The text "to observe the frontend" is already a part of the link - no need to repeat it


