### PR TITLE
docs: add error messages to field validation examples

### DIFF
--- a/frontend/demo/component/combobox/combo-box-validation.ts
+++ b/frontend/demo/component/combobox/combo-box-validation.ts
@@ -21,6 +21,7 @@ export class Example extends LitElement {
         allowed-char-pattern="[A-Z]"
         label="Country code"
         helper-text="2-letter uppercase ISO country code"
+        error-message="Field is required"
         allow-custom-value
         .items="${['DE', 'FI', 'US']}"
       ></vaadin-combo-box>

--- a/frontend/demo/component/combobox/react/combo-box-validation.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-validation.tsx
@@ -10,6 +10,7 @@ function Example() {
       allowedCharPattern="[A-Z]"
       label="Country code"
       helperText="2-letter uppercase ISO country code"
+      errorMessage="Field is required"
       allowCustomValue
       items={['DE', 'FI', 'US']}
     />

--- a/frontend/demo/component/datepicker/date-picker-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-validation.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-picker';
-import { addDays, formatISO, isAfter, isBefore, parseISO } from 'date-fns';
+import { addDays, formatISO } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { DatePicker, DatePickerValidatedEvent } from '@vaadin/date-picker';
@@ -36,14 +36,13 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: DatePickerValidatedEvent) => {
           const field = event.target as DatePicker;
-          const date = parseISO(field.value);
           if (!field.value && (field.inputElement as HTMLInputElement).value) {
             this.errorMessage = 'Invalid date format';
           } else if (!field.value) {
             this.errorMessage = 'Field is required';
-          } else if (isBefore(date, this.minDate)) {
+          } else if (field.value < field.min!) {
             this.errorMessage = 'Too early, choose another date';
-          } else if (isAfter(date, this.maxDate)) {
+          } else if (field.value > field.max!) {
             this.errorMessage = 'Too late, choose another date';
           } else {
             this.errorMessage = '';

--- a/frontend/demo/component/datepicker/date-picker-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-validation.ts
@@ -1,7 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-picker';
-import { addDays, formatISO, isAfter, isBefore } from 'date-fns';
-import dateFnsParse from 'date-fns/parse';
+import { addDays, formatISO, isAfter, isBefore, parseISO } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { DatePicker, DatePickerValidatedEvent } from '@vaadin/date-picker';
@@ -37,9 +36,8 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: DatePickerValidatedEvent) => {
           const field = event.target as DatePicker;
-          const date = dateFnsParse(field.value ?? '', 'yyyy-MM-dd', new Date());
-          const inputElement = field.inputElement as HTMLInputElement;
-          if (!field.value && inputElement.value) {
+          const date = parseISO(field.value);
+          if (!field.value && (field.inputElement as HTMLInputElement).value) {
             this.errorMessage = 'Invalid date format';
           } else if (!field.value) {
             this.errorMessage = 'Field is required';

--- a/frontend/demo/component/datepicker/date-picker-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-validation.ts
@@ -4,7 +4,7 @@ import { addDays, formatISO, isAfter, isBefore } from 'date-fns';
 import dateFnsParse from 'date-fns/parse';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import type { DatePickerChangeEvent } from '@vaadin/date-picker';
+import type { DatePicker, DatePickerValidatedEvent } from '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-validation')
@@ -31,12 +31,19 @@ export class Example extends LitElement {
       <vaadin-date-picker
         label="Appointment date"
         helper-text="Must be within 60 days from today"
+        required
         .min="${formatISO(this.minDate, { representation: 'date' })}"
         .max="${formatISO(this.maxDate, { representation: 'date' })}"
         .errorMessage="${this.errorMessage}"
-        @change="${({ target }: DatePickerChangeEvent) => {
-          const date = dateFnsParse(target.value ?? '', 'yyyy-MM-dd', new Date());
-          if (isBefore(date, this.minDate)) {
+        @validated="${(event: DatePickerValidatedEvent) => {
+          const field = event.target as DatePicker;
+          const date = dateFnsParse(field.value ?? '', 'yyyy-MM-dd', new Date());
+          const inputElement = field.inputElement as HTMLInputElement;
+          if (!field.value && inputElement.value) {
+            this.errorMessage = 'Invalid date format';
+          } else if (!field.value) {
+            this.errorMessage = 'Field is required';
+          } else if (isBefore(date, this.minDate)) {
             this.errorMessage = 'Too early, choose another date';
           } else if (isAfter(date, this.maxDate)) {
             this.errorMessage = 'Too late, choose another date';

--- a/frontend/demo/component/datepicker/react/date-picker-validation.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-validation.tsx
@@ -3,7 +3,7 @@ import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { addDays, formatISO, isAfter, isBefore, parse } from 'date-fns';
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
-import { DatePicker } from '@vaadin/react-components/DatePicker.js';
+import { DatePicker, type DatePickerElement } from '@vaadin/react-components';
 
 function Example() {
   useSignals(); // hidden-source-line
@@ -16,12 +16,19 @@ function Example() {
     <DatePicker
       label="Appointment date"
       helperText="Must be within 60 days from today"
+      required
       min={formatISO(minDate.value, { representation: 'date' })}
       max={formatISO(maxDate.value, { representation: 'date' })}
       errorMessage={errorMessage.value}
-      onChange={({ target }) => {
-        const date = parse(target.value ?? '', 'yyyy-MM-dd', new Date());
-        if (isBefore(date, minDate.value)) {
+      onValidated={(event) => {
+        const field = event.target as DatePickerElement;
+        const date = parse(field.value ?? '', 'yyyy-MM-dd', new Date());
+        const inputElement = field.inputElement as HTMLInputElement;
+        if (!field.value && inputElement.value) {
+          errorMessage.value = 'Invalid date format';
+        } else if (!field.value) {
+          errorMessage.value = 'Field is required';
+        } else if (isBefore(date, minDate.value)) {
           errorMessage.value = 'Too early, choose another date';
         } else if (isAfter(date, maxDate.value)) {
           errorMessage.value = 'Too late, choose another date';

--- a/frontend/demo/component/datepicker/react/date-picker-validation.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-validation.tsx
@@ -1,7 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
-import { addDays, formatISO, isAfter, isBefore, parse } from 'date-fns';
+import { addDays, formatISO, isAfter, isBefore, parseISO } from 'date-fns';
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { DatePicker, type DatePickerElement } from '@vaadin/react-components/DatePicker.js';
 
@@ -22,9 +22,8 @@ function Example() {
       errorMessage={errorMessage.value}
       onValidated={(event) => {
         const field = event.target as DatePickerElement;
-        const date = parse(field.value ?? '', 'yyyy-MM-dd', new Date());
-        const inputElement = field.inputElement as HTMLInputElement;
-        if (!field.value && inputElement.value) {
+        const date = parseISO(field.value);
+        if (!field.value && (field.inputElement as HTMLInputElement).value) {
           errorMessage.value = 'Invalid date format';
         } else if (!field.value) {
           errorMessage.value = 'Field is required';

--- a/frontend/demo/component/datepicker/react/date-picker-validation.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-validation.tsx
@@ -3,7 +3,7 @@ import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { addDays, formatISO, isAfter, isBefore, parse } from 'date-fns';
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
-import { DatePicker, type DatePickerElement } from '@vaadin/react-components';
+import { DatePicker, type DatePickerElement } from '@vaadin/react-components/DatePicker.js';
 
 function Example() {
   useSignals(); // hidden-source-line

--- a/frontend/demo/component/datepicker/react/date-picker-validation.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-validation.tsx
@@ -1,7 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
-import { addDays, formatISO, isAfter, isBefore, parseISO } from 'date-fns';
+import { addDays, formatISO } from 'date-fns';
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { DatePicker, type DatePickerElement } from '@vaadin/react-components/DatePicker.js';
 
@@ -22,14 +22,13 @@ function Example() {
       errorMessage={errorMessage.value}
       onValidated={(event) => {
         const field = event.target as DatePickerElement;
-        const date = parseISO(field.value);
         if (!field.value && (field.inputElement as HTMLInputElement).value) {
           errorMessage.value = 'Invalid date format';
         } else if (!field.value) {
           errorMessage.value = 'Field is required';
-        } else if (isBefore(date, minDate.value)) {
+        } else if (field.value < field.min!) {
           errorMessage.value = 'Too early, choose another date';
-        } else if (isAfter(date, maxDate.value)) {
+        } else if (field.value > field.max!) {
           errorMessage.value = 'Too late, choose another date';
         } else {
           errorMessage.value = '';

--- a/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
@@ -47,7 +47,7 @@ export class Example extends LitElement {
             !timePicker.value && !!(timePicker.inputElement as HTMLInputElement).value;
 
           if (hasBadDateInput || hasBadTimeInput) {
-            this.errorMessage = 'Invalid date and time';
+            this.errorMessage = 'Invalid date or time';
           } else if (!field.value) {
             this.errorMessage = 'Field is required';
           } else if (isBefore(date, this.minDate)) {

--- a/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
@@ -3,18 +3,15 @@ import '@vaadin/date-time-picker';
 import { addDays, format, isAfter, isBefore, parseISO } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import type { DateTimePickerChangeEvent } from '@vaadin/date-time-picker';
+import type { DatePicker } from '@vaadin/date-picker';
+import type { DateTimePicker, DateTimePickerValidatedEvent } from '@vaadin/date-time-picker';
+import type { TimePicker } from '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
-
-const dateTimeFormat = `yyyy-MM-dd'T'HH:00:00`;
 
 @customElement('date-time-picker-validation')
 export class Example extends LitElement {
   @state()
   private errorMessage = '';
-
-  @state()
-  private initialValue = addDays(new Date(), 7);
 
   @state()
   private minDate = new Date();
@@ -33,15 +30,27 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-time-picker
+        required
         label="Appointment date and time"
         helper-text="Must be within 60 days from today"
-        .value="${format(this.initialValue, dateTimeFormat)}"
-        .min="${format(this.minDate, dateTimeFormat)}"
-        .max="${format(this.maxDate, dateTimeFormat)}"
+        .min="${format(this.minDate, `yyyy-MM-dd'T'HH:00:00`)}"
+        .max="${format(this.maxDate, `yyyy-MM-dd'T'HH:00:00`)}"
         .errorMessage="${this.errorMessage}"
-        @change="${({ target }: DateTimePickerChangeEvent) => {
-          const date = parseISO(target.value ?? '');
-          if (isBefore(date, this.minDate)) {
+        @validated="${(event: DateTimePickerValidatedEvent) => {
+          const field = event.target as DateTimePicker;
+          const date = parseISO(field.value);
+          const datePicker: DatePicker = field.querySelector('[slot=date-picker]')!;
+          const timePicker: TimePicker = field.querySelector('[slot=time-picker]')!;
+          const hasBadDateInput =
+            !datePicker.value && !!(datePicker.inputElement as HTMLInputElement).value;
+          const hasBadTimeInput =
+            !timePicker.value && !!(timePicker.inputElement as HTMLInputElement).value;
+
+          if (hasBadDateInput || hasBadTimeInput) {
+            this.errorMessage = 'Invalid date and time';
+          } else if (!field.value) {
+            this.errorMessage = 'Field is required';
+          } else if (isBefore(date, this.minDate)) {
             this.errorMessage = 'Too early, choose another date and time';
           } else if (isAfter(date, this.maxDate)) {
             this.errorMessage = 'Too late, choose another date and time';

--- a/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-time-picker';
-import { addDays, format, isAfter, isBefore, parseISO } from 'date-fns';
+import { addDays, format } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { DatePicker } from '@vaadin/date-picker';
@@ -38,7 +38,6 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: DateTimePickerValidatedEvent) => {
           const field = event.target as DateTimePicker;
-          const date = parseISO(field.value);
           const datePicker: DatePicker = field.querySelector('[slot=date-picker]')!;
           const timePicker: TimePicker = field.querySelector('[slot=time-picker]')!;
           const hasBadDateInput =
@@ -50,9 +49,9 @@ export class Example extends LitElement {
             this.errorMessage = 'Invalid date or time';
           } else if (!field.value) {
             this.errorMessage = 'Field is required';
-          } else if (isBefore(date, this.minDate)) {
+          } else if (field.value < field.min!) {
             this.errorMessage = 'Too early, choose another date and time';
-          } else if (isAfter(date, this.maxDate)) {
+          } else if (field.value > field.max!) {
             this.errorMessage = 'Too late, choose another date and time';
           } else {
             this.errorMessage = '';

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-validation.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-validation.tsx
@@ -3,13 +3,17 @@ import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { addDays, format, isAfter, isBefore, parseISO } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';
-import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
+import {
+  type DatePickerElement,
+  DateTimePicker,
+  type DateTimePickerElement,
+  type TimePickerElement,
+} from '@vaadin/react-components';
 
 // tag::snippet[]
 function Example() {
   useSignals(); // hidden-source-line
   const errorMessage = useSignal('');
-  const value = useSignal(addDays(new Date(), 7));
   const minDate = useSignal(new Date());
   const maxDate = useSignal(addDays(new Date(), 60));
 
@@ -17,14 +21,24 @@ function Example() {
     <DateTimePicker
       label="Appointment date and time"
       helperText="Must be within 60 days from today"
-      value={format(value.value, "yyyy-MM-dd'T'HH:00:00")}
-      min={format(minDate.value, "yyyy-MM-dd'T'HH:00:00")}
-      max={format(maxDate.value, "yyyy-MM-dd'T'HH:00:00")}
+      min={format(minDate.value, `yyyy-MM-dd'T'HH:00:00`)}
+      max={format(maxDate.value, `yyyy-MM-dd'T'HH:00:00`)}
       errorMessage={errorMessage.value}
-      onValueChanged={({ detail: { value: newValue } }) => {
-        const date = parseISO(newValue ?? '');
-        value.value = date;
-        if (isBefore(date, minDate.value)) {
+      onValidated={(event) => {
+        const field = event.target as DateTimePickerElement;
+        const date = parseISO(field.value);
+        const datePicker: DatePickerElement = field.querySelector('[slot=date-picker]')!;
+        const timePicker: TimePickerElement = field.querySelector('[slot=time-picker]')!;
+        const hasBadDateInput =
+          !datePicker.value && !!(datePicker.inputElement as HTMLInputElement).value;
+        const hasBadTimeInput =
+          !timePicker.value && !!(timePicker.inputElement as HTMLInputElement).value;
+
+        if (hasBadDateInput || hasBadTimeInput) {
+          errorMessage.value = 'Invalid date and time';
+        } else if (!field.value) {
+          errorMessage.value = 'Field is required';
+        } else if (isBefore(date, minDate.value)) {
           errorMessage.value = 'Too early, choose another date and time';
         } else if (isAfter(date, maxDate.value)) {
           errorMessage.value = 'Too late, choose another date and time';

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-validation.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-validation.tsx
@@ -35,7 +35,7 @@ function Example() {
           !timePicker.value && !!(timePicker.inputElement as HTMLInputElement).value;
 
         if (hasBadDateInput || hasBadTimeInput) {
-          errorMessage.value = 'Invalid date and time';
+          errorMessage.value = 'Invalid date or time';
         } else if (!field.value) {
           errorMessage.value = 'Field is required';
         } else if (isBefore(date, minDate.value)) {

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-validation.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-validation.tsx
@@ -1,7 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
-import { addDays, format, isAfter, isBefore, parseISO } from 'date-fns';
+import { addDays, format } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {
   type DatePickerElement,
@@ -26,7 +26,6 @@ function Example() {
       errorMessage={errorMessage.value}
       onValidated={(event) => {
         const field = event.target as DateTimePickerElement;
-        const date = parseISO(field.value);
         const datePicker: DatePickerElement = field.querySelector('[slot=date-picker]')!;
         const timePicker: TimePickerElement = field.querySelector('[slot=time-picker]')!;
         const hasBadDateInput =
@@ -38,9 +37,9 @@ function Example() {
           errorMessage.value = 'Invalid date or time';
         } else if (!field.value) {
           errorMessage.value = 'Field is required';
-        } else if (isBefore(date, minDate.value)) {
+        } else if (field.value < field.min!) {
           errorMessage.value = 'Too early, choose another date and time';
-        } else if (isAfter(date, maxDate.value)) {
+        } else if (field.value > field.max!) {
           errorMessage.value = 'Too late, choose another date and time';
         } else {
           errorMessage.value = '';

--- a/frontend/demo/component/emailfield/email-field-validation.ts
+++ b/frontend/demo/component/emailfield/email-field-validation.ts
@@ -26,7 +26,7 @@ export class Example extends LitElement {
         label="Email address"
         helper-text="Only example.com addresses allowed"
         .errorMessage="${this.errorMessage}"
-        @validated=${(event: EmailFieldValidatedEvent) => {
+        @validated="${(event: EmailFieldValidatedEvent) => {
           const field = event.target as EmailField;
           if (!field.value) {
             this.errorMessage = 'Field is required';
@@ -35,7 +35,7 @@ export class Example extends LitElement {
           } else {
             this.errorMessage = '';
           }
-        }}
+        }}"
       ></vaadin-email-field>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/emailfield/email-field-validation.ts
+++ b/frontend/demo/component/emailfield/email-field-validation.ts
@@ -28,9 +28,10 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: EmailFieldValidatedEvent) => {
           const field = event.target as EmailField;
-          if (!field.value) {
+          const { validity } = field.inputElement as HTMLInputElement;
+          if (validity.valueMissing) {
             this.errorMessage = 'Field is required';
-          } else if (!new RegExp(field.pattern).test(field.value)) {
+          } else if (validity.patternMismatch) {
             this.errorMessage = 'Enter a valid example.com email address';
           } else {
             this.errorMessage = '';

--- a/frontend/demo/component/emailfield/email-field-validation.ts
+++ b/frontend/demo/component/emailfield/email-field-validation.ts
@@ -1,7 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/email-field';
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
+import type { EmailField, EmailFieldValidatedEvent } from '@vaadin/email-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('email-field-validation')
@@ -13,15 +14,28 @@ export class Example extends LitElement {
     return root;
   }
 
+  @state()
+  private errorMessage = '';
+
   protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-email-field
-        pattern="^.+@example\\.com$"
         required
+        pattern="^[a-zA-Z0-9_\\-+]+(?:\\.[a-zA-Z0-9_\\-+]+)*@example\\.com$"
         label="Email address"
-        error-message="Enter a valid example.com email address"
         helper-text="Only example.com addresses allowed"
+        .errorMessage="${this.errorMessage}"
+        @validated=${(event: EmailFieldValidatedEvent) => {
+          const field = event.target as EmailField;
+          if (!field.value) {
+            this.errorMessage = 'Field is required';
+          } else if (!new RegExp(field.pattern).test(field.value)) {
+            this.errorMessage = 'Enter a valid example.com email address';
+          } else {
+            this.errorMessage = '';
+          }
+        }}
       ></vaadin-email-field>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/emailfield/react/email-field-validation.tsx
+++ b/frontend/demo/component/emailfield/react/email-field-validation.tsx
@@ -1,16 +1,31 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { EmailField } from '@vaadin/react-components/EmailField.js';
+import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { EmailField, type EmailFieldElement } from '@vaadin/react-components/EmailField.js';
 
 function Example() {
+  useSignals(); // hidden-source-line
+  const errorMessage = useSignal('');
+
   return (
     // tag::snippet[]
     <EmailField
-      pattern="^.+@example\.com$"
       required
+      pattern="^[a-zA-Z0-9_\-+]+(?:\.[a-zA-Z0-9_\-+]+)*@example\.com$"
       label="Email address"
-      errorMessage="Enter a valid example.com email address"
       helperText="Only example.com addresses allowed"
+      errorMessage={errorMessage.value}
+      onValidated={(event) => {
+        const field = event.target as EmailFieldElement;
+        if (!field.value) {
+          errorMessage.value = 'Field is required';
+        } else if (!new RegExp(field.pattern).test(field.value)) {
+          errorMessage.value = 'Enter a valid example.com email address';
+        } else {
+          errorMessage.value = '';
+        }
+      }}
     />
     // end::snippet[]
   );

--- a/frontend/demo/component/emailfield/react/email-field-validation.tsx
+++ b/frontend/demo/component/emailfield/react/email-field-validation.tsx
@@ -18,9 +18,10 @@ function Example() {
       errorMessage={errorMessage.value}
       onValidated={(event) => {
         const field = event.target as EmailFieldElement;
-        if (!field.value) {
+        const { validity } = field.inputElement as HTMLInputElement;
+        if (validity.valueMissing) {
           errorMessage.value = 'Field is required';
-        } else if (!new RegExp(field.pattern).test(field.value)) {
+        } else if (validity.patternMismatch) {
           errorMessage.value = 'Enter a valid example.com email address';
         } else {
           errorMessage.value = '';

--- a/frontend/demo/component/numberfield/number-field-step.ts
+++ b/frontend/demo/component/numberfield/number-field-step.ts
@@ -28,10 +28,11 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: NumberFieldValidatedEvent) => {
           const field = event.target as NumberField;
-          if ((field.inputElement as HTMLInputElement).validity.badInput) {
+          const { validity } = field.inputElement as HTMLInputElement;
+          if (validity.badInput) {
             this.errorMessage = 'Invalid number format';
-          } else if (field.value && Number(field.value) % 0.5 !== 0) {
-            this.errorMessage = 'Duration must be a multiple of 0.5';
+          } else if (validity.stepMismatch) {
+            this.errorMessage = `Duration must be a multiple of ${field.step}`;
           } else {
             this.errorMessage = '';
           }

--- a/frontend/demo/component/numberfield/number-field-step.ts
+++ b/frontend/demo/component/numberfield/number-field-step.ts
@@ -1,7 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/number-field';
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
+import type { NumberField, NumberFieldValidatedEvent } from '@vaadin/number-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-step')
@@ -13,6 +14,9 @@ export class Example extends LitElement {
     return root;
   }
 
+  @state()
+  private errorMessage = '';
+
   protected override render() {
     return html`
       <!-- tag::snippet[] -->
@@ -21,6 +25,17 @@ export class Example extends LitElement {
         step="0.5"
         value="12.5"
         step-buttons-visible
+        .errorMessage="${this.errorMessage}"
+        @validated="${(event: NumberFieldValidatedEvent) => {
+          const field = event.target as NumberField;
+          if ((field.inputElement as HTMLInputElement).validity.badInput) {
+            this.errorMessage = 'Invalid number format';
+          } else if (field.value && Number(field.value) % 0.5 !== 0) {
+            this.errorMessage = 'Duration must be a multiple of 0.5';
+          } else {
+            this.errorMessage = '';
+          }
+        }}"
       ></vaadin-number-field>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/numberfield/number-field-validation.ts
+++ b/frontend/demo/component/numberfield/number-field-validation.ts
@@ -1,7 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/integer-field';
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
+import type { IntegerField, IntegerFieldValidatedEvent } from '@vaadin/integer-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-validation')
@@ -13,16 +14,35 @@ export class Example extends LitElement {
     return root;
   }
 
+  @state()
+  private errorMessage = '';
+
   protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-integer-field
         label="Quantity"
         helper-text="Max 10 items"
-        min="0"
+        required
+        min="1"
         max="10"
         value="2"
         step-buttons-visible
+        .errorMessage="${this.errorMessage}"
+        @validated="${(event: IntegerFieldValidatedEvent) => {
+          const field = event.target as IntegerField;
+          if ((field.inputElement as HTMLInputElement).validity.badInput) {
+            this.errorMessage = 'Invalid number format';
+          } else if (!field.value) {
+            this.errorMessage = 'Field is required';
+          } else if (Number(field.value) < 1) {
+            this.errorMessage = 'Quantity must be at least 1';
+          } else if (Number(field.value) > 10) {
+            this.errorMessage = 'Maximum 10 items available';
+          } else {
+            this.errorMessage = '';
+          }
+        }}"
       ></vaadin-integer-field>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/numberfield/number-field-validation.ts
+++ b/frontend/demo/component/numberfield/number-field-validation.ts
@@ -31,14 +31,15 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: IntegerFieldValidatedEvent) => {
           const field = event.target as IntegerField;
-          if ((field.inputElement as HTMLInputElement).validity.badInput) {
+          const { validity } = field.inputElement as HTMLInputElement;
+          if (validity.badInput) {
             this.errorMessage = 'Invalid number format';
-          } else if (!field.value) {
+          } else if (validity.valueMissing) {
             this.errorMessage = 'Field is required';
-          } else if (Number(field.value) < 1) {
-            this.errorMessage = 'Quantity must be at least 1';
-          } else if (Number(field.value) > 10) {
-            this.errorMessage = 'Maximum 10 items available';
+          } else if (validity.rangeUnderflow) {
+            this.errorMessage = `Quantity must be at least ${field.min}`;
+          } else if (validity.rangeOverflow) {
+            this.errorMessage = `Maximum ${field.max} items available`;
           } else {
             this.errorMessage = '';
           }

--- a/frontend/demo/component/numberfield/react/number-field-step.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-step.tsx
@@ -1,11 +1,36 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { NumberField } from '@vaadin/react-components/NumberField.js';
+import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { NumberField, type NumberFieldElement } from '@vaadin/react-components/NumberField.js';
 
 function Example() {
+  useSignals(); // hidden-source-line
+  const value = useSignal('12.5');
+  const errorMessage = useSignal('');
+
   return (
     // tag::snippet[]
-    <NumberField label="Duration (hours)" step={0.5} value="12.5" stepButtonsVisible />
+    <NumberField
+      label="Duration (hours)"
+      step={0.5}
+      value={value.value}
+      stepButtonsVisible
+      errorMessage={errorMessage.value}
+      onValueChanged={(event) => {
+        value.value = event.detail.value;
+      }}
+      onValidated={(event) => {
+        const field = event.target as NumberFieldElement;
+        if ((field.inputElement as HTMLInputElement).validity.badInput) {
+          errorMessage.value = 'Invalid number format';
+        } else if (field.value && Number(field.value) % 0.5 !== 0) {
+          errorMessage.value = 'Duration must be a multiple of 0.5';
+        } else {
+          errorMessage.value = '';
+        }
+      }}
+    />
     // end::snippet[]
   );
 }

--- a/frontend/demo/component/numberfield/react/number-field-step.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-step.tsx
@@ -26,7 +26,7 @@ function Example() {
         if (validity.badInput) {
           errorMessage.value = 'Invalid number format';
         } else if (validity.stepMismatch) {
-          errorMessage.value = `Duration must be a multiple of ${field.step}`;
+          errorMessage.value = `Must be a multiple of ${field.step}`;
         } else {
           errorMessage.value = '';
         }

--- a/frontend/demo/component/numberfield/react/number-field-step.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-step.tsx
@@ -22,10 +22,11 @@ function Example() {
       }}
       onValidated={(event) => {
         const field = event.target as NumberFieldElement;
-        if ((field.inputElement as HTMLInputElement).validity.badInput) {
+        const { validity } = field.inputElement as HTMLInputElement;
+        if (validity.badInput) {
           errorMessage.value = 'Invalid number format';
-        } else if (field.value && Number(field.value) % 0.5 !== 0) {
-          errorMessage.value = 'Duration must be a multiple of 0.5';
+        } else if (validity.stepMismatch) {
+          errorMessage.value = `Duration must be a multiple of ${field.step}`;
         } else {
           errorMessage.value = '';
         }

--- a/frontend/demo/component/numberfield/react/number-field-validation.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-validation.tsx
@@ -25,14 +25,15 @@ function Example() {
       }}
       onValidated={(event) => {
         const field = event.target as IntegerFieldElement;
-        if ((field.inputElement as HTMLInputElement).validity.badInput) {
+        const { validity } = field.inputElement as HTMLInputElement;
+        if (validity.badInput) {
           errorMessage.value = 'Invalid number format';
-        } else if (!field.value) {
+        } else if (validity.valueMissing) {
           errorMessage.value = 'Field is required';
-        } else if (Number(field.value) < 1) {
-          errorMessage.value = 'Quantity must be at least 1';
-        } else if (Number(field.value) > 10) {
-          errorMessage.value = 'Maximum 10 items available';
+        } else if (validity.rangeUnderflow) {
+          errorMessage.value = `Quantity must be at least ${field.min}`;
+        } else if (validity.rangeOverflow) {
+          errorMessage.value = `Maximum ${field.max} items available`;
         } else {
           errorMessage.value = '';
         }

--- a/frontend/demo/component/numberfield/react/number-field-validation.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-validation.tsx
@@ -1,17 +1,42 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { IntegerField } from '@vaadin/react-components/IntegerField';
+import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { IntegerField, type IntegerFieldElement } from '@vaadin/react-components/IntegerField';
 
 function Example() {
+  useSignals(); // hidden-source-line
+  const value = useSignal('2');
+  const errorMessage = useSignal('');
+
   return (
     // tag::snippet[]
     <IntegerField
       label="Quantity"
       helperText="Max 10 items"
-      min={0}
+      required
+      min={1}
       max={10}
-      value="2"
+      value={value.value}
       stepButtonsVisible
+      errorMessage={errorMessage.value}
+      onValueChanged={(event) => {
+        value.value = event.detail.value;
+      }}
+      onValidated={(event) => {
+        const field = event.target as IntegerFieldElement;
+        if ((field.inputElement as HTMLInputElement).validity.badInput) {
+          errorMessage.value = 'Invalid number format';
+        } else if (!field.value) {
+          errorMessage.value = 'Field is required';
+        } else if (Number(field.value) < 1) {
+          errorMessage.value = 'Quantity must be at least 1';
+        } else if (Number(field.value) > 10) {
+          errorMessage.value = 'Maximum 10 items available';
+        } else {
+          errorMessage.value = '';
+        }
+      }}
     />
     // end::snippet[]
   );

--- a/frontend/demo/component/passwordfield/password-field-validation.ts
+++ b/frontend/demo/component/passwordfield/password-field-validation.ts
@@ -1,7 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
+import type { PasswordField, PasswordFieldValidatedEvent } from '@vaadin/password-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('password-field-validation')
@@ -13,16 +14,35 @@ export class Example extends LitElement {
     return root;
   }
 
+  @state()
+  private errorMessage = '';
+
   protected override render() {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-password-field
-        allowed-char-pattern="[A-Za-z0-9]"
+        pattern="^[A-Za-z0-9]+$"
         required
-        min-length="6"
-        max-length="12"
+        minlength="6"
+        maxlength="12"
         label="Password"
         helper-text="6 to 12 characters. Only letters A-Z and numbers supported."
+        .errorMessage="${this.errorMessage}"
+        @validated="${(event: PasswordFieldValidatedEvent) => {
+          const field = event.target as PasswordField;
+          const value = field.value;
+          if (!value) {
+            this.errorMessage = 'Field is required';
+          } else if (value.length < field.minlength!) {
+            this.errorMessage = `Minimum length is ${field.minlength} characters`;
+          } else if (value.length > field.maxlength!) {
+            this.errorMessage = `Maximum length is ${field.maxlength} characters`;
+          } else if (!new RegExp(field.pattern).test(value)) {
+            this.errorMessage = 'Only letters A-Z and numbers are allowed';
+          } else {
+            this.errorMessage = '';
+          }
+        }}"
       ></vaadin-password-field>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/passwordfield/password-field-validation.ts
+++ b/frontend/demo/component/passwordfield/password-field-validation.ts
@@ -30,14 +30,14 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: PasswordFieldValidatedEvent) => {
           const field = event.target as PasswordField;
-          const value = field.value;
-          if (!value) {
+          const { validity } = field.inputElement as HTMLInputElement;
+          if (validity.valueMissing) {
             this.errorMessage = 'Field is required';
-          } else if (value.length < field.minlength!) {
+          } else if (validity.tooShort) {
             this.errorMessage = `Minimum length is ${field.minlength} characters`;
-          } else if (value.length > field.maxlength!) {
+          } else if (validity.tooLong) {
             this.errorMessage = `Maximum length is ${field.maxlength} characters`;
-          } else if (!new RegExp(field.pattern).test(value)) {
+          } else if (validity.patternMismatch) {
             this.errorMessage = 'Only letters A-Z and numbers are allowed';
           } else {
             this.errorMessage = '';

--- a/frontend/demo/component/passwordfield/react/password-field-validation.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-validation.tsx
@@ -1,17 +1,35 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { PasswordField } from '@vaadin/react-components/PasswordField.js';
+import {
+  PasswordField,
+  type PasswordFieldElement,
+} from '@vaadin/react-components/PasswordField.js';
 
 function Example() {
   return (
     // tag::snippet[]
     <PasswordField
-      allowedCharPattern="[A-Za-z0-9]"
+      pattern="^[A-Za-z0-9]+$"
       required
       minlength={6}
       maxlength={12}
       label="Password"
       helperText="6 to 12 characters. Only letters A-Z and numbers supported."
+      onValidated={(event) => {
+        const field = event.target as PasswordFieldElement;
+        const value = field.value;
+        if (!value) {
+          field.errorMessage = 'Field is required';
+        } else if (value.length < field.minlength!) {
+          field.errorMessage = `Minimum length is ${field.minlength} characters`;
+        } else if (value.length > field.maxlength!) {
+          field.errorMessage = `Maximum length is ${field.maxlength} characters`;
+        } else if (!new RegExp(field.pattern).test(value)) {
+          field.errorMessage = 'Only letters A-Z and numbers are allowed';
+        } else {
+          field.errorMessage = '';
+        }
+      }}
     />
     // end::snippet[]
   );

--- a/frontend/demo/component/passwordfield/react/password-field-validation.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-validation.tsx
@@ -4,8 +4,13 @@ import {
   PasswordField,
   type PasswordFieldElement,
 } from '@vaadin/react-components/PasswordField.js';
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 
 function Example() {
+  useSignals(); // hidden-source-line
+  const errorMessage = useSignal('');
+
   return (
     // tag::snippet[]
     <PasswordField
@@ -15,19 +20,20 @@ function Example() {
       maxlength={12}
       label="Password"
       helperText="6 to 12 characters. Only letters A-Z and numbers supported."
+      errorMessage={errorMessage.value}
       onValidated={(event) => {
         const field = event.target as PasswordFieldElement;
         const value = field.value;
         if (!value) {
-          field.errorMessage = 'Field is required';
+          errorMessage.value = 'Field is required';
         } else if (value.length < field.minlength!) {
-          field.errorMessage = `Minimum length is ${field.minlength} characters`;
+          errorMessage.value = `Minimum length is ${field.minlength} characters`;
         } else if (value.length > field.maxlength!) {
-          field.errorMessage = `Maximum length is ${field.maxlength} characters`;
+          errorMessage.value = `Maximum length is ${field.maxlength} characters`;
         } else if (!new RegExp(field.pattern).test(value)) {
-          field.errorMessage = 'Only letters A-Z and numbers are allowed';
+          errorMessage.value = 'Only letters A-Z and numbers are allowed';
         } else {
-          field.errorMessage = '';
+          errorMessage.value = '';
         }
       }}
     />

--- a/frontend/demo/component/passwordfield/react/password-field-validation.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-validation.tsx
@@ -23,14 +23,14 @@ function Example() {
       errorMessage={errorMessage.value}
       onValidated={(event) => {
         const field = event.target as PasswordFieldElement;
-        const value = field.value;
-        if (!value) {
+        const { validity } = field.inputElement as HTMLInputElement;
+        if (validity.valueMissing) {
           errorMessage.value = 'Field is required';
-        } else if (value.length < field.minlength!) {
+        } else if (validity.tooShort) {
           errorMessage.value = `Minimum length is ${field.minlength} characters`;
-        } else if (value.length > field.maxlength!) {
+        } else if (validity.tooLong) {
           errorMessage.value = `Maximum length is ${field.maxlength} characters`;
-        } else if (!new RegExp(field.pattern).test(value)) {
+        } else if (validity.patternMismatch) {
           errorMessage.value = 'Only letters A-Z and numbers are allowed';
         } else {
           errorMessage.value = '';

--- a/frontend/demo/component/passwordfield/react/password-field-validation.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-validation.tsx
@@ -1,11 +1,11 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
+import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
+import { useSignal } from '@vaadin/hilla-react-signals';
 import {
   PasswordField,
   type PasswordFieldElement,
 } from '@vaadin/react-components/PasswordField.js';
-import { useSignal } from '@vaadin/hilla-react-signals';
-import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 
 function Example() {
   useSignals(); // hidden-source-line

--- a/frontend/demo/component/textarea/react/text-area-validation.tsx
+++ b/frontend/demo/component/textarea/react/text-area-validation.tsx
@@ -22,14 +22,14 @@ function Example() {
       errorMessage={errorMessage.value}
       onValidated={(event) => {
         const field = event.target as TextAreaElement;
-        const value = field.value;
-        if (!value) {
+        const { validity } = field.inputElement as HTMLTextAreaElement;
+        if (validity.valueMissing) {
           errorMessage.value = 'Field is required';
-        } else if (value.length < field.minlength!) {
+        } else if (validity.tooShort) {
           errorMessage.value = `Minimum length is ${field.minlength} characters`;
-        } else if (value.length > field.maxlength!) {
+        } else if (validity.tooLong) {
           errorMessage.value = `Maximum length is ${field.maxlength} characters`;
-        } else if (!new RegExp(field.pattern).test(value)) {
+        } else if (!new RegExp(field.pattern).test(field.value)) {
           errorMessage.value = 'Must be one complete sentence ending in a period';
         } else {
           errorMessage.value = '';

--- a/frontend/demo/component/textarea/react/text-area-validation.tsx
+++ b/frontend/demo/component/textarea/react/text-area-validation.tsx
@@ -1,8 +1,13 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { TextArea } from '@vaadin/react-components/TextArea.js';
+import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { TextArea, type TextAreaElement } from '@vaadin/react-components/TextArea.js';
 
 function Example() {
+  useSignals(); // hidden-source-line
+  const errorMessage = useSignal('');
+
   return (
     // tag::snippet[]
     <TextArea
@@ -14,6 +19,22 @@ function Example() {
       label="Sentence"
       helperText="Must be one complete sentence ending in a period, between 5 and 50 characters long"
       style={{ width: '100%' }}
+      errorMessage={errorMessage.value}
+      onValidated={(event) => {
+        const field = event.target as TextAreaElement;
+        const value = field.value;
+        if (!value) {
+          errorMessage.value = 'Field is required';
+        } else if (value.length < field.minlength!) {
+          errorMessage.value = `Minimum length is ${field.minlength} characters`;
+        } else if (value.length > field.maxlength!) {
+          errorMessage.value = `Maximum length is ${field.maxlength} characters`;
+        } else if (!new RegExp(field.pattern).test(value)) {
+          errorMessage.value = 'Must be one complete sentence ending in a period';
+        } else {
+          errorMessage.value = '';
+        }
+      }}
     />
     // end::snippet[]
   );

--- a/frontend/demo/component/textarea/text-area-validation.ts
+++ b/frontend/demo/component/textarea/text-area-validation.ts
@@ -1,7 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
+import type { TextArea, TextAreaValidatedEvent } from '@vaadin/text-area';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-validation')
@@ -12,6 +13,9 @@ export class Example extends LitElement {
     applyTheme(root);
     return root;
   }
+
+  @state()
+  private errorMessage = '';
 
   protected override render() {
     return html`
@@ -25,6 +29,22 @@ export class Example extends LitElement {
         label="Sentence"
         helper-text="Must be one complete sentence ending in a period, between 5 and 50 characters long"
         style="width:100%"
+        .errorMessage="${this.errorMessage}"
+        @validated="${(event: TextAreaValidatedEvent) => {
+          const field = event.target as TextArea;
+          const value = field.value;
+          if (!value) {
+            field.errorMessage = 'Field is required';
+          } else if (value.length < field.minlength!) {
+            field.errorMessage = `Minimum length is ${field.minlength} characters`;
+          } else if (value.length > field.maxlength!) {
+            field.errorMessage = `Maximum length is ${field.maxlength} characters`;
+          } else if (!new RegExp(field.pattern).test(value)) {
+            field.errorMessage = 'Must be one complete sentence ending in a period';
+          } else {
+            field.errorMessage = '';
+          }
+        }}"
       ></vaadin-text-area>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/textarea/text-area-validation.ts
+++ b/frontend/demo/component/textarea/text-area-validation.ts
@@ -18,8 +18,8 @@ export class Example extends LitElement {
       <!-- tag::snippet[] -->
       <vaadin-text-area
         required
-        min-length="5"
-        max-length="50"
+        minlength="5"
+        maxlength="50"
         pattern="^[A-Z]([A-Za-z0-9,-\\s])*\\.$"
         allowed-char-pattern="[A-Za-z0-9,.\\-\\s]"
         label="Sentence"

--- a/frontend/demo/component/textarea/text-area-validation.ts
+++ b/frontend/demo/component/textarea/text-area-validation.ts
@@ -32,14 +32,14 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: TextAreaValidatedEvent) => {
           const field = event.target as TextArea;
-          const value = field.value;
-          if (!value) {
+          const { validity } = field.inputElement as HTMLTextAreaElement;
+          if (validity.valueMissing) {
             field.errorMessage = 'Field is required';
-          } else if (value.length < field.minlength!) {
+          } else if (validity.tooShort) {
             field.errorMessage = `Minimum length is ${field.minlength} characters`;
-          } else if (value.length > field.maxlength!) {
+          } else if (validity.tooLong) {
             field.errorMessage = `Maximum length is ${field.maxlength} characters`;
-          } else if (!new RegExp(field.pattern).test(value)) {
+          } else if (!new RegExp(field.pattern).test(field.value)) {
             field.errorMessage = 'Must be one complete sentence ending in a period';
           } else {
             field.errorMessage = '';

--- a/frontend/demo/component/textfield/react/text-field-validation.tsx
+++ b/frontend/demo/component/textfield/react/text-field-validation.tsx
@@ -1,8 +1,13 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { TextField } from '@vaadin/react-components/TextField.js';
+import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { TextField, type TextFieldElement } from '@vaadin/react-components/TextField.js';
 
 function Example() {
+  useSignals(); // hidden-source-line
+  const errorMessage = useSignal('');
+
   return (
     // tag::snippet[]
     <TextField
@@ -13,6 +18,22 @@ function Example() {
       allowedCharPattern="[0-9()+-]"
       label="Phone number"
       helperText="Format: +(123)456-7890"
+      errorMessage={errorMessage.value}
+      onValidated={(event) => {
+        const field = event.target as TextFieldElement;
+        const value = field.value;
+        if (!value) {
+          errorMessage.value = 'Field is required';
+        } else if (value.length < field.minlength!) {
+          errorMessage.value = `Minimum length is ${field.minlength} characters`;
+        } else if (value.length > field.maxlength!) {
+          errorMessage.value = `Maximum length is ${field.maxlength} characters`;
+        } else if (!new RegExp(field.pattern).test(value)) {
+          errorMessage.value = 'Invalid phone number format';
+        } else {
+          errorMessage.value = '';
+        }
+      }}
     />
     // end::snippet[]
   );

--- a/frontend/demo/component/textfield/react/text-field-validation.tsx
+++ b/frontend/demo/component/textfield/react/text-field-validation.tsx
@@ -21,14 +21,14 @@ function Example() {
       errorMessage={errorMessage.value}
       onValidated={(event) => {
         const field = event.target as TextFieldElement;
-        const value = field.value;
-        if (!value) {
+        const { validity } = field.inputElement as HTMLInputElement;
+        if (validity.valueMissing) {
           errorMessage.value = 'Field is required';
-        } else if (value.length < field.minlength!) {
+        } else if (validity.tooShort) {
           errorMessage.value = `Minimum length is ${field.minlength} characters`;
-        } else if (value.length > field.maxlength!) {
+        } else if (validity.tooLong) {
           errorMessage.value = `Maximum length is ${field.maxlength} characters`;
-        } else if (!new RegExp(field.pattern).test(value)) {
+        } else if (validity.patternMismatch) {
           errorMessage.value = 'Invalid phone number format';
         } else {
           errorMessage.value = '';

--- a/frontend/demo/component/textfield/text-field-validation.ts
+++ b/frontend/demo/component/textfield/text-field-validation.ts
@@ -22,14 +22,14 @@ export class Example extends LitElement {
       <!-- tag::snippet[] -->
       <vaadin-text-field
         required
-        min-length="5"
-        max-length="18"
+        minlength="5"
+        maxlength="18"
         pattern="^[+]?[\\(]?[0-9]{3}[\\)]?[\\-]?[0-9]{3}[\\-]?[0-9]{4,6}$"
         allowed-char-pattern="[0-9()+-]"
         label="Phone number"
         helper-text="Format: +(123)456-7890"
         .errorMessage="${this.errorMessage}"
-        @validated=${(event: TextFieldValidatedEvent) => {
+        @validated="${(event: TextFieldValidatedEvent) => {
           const field = event.target as TextField;
           const value = field.value;
           if (!value) {
@@ -43,7 +43,7 @@ export class Example extends LitElement {
           } else {
             this.errorMessage = '';
           }
-        }}
+        }}"
       ></vaadin-text-field>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/textfield/text-field-validation.ts
+++ b/frontend/demo/component/textfield/text-field-validation.ts
@@ -1,7 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
+import type { TextField, TextFieldValidatedEvent } from '@vaadin/text-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-validation')
@@ -12,6 +13,9 @@ export class Example extends LitElement {
     applyTheme(root);
     return root;
   }
+
+  @state()
+  private errorMessage = '';
 
   protected override render() {
     return html`
@@ -24,6 +28,22 @@ export class Example extends LitElement {
         allowed-char-pattern="[0-9()+-]"
         label="Phone number"
         helper-text="Format: +(123)456-7890"
+        .errorMessage="${this.errorMessage}"
+        @validated=${(event: TextFieldValidatedEvent) => {
+          const field = event.target as TextField;
+          const value = field.value;
+          if (!value) {
+            this.errorMessage = 'Field is required';
+          } else if (value.length < field.minlength!) {
+            this.errorMessage = `Minimum length is ${field.minlength} characters`;
+          } else if (value.length > field.maxlength!) {
+            this.errorMessage = `Maximum length is ${field.maxlength} characters`;
+          } else if (!new RegExp(field.pattern).test(value)) {
+            this.errorMessage = 'Invalid phone number format';
+          } else {
+            this.errorMessage = '';
+          }
+        }}
       ></vaadin-text-field>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/textfield/text-field-validation.ts
+++ b/frontend/demo/component/textfield/text-field-validation.ts
@@ -31,14 +31,14 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: TextFieldValidatedEvent) => {
           const field = event.target as TextField;
-          const value = field.value;
-          if (!value) {
+          const { validity } = field.inputElement as HTMLInputElement;
+          if (validity.valueMissing) {
             this.errorMessage = 'Field is required';
-          } else if (value.length < field.minlength!) {
+          } else if (validity.tooShort) {
             this.errorMessage = `Minimum length is ${field.minlength} characters`;
-          } else if (value.length > field.maxlength!) {
+          } else if (validity.tooLong) {
             this.errorMessage = `Maximum length is ${field.maxlength} characters`;
-          } else if (!new RegExp(field.pattern).test(value)) {
+          } else if (validity.patternMismatch) {
             this.errorMessage = 'Invalid phone number format';
           } else {
             this.errorMessage = '';

--- a/frontend/demo/component/timepicker/react/time-picker-validation.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-validation.tsx
@@ -2,8 +2,7 @@ import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-lin
 import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
-import type { TimePickerChangeEvent } from '@vaadin/react-components/TimePicker.js';
-import { TimePicker } from '@vaadin/react-components/TimePicker.js';
+import { TimePicker, type TimePickerElement } from '@vaadin/react-components';
 
 function Example() {
   useSignals(); // hidden-source-line
@@ -16,6 +15,7 @@ function Example() {
       label="Appointment time"
       helper-text="Open 8:00-16:00"
       value={currentValue.value}
+      required
       min="08:00"
       max="16:00"
       step={60 * 30}
@@ -23,11 +23,16 @@ function Example() {
       onValueChanged={(event) => {
         currentValue.value = event.detail.value;
       }}
-      onChange={(event: TimePickerChangeEvent) => {
-        const { min, max, value } = event.target;
-        if (value < min) {
+      onValidated={(event) => {
+        const field = event.target as TimePickerElement;
+        const inputElement = field.inputElement as HTMLInputElement;
+        if (!field.value && inputElement.value) {
+          errorMessage.value = 'Invalid time format';
+        } else if (!field.value) {
+          errorMessage.value = 'Field is required';
+        } else if (field.value < field.min) {
           errorMessage.value = 'Too early, choose another time';
-        } else if (value > max) {
+        } else if (field.value > field.max) {
           errorMessage.value = 'Too late, choose another time';
         } else {
           errorMessage.value = '';

--- a/frontend/demo/component/timepicker/react/time-picker-validation.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-validation.tsx
@@ -25,8 +25,7 @@ function Example() {
       }}
       onValidated={(event) => {
         const field = event.target as TimePickerElement;
-        const inputElement = field.inputElement as HTMLInputElement;
-        if (!field.value && inputElement.value) {
+        if (!field.value && (field.inputElement as HTMLInputElement).value) {
           errorMessage.value = 'Invalid time format';
         } else if (!field.value) {
           errorMessage.value = 'Field is required';

--- a/frontend/demo/component/timepicker/time-picker-validation.ts
+++ b/frontend/demo/component/timepicker/time-picker-validation.ts
@@ -31,8 +31,7 @@ export class Example extends LitElement {
         .errorMessage="${this.errorMessage}"
         @validated="${(event: TimePickerValidatedEvent) => {
           const field = event.target as TimePicker;
-          const inputElement = field.inputElement as HTMLInputElement;
-          if (!field.value && inputElement.value) {
+          if (!field.value && (field.inputElement as HTMLInputElement).value) {
             this.errorMessage = 'Invalid time format';
           } else if (!field.value) {
             this.errorMessage = 'Field is required';

--- a/frontend/demo/component/timepicker/time-picker-validation.ts
+++ b/frontend/demo/component/timepicker/time-picker-validation.ts
@@ -2,20 +2,20 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import type { TimePickerChangeEvent } from '@vaadin/time-picker';
+import type { TimePicker, TimePickerValidatedEvent } from '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-validation')
 export class Example extends LitElement {
-  @state()
-  protected errorMessage = '';
-
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
     // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
+
+  @state()
+  protected errorMessage = '';
 
   protected override render() {
     return html`
@@ -24,15 +24,21 @@ export class Example extends LitElement {
         label="Appointment time"
         helper-text="Open 8:00-16:00"
         value="08:30"
+        required
         min="08:00"
         max="16:00"
         .step="${60 * 30}"
-        error-message="${this.errorMessage}"
-        @change="${(event: TimePickerChangeEvent) => {
-          const { min, max, value } = event.target;
-          if (value < min) {
+        .errorMessage="${this.errorMessage}"
+        @validated="${(event: TimePickerValidatedEvent) => {
+          const field = event.target as TimePicker;
+          const inputElement = field.inputElement as HTMLInputElement;
+          if (!field.value && inputElement.value) {
+            this.errorMessage = 'Invalid time format';
+          } else if (!field.value) {
+            this.errorMessage = 'Field is required';
+          } else if (field.value < field.min) {
             this.errorMessage = 'Too early, choose another time';
-          } else if (value > max) {
+          } else if (field.value > field.max) {
             this.errorMessage = 'Too late, choose another time';
           } else {
             this.errorMessage = '';

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxValidation.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxValidation.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.combobox;
 
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.ComboBox.ComboBoxI18n;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
@@ -15,6 +16,8 @@ public class ComboBoxValidation extends HorizontalLayout {
         ComboBox<String> field = new ComboBox<>();
         field.setRequiredIndicatorVisible(true);
         field.setAllowedCharPattern("[A-Z]");
+        field.setI18n(new ComboBoxI18n()
+                .setRequiredErrorMessage("Field is required"));
         // end::snippet[]
         field.setLabel("Country code");
         field.setHelperText("2-letter uppercase ISO country code");

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerCustomValidation.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerCustomValidation.java
@@ -3,6 +3,7 @@ package com.vaadin.demo.component.datepicker;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.Appointment;
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
@@ -14,6 +15,8 @@ public class DatePickerCustomValidation extends Div {
         // tag::snippet[]
         DatePicker datePicker = new DatePicker("Meeting date");
         datePicker.setHelperText("Mondays – Fridays only");
+        datePicker.setI18n(new DatePickerI18n()
+                .setBadInputErrorMessage("Invalid date format"));
 
         Binder<Appointment> binder = new Binder<>(Appointment.class);
         binder.forField(datePicker).withValidator(localDate -> {

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerValidation.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerValidation.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.datepicker;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
@@ -16,21 +17,16 @@ public class DatePickerValidation extends Div {
         // tag::snippet[]
         LocalDate now = LocalDate.now(ZoneId.systemDefault());
 
+        datePicker.setRequiredIndicatorVisible(true);
         datePicker.setMin(now);
         datePicker.setMax(now.plusDays(60));
         datePicker.setHelperText("Must be within 60 days from today");
-        datePicker.addValueChangeListener(event -> {
-            LocalDate value = datePicker.getValue();
-            String errorMessage = null;
-            if (value != null) {
-                if (value.compareTo(datePicker.getMin()) < 0) {
-                    errorMessage = "Too early, choose another date";
-                } else if (value.compareTo(datePicker.getMax()) > 0) {
-                    errorMessage = "Too late, choose another date";
-                }
-            }
-            datePicker.setErrorMessage(errorMessage);
-        });
+
+        datePicker.setI18n(new DatePickerI18n()
+                .setBadInputErrorMessage("Invalid date format")
+                .setRequiredErrorMessage("Field is required")
+                .setMinErrorMessage("Too early, choose another date")
+                .setMaxErrorMessage("Too late, choose another date"));
         // end::snippet[]
 
         add(datePicker);

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerCustomValidation.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerCustomValidation.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.datetimepicker;
 
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
+import com.vaadin.flow.component.datetimepicker.DateTimePicker.DateTimePickerI18n;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
@@ -21,6 +22,8 @@ public class DateTimePickerCustomValidation extends Div {
         dateTimePicker
                 .setHelperText("Open Mondays-Fridays, 8:00-12:00, 13:00-16:00");
         dateTimePicker.setStep(Duration.ofMinutes(30));
+        dateTimePicker.setI18n(new DateTimePickerI18n()
+            .setBadInputErrorMessage("Invalid date or time format"));
         add(dateTimePicker);
 
         String errorMessage = "The selected day of week or time is not available";

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerValidation.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerValidation.java
@@ -36,6 +36,7 @@ public class DateTimePickerValidation extends Div {
         // end::snippet[]
     }
 
-    public static class Exporter extends DemoExporter<DateTimePickerValidation> { // hidden-source-line
+    public static class Exporter
+            extends DemoExporter<DateTimePickerValidation> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerValidation.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerValidation.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.component.datetimepicker;
 
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
+import com.vaadin.flow.component.datetimepicker.DateTimePicker.DateTimePickerI18n;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
@@ -14,24 +15,18 @@ public class DateTimePickerValidation extends Div {
     public DateTimePickerValidation() {
         // tag::snippet[]
         DateTimePicker dateTimePicker = new DateTimePicker();
+        dateTimePicker.setRequiredIndicatorVisible(true);
         dateTimePicker.setLabel("Appointment date and time");
         dateTimePicker.setHelperText("Must be within 60 days from today");
-        dateTimePicker.setAutoOpen(true);
         dateTimePicker.setMin(LocalDateTime.now());
         dateTimePicker.setMax(LocalDateTime.now().plusDays(60));
-        dateTimePicker.setValue(LocalDateTime.now().plusDays(7));
-        dateTimePicker.addValueChangeListener(event -> {
-            LocalDateTime value = event.getValue();
-            String errorMessage = null;
-            if (value != null) {
-                if (value.compareTo(dateTimePicker.getMin()) < 0) {
-                    errorMessage = "Too early, choose another date and time";
-                } else if (value.compareTo(dateTimePicker.getMax()) > 0) {
-                    errorMessage = "Too late, choose another date and time";
-                }
-            }
-            dateTimePicker.setErrorMessage(errorMessage);
-        });
+
+        dateTimePicker.setI18n(new DateTimePickerI18n()
+            .setRequiredErrorMessage("Field is required")
+            .setBadInputErrorMessage("Invalid date or time format")
+            .setMinErrorMessage("Too early, choose another date and time")
+            .setMaxErrorMessage("Too late, choose another date and time"));
+
         add(dateTimePicker);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldValidation.java
+++ b/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldValidation.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.emailfield;
 
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.textfield.EmailField;
+import com.vaadin.flow.component.textfield.EmailField.EmailFieldI18n;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
@@ -14,7 +15,11 @@ public class EmailFieldValidation extends HorizontalLayout {
         // tag::snippet[]
         EmailField field = new EmailField("Email address");
         field.setRequiredIndicatorVisible(true);
-        field.setPattern("^.+@example\\.com$");
+        field.setPattern("^[a-zA-Z0-9_\\-+]+(?:\\.[a-zA-Z0-9_\\-+]+)*@example\\.com$");
+
+        field.setI18n(new EmailFieldI18n()
+            .setRequiredErrorMessage("Field is required")
+            .setPatternErrorMessage("Enter a valid example.com email address"));
         // end::snippet[]
         field.setHelperText("Only example.com addresses allowed");
 

--- a/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldValidation.java
+++ b/src/main/java/com/vaadin/demo/component/emailfield/EmailFieldValidation.java
@@ -15,11 +15,13 @@ public class EmailFieldValidation extends HorizontalLayout {
         // tag::snippet[]
         EmailField field = new EmailField("Email address");
         field.setRequiredIndicatorVisible(true);
-        field.setPattern("^[a-zA-Z0-9_\\-+]+(?:\\.[a-zA-Z0-9_\\-+]+)*@example\\.com$");
+        field.setPattern(
+                "^[a-zA-Z0-9_\\-+]+(?:\\.[a-zA-Z0-9_\\-+]+)*@example\\.com$");
 
         field.setI18n(new EmailFieldI18n()
-            .setRequiredErrorMessage("Field is required")
-            .setPatternErrorMessage("Enter a valid example.com email address"));
+                .setRequiredErrorMessage("Field is required")
+                .setPatternErrorMessage(
+                        "Enter a valid example.com email address"));
         // end::snippet[]
         field.setHelperText("Only example.com addresses allowed");
 

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStep.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStep.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.numberfield;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.component.textfield.NumberField.NumberFieldI18n;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
@@ -15,6 +16,9 @@ public class NumberFieldStep extends Div {
         numberField.setStep(0.5);
         numberField.setValue(12.5);
         numberField.setStepButtonsVisible(true);
+        numberField.setI18n(new NumberFieldI18n()
+            .setBadInputErrorMessage("Invalid number format")
+            .setStepErrorMessage("Duration must be a multiple of 0.5"));
         add(numberField);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStep.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldStep.java
@@ -17,8 +17,8 @@ public class NumberFieldStep extends Div {
         numberField.setValue(12.5);
         numberField.setStepButtonsVisible(true);
         numberField.setI18n(new NumberFieldI18n()
-            .setBadInputErrorMessage("Invalid number format")
-            .setStepErrorMessage("Duration must be a multiple of 0.5"));
+                .setBadInputErrorMessage("Invalid number format")
+                .setStepErrorMessage("Duration must be a multiple of 0.5"));
         add(numberField);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldValidation.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldValidation.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.numberfield;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.IntegerField.IntegerFieldI18n;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
@@ -13,10 +14,18 @@ public class NumberFieldValidation extends Div {
         IntegerField integerField = new IntegerField();
         integerField.setLabel("Quantity");
         integerField.setHelperText("Max 10 items");
-        integerField.setMin(0);
+        integerField.setRequiredIndicatorVisible(true);
+        integerField.setMin(1);
         integerField.setMax(10);
         integerField.setValue(2);
         integerField.setStepButtonsVisible(true);
+
+        integerField.setI18n(new IntegerFieldI18n()
+            .setRequiredErrorMessage("Field is required")
+            .setBadInputErrorMessage("Invalid number format")
+            .setMinErrorMessage("Quantity must be at least 1")
+            .setMaxErrorMessage("Maximum 10 items available"));
+
         add(integerField);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldValidation.java
+++ b/src/main/java/com/vaadin/demo/component/numberfield/NumberFieldValidation.java
@@ -21,10 +21,10 @@ public class NumberFieldValidation extends Div {
         integerField.setStepButtonsVisible(true);
 
         integerField.setI18n(new IntegerFieldI18n()
-            .setRequiredErrorMessage("Field is required")
-            .setBadInputErrorMessage("Invalid number format")
-            .setMinErrorMessage("Quantity must be at least 1")
-            .setMaxErrorMessage("Maximum 10 items available"));
+                .setRequiredErrorMessage("Field is required")
+                .setBadInputErrorMessage("Invalid number format")
+                .setMinErrorMessage("Quantity must be at least 1")
+                .setMaxErrorMessage("Maximum 10 items available"));
 
         add(integerField);
         // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldValidation.java
+++ b/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldValidation.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.passwordfield;
 
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.textfield.PasswordField;
+import com.vaadin.flow.component.textfield.PasswordField.PasswordFieldI18n;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
@@ -14,9 +15,15 @@ public class PasswordFieldValidation extends HorizontalLayout {
         // tag::snippet[]
         PasswordField field = new PasswordField("Password");
         field.setRequiredIndicatorVisible(true);
-        field.setAllowedCharPattern("[A-Za-z0-9]");
+        field.setPattern("^[A-Za-z0-9]+$");
         field.setMinLength(6);
         field.setMaxLength(12);
+
+        field.setI18n(new PasswordFieldI18n()
+                .setRequiredErrorMessage("Field is required")
+                .setMinLengthErrorMessage("Minimum length is 6 characters")
+                .setMaxLengthErrorMessage("Maximum length is 12 characters")
+                .setPatternErrorMessage("Only letters A-Z and numbers are allowed"));
         // end::snippet[]
         field.setHelperText(
                 "6 to 12 characters. Only letters A-Z and numbers supported.");

--- a/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldValidation.java
+++ b/src/main/java/com/vaadin/demo/component/passwordfield/PasswordFieldValidation.java
@@ -23,7 +23,8 @@ public class PasswordFieldValidation extends HorizontalLayout {
                 .setRequiredErrorMessage("Field is required")
                 .setMinLengthErrorMessage("Minimum length is 6 characters")
                 .setMaxLengthErrorMessage("Maximum length is 12 characters")
-                .setPatternErrorMessage("Only letters A-Z and numbers are allowed"));
+                .setPatternErrorMessage(
+                        "Only letters A-Z and numbers are allowed"));
         // end::snippet[]
         field.setHelperText(
                 "6 to 12 characters. Only letters A-Z and numbers supported.");

--- a/src/main/java/com/vaadin/demo/component/textarea/TextAreaValidation.java
+++ b/src/main/java/com/vaadin/demo/component/textarea/TextAreaValidation.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.textarea;
 
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextArea.TextAreaI18n;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
@@ -18,6 +19,12 @@ public class TextAreaValidation extends HorizontalLayout {
         field.setAllowedCharPattern("[A-Za-z0-9,.\\-\\s]");
         field.setMinLength(5);
         field.setMaxLength(50);
+
+        field.setI18n(new TextAreaI18n()
+            .setRequiredErrorMessage("Field is required")
+            .setMinLengthErrorMessage("Minimum length is 5 characters")
+            .setMaxLengthErrorMessage("Maximum length is 50 characters")
+            .setPatternErrorMessage("Must be one complete sentence ending in a period"));
         // end::snippet[]
         field.setHelperText(
                 "Must be one complete sentence ending in a period, between 5 and 50 characters long");

--- a/src/main/java/com/vaadin/demo/component/textarea/TextAreaValidation.java
+++ b/src/main/java/com/vaadin/demo/component/textarea/TextAreaValidation.java
@@ -21,10 +21,11 @@ public class TextAreaValidation extends HorizontalLayout {
         field.setMaxLength(50);
 
         field.setI18n(new TextAreaI18n()
-            .setRequiredErrorMessage("Field is required")
-            .setMinLengthErrorMessage("Minimum length is 5 characters")
-            .setMaxLengthErrorMessage("Maximum length is 50 characters")
-            .setPatternErrorMessage("Must be one complete sentence ending in a period"));
+                .setRequiredErrorMessage("Field is required")
+                .setMinLengthErrorMessage("Minimum length is 5 characters")
+                .setMaxLengthErrorMessage("Maximum length is 50 characters")
+                .setPatternErrorMessage(
+                        "Must be one complete sentence ending in a period"));
         // end::snippet[]
         field.setHelperText(
                 "Must be one complete sentence ending in a period, between 5 and 50 characters long");

--- a/src/main/java/com/vaadin/demo/component/textfield/TextFieldValidation.java
+++ b/src/main/java/com/vaadin/demo/component/textfield/TextFieldValidation.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.textfield;
 
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.textfield.TextField.TextFieldI18n;
 import com.vaadin.flow.router.Route;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
@@ -19,6 +20,12 @@ public class TextFieldValidation extends HorizontalLayout {
         field.setAllowedCharPattern("[0-9()+-]");
         field.setMinLength(5);
         field.setMaxLength(18);
+
+        field.setI18n(new TextFieldI18n()
+                .setRequiredErrorMessage("Field is required")
+                .setMinLengthErrorMessage("Minimum length is 5 characters")
+                .setMaxLengthErrorMessage("Maximum length is 18 characters")
+                .setPatternErrorMessage("Invalid phone number format"));
         // end::snippet[]
         field.setHelperText("Format: +(123)456-7890");
 

--- a/src/main/java/com/vaadin/demo/component/timepicker/TimePickerCustomValidation.java
+++ b/src/main/java/com/vaadin/demo/component/timepicker/TimePickerCustomValidation.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.timepicker;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.component.timepicker.TimePicker.TimePickerI18n;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
 
@@ -22,6 +23,8 @@ public class TimePickerCustomValidation extends Div {
         timePicker.setStep(Duration.ofMinutes(30));
         timePicker.setMin(LocalTime.of(8, 0));
         timePicker.setMax(LocalTime.of(16, 0));
+        timePicker.setI18n(new TimePickerI18n()
+                .setBadInputErrorMessage("Invalid time format"));
         add(timePicker);
 
         Binder<Appointment> binder = new Binder<>(Appointment.class);

--- a/src/main/java/com/vaadin/demo/component/timepicker/TimePickerValidation.java
+++ b/src/main/java/com/vaadin/demo/component/timepicker/TimePickerValidation.java
@@ -2,6 +2,7 @@ package com.vaadin.demo.component.timepicker;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.component.timepicker.TimePicker.TimePickerI18n;
 import com.vaadin.flow.router.Route;
 
 import java.time.Duration;
@@ -15,24 +16,20 @@ public class TimePickerValidation extends Div {
     public TimePickerValidation() {
         // tag::snippet[]
         TimePicker timePicker = new TimePicker();
+        timePicker.setRequiredIndicatorVisible(true);
         timePicker.setLabel("Appointment time");
         timePicker.setHelperText("Open 8:00-16:00");
         timePicker.setStep(Duration.ofMinutes(30));
         timePicker.setValue(LocalTime.of(8, 30));
         timePicker.setMin(LocalTime.of(8, 0));
         timePicker.setMax(LocalTime.of(16, 0));
-        timePicker.addValueChangeListener(event -> {
-            LocalTime value = event.getValue();
-            String errorMessage = null;
-            if (value != null) {
-                if (value.compareTo(timePicker.getMin()) < 0) {
-                    errorMessage = "Too early, choose another time";
-                } else if (value.compareTo(timePicker.getMax()) > 0) {
-                    errorMessage = "Too late, choose another time";
-                }
-            }
-            timePicker.setErrorMessage(errorMessage);
-        });
+
+        timePicker.setI18n(new TimePickerI18n()
+                .setBadInputErrorMessage("Invalid time format")
+                .setRequiredErrorMessage("Field is required")
+                .setMinErrorMessage("Too early, choose another time")
+                .setMaxErrorMessage("Too late, choose another time"));
+
         add(timePicker);
         // end::snippet[]
     }


### PR DESCRIPTION
Added error messages to field validation examples using the available APIs in Flow, Lit and React.

Part of #3548 