### PR TITLE
docs: add docs for Checkbox required and helper features

### DIFF
--- a/articles/components/checkbox/index.adoc
+++ b/articles/components/checkbox/index.adoc
@@ -140,6 +140,39 @@ endif::[]
 --
 
 
+[role="since:com.vaadin:vaadin@V24.4"]
+=== Required
+
+Individual checkboxes can be marked required. This is commonly used for checkboxes that must be checked in order to proceed with an operation, such as submitting a form. Required checkboxes become invalid when validated or if left unchecked after being focused.
+
+Entire checkbox groups can also be marked as required. They become invalid when validated or when blurred if none of their items are checked.
+
+
+[.example]
+--
+
+ifdef::lit[]
+[source,html]
+----
+include::{root}/frontend/demo/component/checkbox/checkbox-required.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/checkbox/CheckboxRequired.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/checkbox/react/checkbox-required.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
+
 === Indeterminate
 
 The indeterminate state can be used for a parent checkbox to show that there is a mix of checked and unchecked child items in a list, and to change the state of all child items at once.

--- a/frontend/demo/component/checkbox/checkbox-group-basic-features.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-basic-features.ts
@@ -4,6 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import '@vaadin/checkbox-group';
 import '@vaadin/tooltip';
+import '@vaadin/vertical-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-group-basic-features')
@@ -17,16 +18,17 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <!-- tag::snippet[] -->
-      <vaadin-checkbox-group label="Label" helper-text="Helper text">
-        <vaadin-tooltip slot="tooltip" text="Tooltip text"></vaadin-tooltip>
+      <vaadin-vertical-layout theme="spacing">
         <!-- tag::snippet[] -->
-        <vaadin-checkbox value="1" label="Item 1"></vaadin-checkbox>
-        <vaadin-checkbox value="2" label="Item 2"></vaadin-checkbox>
-        <vaadin-checkbox value="3" label="Item 3"></vaadin-checkbox>
+        <vaadin-checkbox label="Label" helper-text="Helper text"></vaadin-checkbox>
+        <vaadin-checkbox-group label="Label" helper-text="Helper text">
+          <vaadin-tooltip slot="tooltip" text="Tooltip text"></vaadin-tooltip>
+          <vaadin-checkbox value="1" label="Item 1"></vaadin-checkbox>
+          <vaadin-checkbox value="2" label="Item 2"></vaadin-checkbox>
+          <vaadin-checkbox value="3" label="Item 3"></vaadin-checkbox>
+        </vaadin-checkbox-group>
         <!-- end::snippet[] -->
-      </vaadin-checkbox-group>
-      <!-- end::snippet[] -->
+      </vaadin-vertical-layout>
     `;
   }
 }

--- a/frontend/demo/component/checkbox/checkbox-required.ts
+++ b/frontend/demo/component/checkbox/checkbox-required.ts
@@ -1,0 +1,41 @@
+import 'Frontend/demo/init'; // hidden-source-line
+
+import { html, LitElement } from 'lit';
+import { customElement, query } from 'lit/decorators.js';
+import '@vaadin/button';
+import '@vaadin/checkbox';
+import '@vaadin/horizontal-layout';
+import type { Checkbox } from '@vaadin/checkbox';
+import { applyTheme } from 'Frontend/generated/theme';
+
+@customElement('checkbox-required')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    // Apply custom theme (only supported if your app uses one)
+    applyTheme(root);
+    return root;
+  }
+
+  @query('vaadin-checkbox')
+  protected checkbox!: Checkbox;
+
+  protected override render() {
+    return html`
+      <vaadin-horizontal-layout theme="spacing" style="align-items: baseline">
+        <!-- tag::snippet[] -->
+        <vaadin-checkbox
+          label="I accept the terms and conditions"
+          required
+          error-message="This field is required"
+        ></vaadin-checkbox>
+        <!-- end::snippet[] -->
+        <vaadin-button @click="${this.validate}">Submit</vaadin-button>
+      </vaadin-horizontal-layout>
+    `;
+  }
+
+  protected validate() {
+    this.checkbox.validate();
+  }
+}

--- a/frontend/demo/component/checkbox/checkbox-required.ts
+++ b/frontend/demo/component/checkbox/checkbox-required.ts
@@ -1,11 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
 
 import { html, LitElement } from 'lit';
-import { customElement, query } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/checkbox';
 import '@vaadin/horizontal-layout';
-import type { Checkbox } from '@vaadin/checkbox';
+import { Binder, field, Required } from '@vaadin/hilla-lit-form';
+import UserPermissionsModel from 'Frontend/generated/com/vaadin/demo/domain/UserPermissionsModel';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-required')
@@ -17,17 +18,17 @@ export class Example extends LitElement {
     return root;
   }
 
-  @query('vaadin-checkbox')
-  protected checkbox!: Checkbox;
+  private binder = new Binder(this, UserPermissionsModel);
 
   protected override render() {
     return html`
       <vaadin-horizontal-layout theme="spacing" style="align-items: baseline">
         <!-- tag::snippet[] -->
         <vaadin-checkbox
-          label="I accept the terms and conditions"
+          label="Grant view permissions"
           required
           error-message="This field is required"
+          ${field(this.binder.model.view)}
         ></vaadin-checkbox>
         <!-- end::snippet[] -->
         <vaadin-button @click="${this.validate}">Submit</vaadin-button>
@@ -35,7 +36,11 @@ export class Example extends LitElement {
     `;
   }
 
+  protected override firstUpdated() {
+    this.binder.for(this.binder.model.view).addValidator(new Required());
+  }
+
   protected validate() {
-    this.checkbox.validate();
+    this.binder.validate();
   }
 }

--- a/frontend/demo/component/checkbox/react/checkbox-group-basic-features.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-group-basic-features.tsx
@@ -9,7 +9,7 @@ function Example() {
   // tag::snippet[]
   return (
     <VerticalLayout theme="spacing">
-      <Checkbox label="Label" helperText="Helper text"></Checkbox>
+      <Checkbox label="Label" helperText="Helper text" />
 
       <CheckboxGroup label="Label" helperText="Helper text">
         <Tooltip slot="tooltip" text="Tooltip text" />

--- a/frontend/demo/component/checkbox/react/checkbox-group-basic-features.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-group-basic-features.tsx
@@ -3,17 +3,22 @@ import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 
 function Example() {
   // tag::snippet[]
   return (
-    <CheckboxGroup label="Label" helperText="Helper text">
-      <Tooltip slot="tooltip" text="Tooltip text" />
+    <VerticalLayout theme="spacing">
+      <Checkbox label="Label" helperText="Helper text"></Checkbox>
 
-      <Checkbox value="1" label="Item 1" />
-      <Checkbox value="2" label="Item 2" />
-      <Checkbox value="3" label="Item 3" />
-    </CheckboxGroup>
+      <CheckboxGroup label="Label" helperText="Helper text">
+        <Tooltip slot="tooltip" text="Tooltip text" />
+
+        <Checkbox value="1" label="Item 1" />
+        <Checkbox value="2" label="Item 2" />
+        <Checkbox value="3" label="Item 3" />
+      </CheckboxGroup>
+    </VerticalLayout>
   );
   // end::snippet[]
 }

--- a/frontend/demo/component/checkbox/react/checkbox-required.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-required.tsx
@@ -1,0 +1,29 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React, { useRef } from 'react';
+import { Button } from '@vaadin/react-components/Button.js';
+import { Checkbox, type CheckboxElement } from '@vaadin/react-components/Checkbox.js';
+import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
+
+function Example() {
+  const checkboxRef = useRef<CheckboxElement>(null);
+
+  const validate = () => {
+    checkboxRef.current?.validate();
+  };
+
+  return (
+    // tag::snippet[]
+    <HorizontalLayout theme="spacing" style={{ alignItems: 'baseline' }}>
+      <Checkbox
+        label="I accept the terms and conditions"
+        required
+        ref={checkboxRef}
+        errorMessage="This field is required"
+      />
+      <Button onClick={validate}>Submit</Button>
+    </HorizontalLayout>
+    // end::snippet[]
+  );
+}
+
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/checkbox/react/checkbox-required.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-required.tsx
@@ -1,24 +1,28 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useRef } from 'react';
+import React, { useEffect } from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
-import { Checkbox, type CheckboxElement } from '@vaadin/react-components/Checkbox.js';
+import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
+import { Required } from '@vaadin/hilla-lit-form';
+import { useForm, useFormPart } from '@vaadin/hilla-react-form';
+import UserPermissionsModel from 'Frontend/generated/com/vaadin/demo/domain/UserPermissionsModel';
 
 function Example() {
-  const checkboxRef = useRef<CheckboxElement>(null);
+  const { model, field, validate } = useForm(UserPermissionsModel);
+  const viewField = useFormPart(model.view);
 
-  const validate = () => {
-    checkboxRef.current?.validate();
-  };
+  useEffect(() => {
+    viewField.addValidator(new Required());
+  }, []);
 
   return (
     // tag::snippet[]
     <HorizontalLayout theme="spacing" style={{ alignItems: 'baseline' }}>
       <Checkbox
-        label="I accept the terms and conditions"
+        label="Grant view permissions"
         required
-        ref={checkboxRef}
         errorMessage="This field is required"
+        {...field(model.view)}
       />
       <Button onClick={validate}>Submit</Button>
     </HorizontalLayout>

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBasicFeatures.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBasicFeatures.java
@@ -1,17 +1,22 @@
 package com.vaadin.demo.component.checkbox;
 
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
 @Route("checkbox-group-basic-features")
-public class CheckboxGroupBasicFeatures extends HorizontalLayout {
+public class CheckboxGroupBasicFeatures extends VerticalLayout {
 
     public CheckboxGroupBasicFeatures() {
         setPadding(false);
 
         // tag::snippet[]
+        Checkbox checkbox = new Checkbox();
+        checkbox.setLabel("Label");
+        checkbox.setHelperText("Helper text");
+
         CheckboxGroup<String> field = new CheckboxGroup<>();
         field.setLabel("Label");
         field.setHelperText("Helper text");
@@ -19,7 +24,7 @@ public class CheckboxGroupBasicFeatures extends HorizontalLayout {
         // end::snippet[]
         field.setItems("Item 1", "Item 2", "Item 3");
 
-        add(field);
+        add(checkbox, field);
     }
 
     public static class Exporter extends DemoExporter<CheckboxGroupBasicFeatures> { // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxRequired.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxRequired.java
@@ -1,0 +1,31 @@
+package com.vaadin.demo.component.checkbox;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("checkbox-required")
+public class CheckboxRequired extends HorizontalLayout {
+
+    public CheckboxRequired() {
+        // tag::snippet[]
+        Checkbox checkbox = new Checkbox();
+        checkbox.setLabel("I accept the terms and conditions");
+        checkbox.setRequiredIndicatorVisible(true);
+        checkbox.setErrorMessage("This field is required");
+        // end::snippet[]
+
+        Button button = new Button("Submit", e -> {
+            checkbox.setInvalid(!checkbox.getValue());
+        });
+
+        setAlignItems(FlexComponent.Alignment.BASELINE);
+        add(checkbox, button);
+    }
+
+    public static class Exporter extends DemoExporter<CheckboxRequired> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxRequired.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxRequired.java
@@ -4,7 +4,9 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
+import com.vaadin.demo.domain.UserPermissions;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
 @Route("checkbox-required")
@@ -13,13 +15,17 @@ public class CheckboxRequired extends HorizontalLayout {
     public CheckboxRequired() {
         // tag::snippet[]
         Checkbox checkbox = new Checkbox();
-        checkbox.setLabel("I accept the terms and conditions");
+        checkbox.setLabel("Grant view permissions");
         checkbox.setRequiredIndicatorVisible(true);
-        checkbox.setErrorMessage("This field is required");
+
+        Binder<UserPermissions> binder = new Binder<>(UserPermissions.class);
+        binder.forField(checkbox)
+                .asRequired("This field is required")
+                .bind(UserPermissions::getView, UserPermissions::setView);
         // end::snippet[]
 
         Button button = new Button("Submit", e -> {
-            checkbox.setInvalid(!checkbox.getValue());
+            binder.validate();
         });
 
         setAlignItems(FlexComponent.Alignment.BASELINE);


### PR DESCRIPTION
Fixes #3359

- Added an example of using `required` on individual checkbox
- Added individual checkbox with `helperText` to basic features