### PR TITLE
docs: add since tag to popover description

### DIFF
--- a/articles/components/popover/index.adoc
+++ b/articles/components/popover/index.adoc
@@ -10,7 +10,7 @@ page-links:
 
 = [since:com.vaadin:vaadin@V24.5]#Popover#
 
-A generic overlay whose position is anchored to an element in the UI.
+[since:com.vaadin:vaadin@V24.5]#A generic overlay whose position is anchored to an element in the UI#.
 
 [.example]
 --


### PR DESCRIPTION
Let's add the inline `since` tag since we can't have one on the title due to the tabbed page.

<img width="656" alt="Screenshot 2024-09-05 at 12 00 35" src="https://github.com/user-attachments/assets/78c399e7-838f-4768-8d3a-04ad4a386a7d">
