### PR TITLE
docs: add CheckboxGroup read-only state examples

### DIFF
--- a/articles/components/checkbox/index.adoc
+++ b/articles/components/checkbox/index.adoc
@@ -79,6 +79,7 @@ Disable a field to mark it as currently unavailable. Disabled state is used for 
 
 Disabling can be preferable to hiding an element to prevent changes in layout when the element's visibility changes, and to make users aware of its existence even when currently unavailable.
 
+Disabling is supported both on individual checkboxes, and on an entire checkbox group.
 
 [.example]
 --
@@ -105,9 +106,38 @@ include::{root}/frontend/demo/component/checkbox/react/checkbox-disabled.tsx[ren
 endif::[]
 --
 
-.Read-Only State
-[NOTE]
-Checkbox doesn't support read-only state.
+[role="since:com.vaadin:vaadin@V24.4"]
+=== Read-Only
+
+Fields used to display values should be set to read-only mode to prevent editing. Read-only fields are focusable and visible to screen readers.
+
+Read-only mode is supported both on individual checkboxes and on an entire checkbox group.
+
+
+[.example]
+--
+
+ifdef::lit[]
+[source,html]
+----
+include::{root}/frontend/demo/component/checkbox/checkbox-readonly.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxReadonly.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/checkbox/react/checkbox-readonly.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
 
 
 === Indeterminate

--- a/frontend/demo/component/checkbox/checkbox-readonly.ts
+++ b/frontend/demo/component/checkbox/checkbox-readonly.ts
@@ -1,0 +1,32 @@
+import 'Frontend/demo/init'; // hidden-source-line
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import '@vaadin/checkbox';
+import '@vaadin/checkbox-group';
+import { applyTheme } from 'Frontend/generated/theme';
+
+@customElement('checkbox-group-readonly')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    // Apply custom theme (only supported if your app uses one)
+    applyTheme(root);
+    return root;
+  }
+
+  @state()
+  private value = ['0', '2'];
+
+  protected override render() {
+    return html`
+      <!-- tag::snippet[] -->
+      <vaadin-checkbox-group label="Export data" .value="${this.value}" readonly theme="vertical">
+        <vaadin-checkbox value="0" label="Order ID"></vaadin-checkbox>
+        <vaadin-checkbox value="1" label="Product name"></vaadin-checkbox>
+        <vaadin-checkbox value="2" label="Customer"></vaadin-checkbox>
+        <vaadin-checkbox value="3" label="Status"></vaadin-checkbox>
+      </vaadin-checkbox-group>
+      <!-- end::snippet[] -->
+    `;
+  }
+}

--- a/frontend/demo/component/checkbox/react/checkbox-readonly.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-readonly.tsx
@@ -1,0 +1,21 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React, { useState } from 'react';
+import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
+import { Checkbox } from '@vaadin/react-components/Checkbox.js';
+
+function Example() {
+  const [value] = useState(['0', '2']);
+
+  return (
+    // tag::snippet[]
+    <CheckboxGroup label="Export data" value={value} readonly theme="vertical">
+      <Checkbox value="0" label="Order ID" />
+      <Checkbox value="1" label="Product name" />
+      <Checkbox value="2" label="Customer" />
+      <Checkbox value="3" label="Status" />
+    </CheckboxGroup>
+    // end::snippet[]
+  );
+}
+
+export default reactExample(Example); // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxReadonly.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxReadonly.java
@@ -1,0 +1,28 @@
+package com.vaadin.demo.component.checkbox;
+
+import com.vaadin.flow.component.checkbox.CheckboxGroup;
+import com.vaadin.flow.component.checkbox.CheckboxGroupVariant;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("checkbox-readonly")
+public class CheckboxReadonly extends Div {
+
+    public CheckboxReadonly() {
+        // tag::snippet[]
+        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+        checkboxGroup.setLabel("Export data");
+        checkboxGroup.setItems("Order ID", "Product name", "Customer",
+                "Status");
+        checkboxGroup.select("Order ID", "Customer");
+        checkboxGroup.setReadOnly(true);
+        checkboxGroup.addThemeVariants(CheckboxGroupVariant.LUMO_VERTICAL);
+        add(checkboxGroup);
+        // end::snippet[]
+    }
+
+    public static class Exporter extends DemoExporter<CheckboxReadonly> { // hidden-source-line
+    } // hidden-source-line
+}


### PR DESCRIPTION
Fixes #3358

Added `readonly` examples for the CheckboxGroup and updated the corresponding article.

<img width="778" alt="Screenshot 2024-04-22 at 10 51 41" src="https://github.com/vaadin/docs/assets/10589913/9882c776-3ef2-4a4f-bced-68989a0172fc">
