### PR TITLE
fix: use specific commons-io version to fix spreadsheet examples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.13.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.13.0</version>
+                <version>2.16.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Use a specific commons-io version to fix spreadsheet examples

Note: This is to be revered later once a version required by poi installs without forcing the version in docs.