### PR TITLE
fix: use correct class for basic layouts DemoExporter

### DIFF
--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
@@ -7,7 +7,7 @@ import '@vaadin/radio-group';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/horizontal-layout';
 
-@customElement('basic-layouts-margin')
+@customElement('basic-layouts-horizontal-layout-margin')
 export class Example extends LitElement {
   connectedCallback() {
     super.connectedCallback();

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
@@ -7,7 +7,7 @@ import '@vaadin/radio-group';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/horizontal-layout';
 
-@customElement('basic-layouts-padding')
+@customElement('basic-layouts-horizontal-layout-padding')
 export class Example extends LitElement {
   connectedCallback() {
     super.connectedCallback();

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
@@ -7,7 +7,7 @@ import '@vaadin/radio-group';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/horizontal-layout';
 
-@customElement('basic-layouts-spacing-variants')
+@customElement('basic-layouts-horizontal-layout-spacing-variants')
 export class Example extends LitElement {
   connectedCallback() {
     super.connectedCallback();

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
@@ -7,7 +7,7 @@ import '@vaadin/radio-group';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/horizontal-layout';
 
-@customElement('basic-layouts-spacing')
+@customElement('basic-layouts-horizontal-layout-spacing')
 export class Example extends LitElement {
   connectedCallback() {
     super.connectedCallback();

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutMargin.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutMargin.java
@@ -43,6 +43,6 @@ public class BasicLayoutsHorizontalLayoutMargin extends Div {
     }
 
     public static class Exporter // hidden-source-line
-            extends DemoExporter<BasicLayoutsMargin> { // hidden-source-line
+            extends DemoExporter<BasicLayoutsHorizontalLayoutMargin> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutPadding.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutPadding.java
@@ -36,6 +36,6 @@ public class BasicLayoutsHorizontalLayoutPadding extends Div {
     }
 
     public static class Exporter // hidden-source-line
-            extends DemoExporter<BasicLayoutsPadding> { // hidden-source-line
+            extends DemoExporter<BasicLayoutsHorizontalLayoutPadding> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacing.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacing.java
@@ -36,6 +36,6 @@ public class BasicLayoutsHorizontalLayoutSpacing extends Div {
     }
 
     public static class Exporter // hidden-source-line
-            extends DemoExporter<BasicLayoutsSpacing> { // hidden-source-line
+            extends DemoExporter<BasicLayoutsHorizontalLayoutSpacing> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacingVariants.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacingVariants.java
@@ -43,6 +43,6 @@ public class BasicLayoutsHorizontalLayoutSpacingVariants extends Div {
     }
 
     public static class Exporter extends // hidden-source-line
-            DemoExporter<BasicLayoutsSpacingVariants> { // hidden-source-line
+            DemoExporter<BasicLayoutsHorizontalLayoutSpacingVariants> { // hidden-source-line
     } // hidden-source-line
 }


### PR DESCRIPTION
Fixes #3551

Updated incorrect classes passed to `DemoExporter`. Also updated `@customElement` accordingly.
These examples had this problem since adding them in 38467a301bc744b223019d47f8540cccba6f93d0