### PR TITLE
docs: The commands given by the document missed an space.

### DIFF
--- a/articles/lit/reference/gradle.adoc
+++ b/articles/lit/reference/gradle.adoc
@@ -363,14 +363,14 @@ At the command line:
 [source,bash,subs="+attributes"]
 ----
 <source-info group="Windows"></source-info>
-gradlew -Philla.productionMode=true build
+gradlew -P hilla.productionMode=true build
 ----
 
 .terminal
 [source,bash,subs="+attributes"]
 ----
 <source-info group="macOS / Linux"></source-info>
-./gradlew -Philla.productionMode=true build
+./gradlew -P hilla.productionMode=true build
 ----
 --
 
@@ -430,14 +430,14 @@ When running the Gradle command to create the `WAR` archive, call the `war` task
 [source,bash,subs="+attributes"]
 ----
 <source-info group="Windows"></source-info>
-gradlew -Pvaadin.productionMode=true war
+gradlew -P vaadin.productionMode=true war
 ----
 
 .terminal
 [source,bash,subs="+attributes"]
 ----
 <source-info group="macOS / Linux"></source-info>
-./gradlew -Pvaadin.productionMode=true war
+./gradlew -P vaadin.productionMode=true war
 ----
 --
 


### PR DESCRIPTION
https://github.com/vaadin/hilla/issues/2197

The commands given by the document missed an space.
文档给出的指令漏了个空格。

![image](https://github.com/vaadin/docs/assets/33195150/973fc315-cdd4-4f41-bb3f-82f1c13f9838)

![image](https://github.com/vaadin/docs/assets/33195150/2f7c2cda-916c-4dbe-9247-d16851463b25)
