### PR TITLE
fix: do not use static drop mode for grids in dnd examples

### DIFF
--- a/frontend/demo/component/grid/grid-drag-drop-filters.ts
+++ b/frontend/demo/component/grid/grid-drag-drop-filters.ts
@@ -83,12 +83,12 @@ export class Example extends LitElement {
           this.expandedItems = event.detail.value;
         }}"
         rows-draggable
-        drop-mode="on-top"
+        .dropMode=${this.draggedItem ? 'on-top' : undefined}
         @grid-dragstart="${(event: GridDragStartEvent<Person>) => {
           this.draggedItem = event.detail.draggedItems[0];
         }}"
         @grid-dragend="${() => {
-          delete this.draggedItem;
+          this.draggedItem = undefined;
         }}"
         @grid-drop="${(event: GridDropEvent<Person>) => {
           const manager = event.detail.dropTargetItem;

--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -55,7 +55,7 @@ export class Example extends LitElement {
   };
 
   private clearDraggedItem = () => {
-    delete this.draggedItem;
+    this.draggedItem = undefined;
   };
 
   protected override render() {
@@ -64,7 +64,7 @@ export class Example extends LitElement {
         <vaadin-grid
           .items="${this.grid1Items}"
           rows-draggable
-          drop-mode="on-grid"
+          .dropMode=${this.draggedItem ? 'on-grid' : undefined}
           @grid-dragstart="${this.startDraggingItem}"
           @grid-dragend="${this.clearDraggedItem}"
           @grid-drop="${() => {
@@ -93,7 +93,7 @@ export class Example extends LitElement {
         <vaadin-grid
           .items="${this.grid2Items}"
           rows-draggable
-          drop-mode="on-grid"
+          .dropMode=${this.draggedItem ? 'on-grid' : undefined}
           @grid-dragstart="${this.startDraggingItem}"
           @grid-dragend="${this.clearDraggedItem}"
           @grid-drop="${() => {

--- a/frontend/demo/component/grid/grid-row-reordering.ts
+++ b/frontend/demo/component/grid/grid-row-reordering.ts
@@ -38,12 +38,12 @@ export class Example extends LitElement {
       <vaadin-grid
         .items="${this.items}"
         rows-draggable
-        drop-mode="between"
+        .dropMode=${this.draggedItem ? 'between' : undefined}
         @grid-dragstart="${(event: GridDragStartEvent<Person>) => {
           this.draggedItem = event.detail.draggedItems[0];
         }}"
         @grid-dragend="${() => {
-          delete this.draggedItem;
+          this.draggedItem = undefined;
         }}"
         @grid-drop="${(event: GridDropEvent<Person>) => {
           const { dropTargetItem, dropLocation } = event.detail;

--- a/frontend/demo/component/grid/react/grid-drag-drop-filters.tsx
+++ b/frontend/demo/component/grid/react/grid-drag-drop-filters.tsx
@@ -57,7 +57,7 @@ function Example() {
         expandedItems.value = event.detail.value;
       }}
       rowsDraggable
-      dropMode="on-top"
+      dropMode={draggedItem.value ? 'on-top' : undefined}
       onGridDragstart={(event) => {
         draggedItem.value = event.detail.draggedItems[0];
       }}

--- a/frontend/demo/component/grid/react/grid-drag-rows-between-grids.tsx
+++ b/frontend/demo/component/grid/react/grid-drag-rows-between-grids.tsx
@@ -48,7 +48,7 @@ function Example() {
       <Grid
         items={grid1Items.value}
         rowsDraggable
-        dropMode="on-grid"
+        dropMode={draggedItem.value ? 'on-grid' : undefined}
         style={gridStyle}
         onGridDragstart={startDraggingItem}
         onGridDragend={clearDraggedItem}
@@ -74,7 +74,7 @@ function Example() {
       <Grid
         items={grid2Items.value}
         rowsDraggable
-        dropMode="on-grid"
+        dropMode={draggedItem.value ? 'on-grid' : undefined}
         style={gridStyle}
         onGridDragstart={startDraggingItem}
         onGridDragend={clearDraggedItem}

--- a/frontend/demo/component/grid/react/grid-row-reordering.tsx
+++ b/frontend/demo/component/grid/react/grid-row-reordering.tsx
@@ -51,7 +51,7 @@ function Example() {
     <Grid
       items={items.value}
       rowsDraggable
-      dropMode="between"
+      dropMode={draggedItem.value ? 'between' : undefined}
       onGridDragstart={handleDragStart}
       onGridDragend={handleDragEnd}
       onGridDrop={handleDrop}

--- a/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java
@@ -41,16 +41,21 @@ public class GridDragDropFilters extends Div {
         TreeDataProvider<Person> treeDataProvider = new TreeDataProvider<>(
                 treeData);
         treeGrid.setDataProvider(treeDataProvider);
-
         treeGrid.setRowsDraggable(true);
-        treeGrid.setDropMode(GridDropMode.ON_TOP);
+        
         // Only allow dragging staff
         treeGrid.setDragFilter(person -> !person.isManager());
         // Only allow dropping on managers
         treeGrid.setDropFilter(person -> person.isManager());
 
         treeGrid.addDragStartListener(
-                e -> draggedItem = e.getDraggedItems().get(0));
+                e -> {
+                        treeGrid.setDropMode(GridDropMode.ON_TOP);
+                        draggedItem = e.getDraggedItems().get(0);
+                        // Workaound an issue with the filters not being applied
+                        // when the drop mode is changed dynamically
+                        treeGrid.getDataCommunicator().reset();
+                });
 
         treeGrid.addDropListener(e -> {
             Person newManager = e.getDropTargetItem().orElse(null);
@@ -66,7 +71,10 @@ public class GridDragDropFilters extends Div {
             treeDataProvider.refreshAll();
         });
 
-        treeGrid.addDragEndListener(e -> draggedItem = null);
+        treeGrid.addDragEndListener(e -> {
+                treeGrid.setDropMode(null);
+                draggedItem = null;
+        });
         // end::snippet[]
 
         add(treeGrid);

--- a/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java
@@ -52,7 +52,7 @@ public class GridDragDropFilters extends Div {
                 e -> {
                         treeGrid.setDropMode(GridDropMode.ON_TOP);
                         draggedItem = e.getDraggedItems().get(0);
-                        // Workaound https://github.com/vaadin/flow-components/issues/6310
+                        // Workaround https://github.com/vaadin/flow-components/issues/6310
                         treeGrid.getDataCommunicator().reset();
                 });
 

--- a/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridDragDropFilters.java
@@ -52,8 +52,7 @@ public class GridDragDropFilters extends Div {
                 e -> {
                         treeGrid.setDropMode(GridDropMode.ON_TOP);
                         draggedItem = e.getDraggedItems().get(0);
-                        // Workaound an issue with the filters not being applied
-                        // when the drop mode is changed dynamically
+                        // Workaound https://github.com/vaadin/flow-components/issues/6310
                         treeGrid.getDataCommunicator().reset();
                 });
 

--- a/src/main/java/com/vaadin/demo/component/grid/GridDragRowsBetweenGrids.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridDragRowsBetweenGrids.java
@@ -31,23 +31,37 @@ public class GridDragRowsBetweenGrids extends Div {
         GridListDataView<Person> dataView1 = grid1.setItems(people1);
         GridListDataView<Person> dataView2 = grid2.setItems(people2);
 
-        grid1.setDropMode(GridDropMode.ON_GRID);
         grid1.setRowsDraggable(true);
-        grid1.addDragStartListener(this::handleDragStart);
+        grid1.addDragStartListener(e -> {
+            draggedItem = e.getDraggedItems().get(0);
+            grid1.setDropMode(GridDropMode.ON_GRID);
+            grid2.setDropMode(GridDropMode.ON_GRID);
+        });
         grid1.addDropListener(e -> {
             dataView2.removeItem(draggedItem);
             dataView1.addItem(draggedItem);
         });
-        grid1.addDragEndListener(this::handleDragEnd);
+        grid1.addDragEndListener(e -> {
+            draggedItem = null;
+            grid1.setDropMode(null);
+            grid2.setDropMode(null);
+        });
 
-        grid2.setDropMode(GridDropMode.ON_GRID);
         grid2.setRowsDraggable(true);
-        grid2.addDragStartListener(this::handleDragStart);
+        grid2.addDragStartListener(e -> {
+            draggedItem = e.getDraggedItems().get(0);
+            grid1.setDropMode(GridDropMode.ON_GRID);
+            grid2.setDropMode(GridDropMode.ON_GRID);
+        });
         grid2.addDropListener(e -> {
             dataView1.removeItem(draggedItem);
             dataView2.addItem(draggedItem);
         });
-        grid2.addDragEndListener(this::handleDragEnd);
+        grid2.addDragEndListener(e -> {
+            draggedItem = null;
+            grid1.setDropMode(null);
+            grid2.setDropMode(null);
+        });
         // end::snippet[]
 
         Div container = new Div(grid1, grid2);
@@ -63,14 +77,6 @@ public class GridDragRowsBetweenGrids extends Div {
         setGridStyles(grid);
 
         return grid;
-    }
-
-    private void handleDragStart(GridDragStartEvent<Person> e) {
-        draggedItem = e.getDraggedItems().get(0);
-    }
-
-    private void handleDragEnd(GridDragEndEvent<Person> e) {
-        draggedItem = null;
     }
 
     private static void setGridStyles(Grid<Person> grid) {

--- a/src/main/java/com/vaadin/demo/component/grid/GridRowReordering.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridRowReordering.java
@@ -28,11 +28,13 @@ public class GridRowReordering extends Div {
         List<Person> people = new ArrayList<>(DataService.getPeople());
         GridListDataView<Person> dataView = grid.setItems(people);
 
-        grid.setDropMode(GridDropMode.BETWEEN);
         grid.setRowsDraggable(true);
 
         grid.addDragStartListener(
-                e -> draggedItem = e.getDraggedItems().get(0));
+                e -> {
+                    draggedItem = e.getDraggedItems().get(0);
+                    grid.setDropMode(GridDropMode.BETWEEN);
+                });
 
         grid.addDropListener(e -> {
             Person targetPerson = e.getDropTargetItem().orElse(null);
@@ -53,7 +55,10 @@ public class GridRowReordering extends Div {
             }
         });
 
-        grid.addDragEndListener(e -> draggedItem = null);
+        grid.addDragEndListener(e -> {
+            draggedItem = null;
+            grid.setDropMode(null);
+        });
         // end::snippet[]
 
         add(grid);


### PR DESCRIPTION
Currently, all the grids in the drag & drop examples section use static drop mode values. This means that the drop indicator is shown for them even while dragging unrelated things like text or rows from another example:

https://github.com/vaadin/docs/assets/1222264/f780e578-fe75-41af-b1ed-4ae7725f8753

This PR fixes the issue by updating the examples to dynamically apply the drop mode when a row drag starts and clear the drop mode when the row drag ends.

Related to https://github.com/vaadin/flow-components/issues/6306