### PR TITLE
chore: fix some typos and trailing spaces in articles

### DIFF
--- a/articles/flow/configuration/feature-flags.adoc
+++ b/articles/flow/configuration/feature-flags.adoc
@@ -47,7 +47,7 @@ When finished, restart the application for your changes to take effect.
 
 As mentioned, you can also manage feature flags by editing the properties file. To do so by this method, edit the [filename]`src/main/resources/vaadin-featureflags.properties` file in your application folder -- or create the file if it doesn't already exist.
 
-When you have that file open, sadd a line for each feature in the format of `com.vaadin.experimental.<FEATURE_NAME>=true`. Here's an example of how this might look:
+When you have that file open, add a line for each feature in the format of `com.vaadin.experimental.<FEATURE_NAME>=true`. Here's an example of how this might look:
 
 +
 .`vaadin-featureflags.properties`

--- a/articles/flow/integrations/quarkus.adoc
+++ b/articles/flow/integrations/quarkus.adoc
@@ -184,7 +184,7 @@ public class MainView extends VerticalLayout {
 
 The problem is that by default, Vaadin's Quarkus extension would spin a `QuarkusVaadinServlet` instance that expects every call to the root (`/`) of your Quarkus app to go through it. If there is even a single `@Path("/")` annotation anywhere in the app's code, it may effectively "shadow" the access to the servlet.
 
-To solve that, you need to either remove the `@Path("/")` annotations if possible (may be impossible if those serve the index page of your site alredy, for instance), or create a custom instance of `QuarkusVaadinServlet` that would take place instead of the default one:
+To solve that, you need to either remove the `@Path("/")` annotations if possible (may be impossible if those serve the index page of your site already, for instance), or create a custom instance of `QuarkusVaadinServlet` that would take place instead of the default one:
 
 ```java
 @WebServlet(urlPatterns = "/admin/*", name = "AdminServlet", asyncSupported = true)

--- a/articles/flow/security/advanced-topics/vulnerabilities.adoc
+++ b/articles/flow/security/advanced-topics/vulnerabilities.adoc
@@ -1,6 +1,6 @@
 ---
 title: Common Vulnerabilities
-description: Desriptions of common vulnerabilities (e.g., SQL injections, cross-site request forgeries, cross-site scripting).
+description: Descriptions of common vulnerabilities (e.g., SQL injections, cross-site request forgeries, cross-site scripting).
 order: 30
 ---
 

--- a/articles/flow/testing/end-to-end/page-objects.adoc
+++ b/articles/flow/testing/end-to-end/page-objects.adoc
@@ -1,6 +1,6 @@
 ---
 title: Tests with Page Objects
-description: Ceating maintainable tests using Page Objects.
+description: Creating maintainable tests using Page Objects.
 order: 50
 ---
 

--- a/articles/flow/tutorial/e2e-testing-with-testbench.adoc
+++ b/articles/flow/tutorial/e2e-testing-with-testbench.adoc
@@ -146,7 +146,7 @@ Adding the `@Attribute(name = "class", contains = "login-view")` annotation allo
 LoginViewElement loginView = $(LoginViewElement.class).onPage().first();
 ----
 
-The annotation searches for the `login-view` CSS class name, which is set for the [classname]`LoginLiew` in the constructor. The [methodname]`onPage()` call ensures that the whole page is searched. By default, a `$` query starts from the active element.
+The annotation searches for the `login-view` CSS class name, which is set for the [classname]`LoginView` in the constructor. The [methodname]`onPage()` call ensures that the whole page is searched. By default, a `$` query starts from the active element.
 
 Now that you have the [classname]`LoginViewElement` class, you can simplify your [methodname]`loginAsValidUserSucceeds()` test to be this:
 

--- a/articles/flow/tutorial/production-deployment.adoc
+++ b/articles/flow/tutorial/production-deployment.adoc
@@ -45,7 +45,7 @@ To use Azure Container Apps, you'll need to do the following:
 - Install https://learn.microsoft.com/cli/azure/install-azure-cli[Azure CLI] or make sure you have it up-to-date with `az upgrade`.
 - Log into https://azure.microsoft.com[Azure] using a browser and make sure you have an active Azure subscription. Use Start Free Trial, if you don't have an existing one.
 
-From the commmand-line, login using Azure CLI like so:
+From the command-line, login using Azure CLI like so:
 
 [source,bash]
 ----

--- a/articles/getting-started/tutorial/deployment.adoc
+++ b/articles/getting-started/tutorial/deployment.adoc
@@ -62,7 +62,7 @@ It will then ask if you want to create a [filename]`.dockerignore` file. Again, 
 
 Once the deployment is finished, the tool will give you the URL at which the application can be visited. Try it out!
 
-Remember to delete the app when you no longer need it to avoid unneccessary charges on your credit card:
+Remember to delete the app when you no longer need it to avoid unnecessary charges on your credit card:
 
 [source,terminal]
 ----

--- a/articles/getting-started/tutorial/flow/second-view.adoc
+++ b/articles/getting-started/tutorial/flow/second-view.adoc
@@ -7,7 +7,7 @@ order: 20
 
 = [since:com.vaadin:vaadin@V24.4]#Second View#
 
-To be able to use a chat channel in the example developed in this tutorial, users have to know the channel's UUID. This isn't very user friendly. To remedy this, this page explains how to build a second view that will allow users to see a list of available channels from which to select. 
+To be able to use a chat channel in the example developed in this tutorial, users have to know the channel's UUID. This isn't very user friendly. To remedy this, this page explains how to build a second view that will allow users to see a list of available channels from which to select.
 
 Once finished, the view will contain some necessary user interface components and should look like this:
 
@@ -114,7 +114,7 @@ Now, whenever the view is attached to the UI, it will fetch the channels from [c
 
 === Add New Channel
 
-The next task in preparing the view for user interaction is to add a method for adding a new channel.  
+The next task in preparing the view for user interaction is to add a method for adding a new channel.
 
 // RUSSELL: A short sentence saying what the user is doing here would be helpful, in addition to the details that follow.
 
@@ -155,7 +155,7 @@ private Component createChannelComponent(Channel channel) {
     return new RouterLink(channel.name(), ChannelView.class, channel.id());
 }
 ----
-This will create a link with the channel's name. When clicked, it will naviagate to the channel view and pass the channel's ID as a URL parameter.
+This will create a link with the channel's name. When clicked, it will navigate to the channel view and pass the channel's ID as a URL parameter.
 
 Finally, you enable the renderer by adding this line to the [classname]`LobbyView` constructor, just after [fieldname]`channels` has been created:
 

--- a/articles/getting-started/tutorial/flow/ux-tweaks.adoc
+++ b/articles/getting-started/tutorial/flow/ux-tweaks.adoc
@@ -93,7 +93,7 @@ This sounds more complicated than it is to implement. The implementation consist
 
 - Create a new Spring [annotationname]`@Configuration` class.
 - Inside this class, declare a new bean that implements [interfacename]`VaadinServiceInitListener`.
-- Use lambas to implement both [interfacename]`VaadinServiceInitListener` and [interfacename]`SessionInitListener`.
+- Use lambdas to implement both [interfacename]`VaadinServiceInitListener` and [interfacename]`SessionInitListener`.
 
 Create a new class called [classname]`CustomErrorHandlerConfig` inside the [packagename]`com.example.application.views` package like this:
 

--- a/articles/getting-started/tutorial/hilla/first-view.adoc
+++ b/articles/getting-started/tutorial/hilla/first-view.adoc
@@ -113,7 +113,7 @@ image::images/channel_view_without_styles.png[A web application with an input fi
 The screenshot above does not look like the screenshot in the beginning of this article. This is because all the components have their default sizes:
 
 * The vertical layout's width is 100% and its height is determined by the size of its children.
-* The message list is empty, which gives it a height of zero, effecitvely rendering it invisible.
+* The message list is empty, which gives it a height of zero, effectively rendering it invisible.
 * The message input is just big enough to show the text field and button inside it.
 
 You have to add CSS styles to change the sizes of the components. There are different ways of doing this, but in this case, you are going to use CSS utility classes provided by the Vaadin Lumo theme.

--- a/articles/getting-started/tutorial/hilla/layout.adoc
+++ b/articles/getting-started/tutorial/hilla/layout.adoc
@@ -137,7 +137,7 @@ You can find more information about the side navigation in the <<{articles}/comp
 
 === Add View Title
 
-At the start of this page, you learned that the navbar is going to be used for the view title in this tutorial. You are now going to add that. You could get the view title from Hilla, but that would only work for view titles that are static (i.e. they never change once declared). In this tutorial, the channel view uses dynamic titles that change dependning on which channel ID you have passed in as a URL parameter.
+At the start of this page, you learned that the navbar is going to be used for the view title in this tutorial. You are now going to add that. You could get the view title from Hilla, but that would only work for view titles that are static (i.e. they never change once declared). In this tutorial, the channel view uses dynamic titles that change depending on which channel ID you have passed in as a URL parameter.
 
 To handle this situation, you have to declare a signal that will contain the current view title. Add the following to [filename]`@layout.tsx`:
 
@@ -152,7 +152,7 @@ effect(() => {
     document.title = pageTitle.value // <2>
 })
 
-export defualt function MainLayout() {
+export default function MainLayout() {
     ...
 }
 ----

--- a/articles/getting-started/tutorial/hilla/message-history.adoc
+++ b/articles/getting-started/tutorial/hilla/message-history.adoc
@@ -16,7 +16,7 @@ Always set an upper limit on all backend queries. Unless you know a query will r
 
 == Function for Receiving Messages
 
-The first step for being able to provide message history to the user is to create a new function that will be called whenver a new batch of messages are received from the server. It does not matter if the messages are coming from the message history or the live stream, they will be treated in the same way: sort the messages according to a sequence number provided by the server, remove any duplicates by comparing the message IDs (also provided by the server) and remove the oldest messages if the total number of messages exceeds the limit.
+The first step for being able to provide message history to the user is to create a new function that will be called whenever a new batch of messages are received from the server. It does not matter if the messages are coming from the message history or the live stream, they will be treated in the same way: sort the messages according to a sequence number provided by the server, remove any duplicates by comparing the message IDs (also provided by the server) and remove the oldest messages if the total number of messages exceeds the limit.
 
 Open [filename]`views/channel/{channelId}/@index.tsx` and add the following:
 
@@ -82,7 +82,7 @@ export default function ChannelView() {
 ----
 <1> Instead of manipulating the [variablename]`messages` signal directly, you're now calling [functionname]`receiveMessages()` when new messages arrive over the live stream.
 <2> This line fetches the 20 (`HISTORY_SIZE`) latest messages from the server. You'll address the third `undefined` parameter later in this tutorial.
-<3> This line calles [functionname]`receiveMessages()` as soon as the message history arrives from the server.
+<3> This line calls [functionname]`receiveMessages()` as soon as the message history arrives from the server.
 
 You can now try the new functionality. In your web browser, open any channel and post 20 messages (you can number them from 1 to 20). They should all show up in the window. Then post another message. The oldest message (the first) should now have disappeared from the window. As you keep posting messages, the older messages are disappearing to make sure there are always at most 20 messages visible.
 

--- a/articles/getting-started/tutorial/hilla/reconnects.adoc
+++ b/articles/getting-started/tutorial/hilla/reconnects.adoc
@@ -14,7 +14,7 @@ In a Hilla/React application, things are different. Since the user interface is 
 
 ## Detect Issue
 
-Under the hood, the live stream is a websocket connection established for you by Vaadin. Unfortunately, at the moment, Vaadin does not provide a good API for detecing and handling disconnects and reconnects. Fortunately, there is a workaround that you can apply.
+Under the hood, the live stream is a websocket connection established for you by Vaadin. Unfortunately, at the moment, Vaadin does not provide a good API for detecting and handling disconnects and reconnects. Fortunately, there is a workaround that you can apply.
 
 In your IDE, create a new directory [directoryname]`src/main/frontend/util` and inside it, a new file called [filename]`ConnectionUtil.ts`. Then copy-paste the following code into it:
 
@@ -76,7 +76,7 @@ While online, open any channel and post some messages. Then go offline. Try to p
 
 The chat application will now reconnect to the server when the browser comes back online. But what about any messages received while the browser was offline? Because of the way you implemented fetching the <<message-history#,message history>>, you have actually already covered this part! Whenever you go back online, you call the [functionname]`subscribe()` function and that function fetches the message history. However, there is one small improvement that you can do.
 
-Recall that you are only keeping the 20 last messages. Refetching the entire message history is not a big deal in this case. But what if you kept a lot more messages than that? Woudln't it be better to only fetch the messages that arrived while the browser was offline? Because this tutorial - simple as it may be - is teaching you to write real-world applications, you're going to do just that.
+Recall that you are only keeping the 20 last messages. Refetching the entire message history is not a big deal in this case. But what if you kept a lot more messages than that? Wouldn't it be better to only fetch the messages that arrived while the browser was offline? Because this tutorial - simple as it may be - is teaching you to write real-world applications, you're going to do just that.
 
 The Chat Service already has support the functionality you want: if you pass in the ID of the last message you have seen, you will only get the messages that have been posted _after_ that message. All you need to do is to get this parameter and pass it on to the server. Look up the [functionname]`subscribe()` function and make the following changes:
 

--- a/articles/getting-started/tutorial/hilla/second-view.adoc
+++ b/articles/getting-started/tutorial/hilla/second-view.adoc
@@ -46,7 +46,7 @@ If you now navigate to http://localhost:8080/ in your browser, the view looks li
 
 image::images/lobby_view_without_styles.png[]
 
-The view looks broken. You are going to fix this next, by using the CSS utiltiy classes from the Lumo theme (you also used them to style the channel view). Update the lobby view like this:
+The view looks broken. You are going to fix this next, by using the CSS utility classes from the Lumo theme (you also used them to style the channel view). Update the lobby view like this:
 
 .@index.tsx
 [source,tsx]
@@ -154,7 +154,7 @@ export default function LobbyView() {
 }
 ----
 
-If you now look at the browser, the list does not contain any channels at all. The reason for this is that you have not yet specified a renderer for the virutal list to use when it renders items. The renderer is a function that takes an object as the input parameter and returns a React node. One property of this input object is the [propertyname]`item` property, which refers to the item being rendered - or in this case, the channel being rendered.
+If you now look at the browser, the list does not contain any channels at all. The reason for this is that you have not yet specified a renderer for the virtual list to use when it renders items. The renderer is a function that takes an object as the input parameter and returns a React node. One property of this input object is the [propertyname]`item` property, which refers to the item being rendered - or in this case, the channel being rendered.
 
 You are now going to add a simple renderer to the virtual list. It will render a simple link for every channel in the list. When the user clicks a link, the browser navigates to the corresponding channel view. Change the lobby view like this:
 

--- a/articles/getting-started/tutorial/index.adoc
+++ b/articles/getting-started/tutorial/index.adoc
@@ -18,7 +18,7 @@ For understanding and getting the most from the Hilla part of this tutorial, in 
 
 == Learning Tasks & Concepts
 
-In this tutorial, which is spread over several pages here, you'll build a simple application and deploy it. The same application will be developed in both Flow and Hilla. For each, it'll be a chat application, using the same backend -- demonstrating the similarities and differences. The results will look and behave the same, but will be implemented differently, from a different development prospective. 
+In this tutorial, which is spread over several pages here, you'll build a simple application and deploy it. The same application will be developed in both Flow and Hilla. For each, it'll be a chat application, using the same backend -- demonstrating the similarities and differences. The results will look and behave the same, but will be implemented differently, from a different development prospective.
 
 The finished application will look like what you see in this screenshot:
 
@@ -35,9 +35,9 @@ As for tools, you'll use a web browser, Maven, and a Java IDE of your choice (e.
 
 == Key Concepts
 
-Several concepts key for Vaadin will be explored and higlighted in this tutorial: views, routing, layout, server push, backend integration, and security. 
+Several concepts key for Vaadin will be explored and highlighted in this tutorial: views, routing, layout, server push, backend integration, and security.
 
-View:: 
+View::
 A view is an application's user interface page, or rather a composite of text, images, interactive components, and other elements the user may view and with which the user may interact. It typically fills up an entire browser tab, or a big portion of it.
 
 Routing::

--- a/articles/getting-started/tutorial/production-build.adoc
+++ b/articles/getting-started/tutorial/production-build.adoc
@@ -12,7 +12,7 @@ Up to this point, you've been running the application in development mode. As yo
 
 == Maven Plugin Configuration
 
-In a Vaadin application, you'd use the Vaadin maven plugin to make a production build. Typically, this is done by activating the `production` profile, like this: 
+In a Vaadin application, you'd use the Vaadin maven plugin to make a production build. Typically, this is done by activating the `production` profile, like this:
 
 [source,terminal]
 ----
@@ -28,7 +28,7 @@ If you open the [filename]`pom.xml` file, you'll find the following:
 [source,xml]
 ----
 <profiles>
-    <profile>    
+    <profile>
         <id>production</id> <!--1-->
         <dependencies>
             <dependency>
@@ -72,7 +72,7 @@ You can find more information about production builds in the Flow documentation 
 
 == Try It!
 
-You can now make your first production build of your application. Run the followig command to start the build:
+You can now make your first production build of your application. Run the following command to start the build:
 
 [source,terminal]
 ----

--- a/articles/getting-started/tutorial/project-setup.adoc
+++ b/articles/getting-started/tutorial/project-setup.adoc
@@ -10,7 +10,7 @@ In this tutorial, you can choose to implement the user interface of the chat app
 
 In a Vaadin application, things are a little different. Flow allows you to write user interfaces using Java only. That means a big part of your user interface is actually running on the server -- the backend. There's also a frontend runtime, but you don't have to touch it unless you want.
 
-Hilla follows the more traditional approach in which the user interface runs solely in the browser. The following graphic illustrates this differece:
+Hilla follows the more traditional approach in which the user interface runs solely in the browser. The following graphic illustrates this difference:
 
 image::images/hilla_and_flow_uis.png[]
 

--- a/articles/hilla/guides/routing.adoc
+++ b/articles/hilla/guides/routing.adoc
@@ -116,7 +116,7 @@ The file name part following the three dots (as in, for example, `{pass:[...]nam
 
 == Adding Layout Routes
 
-Layouts are special view components that wrap around other views. It is common for applications to have at least one layout: the main layout that renders the toolbar, the main manu, and similar functionality.
+Layouts are special view components that wrap around other views. It is common for applications to have at least one layout: the main layout that renders the toolbar, the main menu, and similar functionality.
 
 For adding a layout, create a view file named `@layout.tsx` in the views directory, and render the `<Outlet/>` in the component. You can also use the <</components/app-layout#,`App Layout`>> component to add common application layout parts.
 
@@ -206,7 +206,7 @@ To customize the route to a route, in your view source file, export an object na
 ----
 import { ViewConfig } from "@vaadin/hilla-file-router/types.js";
 
-export default fuction AboutView() {
+export default function AboutView() {
   return (
     /* ... */
   );

--- a/articles/hilla/lit/guides/forms/vaadin-components.adoc
+++ b/articles/hilla/lit/guides/forms/vaadin-components.adoc
@@ -312,7 +312,7 @@ Hilla has several components for selection based on option lists, each one cover
 
 Options for these components can be set by calling a server-side service that provides the list of strings. Since the call to the endpoint is asynchronous, one easy way is to
 ifdef::hilla-react[]
-use the Typescript [mathodname]`map` on the list received from the endpoints.
+use the Typescript [methodname]`map` on the list received from the endpoints.
 endif::hilla-react[]
 ifdef::hilla-lit[]
 combine the [methodname]`until()` and [methodname]`repeat()` methods from the Lit library.

--- a/articles/hilla/lit/guides/upgrading/index.adoc
+++ b/articles/hilla/lit/guides/upgrading/index.adoc
@@ -262,7 +262,7 @@ In case you've used Hilla CRUD helpers (e.g., AutoCRUD, AutoGrid, and AutoForm),
 
 Starting from Vaadin 24.4, the [methodname]`login()` and [methodname]`logout()` Hilla authentication methods automatically reload the page upon successful result from the server. Applications involving client-side handling of successful result, for example, for user info retrieval and offline storage, need to use the [methodname]`onSuccess()` callback instead of awaiting the [classname]`Promise` result.
 
-You can check if your application relies on the authentication result by searching for the ` [methodname]`login()` and [methodname]`logout()` in TypeScript source files. Move any code that depends on the successful result to the [methodname]`onSucces()` callback:
+You can check if your application relies on the authentication result by searching for the [methodname]`login()` and [methodname]`logout()` in TypeScript source files. Move any code that depends on the successful result to the [methodname]`onSuccess()` callback:
 
 [source,diff]
 .`frontend/auth.ts`

--- a/articles/tools/observability/customization.adoc
+++ b/articles/tools/observability/customization.adoc
@@ -54,7 +54,7 @@ public class ImageListView {
 }
 ----
 
-Method parameters can be added as attributes to the span by using the [annotationname]`@SpanAttibute` annotation like so:
+Method parameters can be added as attributes to the span by using the [annotationname]`@SpanAttribute` annotation like so:
 
 .Store Fetch URL as Annotation
 [source,java]


### PR DESCRIPTION
Run `cspell` and fixed a few typos that it reported (also auto-fixed trailing spaces by VSCode).