### PR TITLE
add --wait flag to control-center helm install command

### DIFF
--- a/articles/control-center/getting-started/index.adoc
+++ b/articles/control-center/getting-started/index.adoc
@@ -23,7 +23,8 @@ The process begins with deploying Control Center to your Kubernetes cluster. Thi
 helm install control-center oci://docker.io/vaadin/control-center \
     -n control-center --create-namespace \
     --set serviceAccount.clusterAdmin=true \
-    --set service.type=LoadBalancer --set service.port=8000
+    --set service.type=LoadBalancer --set service.port=8000 \
+    --wait
 ----
 
 This command does several things:
@@ -36,6 +37,7 @@ ensures that a dedicated namespace is created for Control Center, keeping it iso
 grants Control Center administrative privileges, allowing it to manage cluster resources, effectively;
 - `--set service.type=LoadBalancer --set service.port=8000`
 configures the service to use a load-balancer -- which is ideal for cloud deployments -- and sets the service port to 8000. This port works on a local cluster; otherwise, use whatever port connects to your cloud provider.
+- `--wait` tells Helm to wait until Control Center is ready.
 
 [NOTE]
 You don't have to grant Control Center administrative privileges on the cluster, but it'll allow automatic installation of required dependencies. Otherwise, you'll need to install any required resource, manually.


### PR DESCRIPTION
Add the `--wait` flag to the `helm install` command example of Control Center docs.

Fixes https://github.com/vaadin/control-center/issues/269.