### PR TITLE
Hilla-dev exclusions are not needed for non-Spring projects

### DIFF
--- a/articles/flow/integrations/cdi/index.adoc
+++ b/articles/flow/integrations/cdi/index.adoc
@@ -57,24 +57,6 @@ If you are a `vaadin-platform` user, add the following dependencies in your [fil
 <dependencies>
 ----
 
-The Vaadin platform includes Hilla dependencies by default in `com.vaadin:vaadin` and `com.vaadin:vaadin-core`. If you don't use Hilla in your project and have `com.vaadin:vaadin` in your [filename]`pom.xml`, you can exclude those dependencies:
-
-.`pom.xml`
-[source,xml]
-----
-<dependency>
-    <groupId>com.vaadin</groupId>
-    <!-- Replace artifactId with vaadin-core to use only free components -->
-    <artifactId>vaadin</artifactId>
-    <exclusions>
-        <exclusion>
-            <groupId>com.vaadin</groupId>
-            <artifactId>hilla-dev</artifactId>
-        </exclusion>
-    </exclusions>
-</dependency>
-----
-
 == Vaadin Version Compatibility
 
 The version for `vaadin-cdi` is managed by `vaadin-bom`.

--- a/articles/tools/mpr/configuration/mpr-cdi-tutorial.adoc
+++ b/articles/tools/mpr/configuration/mpr-cdi-tutorial.adoc
@@ -81,23 +81,6 @@ Add the `vaadin-cdi` dependency. The version isn't needed since it's defined by 
 </dependency>
 ----
 
-The Vaadin platform includes Hilla dependencies by default. If you don't use Hilla in your project, you can exclude those dependencies:
-
-.`pom.xml`
-[source,xml]
-----
-<dependency>
-    <groupId>com.vaadin</groupId>
-    <artifactId>vaadin-core</artifactId>
-    <exclusions>
-        <exclusion>
-            <groupId>com.vaadin</groupId>
-            <artifactId>hilla-dev</artifactId>
-        </exclusion>
-    </exclusions>
-</dependency>
-----
-
 Since the root path of the application is managed by Vaadin 7, you need to define the Vaadin 14 servlet manually. Also, set its URL pattern to a value that doesn't collide with any of the V7 servlets.
 
 [source,java]


### PR DESCRIPTION
As now `hilla-dev` marks `hilla-endpoints` dependency as optional and, if no `vaadin-spring-boot-starter` in a project, the Hilla endpoints are not added, i.e. no need to exclude.

Note that the `hilla-dev` module will be removed soon as a part of unification for Vaadin HotSwap agent plugin.