### PR TITLE
fix: add info on security behaviour change

### DIFF
--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -216,6 +216,18 @@ public class SecurityConfig extends VaadinWebSecurity {
 In this example, `AuthenticationManagerBuilder` -- used in Spring Boot 2 -- is replaced by `UserDetailsService`. Also, `http.authorizeRequests().antMatchers()` is replaced with `http.authorizeHttpRequests(auth -> auth.requestMatchers())`.
 
 
+=== Spring Security
+
+If the application is using Spring Security 5 the default behavior is for the SecurityContext to automatically be saved to the SecurityContextRepository using the SecurityContextPersistenceFilter.
+
+The update will move to Spring Security 6 where users now must explicitly save the SecurityContext with the SecurityContextRepository.
+
+The simple change to return old functionality is to add into [methodname]`configuration(HttpSecurity)` the line `http.securityContext((securityContext) -> securityContext.requireExplicitSave(false));`.
+This will return the old functionality.
+
+For more information see https://docs.spring.io/spring-security/reference/5.8/migration/servlet/session-management.html#_require_explicit_saving_of_securitycontextrepository[Servlet Migrations - Session Management]
+
+
 == Java Version
 
 Java 17 or later is required. Below is an example of how to use this version:


### PR DESCRIPTION
Add information on change in
SecurityContext storage when using
Spring Security 6 vs 5


