### PR TITLE
feat(hilla): use the new FilterTransformer in example and adapt doc

### DIFF
--- a/articles/components/auto-grid/index.adoc
+++ b/articles/components/auto-grid/index.adoc
@@ -298,23 +298,13 @@ include::{root}/src/main/java/com/vaadin/demo/fusion/crud/ProductRepository.java
 
 The example above works for an ideal case, where the DTO class structure maps one-to-one to the JPA entity class structure. In practice, however, this is often not the case. For example, you might want to flatten nested properties, use different property names or create computed properties that are not present in the JPA entity. Alternatively, you might want to use a different data source than JPA.
 
-For these cases you need to implement pagination, sorting and filtering manually using the parameters provided to the `list` method. The method receives a `org.springframework.data.domain.Pageable` and `com.vaadin.hilla.crud.filter.Filter` instances as parameters, which can be used to extract the following information:
-
-* `Pageable.getOffset`: The offset of the first item to fetch
-* `Pageable.getPageSize`: The maximum number of items to fetch
-* `Pageable.getSort`: The sort order of the items. Each sort order contains the property to sort by (`Sort.Order.getProperty()`), and the direction (`Sort.Order.getDirection()`)
-* `Filter`: The filter to apply to the items. The filter is a tree structure of `Filter` instances, where each `Filter` instance is either an `AndFilter`, an `OrFilter`, or a `PropertyStringFilter`:
-** `AndFilter` contains a list of nested filters (`AndFilter.getChildren()`) that should all match.
-** `OrFilter` contains a list of nested filters (`OrFilter.getChildren()`) of which at least one should match.
-** `PropertyStringFilter` filters an individual property against a value. It contains the name of the property to filter (`PropertyStringFilter.getPropertyId()`), the value to filter against (`PropertyStringFilter.getFilterValue()`), and the matcher to use (`PropertyStringFilter.getMatcher()`). The filter value is always a string and needs to be converted into a respective type or format that works with the type of the property. The matcher specifies the type of filter operation, such as `EQUALS`, `CONTAINS`, `GREATER_THAN`, etc.
-
-When using the default header filters, the filter is always an `AndFilter` with a list of `PropertyStringFilter` instances. The `PropertyStringFilter` instances are created based on the filter values entered by the user in the header filters. When using an external filter, the filter can be of any structure.
-
 The following example shows a more complex use case:
 
 - The DTO class uses different property names than the JPA entity class and flattens nested properties. It also adds a computed property that is not present in the JPA entity.
 - The sort implementation maps the DTO property names to the JPA entity class structure.
 - The filter implementation creates JPA filter specifications based on the filter values entered by the user in the header filters. As part of that it demonstrates how to handle different matcher types, and how to filter for computed properties.
+
+This example uses a [classname]`FilterTransformer` to automatically adapt filtering and sorting to the fields as expected by the DTO class.
 
 [.example]
 --
@@ -339,3 +329,15 @@ include::{root}/src/main/java/com/vaadin/demo/fusion/crud/Product.java[tags=snip
 include::{root}/src/main/java/com/vaadin/demo/fusion/crud/ProductRepository.java[tags=snippet,indent=0]
 ----
 --
+
+For even more complex use cases you need to implement pagination, sorting and filtering manually using the parameters provided to the `list` method. The method receives a `org.springframework.data.domain.Pageable` and `com.vaadin.hilla.crud.filter.Filter` instances as parameters, which can be used to extract the following information:
+
+* `Pageable.getOffset`: The offset of the first item to fetch
+* `Pageable.getPageSize`: The maximum number of items to fetch
+* `Pageable.getSort`: The sort order of the items. Each sort order contains the property to sort by (`Sort.Order.getProperty()`), and the direction (`Sort.Order.getDirection()`)
+* `Filter`: The filter to apply to the items. The filter is a tree structure of `Filter` instances, where each `Filter` instance is either an `AndFilter`, an `OrFilter`, or a `PropertyStringFilter`:
+** `AndFilter` contains a list of nested filters (`AndFilter.getChildren()`) that should all match.
+** `OrFilter` contains a list of nested filters (`OrFilter.getChildren()`) of which at least one should match.
+** `PropertyStringFilter` filters an individual property against a value. It contains the name of the property to filter (`PropertyStringFilter.getPropertyId()`), the value to filter against (`PropertyStringFilter.getFilterValue()`), and the matcher to use (`PropertyStringFilter.getMatcher()`). The filter value is always a string and needs to be converted into a respective type or format that works with the type of the property. The matcher specifies the type of filter operation, such as `EQUALS`, `CONTAINS`, `GREATER_THAN`, etc.
+
+When using the default header filters, the filter is always an `AndFilter` with a list of `PropertyStringFilter` instances. The `PropertyStringFilter` instances are created based on the filter values entered by the user in the header filters. When using an external filter, the filter can be of any structure.


### PR DESCRIPTION
In Vaadin 24.4 the AutoGrid has a new FilterTransformer that simplifies the handling of DTO field names that do not map directly to entity field names.

This allows to greatly simplify the advanced DTO example.

I chose to keep the old documentation paragraph and move it lower in the page, since in theory it's always possible to find a use case where a completely custom implementation is needed.

Closes #3346.