### PR TITLE
chore: format demo exporter lines for Java examples

### DIFF
--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutVerticalAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutVerticalAlignment.java
@@ -23,8 +23,8 @@ public class BasicLayoutsVerticalLayoutVerticalAlignment extends Div {
         layout.setClassName("height-4xl");
         this.add(layout);
     }
-    
+
     public static class Exporter extends // hidden-source-line
-        DemoExporter<BasicLayoutsVerticalLayoutVerticalAlignment> { // hidden-source-line
+            DemoExporter<BasicLayoutsVerticalLayoutVerticalAlignment> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSplineRange.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSplineRange.java
@@ -268,6 +268,7 @@ public class ChartTypeAreaSplineRange extends Div {
                 { 1262221200000d, -12.2, -6.5 } };
     }
 
-    public static class Exporter extends DemoExporter<ChartTypeAreaSplineRange> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ChartTypeAreaSplineRange> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBasicFeatures.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxGroupBasicFeatures.java
@@ -27,6 +27,7 @@ public class CheckboxGroupBasicFeatures extends VerticalLayout {
         add(checkbox, field);
     }
 
-    public static class Exporter extends DemoExporter<CheckboxGroupBasicFeatures> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<CheckboxGroupBasicFeatures> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxReadonlyAndDisabled.java
@@ -25,6 +25,7 @@ public class ComboBoxReadonlyAndDisabled extends HorizontalLayout {
         add(readonlyField, disabledField);
     }
 
-    public static class Exporter extends DemoExporter<ComboBoxReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<ComboBoxReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerReadonlyAndDisabled.java
@@ -27,6 +27,7 @@ public class DatePickerReadonlyAndDisabled extends HorizontalLayout {
         add(readonlyField, disabledField);
     }
 
-    public static class Exporter extends DemoExporter<DatePickerReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DatePickerReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerBasicFeatures.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerBasicFeatures.java
@@ -23,6 +23,7 @@ public class DateTimePickerBasicFeatures extends HorizontalLayout {
         add(field);
     }
 
-    public static class Exporter extends DemoExporter<DateTimePickerBasicFeatures> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerBasicFeatures> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerReadonlyAndDisabled.java
@@ -27,6 +27,7 @@ public class DateTimePickerReadonlyAndDisabled extends VerticalLayout {
         add(readonlyField, disabledField);
     }
 
-    public static class Exporter extends DemoExporter<DateTimePickerReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldReadonlyAndDisabled.java
@@ -24,6 +24,7 @@ public class EmailFieldReadonlyAndDisabled extends HorizontalLayout {
         add(readonlyField, disabledField);
     }
 
-    public static class Exporter extends DemoExporter<EmailFieldReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<EmailFieldReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginOverlayCustomFormArea.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginOverlayCustomFormArea.java
@@ -23,6 +23,7 @@ public class LoginOverlayCustomFormArea extends Div {
         loginOverlay.getElement().setAttribute("no-autofocus", "");
     }
 
-    public static class Exporter extends DemoExporter<LoginOverlayCustomFormArea> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<LoginOverlayCustomFormArea> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldBasicFeatures.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldBasicFeatures.java
@@ -27,6 +27,7 @@ public class NumberFieldBasicFeatures extends HorizontalLayout {
         add(field);
     }
 
-    public static class Exporter extends DemoExporter<NumberFieldBasicFeatures> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<NumberFieldBasicFeatures> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldReadonlyAndDisabled.java
@@ -24,6 +24,7 @@ public class NumberFieldReadonlyAndDisabled extends HorizontalLayout {
         add(readonlyField, disabledField);
     }
 
-    public static class Exporter extends DemoExporter<NumberFieldReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<NumberFieldReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldBasicFeatures.java
+++ b/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldBasicFeatures.java
@@ -25,6 +25,7 @@ public class PasswordFieldBasicFeatures extends HorizontalLayout {
         add(field);
     }
 
-    public static class Exporter extends DemoExporter<PasswordFieldBasicFeatures> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<PasswordFieldBasicFeatures> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldConstraints.java
+++ b/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldConstraints.java
@@ -23,6 +23,7 @@ public class PasswordFieldConstraints extends HorizontalLayout {
         add(field);
     }
 
-    public static class Exporter extends DemoExporter<PasswordFieldConstraints> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<PasswordFieldConstraints> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldReadonlyAndDisabled.java
@@ -24,6 +24,7 @@ public class PasswordFieldReadonlyAndDisabled extends HorizontalLayout {
         add(readonlyField, disabledField);
     }
 
-    public static class Exporter extends DemoExporter<PasswordFieldReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<PasswordFieldReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupBasicFeatures.java
+++ b/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonGroupBasicFeatures.java
@@ -22,6 +22,7 @@ public class RadioButtonGroupBasicFeatures extends HorizontalLayout {
         add(field);
     }
 
-    public static class Exporter extends DemoExporter<RadioButtonGroupBasicFeatures> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<RadioButtonGroupBasicFeatures> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/select/SelectReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectReadonlyAndDisabled.java
@@ -20,7 +20,7 @@ public class SelectReadonlyAndDisabled extends HorizontalLayout {
                 "Rating: low to high", "Price: high to low",
                 "Price: low to high");
         readonlyField.setValue("Most recent first");
-        
+
         // tag::snippet[]
         Select<String> disabledField = new Select<>();
         disabledField.setEnabled(false);
@@ -29,6 +29,7 @@ public class SelectReadonlyAndDisabled extends HorizontalLayout {
         add(readonlyField, disabledField);
     }
 
-    public static class Exporter extends DemoExporter<SelectReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<SelectReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/textarea/TextAreaReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/textarea/TextAreaReadonlyAndDisabled.java
@@ -26,6 +26,7 @@ public class TextAreaReadonlyAndDisabled extends HorizontalLayout {
         add(readonlyArea, disabledArea);
     }
 
-    public static class Exporter extends DemoExporter<TextAreaReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<TextAreaReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/textfield/TextFieldReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/textfield/TextFieldReadonlyAndDisabled.java
@@ -24,6 +24,7 @@ public class TextFieldReadonlyAndDisabled extends HorizontalLayout {
         add(readonlyField, disabledField);
     }
 
-    public static class Exporter extends DemoExporter<TextFieldReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<TextFieldReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/timepicker/TimePickerReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/timepicker/TimePickerReadonlyAndDisabled.java
@@ -27,6 +27,7 @@ public class TimePickerReadonlyAndDisabled extends HorizontalLayout {
         add(readonlyField, disabledField);
     }
 
-    public static class Exporter extends DemoExporter<TimePickerReadonlyAndDisabled> { // hidden-source-line
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<TimePickerReadonlyAndDisabled> { // hidden-source-line
     } // hidden-source-line
 }


### PR DESCRIPTION
Found these after running `mvn formatter:format` and extracted to separate PR to make the one about formatting smaller.