### PR TITLE
docs: document applicationIdentifier property

### DIFF
--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -100,6 +100,10 @@ The following table contains the properties that are defined in the [classname]`
 |===
 |Property Name |Default Value |Description
 
+|`applicationIdentifier`
+|`default-project-id`
+|Application identifier that is by default generated based on the project build settings, e.g. maven's groupId and artifactId, during a production build.
+
 |`brotli`
 |`true`
 |Determines whether pre-compressed https://github.com/google/brotli[Brotli] files should be used if accepted by the browser. Brotli files are created during a production build. The property is used only in production mode. Set to `false` if you want to serve uncompressed static resources.


### PR DESCRIPTION
`applicationIdentifier` property was added for 24.5 for DAU License Checking feature but not limited just for it.


