### PR TITLE
docs: remove mentions of deleted webpackTemplate

### DIFF
--- a/articles/hilla/guides/production/production-build.adoc
+++ b/articles/hilla/guides/production/production-build.adoc
@@ -125,12 +125,6 @@ This goal has a few parameters. They're listed here with the default values in p
 *npmFolder* (`${project.basedir}`)::
     The folder where the [filename]`package.json` file is located. The default is the project root folder.
 
-*webpackTemplate* (`webpack.config.js`)::
-    Copy [filename]`webapp.config.js` from the specified URL if it's missing. The default is the template provided by this plugin. Set it to an empty string to disable the feature.
-
-*webpackGeneratedTemplate* (`webpack.generated.js`)::
-    Copy [filename]`webapp.config.js` from the specified URL if it's missing. The default is the template provided by this plugin. Set it to an empty string to disable the feature.
-
 *generatedTsFolder* (`${project.basedir}/src/main/frontend/generated`)::
     The folder where Vaadin puts generated files. If not given, will be `generated` folder under `frontendDirectory` parameter.
 

--- a/articles/hilla/lit/guides/production/production-build.adoc
+++ b/articles/hilla/lit/guides/production/production-build.adoc
@@ -127,12 +127,6 @@ They're listed here with the default values in parentheses, along with comments 
 *npmFolder* (`${project.basedir}`)::
     The folder where the [filename]`package.json` file is located. The default is the project root folder.
 
-*webpackTemplate* (`webpack.config.js`)::
-    Copy [filename]`webapp.config.js` from the specified URL if it's missing. The default is the template provided by this plugin. Set it to an empty string to disable the feature.
-
-*webpackGeneratedTemplate* (`webpack.generated.js`)::
-    Copy [filename]`webapp.config.js` from the specified URL if it's missing. The default is the template provided by this plugin. Set it to an empty string to disable the feature.
-
 *generatedTsFolder* (`${project.basedir}/src/main/frontend/generated`)::
     The folder where Vaadin puts generated files. If not given, will be `generated` folder under `frontendDirectory` parameter.
 


### PR DESCRIPTION
These have been removed long ago, see https://github.com/vaadin/flow/pull/13083 (and Vite is now used instead of webpack).