### PR TITLE
docs: add Popover to related components tables

### DIFF
--- a/articles/components/context-menu/index.adoc
+++ b/articles/components/context-menu/index.adoc
@@ -361,6 +361,9 @@ Suffix a menu item with “...” when the associated action won't be executed, 
 |<<../menu-bar#,Menu Bar>>
 |Component for displaying a horizontal menu with multi-level sub-menus.
 
+|<<../popover#,Popover>>
+|A generic overlay whose position is anchored to an element in the UI.
+
 |===
 
 

--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -336,6 +336,9 @@ See <<../button#buttons-in-dialogs, Buttons in Dialogs>>.
 
 |<<../confirm-dialog#,Confirm Dialog>>|Dialog for confirming user actions and decisions
 
+|<<../popover#,Popover>>
+|A generic overlay whose position is anchored to an element in the UI.
+
 |===
 
 ifdef::flow[]

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -623,6 +623,10 @@ Menu Bar is an interactive component. Using other interactive components like Co
 
 |<<../context-menu#,Context Menu>>
 |A generic drop-down menu that can be triggered from any component.
+
+|<<../popover#,Popover>>
+|A generic overlay whose position is anchored to an element in the UI.
+
 |===
 
 [discussion-id]`BCC76FD2-FB02-4F71-A6DF-7574CAC1C662`

--- a/articles/components/tooltip/index.adoc
+++ b/articles/components/tooltip/index.adoc
@@ -223,6 +223,17 @@ Tooltips should be used only to provide additional information, not for mission-
 
 On input field components, tooltips should be considered a last resort if neither the label -- not the helper -- nor the placeholder text can be used to provide the necessary information.
 
+== Related Components
+
+|===
+|Component |Usage recommendations
+
+|<<../popover#,Popover>>
+|A generic overlay whose position is anchored to an element in the UI.
+
+|===
+
+
 ++++
 <style>
 /* Ensure positioning example fits all the icons */


### PR DESCRIPTION
I missed to cover this part of the docs page draft. This PR fixes that.

> Also mention Popover in Dialog, Tooltip, ContextMenu and MenuBar pages.