### PR TITLE
Document to reduce start up time with JRebel Debug Mode in latest Vaadin versions

### DIFF
--- a/.github/workflows/alex.yml
+++ b/.github/workflows/alex.yml
@@ -1,0 +1,16 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  alex:
+    name: runner / alex
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-alex@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
+          reporter: github-pr-review
+          # Change reporter level if you need.
+          # GitHub Status Check won't become failure with warning.
+          level: warning

--- a/articles/flow/configuration/live-reload/jrebel.adoc
+++ b/articles/flow/configuration/live-reload/jrebel.adoc
@@ -21,6 +21,13 @@ Use at least the `2020.2.1` version, which contains built-in live reload integra
 
 When using the Jetty Maven plugin together with JRebel, ensure that automatic restart is disabled (omit or set `<scanIntervalSeconds>` to a value of `0` or less).
 
+== Troubleshooting Startup Delays with JRebel
+This step can be followed to reduce the startup time when using JRebel in debug mode in IntelliJ IDE.
+Disable the Reactive Debugger:
+
+- Navigate to File → Settings → Languages & Frameworks → Reactive Streams.
+- Uncheck the Enable Reactor Debug mode checkbox.
+
 == Current Limitations
 
 Since the server doesn't restart, modifications to startup listeners and code that connects frontend and backend components, such as adding a new [classname]`LitTemplate` class, aren't reflected. However, modifications to routes are picked up.


### PR DESCRIPTION
This document shows how to reduce start up time with JRebel Debug Mode by disabling Reactive Debugger


Fixes #19459