### PR TITLE
fix typo in enabling-security article

### DIFF
--- a/articles/flow/security/enabling-security.adoc
+++ b/articles/flow/security/enabling-security.adoc
@@ -413,7 +413,7 @@ public class MyView extends VerticalLayout {
 
 If the user is already authenticated and tries to navigate to a view for which they don't have permission, an error message is displayed. The message depends on the application mode.
 
-In development mode, Vaadin shows the [classname]`RouteAccessDeniedError` view, which shows an _Access Denied_ message with a list of available routes. In production mode, Vaadin shows the [classname]`RouteAccessDeniedError` view, which shows by default a message that reads, _Could Not Vavigate to 'RequestedRouteName'_. As a security precaution, the message won't say whether the navigation target exists.
+In development mode, Vaadin shows the [classname]`RouteAccessDeniedError` view, which shows an _Access Denied_ message with a list of available routes. In production mode, Vaadin shows the [classname]`RouteAccessDeniedError` view, which shows by default a message that reads, _Could Not Navigate to 'RequestedRouteName'_. As a security precaution, the message won't say whether the navigation target exists.
 
 The [classname]`RouteAccessDeniedError` is not by default a view, but a reroute to the [classname]`RouteNotFoundError` view for better backwards compatibility.
 


### PR DESCRIPTION
change "Could Not Vavigate" to "Could Not Navigate"