### PR TITLE
fix: allow to resolve tsx file extension

### DIFF
--- a/webpack.dspublisher.js
+++ b/webpack.dspublisher.js
@@ -137,5 +137,5 @@ export default async function (config) {
     }
   };
 
-  config.resolve.extensionAlias = { '.js': ['.js', '.ts'] }
-};
+  config.resolve.extensionAlias = { '.js': ['.js', '.ts', '.tsx'] };
+}


### PR DESCRIPTION
This fixes the following error:

```
Module not found: Error: Can't resolve 'Frontend/generated/flow/ReactAdapter.js'
 in '/Users/serhii/vaadin/docs/frontend/generated/jar-resources'
```

The file is there but has `.tsx` extension which isn't currently resolved.