### PR TITLE
fix: remove incorrect unclosed snippet tag

### DIFF
--- a/frontend/demo/component/popover/popover-anchored-dialog.ts
+++ b/frontend/demo/component/popover/popover-anchored-dialog.ts
@@ -33,7 +33,6 @@ export class Example extends LitElement {
     return root;
   }
 
-  // tag::snippet[]
   @state()
   private items: Person[] = [];
 


### PR DESCRIPTION
Fixes a warning for the `popover-anchored-dialog.ts`

```
warn /Users/serhii/vaadin/docs/articles/components/popover/index.adoc, line 3 - detected unclosed tag 'snippet' starting at line 36 of include file: /Users/serhii/vaadin/docs/frontend/demo/component/popover/popover-anchored-dialog.ts
```