### PR TITLE
Mention ViewConfig in related options reference

### DIFF
--- a/articles/hilla/guides/routing.adoc
+++ b/articles/hilla/guides/routing.adoc
@@ -259,9 +259,9 @@ export default function MainLayout() {
 ----
 ====
 
-=== Route Config Reference
+=== ViewConfig Options Reference
 
-Here are the options currently supported in the `config` object:
+Here are the options currently supported in the `config: ViewConfig` object:
 
 `title: string`::
   View title for use in the main layout header, in the browser window `document.title`, and as the default for the menu entry. If not defined, the component name will be taken, transformed from camelCase.


### PR DESCRIPTION
Makes it easier to find the reference section by searching for 'ViewConfig'


