### PR TITLE
chore: enable icon and tooltip in select example

### DIFF
--- a/frontend/demo/component/select/react/select-basic-features.tsx
+++ b/frontend/demo/component/select/react/select-basic-features.tsx
@@ -32,9 +32,8 @@ function Example() {
   return (
     // tag::snippet[]
     <Select label="Label" helperText="Helper text" placeholder="Placeholder" items={items}>
-      {/* Icon and Tooltip are currently disabled due to https://github.com/vaadin/react-components/issues/131 />}
-      {/* <Tooltip slot="tooltip" text="Tooltip text" />
-      <Icon slot="prefix" icon="vaadin:vaadin-h" /> */}
+      <Tooltip slot="tooltip" text="Tooltip text" />
+      <Icon slot="prefix" icon="vaadin:vaadin-h" />
     </Select>
     // end::snippet[]
   );


### PR DESCRIPTION
Mentioned issue has been resolved and the features work now.