### PR TITLE
refactor: remove unnecessary setInvalid call

### DIFF
--- a/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldBasic.java
+++ b/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldBasic.java
@@ -25,7 +25,6 @@ public class EmailFieldBasic extends HorizontalLayout {
         invalidEmailField.setValue("This is not an email");
         invalidEmailField.setErrorMessage("Enter a valid email address");
         invalidEmailField.setClearButtonVisible(true);
-        invalidEmailField.setInvalid(true);
 
         add(validEmailField, invalidEmailField);
         // end::snippet[]


### PR DESCRIPTION
The manual `setInvalid` call is unnecessary, as setting an invalid email already makes the component invalid.