### PR TITLE
fix: escape special chars correctly in pattern

### DIFF
--- a/frontend/demo/component/custom-field/react/custom-field-native-input.tsx
+++ b/frontend/demo/component/custom-field/react/custom-field-native-input.tsx
@@ -22,14 +22,14 @@ function Example() {
         <HorizontalLayout theme="spacing-s">
           <input
             aria-label="Cardholder name"
-            pattern="[\\p{L} \\-]+"
+            pattern="[\p{L} \-]+"
             placeholder="Cardholder name"
             required
             type="text"
           />
           <input
             aria-label="Card number"
-            pattern="[\\d ]{12,23}"
+            pattern="[\d ]{12,23}"
             placeholder="Card number"
             required
             type="text"

--- a/frontend/demo/component/textfield/react/text-field-constraints.tsx
+++ b/frontend/demo/component/textfield/react/text-field-constraints.tsx
@@ -9,7 +9,7 @@ function Example() {
       required
       minlength={5}
       maxlength={18}
-      pattern="^[+]?[\\(]?[0-9]{3}[\\)]?[\\-s.]?[0-9]{3}[\\-s.]?[0-9]{4,6}$"
+      pattern="^[+]?[\(]?[0-9]{3}[\)]?[\-]?[0-9]{3}[\-]?[0-9]{4,6}$"
       allowedCharPattern="[0-9()+-]"
       label="Phone number"
       helperText="Format: +(123)456-7890"

--- a/frontend/demo/component/textfield/text-field-constraints.ts
+++ b/frontend/demo/component/textfield/text-field-constraints.ts
@@ -21,7 +21,7 @@ export class Example extends LitElement {
         required
         min-length="5"
         max-length="18"
-        pattern="^[+]?[\\(]?[0-9]{3}[\\)]?[\\-s.]?[0-9]{3}[\\-s.]?[0-9]{4,6}$"
+        pattern="^[+]?[\\(]?[0-9]{3}[\\)]?[-]?[0-9]{3}[\\-]?[0-9]{4,6}$"
         allowed-char-pattern="[0-9()+-]"
         label="Phone number"
         helper-text="Format: +(123)456-7890"

--- a/frontend/demo/component/textfield/text-field-constraints.ts
+++ b/frontend/demo/component/textfield/text-field-constraints.ts
@@ -21,7 +21,7 @@ export class Example extends LitElement {
         required
         min-length="5"
         max-length="18"
-        pattern="^[+]?[\\(]?[0-9]{3}[\\)]?[-]?[0-9]{3}[\\-]?[0-9]{4,6}$"
+        pattern="^[+]?[\\(]?[0-9]{3}[\\)]?[\\-]?[0-9]{3}[\\-]?[0-9]{4,6}$"
         allowed-char-pattern="[0-9()+-]"
         label="Phone number"
         helper-text="Format: +(123)456-7890"

--- a/src/main/java/com/vaadin/demo/component/textfield/TextFieldConstraints.java
+++ b/src/main/java/com/vaadin/demo/component/textfield/TextFieldConstraints.java
@@ -15,7 +15,7 @@ public class TextFieldConstraints extends HorizontalLayout {
         TextField field = new TextField("Phone number");
         field.setRequiredIndicatorVisible(true);
         field.setPattern(
-                "^[+]?[(]?[0-9]{3}[)]?[-s.]?[0-9]{3}[-s.]?[0-9]{4,6}$");
+                "^[+]?[\\(]?[0-9]{3}[\\)]?[\\-]?[0-9]{3}[\\-]?[0-9]{4,6}$");
         field.setAllowedCharPattern("[0-9()+-]");
         field.setMinLength(5);
         field.setMaxLength(18);


### PR DESCRIPTION
Added missing escaping in Java examples and removed incorrect escaping in React examples. This makes the pattern property work in those examples.