### PR TITLE
docs: add examples for GridPro cell editability

### DIFF
--- a/articles/components/grid-pro/index.adoc
+++ b/articles/components/grid-pro/index.adoc
@@ -260,6 +260,36 @@ include::{root}/frontend/demo/component/gridpro/react/grid-pro-prevent-save.tsx[
 endif::[]
 --
 
+[role="since:com.vaadin:vaadin@V24.4"]
+== Conditional Editability
+
+In some situations you might need to disable editing of specific cells in an edit column. This can be achieved through a function that determines the editability of each cell. This function is automatically re-evaluated when an item in the Grid is modified, so that modifying the value in one cell can immediately affect the editability of other cells.
+
+[.example]
+--
+
+ifdef::lit[]
+[source,typescript]
+----
+include::{root}/frontend/demo/component/gridpro/grid-pro-cell-editability.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/gridpro/GridProCellEditability.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/gridpro/react/grid-pro-cell-editability.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
+
 == Distinguish Editable / Read-Only Cells
 
 Editable cells are indicated with a hover effect by default, but you can give further help to users in distinguishing these by highlighting either editable or read-only cells.

--- a/frontend/demo/component/gridpro/grid-pro-cell-editability.ts
+++ b/frontend/demo/component/gridpro/grid-pro-cell-editability.ts
@@ -1,0 +1,55 @@
+import 'Frontend/demo/init'; // hidden-source-line
+
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import '@vaadin/grid-pro';
+import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import type { GridItemModel } from '@vaadin/grid';
+import { applyTheme } from 'Frontend/generated/theme';
+
+type Transaction = {
+  name: string;
+  amount: number;
+  approved: boolean;
+};
+
+@customElement('grid-pro-cell-editability')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    // Apply custom theme (only supported if your app uses one)
+    applyTheme(root);
+    return root;
+  }
+
+  @state()
+  private items: Transaction[] = [
+    { name: 'Transaction 1', amount: 100, approved: true },
+    { name: 'Transaction 2', amount: 200, approved: false },
+  ];
+
+  protected override render() {
+    return html`
+      <!-- tag::snippet[] -->
+      <vaadin-grid-pro .items="${this.items}">
+        <vaadin-grid-pro-edit-column
+          path="name"
+          .isCellEditable="${this.isNotApproved}"
+        ></vaadin-grid-pro-edit-column>
+        <vaadin-grid-pro-edit-column
+          path="amount"
+          .isCellEditable="${this.isNotApproved}"
+        ></vaadin-grid-pro-edit-column>
+        <vaadin-grid-pro-edit-column
+          path="approved"
+          editor-type="checkbox"
+        ></vaadin-grid-pro-edit-column>
+      </vaadin-grid-pro>
+      <!-- end::snippet[] -->
+    `;
+  }
+
+  protected isNotApproved(model: GridItemModel<Transaction>) {
+    return !model.item.approved;
+  }
+}

--- a/frontend/demo/component/gridpro/grid-pro-cell-editability.ts
+++ b/frontend/demo/component/gridpro/grid-pro-cell-editability.ts
@@ -5,13 +5,9 @@ import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import type { GridItemModel } from '@vaadin/grid';
+import { getPeople } from 'Frontend/demo/domain/DataService';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
-
-type Transaction = {
-  name: string;
-  amount: number;
-  approved: boolean;
-};
 
 @customElement('grid-pro-cell-editability')
 export class Example extends LitElement {
@@ -23,25 +19,25 @@ export class Example extends LitElement {
   }
 
   @state()
-  private items: Transaction[] = [
-    { name: 'Transaction 1', amount: 100, approved: true },
-    { name: 'Transaction 2', amount: 200, approved: false },
-  ];
+  private items: Person[] = [];
+
+  protected override async firstUpdated() {
+    const { people } = await getPeople();
+    this.items = people;
+  }
 
   protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-grid-pro .items="${this.items}">
+        <vaadin-grid-pro-edit-column path="firstName"></vaadin-grid-pro-edit-column>
+        <vaadin-grid-pro-edit-column path="lastName"></vaadin-grid-pro-edit-column>
         <vaadin-grid-pro-edit-column
-          path="name"
-          .isCellEditable="${this.isNotApproved}"
+          path="email"
+          .isCellEditable="${this.isSubscriber}"
         ></vaadin-grid-pro-edit-column>
         <vaadin-grid-pro-edit-column
-          path="amount"
-          .isCellEditable="${this.isNotApproved}"
-        ></vaadin-grid-pro-edit-column>
-        <vaadin-grid-pro-edit-column
-          path="approved"
+          path="subscriber"
           editor-type="checkbox"
         ></vaadin-grid-pro-edit-column>
       </vaadin-grid-pro>
@@ -49,7 +45,7 @@ export class Example extends LitElement {
     `;
   }
 
-  protected isNotApproved(model: GridItemModel<Transaction>) {
-    return !model.item.approved;
+  protected isSubscriber(model: GridItemModel<Person>) {
+    return model.item.subscriber;
   }
 }

--- a/frontend/demo/component/gridpro/react/grid-pro-cell-editability.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-cell-editability.tsx
@@ -1,0 +1,32 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React, { useState } from 'react';
+import { GridPro } from '@vaadin/react-components/GridPro.js';
+import { GridProEditColumn } from '@vaadin/react-components/GridProEditColumn.js';
+import type { GridItemModel } from '@vaadin/react-components/Grid.js';
+
+type Transaction = {
+  name: string;
+  amount: number;
+  approved: boolean;
+};
+
+function Example() {
+  const [items] = useState<Transaction[]>([
+    { name: 'Transaction 1', amount: 100, approved: true },
+    { name: 'Transaction 2', amount: 200, approved: false },
+  ]);
+
+  const isNotApproved = (model: GridItemModel<Transaction>) => !model.item.approved;
+
+  return (
+    // tag::snippet[]
+    <GridPro items={items}>
+      <GridProEditColumn path="name" isCellEditable={isNotApproved} />
+      <GridProEditColumn path="amount" isCellEditable={isNotApproved} />
+      <GridProEditColumn path="approved" editorType="checkbox" />
+    </GridPro>
+    // end::snippet[]
+  );
+}
+
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/gridpro/react/grid-pro-cell-editability.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-cell-editability.tsx
@@ -1,29 +1,27 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { GridPro } from '@vaadin/react-components/GridPro.js';
 import { GridProEditColumn } from '@vaadin/react-components/GridProEditColumn.js';
 import type { GridItemModel } from '@vaadin/react-components/Grid.js';
-
-type Transaction = {
-  name: string;
-  amount: number;
-  approved: boolean;
-};
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { getPeople } from 'Frontend/demo/domain/DataService';
 
 function Example() {
-  const [items] = useState<Transaction[]>([
-    { name: 'Transaction 1', amount: 100, approved: true },
-    { name: 'Transaction 2', amount: 200, approved: false },
-  ]);
+  const [items, setItems] = useState<Person[]>([]);
 
-  const isNotApproved = (model: GridItemModel<Transaction>) => !model.item.approved;
+  useEffect(() => {
+    getPeople().then(({ people }) => setItems(people));
+  }, []);
+
+  const isSubscriber = (model: GridItemModel<Person>) => model.item.subscriber;
 
   return (
     // tag::snippet[]
     <GridPro items={items}>
-      <GridProEditColumn path="name" isCellEditable={isNotApproved} />
-      <GridProEditColumn path="amount" isCellEditable={isNotApproved} />
-      <GridProEditColumn path="approved" editorType="checkbox" />
+      <GridProEditColumn path="firstName" />
+      <GridProEditColumn path="lastName" />
+      <GridProEditColumn path="email" isCellEditable={isSubscriber} />
+      <GridProEditColumn path="subscriber" editorType="checkbox" />
     </GridPro>
     // end::snippet[]
   );

--- a/frontend/demo/component/gridpro/react/grid-pro-cell-editability.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-cell-editability.tsx
@@ -1,5 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { GridPro } from '@vaadin/react-components/GridPro.js';
 import { GridProEditColumn } from '@vaadin/react-components/GridProEditColumn.js';
 import type { GridItemModel } from '@vaadin/react-components/Grid.js';
@@ -7,17 +9,20 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 
 function Example() {
-  const [items, setItems] = useState<Person[]>([]);
+  useSignals(); // hidden-source-line
+  const items = useSignal<Person[]>([]);
 
   useEffect(() => {
-    getPeople().then(({ people }) => setItems(people));
+    getPeople().then(({ people }) => {
+      items.value = people;
+    });
   }, []);
 
   const isSubscriber = (model: GridItemModel<Person>) => model.item.subscriber;
 
   return (
     // tag::snippet[]
-    <GridPro items={items}>
+    <GridPro items={items.value}>
       <GridProEditColumn path="firstName" />
       <GridProEditColumn path="lastName" />
       <GridProEditColumn path="email" isCellEditable={isSubscriber} />

--- a/src/main/java/com/vaadin/demo/component/gridpro/GridProCellEditability.java
+++ b/src/main/java/com/vaadin/demo/component/gridpro/GridProCellEditability.java
@@ -1,0 +1,69 @@
+package com.vaadin.demo.component.gridpro;
+
+import com.vaadin.flow.component.gridpro.GridPro;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("grid-pro-cell-editability")
+public class GridProCellEditability extends Div {
+    public GridProCellEditability() {
+        GridPro<Transaction> grid = new GridPro<>();
+        grid.setItems(new Transaction("Transaction 1", 100, true),
+                new Transaction("Transaction 2", 200, false));
+        grid.addEditColumn(Transaction::getName).text(Transaction::setName)
+                .setHeader("Name");
+        // tag::snippet[]
+        grid.addEditColumn(Transaction::getAmount)
+                .withCellEditableProvider(
+                        transaction -> !transaction.isApproved())
+                .text((item, value) -> item.setAmount(Integer.parseInt(value)))
+                .setHeader("Amount");
+        grid.addEditColumn(Transaction::isApproved)
+                .withCellEditableProvider(
+                        transaction -> !transaction.isApproved())
+                .checkbox(Transaction::setApproved)
+                .setHeader("Approved");
+        // end::snippet[]
+        add(grid);
+    }
+
+    public static class Transaction {
+        private String name;
+        private int amount;
+        private boolean approved;
+
+        public Transaction(String name, int amount, boolean approved) {
+            this.name = name;
+            this.amount = amount;
+            this.approved = approved;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getAmount() {
+            return amount;
+        }
+
+        public void setAmount(int amount) {
+            this.amount = amount;
+        }
+
+        public boolean isApproved() {
+            return approved;
+        }
+
+        public void setApproved(boolean approved) {
+            this.approved = approved;
+        }
+    }
+
+    public static class Exporter extends DemoExporter<GridProCellEditability> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/gridpro/GridProCellEditability.java
+++ b/src/main/java/com/vaadin/demo/component/gridpro/GridProCellEditability.java
@@ -1,67 +1,36 @@
 package com.vaadin.demo.component.gridpro;
 
+import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.gridpro.GridPro;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
+import com.vaadin.demo.domain.DataService;
+import java.util.List;
 
 @Route("grid-pro-cell-editability")
 public class GridProCellEditability extends Div {
     public GridProCellEditability() {
-        GridPro<Transaction> grid = new GridPro<>();
-        grid.setItems(new Transaction("Transaction 1", 100, true),
-                new Transaction("Transaction 2", 200, false));
-        grid.addEditColumn(Transaction::getName).text(Transaction::setName)
-                .setHeader("Name");
+        GridPro<Person> grid = new GridPro<>();
+
+        grid.addEditColumn(Person::getFirstName).text(Person::setFirstName)
+                .setHeader("First name");
+
+        grid.addEditColumn(Person::getLastName).text(Person::setLastName)
+                .setHeader("Last name");
+
         // tag::snippet[]
-        grid.addEditColumn(Transaction::getAmount)
-                .withCellEditableProvider(
-                        transaction -> !transaction.isApproved())
-                .text((item, value) -> item.setAmount(Integer.parseInt(value)))
-                .setHeader("Amount");
-        grid.addEditColumn(Transaction::isApproved)
-                .withCellEditableProvider(
-                        transaction -> !transaction.isApproved())
-                .checkbox(Transaction::setApproved)
-                .setHeader("Approved");
+        grid.addEditColumn(Person::getEmail)
+                .withCellEditableProvider(item -> item.isSubscriber())
+                .text(Person::setEmail).setHeader("Email");
         // end::snippet[]
+
+        grid.addEditColumn(Person::isSubscriber).checkbox(Person::setSubscriber)
+                .setHeader("Subscriber");
+
+        List<Person> people = DataService.getPeople();
+        grid.setItems(people);
         add(grid);
-    }
-
-    public static class Transaction {
-        private String name;
-        private int amount;
-        private boolean approved;
-
-        public Transaction(String name, int amount, boolean approved) {
-            this.name = name;
-            this.amount = amount;
-            this.approved = approved;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public int getAmount() {
-            return amount;
-        }
-
-        public void setAmount(int amount) {
-            this.amount = amount;
-        }
-
-        public boolean isApproved() {
-            return approved;
-        }
-
-        public void setApproved(boolean approved) {
-            this.approved = approved;
-        }
     }
 
     public static class Exporter extends DemoExporter<GridProCellEditability> { // hidden-source-line


### PR DESCRIPTION
Fixes #3355

Added the example based on the Flow components IT for the feature:

<img width="806" alt="Screenshot 2024-04-22 at 17 03 38" src="https://github.com/vaadin/docs/assets/10589913/1d2edb3c-a46c-42d9-a106-2b81b803b3c7">
