### PR TITLE
Escape ...

### DIFF
--- a/articles/hilla/guides/routing.adoc
+++ b/articles/hilla/guides/routing.adoc
@@ -59,14 +59,14 @@ Hilla file router supports the following file naming conventions for the `.tsx`/
   The file name part between the braces is mapped to a required route parameter, as described in <<Adding Routes with Parameters>> below.
 `{{optionalParameter}}.tsx` — optional parameter mapping::
   Same as above, but the mapped route parameter is optional.
-`{...wildcard}.tsx` — wildcard mapping::
+`{\...wildcard}.tsx` — wildcard mapping::
   Creates a route mapping for the wildcard parameter (`"*"`), which matches any characters.
 
 
 == Adding Routes with Parameters
 
 Sometimes, you may need to create routes that accept dynamic parameters, such as product IDs or names. This can be done by using one of the parameter filename conventions:
-`{parameter}.tsx`, `{{optionalParameter}}.tsx`, or `{...wildcard}.tsx`.
+`{parameter}.tsx`, `{{optionalParameter}}.tsx`, or `{\...wildcard}.tsx`.
 
 For example, create the file named `{productId}.tsx` in the `src/main/frontend/views/products/` directory with the following content:
 
@@ -103,7 +103,7 @@ To link to this route with a specific `productId`, you can use the `to` property
 Due to a limitation in React Router, the wildcard parameter is always named `*` in the `useParams()` result. Use a destructuring rename for convenience:
 
 [source,tsx]
-.`{...wildcard}.tsx`
+.`{\...wildcard}.tsx`
 ----
 export default function WildcardView() {
   const { "*": wildcard } = useParams();
@@ -111,7 +111,7 @@ export default function WildcardView() {
 }
 ----
 
-The file name part following the three dots (as in, for example, `{...name}.tsx`) is ignored.
+The file name part following the three dots (as in, for example, `{\...name}.tsx`) is ignored.
 ====
 
 == Adding Layout Routes


### PR DESCRIPTION
Asciidoc converts `...` (three dots) to `…` (ellipsis) unless escaped which becomes wrong for the special file names associated with the FS router.


