### PR TITLE
chore: remove unused imports, apply Prettier formatting

### DIFF
--- a/frontend/demo/auth/LoginView.tsx
+++ b/frontend/demo/auth/LoginView.tsx
@@ -1,14 +1,13 @@
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { LoginOverlay } from '@vaadin/react-components/LoginOverlay.js';
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
 import { useAuth } from './auth';
-import { ViewConfig } from "@vaadin/hilla-file-router/types.js";
+import type { ViewConfig } from '@vaadin/hilla-file-router/types.js';
 
 export const config: ViewConfig = {
-    menu: { exclude: true}
-}
+  menu: { exclude: true },
+};
 
 // tag::snippet[]
 export default function LoginView() {

--- a/frontend/demo/auth/index.tsx
+++ b/frontend/demo/auth/index.tsx
@@ -6,9 +6,11 @@ import router from './routes';
 import { AuthProvider } from './auth';
 
 function App() {
-    return <AuthProvider>
-        <RouterProvider router={router} />
-    </AuthProvider>;
+  return (
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
+  );
 }
 
 createRoot(document.getElementById('outlet')!).render(createElement(App));

--- a/frontend/demo/auth/routes.tsx
+++ b/frontend/demo/auth/routes.tsx
@@ -1,5 +1,5 @@
 import { protectRoutes } from '@vaadin/hilla-react-auth';
-import { createBrowserRouter, RouteObject } from 'react-router-dom';
+import { createBrowserRouter, type RouteObject } from 'react-router-dom';
 import MainLayout from './MainLayout';
 import LoginView from './LoginView';
 import AboutView from './AboutView';

--- a/frontend/demo/component/formlayout/form-layout-custom-field.ts
+++ b/frontend/demo/component/formlayout/form-layout-custom-field.ts
@@ -9,7 +9,6 @@ import '@vaadin/custom-field';
 import '@vaadin/horizontal-layout';
 
 import { applyTheme } from 'Frontend/generated/theme';
-import type { Select } from '@vaadin/select';
 
 @customElement('form-layout-custom-field')
 export class Example extends LitElement {

--- a/frontend/demo/component/grid/react/grid-column-filtering.tsx
+++ b/frontend/demo/component/grid/react/grid-column-filtering.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react';
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { Grid } from '@vaadin/react-components/Grid.js';
-import { GridColumn } from '@vaadin/react-components/GridColumn.js';
 import { GridFilterColumn } from '@vaadin/react-components/GridFilterColumn.js';
 import { Avatar } from '@vaadin/react-components/Avatar.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';

--- a/frontend/demo/component/grid/react/grid-column-freezing.tsx
+++ b/frontend/demo/component/grid/react/grid-column-freezing.tsx
@@ -1,8 +1,8 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
-import { Grid, type GridElement } from '@vaadin/react-components/Grid.js';
+import { Grid } from '@vaadin/react-components/Grid.js';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { getPeople } from 'Frontend/demo/domain/DataService';

--- a/frontend/demo/component/gridpro/react/grid-pro-prevent-save.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-prevent-save.tsx
@@ -2,7 +2,10 @@ import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-lin
 import React, { useEffect } from 'react';
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
-import { GridPro, type GridProItemPropertyChangedEvent } from '@vaadin/react-components-pro/GridPro.js';
+import {
+  GridPro,
+  type GridProItemPropertyChangedEvent,
+} from '@vaadin/react-components-pro/GridPro.js';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { Notification } from '@vaadin/notification';
 import { GridProEditColumn } from '@vaadin/react-components-pro/GridProEditColumn.js';

--- a/frontend/demo/component/tree-grid/react/tree-grid-column.tsx
+++ b/frontend/demo/component/tree-grid/react/tree-grid-column.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import {

--- a/frontend/demo/component/tree-grid/react/tree-grid-scroll-to-index.tsx
+++ b/frontend/demo/component/tree-grid/react/tree-grid-scroll-to-index.tsx
@@ -51,7 +51,7 @@ function Example() {
         people.forEach((person, idx) => {
           const index = startIndex + idx;
           const parentIndexes = params.parentItem
-            ? idToIndexes.get(params.parentItem.id) ?? []
+            ? (idToIndexes.get(params.parentItem.id) ?? [])
             : [];
           const indexAddress = [...parentIndexes, index];
           idToIndexes.set(person.id, indexAddress);

--- a/frontend/demo/component/tree-grid/tree-grid-scroll-to-index.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-scroll-to-index.ts
@@ -60,7 +60,7 @@ export class Example extends LitElement {
     people.forEach((person, idx) => {
       const index = startIndex + idx;
       const parentIndexes = params.parentItem
-        ? this.idToIndexes.get(params.parentItem.id) ?? []
+        ? (this.idToIndexes.get(params.parentItem.id) ?? [])
         : [];
       const indexes = [...parentIndexes, index];
       this.idToIndexes = new Map(this.idToIndexes).set(person.id, indexes);

--- a/frontend/demo/flow/integration/react/rgba-color-picker.tsx
+++ b/frontend/demo/flow/integration/react/rgba-color-picker.tsx
@@ -1,22 +1,16 @@
-import {type ReactElement} from 'react';
-import {type RgbaColor, RgbaColorPicker} from "react-colorful";
-import {ReactAdapterElement, type RenderHooks} from "Frontend/generated/flow/ReactAdapter";
+import type { ReactElement } from 'react';
+import { type RgbaColor, RgbaColorPicker } from 'react-colorful';
+import { ReactAdapterElement, type RenderHooks } from 'Frontend/generated/flow/ReactAdapter';
 
 // tag::class[]
 class RgbaColorPickerElement extends ReactAdapterElement {
+  /* prettier-ignore */ // hidden-source-line
   protected override render(hooks: RenderHooks): ReactElement | null { // <1>
-    const [color, setColor] =
-      hooks.useState<RgbaColor>("color"); // <2>
+    const [color, setColor] = hooks.useState<RgbaColor>('color'); // <2>
 
-    return <RgbaColorPicker
-      color={color}
-      onChange={setColor}
-    />; // <3>
+    return <RgbaColorPicker color={color} onChange={setColor} />; // <3>
   }
 }
 
-customElements.define(
-  "rgba-color-picker",
-  RgbaColorPickerElement
-); // <4>
+customElements.define('rgba-color-picker', RgbaColorPickerElement); // <4>
 // end::class[]


### PR DESCRIPTION
Fixed some ESLint and Prettier warnings related to unused imports and formatting.

The `rgba-color-picker` code example required `prettier-ignore` so that the comment would remain in place:
<img width="783" alt="Screenshot 2024-09-06 at 13 15 54" src="https://github.com/user-attachments/assets/52031865-5607-4b6e-bcfe-6da0d6274ac8">
