### PR TITLE
add new line to the encoded passKey to allow correctly be decoded

### DIFF
--- a/articles/control-center/getting-started/index.adoc
+++ b/articles/control-center/getting-started/index.adoc
@@ -54,7 +54,7 @@ The wizard requires a passkey to proceed. Run the following command to retrieve 
 .Terminal
 [source,bash]
 ----
-kubectl -n control-center get secret control-center-passkey -o jsonpath='{.data.passkey}' | base64 --decode
+kubectl -n control-center get secret control-center-passkey -o jsonpath='{.data.passkey}{"\n"}' | base64 --decode
 ----
 
 On Windows, you might need to remove `| base64 --decode` and use a separate tool to decode the base64 output.


### PR DESCRIPTION
related to: https://github.com/vaadin/control-center/issues/519


