### PR TITLE
fix diff highlighting in Hilla upgrade guide

### DIFF
--- a/articles/hilla/lit/guides/upgrading/index.adoc
+++ b/articles/hilla/lit/guides/upgrading/index.adoc
@@ -35,11 +35,11 @@ To update your Maven project to use Vaadin 24.4.0, you'll need to adjust your [f
 
 Update the property name that defines the framework version, from `hilla.version` property to `vaadin.version`. Then set its value to `24.4.x`, or rather the version you're using. This change ensures that all subsequent dependencies use the correct version variable:
 
-[source,xml]
+[source,diff]
 ----
 <properties>
-    - <hilla.version>2.x</hilla.version>
-    + <vaadin.version>24.4.0</vaadin.version>
+-    <hilla.version>2.x</hilla.version>
++    <vaadin.version>24.4.0</vaadin.version>
 </properties>
 ----
 
@@ -49,24 +49,24 @@ Update the property name that defines the framework version, from `hilla.version
 
 Change the Bill of Materials (BOM) from Hilla to Vaadin. This will ensure that your project uses compatible versions of Vaadin libraries:
 
-[source,xml]
+[source,diff]
 ----
 <dependencyManagement>
     <dependencies>
-        - <dependency>
-        -     <groupId>dev.hilla</groupId>
-        -     <artifactId>hilla-bom</artifactId>
-        -     <version>${hilla.version}</version>
-        -     <type>pom</type>
-        -     <scope>import</scope>
-        - </dependency>
-        + <dependency>
-        +     <groupId>com.vaadin</groupId>
-        +     <artifactId>vaadin-bom</artifactId>
-        +     <version>${vaadin.version}</version>
-        +     <type>pom</type>
-        +     <scope>import</scope>
-        + </dependency>
+-        <dependency>
+-            <groupId>dev.hilla</groupId>
+-            <artifactId>hilla-bom</artifactId>
+-            <version>${hilla.version}</version>
+-            <type>pom</type>
+-            <scope>import</scope>
+-        </dependency>
++        <dependency>
++            <groupId>com.vaadin</groupId>
++            <artifactId>vaadin-bom</artifactId>
++            <version>${vaadin.version}</version>
++            <type>pom</type>
++            <scope>import</scope>
++        </dependency>
     </dependencies>
 </dependencyManagement>
 ----
@@ -77,17 +77,17 @@ Change the Bill of Materials (BOM) from Hilla to Vaadin. This will ensure that y
 
 Replace the core Hilla library dependency with the equivalent Vaadin library:
 
-[source,xml]
+[source,diff]
 ----
 <dependencies>
-    - <dependency>
-    -     <groupId>dev.hilla</groupId>
-    -     <artifactId>hilla</artifactId>
-    - </dependency>
-    + <dependency>
-    +     <groupId>com.vaadin</groupId>
-    +     <artifactId>vaadin</artifactId>
-    + </dependency>
+-    <dependency>
+-        <groupId>dev.hilla</groupId>
+-        <artifactId>hilla</artifactId>
+-    </dependency>
++    <dependency>
++        <groupId>com.vaadin</groupId>
++        <artifactId>vaadin</artifactId>
++    </dependency>
 </dependencies>
 ----
 
@@ -97,17 +97,17 @@ Replace the core Hilla library dependency with the equivalent Vaadin library:
 
 Change the Hilla Spring Boot starter dependency to Vaadin's Spring Boot starter:
 
-[source,xml]
+[source,diff]
 ----
 <dependencies>
-    - <dependency>
-    -     <groupId>dev.hilla</groupId>
-    -     <artifactId>hilla-spring-boot-starter</artifactId>
-    - </dependency>
-    + <dependency>
-    +     <groupId>com.vaadin</groupId>
-    +     <artifactId>vaadin-spring-boot-starter</artifactId>
-    + </dependency>
+-    <dependency>
+-        <groupId>dev.hilla</groupId>
+-        <artifactId>hilla-spring-boot-starter</artifactId>
+-    </dependency>
++    <dependency>
++        <groupId>com.vaadin</groupId>
++        <artifactId>vaadin-spring-boot-starter</artifactId>
++    </dependency>
 </dependencies>
 ----
 
@@ -117,17 +117,17 @@ Change the Hilla Spring Boot starter dependency to Vaadin's Spring Boot starter:
 
 Ensure that any React-specific Spring Boot starters are also updated:
 
-[source,xml]
+[source,diff]
 ----
 <dependencies>
-    - <dependency>
-    -     <groupId>dev.hilla</groupId>
-    -     <artifactId>hilla-react-spring-boot-starter</artifactId>
-    - </dependency>
-    + <dependency>
-    +     <groupId>com.vaadin</groupId>
-    +     <artifactId>vaadin-spring-boot-starter</artifactId>
-    + </dependency>
+-    <dependency>
+-        <groupId>dev.hilla</groupId>
+-        <artifactId>hilla-react-spring-boot-starter</artifactId>
+-    </dependency>
++    <dependency>
++        <groupId>com.vaadin</groupId>
++        <artifactId>vaadin-spring-boot-starter</artifactId>
++    </dependency>
 </dependencies>
 ----
 
@@ -137,18 +137,18 @@ Ensure that any React-specific Spring Boot starters are also updated:
 
 Switch the Maven plugin from Hilla to Vaadin to use Vaadin's build plugin capabilities:
 
-[source,xml]
+[source,diff]
 ----
 <build>
     <plugins>
-        - <plugin>
-        -     <groupId>dev.hilla</groupId>
-        -     <artifactId>hilla-maven-plugin</artifactId>
-        - </plugin>
-        + <plugin>
-        +     <groupId>com.vaadin</groupId>
-        +     <artifactId>vaadin-maven-plugin</artifactId>
-        + </plugin>
+-       <plugin>
+-           <groupId>dev.hilla</groupId>
+-           <artifactId>hilla-maven-plugin</artifactId>
+-       </plugin>
++       <plugin>
++           <groupId>com.vaadin</groupId>
++           <artifactId>vaadin-maven-plugin</artifactId>
++       </plugin>
     </plugins>
 </build>
 ----
@@ -168,14 +168,14 @@ For projects specifically utilizing Hilla React, some dependencies can now be re
 
 With the integration of Hilla functionalities into Vaadin core artifacts, the separate `dev.hilla:hilla-react` dependency is no longer required and should be removed from your project's dependency management to avoid redundancy and potential conflicts.
 
-[source,xml]
+[source,diff]
 ----
 <dependencies>
     <!-- other dependencies -->
-    - <dependency>
-    -     <groupId>dev.hilla</groupId>
-    -     <artifactId>hilla-react</artifactId>
-    - </dependency>
+-   <dependency>
+-       <groupId>dev.hilla</groupId>
+-       <artifactId>hilla-react</artifactId>
+-   </dependency>
     <!-- other dependencies -->
 </dependencies>
 ----
@@ -187,11 +187,14 @@ Confirm that all functionalities are operational post update. Vaadin should nati
 
 Update Java source files to reflect the new package names. Replace all occurrences of `dev.hilla` to `com.vaadin.hilla`, for example, in imports:
 
-[source,java]
+[source,diff]
 ----
-import com.vaadin.hilla.BrowserCallable;
-import com.vaadin.hilla.Nullable;
-import com.vaadin.hilla.crud.CrudRepositoryService;
+- import dev.hilla.BrowserCallable;
+- import dev.hilla.Nullable;
+- import dev.hilla.crud.CrudRepositoryService;
++ import com.vaadin.hilla.BrowserCallable;
++ import com.vaadin.hilla.Nullable;
++ import com.vaadin.hilla.crud.CrudRepositoryService;
 ----
 
 
@@ -207,7 +210,7 @@ The general rule is to replace all occurrences of `@hilla/` with `@vaadin/hilla-
 
 Change `@hilla/form` to `@vaadin/hilla-lit-form`:
 
-[source,typescript]
+[source,diff]
 ----
 - import { Binder, field } from '@hilla/form';
 + import { Binder, field } from '@vaadin/hilla-lit-form';
@@ -219,7 +222,7 @@ Change `@hilla/form` to `@vaadin/hilla-lit-form`:
 
 Change `@hilla/react-components/` to `@vaadin/react-components/`:
 
-[source,typescript]
+[source,diff]
 ----
 - import { TextField } from "@hilla/react-components/TextField.js";
 + import { TextField } from "@vaadin/react-components/TextField.js";
@@ -231,7 +234,7 @@ Change `@hilla/react-components/` to `@vaadin/react-components/`:
 
 Ensure that any remaining imports using the old `@hilla/` namespace are updated to `@vaadin/hilla-`:
 
-[source,typescript]
+[source,diff]
 ----
 - import { something } from '@hilla/some-module';
 + import { something } from '@vaadin/hilla-some-module';
@@ -245,7 +248,7 @@ This includes updates to any miscellaneous modules that may not have been explic
 
 In case you've used Hilla CRUD helpers (e.g., AutoCRUD, AutoGrid, and AutoForm), there is chance that you imported generated paths from the old Hilla structure. You need to update these paths according to the new Vaadin package structure:
 
-[source,typescript]
+[source,diff]
 ----
 - import type FilterUnion from 'Frontend/generated/dev/hilla/crud/filter/FilterUnion.js';
 - import type OrFilter from 'Frontend/generated/dev/hilla/crud/filter/OrFilter.js';
@@ -277,7 +280,7 @@ Update the `hillaVersion` property to `vaadinVersion`, and set the value to the 
 
 `gradle.properties`:
 
-[source]
+[source,diff]
 ----
 - hillaVersion=2.x
 + vaadinVersion=24.4.x
@@ -291,12 +294,12 @@ Don't forget to update any references in `settings.gradle` and `build.gradle`.
 
 Change the Bill of Materials (BOM) from Hilla to Vaadin in your `dependencyManagement` closure:
 
-[source,groovy]
+[source,diff]
 ----
 dependencyManagement {
     imports {
-        - implementation platform('dev.hilla:hilla-bom:${hillaVersion}')
-        + implementation platform('com.vaadin:vaadin-bom:${vaadinVersion}')
+-        implementation platform('dev.hilla:hilla-bom:${hillaVersion}')
++        implementation platform('com.vaadin:vaadin-bom:${vaadinVersion}')
     }
 }
 ----
@@ -307,11 +310,11 @@ dependencyManagement {
 
 Replace any core Hilla library dependency with the equivalent Vaadin library in your `build.gradle`:
 
-[source,groovy]
+[source,diff]
 ----
 dependencies {
-    - implementation 'dev.hilla:hilla'
-    + implementation 'com.vaadin:vaadin'
+-    implementation 'dev.hilla:hilla'
++    implementation 'com.vaadin:vaadin'
 }
 ----
 
@@ -321,11 +324,11 @@ dependencies {
 
 Change the Hilla Spring Boot starter dependency to Vaadin's Spring Boot starter:
 
-[source,groovy]
+[source,diff]
 ----
 dependencies {
-    - implementation 'dev.hilla:hilla-spring-boot-starter'
-    + implementation 'com.vaadin:vaadin-spring-boot-starter'
+-    implementation 'dev.hilla:hilla-spring-boot-starter'
++    implementation 'com.vaadin:vaadin-spring-boot-starter'
 }
 ----
 
@@ -335,11 +338,11 @@ dependencies {
 
 Ensure that any React-specific Spring Boot starters are also updated:
 
-[source,groovy]
+[source,diff]
 ----
 dependencies {
-    - implementation 'dev.hilla:hilla-react-spring-boot-starter'
-    + implementation 'com.vaadin:vaadin-spring-boot-starter'
+-    implementation 'dev.hilla:hilla-react-spring-boot-starter'
++    implementation 'com.vaadin:vaadin-spring-boot-starter'
 }
 ----
 
@@ -349,11 +352,11 @@ dependencies {
 
 Switch the Gradle plugin from Hilla to Vaadin to utilize latest Vaadin's build capabilities:
 
-[source,groovy]
+[source,diff]
 ----
 plugins {
-    - id 'dev.hilla' version '2.x'
-    + id 'com.vaadin' version '24.4.0'
+-    id 'dev.hilla' version '2.x'
++    id 'com.vaadin' version '24.4.0'
 }
 ----
 
@@ -368,10 +371,10 @@ For projects that specifically utilize Hilla React, some dependencies can now be
 
 With the integration of Hilla functionalities into Vaadin core artifacts, the separate `dev.vaadin:hilla-react` dependency is no longer required and should be removed from your project's dependency management to avoid redundancy and potential conflicts.
 
-[source,groovy]
+[source,diff]
 ----
 dependencies {
-    - implementation 'dev.hilla:hilla-react'
+-    implementation 'dev.hilla:hilla-react'
 }
 ----
 


### PR DESCRIPTION
This fixes the diff highlighting in the Hilla upgrade guide article. The output is much better that before with just some `-` and `+` in the code blocks:
![Screenshot 2024-05-03 at 11 43 55](https://github.com/vaadin/docs/assets/70698630/f33e9e9b-f152-4e9f-9c71-10057b48aada)
![Screenshot 2024-05-03 at 11 45 06](https://github.com/vaadin/docs/assets/70698630/b29cfadf-80ff-4015-9156-fea2da0790c7)
![Screenshot 2024-05-03 at 11 45 25](https://github.com/vaadin/docs/assets/70698630/13ed7fec-40b0-47bd-be99-190abc8e26c7)
![Screenshot 2024-05-03 at 11 45 47](https://github.com/vaadin/docs/assets/70698630/7b1d5823-4598-446d-ac8c-c0ba8c5c5ae4)
