### PR TITLE
docs: update source group names

### DIFF
--- a/articles/components/button/index.adoc
+++ b/articles/components/button/index.adoc
@@ -463,7 +463,7 @@ Buttons can receive keyboard focus automatically when the UI in which they appea
 ifdef::lit[]
 [source,html]
 ----
-<source-info group="TypeScript"></source-info>
+<source-info group="Lit"></source-info>
 <vaadin-button autofocus>Button</vaadin-button>
 ----
 endif::[]
@@ -471,7 +471,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-<source-info group="Java"></source-info>
+<source-info group="Flow"></source-info>
 Button button = new Button("Button");
 button.setAutofocus(true);
 ----

--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -174,7 +174,7 @@ Use non-modal dialogs:
 ifdef::lit[]
 [source,html]
 ----
-<source-info group="TypeScript"></source-info>
+<source-info group="Lit"></source-info>
 <vaadin-dialog modeless>...</vaadin-dialog>
 ----
 endif::[]
@@ -182,7 +182,7 @@ endif::[]
 ifdef::flow[]
 [source,java]
 ----
-<source-info group="Java"></source-info>
+<source-info group="Flow"></source-info>
 Dialog dialog = new Dialog();
 dialog.setModal(false);
 ----

--- a/articles/components/upload/file-handling.adoc
+++ b/articles/components/upload/file-handling.adoc
@@ -18,7 +18,7 @@ The following built-in implementations of [classname]`Receiver` are available:
 
 - [classname]`MemoryBuffer`;
 - [classname]`MultiFileMemoryBuffer`;
-- [classname]`FileBuffer`; and 
+- [classname]`FileBuffer`; and
 - [classname]`MultiFileBuffer`.
 
 These are described in the sub-sections that follow.
@@ -87,7 +87,7 @@ FileBuffer fileBuffer = new FileBuffer();
 
 Upload upload = new Upload(fileBuffer);
 upload.addSucceededListener(event -> {
-    // Get information about the file that was 
+    // Get information about the file that was
     // written to the file system.
     FileData savedFileData = fileBuffer.getFileData();
     String absolutePath = savedFileData.getFile().getAbsolutePath();
@@ -136,7 +136,7 @@ Use the `target` attribute to specify a different URL that should handle the upl
 ifdef::lit[]
 [source,html]
 ----
-<source-info group="TypeScript"></source-info>
+<source-info group="Lit"></source-info>
 <vaadin-upload
   method="PUT"
   target="/api/upload-handler"


### PR DESCRIPTION
Update group names of inline code examples to match the group names of rendered code examples.