### PR TITLE
chore: fix Prettier formatting, use single quotes in imports

### DIFF
--- a/frontend/demo/component/avatar/react/avatar-group-basic.tsx
+++ b/frontend/demo/component/avatar/react/avatar-group-basic.tsx
@@ -11,7 +11,7 @@ function Example() {
   const peopleData = useSignal<Person[]>([]);
 
   useEffect(() => {
-    getPeople({count: 3}).then(({people}) => {
+    getPeople({ count: 3 }).then(({ people }) => {
       peopleData.value = people;
     });
   }, []);
@@ -23,9 +23,7 @@ function Example() {
     }))
   );
 
-  return (
-    <AvatarGroup items={avatars.value}/>
-  );
+  return <AvatarGroup items={avatars.value} />;
   // end::snippet[]
 }
 

--- a/frontend/demo/component/avatar/react/avatar-group-bg-color.tsx
+++ b/frontend/demo/component/avatar/react/avatar-group-bg-color.tsx
@@ -24,9 +24,7 @@ function Example() {
     }))
   );
 
-  return (
-    <AvatarGroup items={avatars.value}/>
-  );
+  return <AvatarGroup items={avatars.value} />;
   // end::snippet[]
 }
 

--- a/frontend/demo/component/avatar/react/avatar-group-max-items.tsx
+++ b/frontend/demo/component/avatar/react/avatar-group-max-items.tsx
@@ -24,10 +24,7 @@ function Example() {
 
   return (
     // tag::snippet[]
-    <AvatarGroup
-      maxItemsVisible={3}
-      items={avatars.value}
-    />
+    <AvatarGroup maxItemsVisible={3} items={avatars.value} />
     // end::snippet[]
   );
 }

--- a/frontend/demo/component/button/react/button-disable-long-action.tsx
+++ b/frontend/demo/component/button/react/button-disable-long-action.tsx
@@ -1,7 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, {
-  useEffect
-} from 'react'; // hidden-source-line
+import React, { useEffect } from 'react';
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/contextmenu/react/context-menu-basic.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-basic.tsx
@@ -14,7 +14,7 @@ function Example() {
   const gridRef = useRef<GridElement>(null);
 
   useEffect(() => {
-    getPeople({count: 5}).then(({people}) => {
+    getPeople({ count: 5 }).then(({ people }) => {
       gridItems.value = people;
     });
   }, []);

--- a/frontend/demo/component/contextmenu/react/context-menu-dividers.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-dividers.tsx
@@ -14,7 +14,7 @@ function Example() {
   const gridRef = useRef<GridElement>(null);
 
   useEffect(() => {
-    getPeople({count: 5}).then(({people}) => {
+    getPeople({ count: 5 }).then(({ people }) => {
       gridItems.value = people;
     });
   }, []);

--- a/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
@@ -58,43 +58,33 @@ function Example() {
   const gridRef = useRef<GridElement>(null);
 
   useEffect(() => {
-    getPeople({count: 5}).then(({people}) => {
+    getPeople({ count: 5 }).then(({ people }) => {
       gridItems.value = people;
       // tag::snippet[]
       const contextMenuItems: ContextMenuItem[] = [
-        {component: createItem('vaadin:file-search', 'Open')},
+        { component: createItem('vaadin:file-search', 'Open') },
         {
           component: createItem('vaadin:user-check', 'Assign'),
           children: [
             {
-              component:
-                <Item
-                  person={people[0]}/>
+              component: <Item person={people[0]} />,
             },
             {
-              component:
-                <Item
-                  person={people[1]}/>
+              component: <Item person={people[1]} />,
             },
             {
-              component:
-                <Item
-                  person={people[2]}/>
+              component: <Item person={people[2]} />,
             },
             {
-              component:
-                <Item
-                  person={people[3]}/>
+              component: <Item person={people[3]} />,
             },
             {
-              component:
-                <Item
-                  person={people[4]}/>
+              component: <Item person={people[4]} />,
             },
           ],
         },
-        {component: 'hr'},
-        {component: createItem('vaadin:trash', 'Delete')},
+        { component: 'hr' },
+        { component: createItem('vaadin:trash', 'Delete') },
       ];
 
       items.value = contextMenuItems;

--- a/frontend/demo/component/datepicker/react/date-picker-individual-input-fields.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-individual-input-fields.tsx
@@ -8,7 +8,7 @@ import getDaysInMonth from 'date-fns/getDaysInMonth';
 
 function Example() {
   useSignals(); // hidden-source-line
-  const months = useComputed<string []>(() => [
+  const months = useComputed<string[]>(() => [
     'January',
     'February',
     'March',
@@ -23,15 +23,14 @@ function Example() {
     'December',
   ]);
 
-  const years = useComputed<number []>(() => Array.from(
-    { length: 100 },
-    (_, k) => new Date().getFullYear() - 99 + k),
+  const years = useComputed<number[]>(() =>
+    Array.from({ length: 100 }, (_, k) => new Date().getFullYear() - 99 + k)
   );
 
   const selectedYear = useSignal<number | undefined>(undefined);
   const selectedMonth = useSignal<string | undefined>(undefined);
   const selectedDay = useSignal<number | undefined>(undefined);
-  const selectableDays = useComputed<number []>(() => {
+  const selectableDays = useComputed<number[]>(() => {
     if (!selectedYear.value || !selectedMonth.value) {
       return [];
     }

--- a/frontend/demo/component/datepicker/react/date-picker-initial-position.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-initial-position.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { useComputed } from "@vaadin/hilla-react-signals";
+import { useComputed } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
 import { formatISO, lastDayOfYear } from 'date-fns';

--- a/frontend/demo/component/formlayout/react/form-layout-custom-field.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-custom-field.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { useComputed } from "@vaadin/hilla-react-signals";
+import { useComputed } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';
 import { FormItem } from '@vaadin/react-components/FormItem.js';
@@ -12,14 +12,16 @@ function Example() {
   useSignals(); // hidden-source-line
   // tag::snippet[]
   const monthItems = useComputed(() =>
-    Array
-      .from({ length: 12 }, (_, i) => `${i + 1}`.padStart(2, '0'))
-      .map((month) => ({ label: month, value: month }))
+    Array.from({ length: 12 }, (_, i) => `${i + 1}`.padStart(2, '0')).map((month) => ({
+      label: month,
+      value: month,
+    }))
   );
   const yearItems = useComputed(() =>
-    Array
-      .from({ length: 11 }, (_, i) => `${i + new Date().getFullYear()}`)
-      .map((year) => ({ label: year, value: year }))
+    Array.from({ length: 11 }, (_, i) => `${i + new Date().getFullYear()}`).map((year) => ({
+      label: year,
+      value: year,
+    }))
   );
 
   return (
@@ -31,16 +33,8 @@ function Example() {
           formatValue={(values: unknown[]) => (values[0] && values[1] ? values.join('/') : '')}
         >
           <HorizontalLayout theme="spacing-xs">
-            <Select
-              accessibleName="Month"
-              placeholder="Month"
-              items={monthItems.value}
-            />
-            <Select
-              accessibleName="Year"
-              placeholder="Year"
-              items={yearItems.value}
-            />
+            <Select accessibleName="Month" placeholder="Month" items={monthItems.value} />
+            <Select accessibleName="Year" placeholder="Year" items={yearItems.value} />
           </HorizontalLayout>
         </CustomField>
       </FormItem>

--- a/frontend/demo/component/grid/react/grid-context-menu.tsx
+++ b/frontend/demo/component/grid/react/grid-context-menu.tsx
@@ -20,7 +20,7 @@ function Example() {
   const gridRef = useRef<GridElement>(null);
 
   useEffect(() => {
-    getPeople().then(({people}) => {
+    getPeople().then(({ people }) => {
       items.value = people;
     });
   }, []);

--- a/frontend/demo/component/upload/react/upload-all-files.tsx
+++ b/frontend/demo/component/upload/react/upload-all-files.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useRef, useEffect } from 'react';
-import { useComputed } from "@vaadin/hilla-react-signals";
+import { useComputed } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { Upload, type UploadElement } from '@vaadin/react-components/Upload.js';
 import { createFakeFilesUploadAllFiles } from './upload-demo-mock-files'; // hidden-source-line

--- a/frontend/demo/component/upload/react/upload-auto-upload-disabled.tsx
+++ b/frontend/demo/component/upload/react/upload-auto-upload-disabled.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useRef, useEffect } from 'react';
-import { useComputed } from "@vaadin/hilla-react-signals"; // hidden-source-line
+import { useComputed } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { Upload, type UploadElement } from '@vaadin/react-components/Upload.js';
 import { createFakeFilesUploadAutoUploadDisabled } from './upload-demo-mock-files';

--- a/frontend/demo/component/upload/react/upload-basic.tsx
+++ b/frontend/demo/component/upload/react/upload-basic.tsx
@@ -1,7 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { useComputed } from "@vaadin/hilla-react-signals";
-import { useSignals } from "@preact/signals-react/runtime";
+import { useComputed } from '@vaadin/hilla-react-signals';
+import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { Upload } from '@vaadin/react-components/Upload.js';
 import { createFakeFilesUploadBasic } from './upload-demo-mock-files';
 

--- a/frontend/demo/component/upload/react/upload-clear-button.tsx
+++ b/frontend/demo/component/upload/react/upload-clear-button.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { useComputed } from "@vaadin/hilla-react-signals";
+import { useComputed } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { Upload } from '@vaadin/react-components/Upload.js';
 import { createFakeUploadFiles } from './upload-demo-helpers';

--- a/frontend/demo/component/upload/react/upload-error-messages.tsx
+++ b/frontend/demo/component/upload/react/upload-error-messages.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useEffect, useRef } from 'react';
-import { useComputed } from "@vaadin/hilla-react-signals";
+import { useComputed } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { FormLayout, type FormLayoutResponsiveStep } from '@vaadin/react-components/FormLayout.js';
 import { Upload, type UploadElement } from '@vaadin/react-components/Upload.js';

--- a/frontend/demo/component/upload/react/upload-start-button.tsx
+++ b/frontend/demo/component/upload/react/upload-start-button.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { useComputed } from "@vaadin/hilla-react-signals";
+import { useComputed } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { Upload } from '@vaadin/react-components/Upload.js';
 import { createFakeUploadFiles } from './upload-demo-helpers';


### PR DESCRIPTION
Follow-up to #3217 

The change to add Signals affected formatting for some React examples. This PR fixes that by running Prettier.