### PR TITLE
docs: remove no longer needed class name from grid example

### DIFF
--- a/frontend/demo/component/grid/grid-styling.ts
+++ b/frontend/demo/component/grid/grid-styling.ts
@@ -40,12 +40,7 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-grid
-        .items="${this.items}"
-        .cellPartNameGenerator="${this.cellPartNameGenerator}"
-        class="styling"
-      >
-        <vaadin-grid-column path="firstName"></vaadin-grid-column>
+      <vaadin-grid .items="${this.items}" .cellPartNameGenerator="${this.cellPartNameGenerator}">
         <vaadin-grid-column path="lastName"></vaadin-grid-column>
         <vaadin-grid-column path="profession"></vaadin-grid-column>
         <vaadin-grid-column

--- a/frontend/demo/component/grid/react/grid-styling.tsx
+++ b/frontend/demo/component/grid/react/grid-styling.tsx
@@ -53,7 +53,7 @@ function Example() {
   }, []);
 
   return (
-    <Grid items={items.value} cellPartNameGenerator={cellPartNameGenerator} className="styling">
+    <Grid items={items.value} cellPartNameGenerator={cellPartNameGenerator}>
       <GridColumn path="firstName" />
       <GridColumn path="lastName" />
       <GridColumn path="profession" />

--- a/frontend/themes/docs/grid-styling.css
+++ b/frontend/themes/docs/grid-styling.css
@@ -1,18 +1,14 @@
 /* Add this to your global CSS, for example in: */
 /* frontend/theme/[my-theme]/styles.css */
 
-vaadin-grid.styling::part(high-rating) {
+vaadin-grid::part(high-rating) {
     background-color: var(--lumo-success-color-10pct);
 }
 
-vaadin-grid.styling::part(low-rating) {
+vaadin-grid::part(low-rating) {
     background-color: var(--lumo-error-color-10pct);
 }
 
-vaadin-grid.styling::part(loading-row-cell) {
-    background-color: var(--lumo-base-color);
-}
-
-vaadin-grid.styling::part(font-weight-bold) {
+vaadin-grid::part(font-weight-bold) {
     font-weight: bold;
 }

--- a/src/main/java/com/vaadin/demo/component/grid/GridStyling.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridStyling.java
@@ -15,7 +15,6 @@ public class GridStyling extends Div {
     public GridStyling() {
         // tag::snippet[]
         Grid<PersonWithRating> grid = new Grid<>(PersonWithRating.class, false);
-        grid.addClassName("styling");
         grid.addColumn(PersonWithRating::getFirstName).setHeader("First name");
         grid.addColumn(PersonWithRating::getLastName).setHeader("Last name");
         grid.addColumn(PersonWithRating::getProfession).setHeader("Profession");


### PR DESCRIPTION
Fixes #3442

This essentially reverts #2866 as the related issue https://github.com/vaadin/web-components/issues/7447 is now fixed.