### PR TITLE
feat: push-/replaceState with server callback

### DIFF
--- a/articles/flow/advanced/history-api.adoc
+++ b/articles/flow/advanced/history-api.adoc
@@ -82,5 +82,12 @@ Otherwise, browser throws an exception and the history isn't updated.
 [NOTE]
 If you use either [methodname]`pushState()` or [methodname]`replaceState()`, the framework internal scroll position restoration on navigation doesn't work, since it stores data in the `history.state` to keep track of the scroll position.
 
+For cases where the new pushed/replaced url is wanted to be available on the server there are overloaded methods with the `callback` boolean.
+Having the callback as `true` will generate a history event to the server when doing a [methodname]`pushState` or [methodname]`replaceState`.
+
+This could be wanted for instance when changing query parameters so then the server would get updated without the need to get the url from the client by using [methodname]`fetchCurrentURL` in [classname]`Page`.
+
+[NOTE]
+Callback only works when using the react-router.
 
 [discussion-id]`CDD7DD56-9749-4F4C-9126-9C984B65B066`


### PR DESCRIPTION
Add note about making a pushState
or replaceState so that it creates
a server history state change event
when using the react-router.

documents vaadin/flow#19736


