### PR TITLE
chore: capitalize react view function name

### DIFF
--- a/articles/flow/integrations/hilla.adoc
+++ b/articles/flow/integrations/hilla.adoc
@@ -35,7 +35,7 @@ import React, { useState } from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 
-export default function counter() {
+export default function Counter() {
   const [counter, setCounter] = useState(0);
 
   return (


### PR DESCRIPTION
If the function is not capitalized, changes to the view are not immediately applied in the browser.


