### PR TITLE
refactor: add ESLint plugin to sort imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,9 @@
     "ecmaVersion": 2021,
     "project": "./tsconfig.json"
   },
+  "plugins": [
+    "simple-import-sort"
+  ],
   "extends": [
     "vaadin/typescript-requiring-type-checking",
     "vaadin/lit",
@@ -34,6 +37,27 @@
     "prefer-destructuring": "off",
     "radix": "off",
     "require-unicode-regexp": "off",
-    "sort-keys": "off"
+    "sort-keys": "off",
+    "simple-import-sort/imports": [
+      "error",
+      {
+        "groups": [
+          [
+            // Side-effects group
+            "^\\u0000",
+            // External group
+            "^",
+            // Vaadin group
+            "^@vaadin",
+            // Frontend group
+            "^Frontend",
+            // Parent group
+            "^\\.\\.",
+            // Sibling group
+            "^\\."
+          ]
+        ]
+      }
+    ]
   }
 }

--- a/frontend/demo/auth/routing.ts
+++ b/frontend/demo/auth/routing.ts
@@ -1,8 +1,6 @@
 import { useMatches } from 'react-router-dom';
 
-type RouteMetadata = {
-  [key: string]: any;
-};
+type RouteMetadata = Record<string, any>;
 
 /**
  * Returns the `handle` object containing the metadata for the current route,

--- a/frontend/demo/component/accordion/accordion-basic.ts
+++ b/frontend/demo/component/accordion/accordion-basic.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/accordion';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-basic')

--- a/frontend/demo/component/accordion/accordion-content.ts
+++ b/frontend/demo/component/accordion/accordion-content.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/accordion';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-content')

--- a/frontend/demo/component/accordion/accordion-disabled-panels.ts
+++ b/frontend/demo/component/accordion/accordion-disabled-panels.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/accordion';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-disabled-panels')

--- a/frontend/demo/component/accordion/accordion-filled-panels.ts
+++ b/frontend/demo/component/accordion/accordion-filled-panels.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/accordion';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-filled-panels')

--- a/frontend/demo/component/accordion/accordion-reverse-panels.ts
+++ b/frontend/demo/component/accordion/accordion-reverse-panels.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/accordion';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-reverse-panels')

--- a/frontend/demo/component/accordion/accordion-small-panels.ts
+++ b/frontend/demo/component/accordion/accordion-small-panels.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/accordion';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('accordion-small-panels')

--- a/frontend/demo/component/accordion/accordion-summary.ts
+++ b/frontend/demo/component/accordion/accordion-summary.ts
@@ -1,7 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/accordion';
 import '@vaadin/button';
 import '@vaadin/combo-box';
@@ -10,13 +7,15 @@ import '@vaadin/form-layout';
 import '@vaadin/horizontal-layout';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { AccordionOpenedChangedEvent } from '@vaadin/accordion';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
-import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { getCountries } from 'Frontend/demo/domain/DataService';
 import { Binder, field } from '@vaadin/hilla-lit-form';
-import PersonModel from 'Frontend/generated/com/vaadin/demo/domain/PersonModel';
+import { getCountries } from 'Frontend/demo/domain/DataService';
 import CardModel from 'Frontend/generated/com/vaadin/demo/domain/CardModel';
+import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
+import PersonModel from 'Frontend/generated/com/vaadin/demo/domain/PersonModel';
 import { applyTheme } from 'Frontend/generated/theme';
 
 const responsiveSteps: FormLayoutResponsiveStep[] = [

--- a/frontend/demo/component/app-layout/app-layout-basic.ts
+++ b/frontend/demo/component/app-layout/app-layout-basic.ts
@@ -1,14 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/app-layout/vaadin-drawer-toggle';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/scroller';
 import '@vaadin/side-nav';
-import { applyTheme } from 'Frontend/generated/theme';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/app-layout/vaadin-drawer-toggle';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/horizontal-layout';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 import { patchAppLayoutNavigation } from './app-layout-helper'; // hidden-source-line
 

--- a/frontend/demo/component/app-layout/app-layout-drawer.ts
+++ b/frontend/demo/component/app-layout/app-layout-drawer.ts
@@ -1,14 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/app-layout/vaadin-drawer-toggle';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/scroller';
 import '@vaadin/side-nav';
-import { applyTheme } from 'Frontend/generated/theme';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-drawer')
 export class Example extends LitElement {

--- a/frontend/demo/component/app-layout/app-layout-height-auto.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-auto.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/grid';
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/app-layout/app-layout-height-full.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-full.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/grid';
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
@@ -1,14 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/app-layout/vaadin-drawer-toggle';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/scroller';
 import '@vaadin/side-nav';
-import { applyTheme } from 'Frontend/generated/theme';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-navbar-placement-side')
 export class Example extends LitElement {

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
@@ -1,14 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/app-layout/vaadin-drawer-toggle';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/scroller';
 import '@vaadin/side-nav';
-import { applyTheme } from 'Frontend/generated/theme';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('app-layout-navbar-placement')
 export class Example extends LitElement {

--- a/frontend/demo/component/app-layout/app-layout-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/app-layout/vaadin-drawer-toggle';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/horizontal-layout';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 import { patchAppLayoutNavigation } from './app-layout-helper'; // hidden-source-line
 

--- a/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
+++ b/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
@@ -1,6 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/app-layout/vaadin-drawer-toggle';
 import '@vaadin/horizontal-layout';
@@ -9,8 +7,10 @@ import '@vaadin/icons';
 import '@vaadin/scroller';
 import '@vaadin/side-nav';
 import '@vaadin/vertical-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 import { patchAppLayoutNavigation } from './app-layout-helper'; // hidden-source-line
 
 @customElement('app-layout-secondary-navigation')

--- a/frontend/demo/component/auto-grid/react/auto-grid-host-styles.ts
+++ b/frontend/demo/component/auto-grid/react/auto-grid-host-styles.ts
@@ -1,10 +1,10 @@
 import { css, unsafeCSS } from 'lit';
-// @ts-ignore
-import autoGridStyles from '@vaadin/hilla-react-crud/autogrid.obj.js';
-// @ts-ignore
-import autoFormStyles from '@vaadin/hilla-react-crud/autoform.obj.js';
-// @ts-ignore
+// @ts-expect-error
 import autoCrudStyles from '@vaadin/hilla-react-crud/autocrud.obj.js';
+// @ts-expect-error
+import autoFormStyles from '@vaadin/hilla-react-crud/autoform.obj.js';
+// @ts-expect-error
+import autoGridStyles from '@vaadin/hilla-react-crud/autogrid.obj.js';
 
 function extractCss(stylesheet: CSSStyleSheet): string {
   return Array.from(stylesheet.cssRules)

--- a/frontend/demo/component/avatar/avatar-abbreviation.ts
+++ b/frontend/demo/component/avatar/avatar-abbreviation.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-abbreviation')

--- a/frontend/demo/component/avatar/avatar-basic.ts
+++ b/frontend/demo/component/avatar/avatar-basic.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/horizontal-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-group-basic.ts
+++ b/frontend/demo/component/avatar/avatar-group-basic.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/avatar-group';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/avatar-group';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-group-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-group-bg-color.ts
+++ b/frontend/demo/component/avatar/avatar-group-bg-color.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/avatar-group';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/avatar-group';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-group-bg-color')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-group-internationalisation.ts
+++ b/frontend/demo/component/avatar/avatar-group-internationalisation.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/avatar-group';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/avatar-group';
 import type { AvatarGroupI18n } from '@vaadin/avatar-group';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-group-internationalistion')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-group-max-items.ts
+++ b/frontend/demo/component/avatar/avatar-group-max-items.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/avatar-group';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/avatar-group';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-group-max-items')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/horizontal-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 import companyLogo from '../../../../src/main/resources/images/company-logo.png';
 
 @customElement('avatar-image')

--- a/frontend/demo/component/avatar/avatar-menu-bar.ts
+++ b/frontend/demo/component/avatar/avatar-menu-bar.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/menu-bar';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { MenuBarItem } from '@vaadin/menu-bar';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-menu-bar')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-name.ts
+++ b/frontend/demo/component/avatar/avatar-name.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/avatar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/avatar';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-name')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/horizontal-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('avatar-sizes')
 export class Example extends LitElement {

--- a/frontend/demo/component/badge/badge-basic.ts
+++ b/frontend/demo/component/badge/badge-basic.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-basic')

--- a/frontend/demo/component/badge/badge-highlight.ts
+++ b/frontend/demo/component/badge/badge-highlight.ts
@@ -1,12 +1,12 @@
-import { getReports, ReportStatus } from 'Frontend/demo/domain/DataService'; // hidden-source-line
 import 'Frontend/demo/init'; // hidden-source-line
-import type Report from 'Frontend/generated/com/vaadin/demo/domain/Report'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import { getReports, ReportStatus } from 'Frontend/demo/domain/DataService'; // hidden-source-line
+import type Report from 'Frontend/generated/com/vaadin/demo/domain/Report'; // hidden-source-line
 import { applyTheme } from 'Frontend/generated/theme';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {

--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -1,13 +1,13 @@
-import { getUserPermissions } from 'Frontend/demo/domain/DataService'; // hidden-source-line
 import 'Frontend/demo/init'; // hidden-source-line
-import type UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermissions'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import { getUserPermissions } from 'Frontend/demo/domain/DataService'; // hidden-source-line
+import type UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermissions'; // hidden-source-line
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-icons-only-table')

--- a/frontend/demo/component/badge/badge-icons-only.ts
+++ b/frontend/demo/component/badge/badge-icons-only.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-icons-only')
 export class Example extends LitElement {

--- a/frontend/demo/component/badge/badge-icons.ts
+++ b/frontend/demo/component/badge/badge-icons.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-icons')
 export class Example extends LitElement {

--- a/frontend/demo/component/badge/badge-interactive.ts
+++ b/frontend/demo/component/badge/badge-interactive.ts
@@ -1,4 +1,3 @@
-import { getPeople } from 'Frontend/demo/domain/DataService'; // hidden-source-line
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/flow-frontend/comboBoxConnector'; // hidden-source-line
 import '@vaadin/button';
@@ -7,11 +6,12 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
-import type { Button } from '@vaadin/button';
-import type { ComboBoxChangeEvent } from '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
+import type { Button } from '@vaadin/button';
+import type { ComboBoxChangeEvent } from '@vaadin/combo-box';
+import { getPeople } from 'Frontend/demo/domain/DataService'; // hidden-source-line
 import { applyTheme } from 'Frontend/generated/theme';
 
 type Profession = string;

--- a/frontend/demo/component/badge/badge-shape.ts
+++ b/frontend/demo/component/badge/badge-shape.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-shape')

--- a/frontend/demo/component/badge/badge-size.ts
+++ b/frontend/demo/component/badge/badge-size.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('badge-size')

--- a/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/radio-group';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('basic-layouts-expanding-items')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/button';
-import '@vaadin/horizontal-layout';
 
 @customElement('basic-layouts-horizontal-layout-horizontal-alignment')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/horizontal-layout';
+import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/horizontal-layout';
-import '@vaadin/text-area';
 
 @customElement('basic-layouts-horizontal-layout-individual-alignment')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/radio-group';
-import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('basic-layouts-horizontal-layout-margin')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/radio-group';
-import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('basic-layouts-horizontal-layout-padding')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/radio-group';
-import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('basic-layouts-horizontal-layout-spacing-variants')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/radio-group';
-import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('basic-layouts-horizontal-layout-spacing')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/horizontal-layout';
+import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/horizontal-layout';
-import '@vaadin/text-area';
 
 @customElement('basic-layouts-horizontal-layout-vertical-alignment')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/button';
-import '@vaadin/horizontal-layout';
 
 @customElement('basic-layouts-horizontal-layout')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/radio-group';
-import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('basic-layouts-margin')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/radio-group';
-import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('basic-layouts-padding')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/radio-group';
-import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('basic-layouts-spacing-variants')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/radio-group';
-import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('basic-layouts-spacing')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
+import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/button';
-import '@vaadin/vertical-layout';
 
 @customElement('basic-layouts-vertical-layout-horizontal-alignment')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
+import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/button';
-import '@vaadin/vertical-layout';
 
 @customElement('basic-layouts-vertical-layout-individual-alignment')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
+import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/button';
-import '@vaadin/vertical-layout';
 
 @customElement('basic-layouts-vertical-layout-vertical-alignment')
 export class Example extends LitElement {

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
+import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/button';
-import '@vaadin/vertical-layout';
 
 @customElement('basic-layouts-vertical-layout')
 export class Example extends LitElement {

--- a/frontend/demo/component/board/board-basic.ts
+++ b/frontend/demo/component/board/board-basic.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/board';
-import { applyTheme } from 'Frontend/generated/theme';
 import './example-indicator';
 import './example-chart';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('board-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/board/board-breakpoints.ts
+++ b/frontend/demo/component/board/board-breakpoints.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/board';
 import '@vaadin/split-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('board-breakpoints')

--- a/frontend/demo/component/board/board-column-span.ts
+++ b/frontend/demo/component/board/board-column-span.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/board';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/board';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('board-column-span')

--- a/frontend/demo/component/board/board-column-wrapping.ts
+++ b/frontend/demo/component/board/board-column-wrapping.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/board';
 import '@vaadin/split-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('board-column-wrapping')

--- a/frontend/demo/component/board/board-nested.ts
+++ b/frontend/demo/component/board/board-nested.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/board';
-import { applyTheme } from 'Frontend/generated/theme';
 import './example-indicator';
 import './example-statistics';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('board-nested')
 export class Example extends LitElement {

--- a/frontend/demo/component/board/example-chart.ts
+++ b/frontend/demo/component/board/example-chart.ts
@@ -1,9 +1,9 @@
-import { getViewEvents } from 'Frontend/demo/domain/DataService'; // hidden-source-line
-import type ViewEvent from 'Frontend/generated/com/vaadin/demo/domain/ViewEvent'; // hidden-source-line
+import '@vaadin/charts';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import '@vaadin/charts';
+import { getViewEvents } from 'Frontend/demo/domain/DataService'; // hidden-source-line
+import type ViewEvent from 'Frontend/generated/com/vaadin/demo/domain/ViewEvent'; // hidden-source-line
 
 const monthNames = [
   'Jan',

--- a/frontend/demo/component/board/example-indicator.ts
+++ b/frontend/demo/component/board/example-indicator.ts
@@ -1,9 +1,9 @@
-import { applyTheme } from 'Frontend/generated/theme';
-import { css, html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/vertical-layout';
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('example-indicator')
 export class ExampleIndicator extends LitElement {

--- a/frontend/demo/component/board/example-statistics.ts
+++ b/frontend/demo/component/board/example-statistics.ts
@@ -1,8 +1,8 @@
-import { getServiceHealth } from 'Frontend/demo/domain/DataService';
-import type ServiceHealth from 'Frontend/generated/com/vaadin/demo/domain/ServiceHealth';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { getServiceHealth } from 'Frontend/demo/domain/DataService';
+import type ServiceHealth from 'Frontend/generated/com/vaadin/demo/domain/ServiceHealth';
 
 @customElement('example-statistics')
 export class ExampleStatistics extends LitElement {

--- a/frontend/demo/component/button/button-basic.ts
+++ b/frontend/demo/component/button/button-basic.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-basic')

--- a/frontend/demo/component/button/button-contrast.ts
+++ b/frontend/demo/component/button/button-contrast.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-contrast')

--- a/frontend/demo/component/button/button-dialog.ts
+++ b/frontend/demo/component/button/button-dialog.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/email-field';
 import '@vaadin/form-layout';
 import '@vaadin/horizontal-layout';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-dialog')

--- a/frontend/demo/component/button/button-disable-long-action.ts
+++ b/frontend/demo/component/button/button-disable-long-action.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/progress-bar';
-import { applyTheme } from 'Frontend/generated/theme';
 import './fake-progress-bar';
+import { html, LitElement } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 import type { FakeProgressBar } from './fake-progress-bar';
 
 @customElement('button-disable-long-action')

--- a/frontend/demo/component/button/button-disabled.ts
+++ b/frontend/demo/component/button/button-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-disabled')

--- a/frontend/demo/component/button/button-error.ts
+++ b/frontend/demo/component/button/button-error.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-error')

--- a/frontend/demo/component/button/button-focus.ts
+++ b/frontend/demo/component/button/button-focus.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-focus')

--- a/frontend/demo/component/button/button-form.ts
+++ b/frontend/demo/component/button/button-form.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/email-field';
 import '@vaadin/form-layout';
 import '@vaadin/horizontal-layout';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-form')

--- a/frontend/demo/component/button/button-grid.ts
+++ b/frontend/demo/component/button/button-grid.ts
@@ -1,17 +1,16 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-selection-column';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { GridSelectedItemsChangedEvent } from '@vaadin/grid';
 import type { GridSelectionColumnSelectAllChangedEvent } from '@vaadin/grid/vaadin-grid-selection-column';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-grid')
 export class Example extends LitElement {

--- a/frontend/demo/component/button/button-icons.ts
+++ b/frontend/demo/component/button/button-icons.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-icons')

--- a/frontend/demo/component/button/button-images.ts
+++ b/frontend/demo/component/button/button-images.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
 import { applyTheme } from 'Frontend/generated/theme';
 import img from '../../../../src/main/resources/images/vaadin-logo-dark.png';
 

--- a/frontend/demo/component/button/button-labels.ts
+++ b/frontend/demo/component/button/button-labels.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { css, html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/email-field';
-import type { EmailFieldValueChangedEvent } from '@vaadin/email-field';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { EmailFieldValueChangedEvent } from '@vaadin/email-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-labels')

--- a/frontend/demo/component/button/button-sizes.ts
+++ b/frontend/demo/component/button/button-sizes.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-sizes')

--- a/frontend/demo/component/button/button-styles.ts
+++ b/frontend/demo/component/button/button-styles.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-styles')

--- a/frontend/demo/component/button/button-success.ts
+++ b/frontend/demo/component/button/button-success.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-success')

--- a/frontend/demo/component/button/button-tertiary-inline.ts
+++ b/frontend/demo/component/button/button-tertiary-inline.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-tertiary-inline')

--- a/frontend/demo/component/button/button-warning.ts
+++ b/frontend/demo/component/button/button-warning.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('button-warning')

--- a/frontend/demo/component/button/fake-progress-bar.ts
+++ b/frontend/demo/component/button/fake-progress-bar.ts
@@ -1,6 +1,6 @@
+import '@vaadin/progress-bar';
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import '@vaadin/progress-bar';
 
 @customElement('fake-progress-bar')
 export class FakeProgressBar extends LitElement {

--- a/frontend/demo/component/charts/charts-area.ts
+++ b/frontend/demo/component/charts/charts-area.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/charts';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/charts';
 
 @customElement('charts-area')
 export class Example extends LitElement {

--- a/frontend/demo/component/charts/charts-column.ts
+++ b/frontend/demo/component/charts/charts-column.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/charts';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/charts';
 
 @customElement('charts-column')
 export class Example extends LitElement {

--- a/frontend/demo/component/charts/charts-overview.ts
+++ b/frontend/demo/component/charts/charts-overview.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, css, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/charts';
 import type { Options, PointOptionsObject } from 'highcharts';
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('charts-overview')
 export class Example extends LitElement {

--- a/frontend/demo/component/charts/charts-pie.ts
+++ b/frontend/demo/component/charts/charts-pie.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/charts';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/charts';
 
 @customElement('charts-pie')
 export class Example extends LitElement {

--- a/frontend/demo/component/charts/charts-polar.ts
+++ b/frontend/demo/component/charts/charts-polar.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/charts';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/charts';
 
 @customElement('charts-polar')
 export class Example extends LitElement {

--- a/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts
+++ b/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-adjacent-groups')

--- a/frontend/demo/component/checkbox/checkbox-basic.ts
+++ b/frontend/demo/component/checkbox/checkbox-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/checkbox';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/checkbox';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-basic')

--- a/frontend/demo/component/checkbox/checkbox-disabled.ts
+++ b/frontend/demo/component/checkbox/checkbox-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-disabled')

--- a/frontend/demo/component/checkbox/checkbox-group-basic-features.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-basic-features.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/checkbox-group';
 import '@vaadin/tooltip';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-group-basic-features')

--- a/frontend/demo/component/checkbox/checkbox-group-basic.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-basic.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { CheckboxGroupValueChangedEvent } from '@vaadin/checkbox-group';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/checkbox/checkbox-group-styles.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/checkbox-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/checkbox-group';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-group-styles')

--- a/frontend/demo/component/checkbox/checkbox-horizontal.ts
+++ b/frontend/demo/component/checkbox/checkbox-horizontal.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-horizontal')

--- a/frontend/demo/component/checkbox/checkbox-indeterminate.ts
+++ b/frontend/demo/component/checkbox/checkbox-indeterminate.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { CheckboxGroupValueChangedEvent } from '@vaadin/checkbox-group';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/checkbox/checkbox-labeling.ts
+++ b/frontend/demo/component/checkbox/checkbox-labeling.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/checkbox';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/checkbox';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/checkbox/checkbox-readonly.ts
+++ b/frontend/demo/component/checkbox/checkbox-readonly.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-group-readonly')

--- a/frontend/demo/component/checkbox/checkbox-required.ts
+++ b/frontend/demo/component/checkbox/checkbox-required.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/checkbox';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { Binder, field, Required } from '@vaadin/hilla-lit-form';
 import UserPermissionsModel from 'Frontend/generated/com/vaadin/demo/domain/UserPermissionsModel';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/checkbox/checkbox-vertical.ts
+++ b/frontend/demo/component/checkbox/checkbox-vertical.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('checkbox-vertical')

--- a/frontend/demo/component/combobox/combo-box-auto-open.ts
+++ b/frontend/demo/component/combobox/combo-box-auto-open.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/combobox/combo-box-basic-features.ts
+++ b/frontend/demo/component/combobox/combo-box-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/combo-box';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-basic-features')

--- a/frontend/demo/component/combobox/combo-box-basic.ts
+++ b/frontend/demo/component/combobox/combo-box-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-custom-entry-1')

--- a/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import type { ComboBoxCustomValueSetEvent } from '@vaadin/combo-box';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/combobox/combo-box-filtering-1.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-1.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/combobox/combo-box-filtering-2.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-2.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import type { ComboBoxFilterChangedEvent } from '@vaadin/combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';

--- a/frontend/demo/component/combobox/combo-box-item-class-name.ts
+++ b/frontend/demo/component/combobox/combo-box-item-class-name.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-item-class-name')

--- a/frontend/demo/component/combobox/combo-box-popup-width.ts
+++ b/frontend/demo/component/combobox/combo-box-popup-width.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
-import { comboBoxRenderer } from '@vaadin/combo-box/lit.js';
-import type { ComboBoxLitRenderer } from '@vaadin/combo-box/lit.js';
 import type { ComboBoxFilterChangedEvent } from '@vaadin/combo-box';
+import type { ComboBoxLitRenderer } from '@vaadin/combo-box/lit.js';
+import { comboBoxRenderer } from '@vaadin/combo-box/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/combobox/combo-box-readonly-and-disabled.ts
+++ b/frontend/demo/component/combobox/combo-box-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/combo-box';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-readonly-and-disabled')

--- a/frontend/demo/component/combobox/combo-box-styles.ts
+++ b/frontend/demo/component/combobox/combo-box-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-styles')

--- a/frontend/demo/component/combobox/combo-box-validation.ts
+++ b/frontend/demo/component/combobox/combo-box-validation.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('combo-box-validation')

--- a/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, css, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/confirm-dialog';
 import '@vaadin/horizontal-layout';
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { ConfirmDialogOpenedChangedEvent } from '@vaadin/confirm-dialog';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/confirm-dialog';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { ConfirmDialogOpenedChangedEvent } from '@vaadin/confirm-dialog';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/confirm-dialog';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { ConfirmDialogOpenedChangedEvent } from '@vaadin/confirm-dialog';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/confirm-dialog';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { ConfirmDialogOpenedChangedEvent } from '@vaadin/confirm-dialog';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/contextmenu/context-menu-basic.ts
+++ b/frontend/demo/component/contextmenu/context-menu-basic.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/context-menu';
 import '@vaadin/grid';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/contextmenu/context-menu-best-practices.ts
+++ b/frontend/demo/component/contextmenu/context-menu-best-practices.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/context-menu';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { Grid } from '@vaadin/grid';
 import '@vaadin/menu-bar';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { Grid } from '@vaadin/grid';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 interface FileItem {

--- a/frontend/demo/component/contextmenu/context-menu-checkable.ts
+++ b/frontend/demo/component/contextmenu/context-menu-checkable.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/context-menu';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/context-menu';
 import type { ContextMenuItem, ContextMenuItemSelectedEvent } from '@vaadin/context-menu';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/contextmenu/context-menu-classname.ts
+++ b/frontend/demo/component/contextmenu/context-menu-classname.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/context-menu';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { ContextMenuItem } from '@vaadin/context-menu';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/contextmenu/context-menu-disabled.ts
+++ b/frontend/demo/component/contextmenu/context-menu-disabled.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/context-menu';
 import '@vaadin/grid';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { Grid } from '@vaadin/grid';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/contextmenu/context-menu-dividers.ts
+++ b/frontend/demo/component/contextmenu/context-menu-dividers.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/context-menu';
 import '@vaadin/grid';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
+++ b/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/context-menu';
 import '@vaadin/grid';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { Grid } from '@vaadin/grid';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/contextmenu/context-menu-left-click.ts
+++ b/frontend/demo/component/contextmenu/context-menu-left-click.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/context-menu';
+import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/context-menu';
 import type { ContextMenuOpenedChangedEvent } from '@vaadin/context-menu';
-import '@vaadin/grid';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/contextmenu/context-menu-presentation.ts
+++ b/frontend/demo/component/contextmenu/context-menu-presentation.ts
@@ -1,16 +1,16 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement, render } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/context-menu';
-import type { ContextMenuItem } from '@vaadin/context-menu';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { Grid } from '@vaadin/grid';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
+import { html, LitElement, render } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { ContextMenuItem } from '@vaadin/context-menu';
+import type { Grid } from '@vaadin/grid';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/cookieconsent/cookie-consent-basic.ts
+++ b/frontend/demo/component/cookieconsent/cookie-consent-basic.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './example-cleanup'; // hidden-source-line
+import '@vaadin/cookie-consent';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/cookie-consent';
 
 @customElement('cookie-consent-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/cookieconsent/cookie-consent-localization.ts
+++ b/frontend/demo/component/cookieconsent/cookie-consent-localization.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './example-cleanup'; // hidden-source-line
+import '@vaadin/cookie-consent';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/cookie-consent';
 
 @customElement('cookie-consent-localization')
 export class Example extends LitElement {

--- a/frontend/demo/component/cookieconsent/cookie-consent-theming.ts
+++ b/frontend/demo/component/cookieconsent/cookie-consent-theming.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './example-cleanup'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/cookie-consent';
 import '@vaadin/vaadin-lumo-styles/all-imports';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 @customElement('cookie-consent-theming')
 export class Example extends LitElement {

--- a/frontend/demo/component/crud/crud-basic.ts
+++ b/frontend/demo/component/crud/crud-basic.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import '@vaadin/email-field';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/crud/crud-columns.ts
+++ b/frontend/demo/component/crud/crud-columns.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import '@vaadin/date-picker';
 import '@vaadin/email-field';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/crud/crud-editor-aside.ts
+++ b/frontend/demo/component/crud/crud-editor-aside.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/crud';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/crud/crud-editor-bottom.ts
+++ b/frontend/demo/component/crud/crud-editor-bottom.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/crud';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/crud/crud-editor-content.ts
+++ b/frontend/demo/component/crud/crud-editor-content.ts
@@ -1,12 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/combo-box';
 import '@vaadin/crud';
 import '@vaadin/form-layout';
-import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import '@vaadin/email-field';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/crud/crud-grid-replacement.ts
+++ b/frontend/demo/component/crud/crud-grid-replacement.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/crud';
 import '@vaadin/grid';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/crud/crud-hidden-toolbar.ts
+++ b/frontend/demo/component/crud/crud-hidden-toolbar.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/crud';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/crud/crud-item-initialization.ts
+++ b/frontend/demo/component/crud/crud-item-initialization.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/crud';
+import '@vaadin/email-field';
 import { html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
-import '@vaadin/crud';
 import type { Crud, CrudNewEvent } from '@vaadin/crud';
-import '@vaadin/email-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/crud/crud-localization.ts
+++ b/frontend/demo/component/crud/crud-localization.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/crud';
 import { html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
-import '@vaadin/crud';
 import type { Crud } from '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/crud/crud-open-editor.ts
+++ b/frontend/demo/component/crud/crud-open-editor.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/crud';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/crud';
 import type { CrudEditedItemChangedEvent } from '@vaadin/crud';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';

--- a/frontend/demo/component/crud/crud-sorting-filtering.ts
+++ b/frontend/demo/component/crud/crud-sorting-filtering.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/crud';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/crud/crud-toolbar.ts
+++ b/frontend/demo/component/crud/crud-toolbar.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/crud';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/custom-field/custom-field-basic.ts
+++ b/frontend/demo/component/custom-field/custom-field-basic.ts
@@ -1,12 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/custom-field';
 import '@vaadin/date-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { differenceInDays, isAfter, parseISO } from 'date-fns';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { Binder, field } from '@vaadin/hilla-lit-form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
-import { differenceInDays, parseISO, isAfter } from 'date-fns';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('custom-field-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/custom-field/custom-field-native-input.ts
+++ b/frontend/demo/component/custom-field/custom-field-native-input.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/custom-field';
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/custom-field';
 import type { CustomFieldChangeEvent } from '@vaadin/custom-field';
-import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('custom-field-native-input')

--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/custom-field';
 import '@vaadin/horizontal-layout';
 import '@vaadin/select';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('custom-field-size-variants')

--- a/frontend/demo/component/datepicker/date-picker-auto-open.ts
+++ b/frontend/demo/component/datepicker/date-picker-auto-open.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-auto-open')

--- a/frontend/demo/component/datepicker/date-picker-basic-features.ts
+++ b/frontend/demo/component/datepicker/date-picker-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/date-picker';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-basic-features')

--- a/frontend/demo/component/datepicker/date-picker-basic.ts
+++ b/frontend/demo/component/datepicker/date-picker-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-basic')

--- a/frontend/demo/component/datepicker/date-picker-custom-functions.ts
+++ b/frontend/demo/component/datepicker/date-picker-custom-functions.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/date-picker';
-import type { DatePicker, DatePickerDate, DatePickerChangeEvent } from '@vaadin/date-picker';
-import { applyTheme } from 'Frontend/generated/theme';
 import dateFnsFormat from 'date-fns/format';
 import dateFnsParse from 'date-fns/parse';
+import { html, LitElement } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
+import type { DatePicker, DatePickerChangeEvent, DatePickerDate } from '@vaadin/date-picker';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-custom-functions')
 export class Example extends LitElement {

--- a/frontend/demo/component/datepicker/date-picker-custom-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-custom-validation.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-picker';
 import { Binder, field } from '@vaadin/hilla-lit-form';
-import { applyTheme } from 'Frontend/generated/theme';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-custom-validation')
 export class Example extends LitElement {

--- a/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-date-format-indicator')

--- a/frontend/demo/component/datepicker/date-picker-date-range.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-range.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-picker';
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/date-picker';
 import type { DatePickerValueChangedEvent } from '@vaadin/date-picker';
-import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-date-range')

--- a/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
+++ b/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/combo-box';
+import '@vaadin/horizontal-layout';
+import getDaysInMonth from 'date-fns/getDaysInMonth';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/combo-box';
 import type { ComboBoxSelectedItemChangedEvent } from '@vaadin/combo-box';
-import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
-import getDaysInMonth from 'date-fns/getDaysInMonth';
 
 @customElement('date-picker-individual-input-fields')
 export class Example extends LitElement {

--- a/frontend/demo/component/datepicker/date-picker-initial-position.ts
+++ b/frontend/demo/component/datepicker/date-picker-initial-position.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-picker';
+import { formatISO, lastDayOfYear } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
-import { formatISO, lastDayOfYear } from 'date-fns';
 
 @customElement('date-picker-initial-position')
 export class Example extends LitElement {

--- a/frontend/demo/component/datepicker/date-picker-internationalization.ts
+++ b/frontend/demo/component/datepicker/date-picker-internationalization.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import '@vaadin/date-picker';
 import type { DatePicker } from '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/datepicker/date-picker-readonly-and-disabled.ts
+++ b/frontend/demo/component/datepicker/date-picker-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/date-picker';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-readonly-and-disabled')

--- a/frontend/demo/component/datepicker/date-picker-styles.ts
+++ b/frontend/demo/component/datepicker/date-picker-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-styles')

--- a/frontend/demo/component/datepicker/date-picker-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-validation.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/date-picker';
-import type { DatePickerChangeEvent } from '@vaadin/date-picker';
-import { applyTheme } from 'Frontend/generated/theme';
 import { addDays, formatISO, isAfter, isBefore } from 'date-fns';
 import dateFnsParse from 'date-fns/parse';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { DatePickerChangeEvent } from '@vaadin/date-picker';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-picker-validation')
 export class Example extends LitElement {

--- a/frontend/demo/component/datepicker/date-picker-week-numbers.ts
+++ b/frontend/demo/component/datepicker/date-picker-week-numbers.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import '@vaadin/date-picker';
 import type { DatePicker } from '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-auto-open')

--- a/frontend/demo/component/datetimepicker/date-time-picker-basic-features.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/date-time-picker';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-basic-features')

--- a/frontend/demo/component/datetimepicker/date-time-picker-basic.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-basic')

--- a/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import { Binder, field } from '@vaadin/hilla-lit-form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/date-time-picker';
-import { applyTheme } from 'Frontend/generated/theme';
-import startOfMonth from 'date-fns/startOfMonth';
 import addMonths from 'date-fns/addMonths';
 import formatISO from 'date-fns/formatISO';
+import startOfMonth from 'date-fns/startOfMonth';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 const startOfNextMonth = startOfMonth(addMonths(new Date(), 1));
 const startOfNextMonthISOString = formatISO(startOfNextMonth, { representation: 'date' });

--- a/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, query } from 'lit/decorators.js';
 import '@vaadin/date-time-picker';
-import { applyTheme } from 'Frontend/generated/theme';
-import type { DateTimePicker } from '@vaadin/date-time-picker';
 import dateFnsFormat from 'date-fns/format';
 import dateFnsParse from 'date-fns/parse';
+import { html, LitElement } from 'lit';
+import { customElement, query } from 'lit/decorators.js';
 import type { DatePickerDate } from '@vaadin/date-picker';
+import type { DateTimePicker } from '@vaadin/date-time-picker';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-input-format')
 export class Example extends LitElement {

--- a/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import type { DateTimePicker } from '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-minutes-step')

--- a/frontend/demo/component/datetimepicker/date-time-picker-range.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-range.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import type { DateTimePickerValueChangedEvent } from '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/datetimepicker/date-time-picker-readonly-and-disabled.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/vertical-layout';
 import '@vaadin/date-time-picker';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-readonly-and-disabled')

--- a/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-seconds-step')

--- a/frontend/demo/component/datetimepicker/date-time-picker-styles.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('date-time-picker-styles')

--- a/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
+import { addDays, format, isAfter, isBefore, parseISO } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import type { DateTimePickerChangeEvent } from '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
-import { addDays, format, isAfter, isBefore, parseISO } from 'date-fns';
 
 const dateTimeFormat = `yyyy-MM-dd'T'HH:00:00`;
 

--- a/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import '@vaadin/date-time-picker';
 import type { DateTimePicker } from '@vaadin/date-time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/details/details-basic.ts
+++ b/frontend/demo/component/details/details-basic.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/details';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('details-basic')

--- a/frontend/demo/component/details/details-content.ts
+++ b/frontend/demo/component/details/details-content.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/details';
 import '@vaadin/vertical-layout';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/details/details-disabled.ts
+++ b/frontend/demo/component/details/details-disabled.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/details';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/details';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/details/details-filled.ts
+++ b/frontend/demo/component/details/details-filled.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/details';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/details';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/details/details-reverse.ts
+++ b/frontend/demo/component/details/details-reverse.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/details';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/details';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/details/details-small.ts
+++ b/frontend/demo/component/details/details-small.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/details';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/details';
 import { applyTheme } from 'Frontend/generated/theme';
 
 // tag::snippet[]

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -1,17 +1,16 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/combo-box';
 import '@vaadin/details';
 import '@vaadin/form-layout';
-import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/text-field';
 import '@vaadin/vaadin-lumo-styles/sizing';
 import '@vaadin/vaadin-lumo-styles/color';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/dialog/dialog-basic.ts
+++ b/frontend/demo/component/dialog/dialog-basic.ts
@@ -1,14 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { css, html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-
 import '@vaadin/button';
 import '@vaadin/dialog';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
-import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
+import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-basic')

--- a/frontend/demo/component/dialog/dialog-closing.ts
+++ b/frontend/demo/component/dialog/dialog-closing.ts
@@ -1,13 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-
 import '@vaadin/button';
 import '@vaadin/dialog';
 import '@vaadin/vertical-layout';
-import { dialogRenderer } from '@vaadin/dialog/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
+import { dialogRenderer } from '@vaadin/dialog/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-closing')

--- a/frontend/demo/component/dialog/dialog-draggable.ts
+++ b/frontend/demo/component/dialog/dialog-draggable.ts
@@ -1,15 +1,13 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-
 import '@vaadin/button';
 import '@vaadin/dialog';
 import '@vaadin/text-area';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
-import { dialogFooterRenderer, dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
+import { dialogFooterRenderer, dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-draggable')

--- a/frontend/demo/component/dialog/dialog-footer.ts
+++ b/frontend/demo/component/dialog/dialog-footer.ts
@@ -1,15 +1,13 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-
 import '@vaadin/button';
 import '@vaadin/dialog';
-import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
-import { applyTheme } from 'Frontend/generated/theme';
+import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-footer')
 export class Example extends LitElement {

--- a/frontend/demo/component/dialog/dialog-header.ts
+++ b/frontend/demo/component/dialog/dialog-header.ts
@@ -1,9 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
-
 import '@vaadin/button';
 import '@vaadin/dialog';
 import '@vaadin/email-field';
@@ -11,11 +6,14 @@ import '@vaadin/icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
-import { dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
-import { applyTheme } from 'Frontend/generated/theme';
+import { dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-header')
 export class Example extends LitElement {

--- a/frontend/demo/component/dialog/dialog-no-padding.ts
+++ b/frontend/demo/component/dialog/dialog-no-padding.ts
@@ -1,19 +1,16 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-
 import '@vaadin/button';
 import '@vaadin/dialog';
-import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
-import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-selection-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
+import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-no-padding')
 export class Example extends LitElement {

--- a/frontend/demo/component/dialog/dialog-resizable.ts
+++ b/frontend/demo/component/dialog/dialog-resizable.ts
@@ -1,18 +1,15 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-
 import '@vaadin/button';
 import '@vaadin/dialog';
 import '@vaadin/grid';
 import '@vaadin/vertical-layout';
-import { dialogRenderer } from '@vaadin/dialog/lit.js';
-
-import { applyTheme } from 'Frontend/generated/theme';
-import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { getPeople } from 'Frontend/demo/domain/DataService';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { DialogOpenedChangedEvent } from '@vaadin/dialog';
+import { dialogRenderer } from '@vaadin/dialog/lit.js';
+import { getPeople } from 'Frontend/demo/domain/DataService';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('dialog-resizable')
 export class Example extends LitElement {

--- a/frontend/demo/component/emailfield/email-field-basic-features.ts
+++ b/frontend/demo/component/emailfield/email-field-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/email-field';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('email-field-basic-features')

--- a/frontend/demo/component/emailfield/email-field-basic.ts
+++ b/frontend/demo/component/emailfield/email-field-basic.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/email-field';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('email-field-basic')

--- a/frontend/demo/component/emailfield/email-field-readonly-and-disabled.ts
+++ b/frontend/demo/component/emailfield/email-field-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/email-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('email-field-readonly-and-disabled')

--- a/frontend/demo/component/emailfield/email-field-styles.ts
+++ b/frontend/demo/component/emailfield/email-field-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/email-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/email-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('email-field-styles')

--- a/frontend/demo/component/emailfield/email-field-validation.ts
+++ b/frontend/demo/component/emailfield/email-field-validation.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/email-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/email-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('email-field-validation')

--- a/frontend/demo/component/formlayout/form-layout-basic.ts
+++ b/frontend/demo/component/formlayout/form-layout-basic.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/form-layout';
-import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import '@vaadin/password-field';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-basic')

--- a/frontend/demo/component/formlayout/form-layout-colspan.ts
+++ b/frontend/demo/component/formlayout/form-layout-colspan.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/date-picker';
 import '@vaadin/form-layout';
-import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import '@vaadin/text-field';
 import '@vaadin/time-picker';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-custom-layout')

--- a/frontend/demo/component/formlayout/form-layout-custom-field.ts
+++ b/frontend/demo/component/formlayout/form-layout-custom-field.ts
@@ -1,13 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/form-layout';
 import '@vaadin/form-layout/vaadin-form-item';
 import '@vaadin/select';
 import '@vaadin/custom-field';
 import '@vaadin/horizontal-layout';
-
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-custom-field')

--- a/frontend/demo/component/formlayout/form-layout-custom-layout.ts
+++ b/frontend/demo/component/formlayout/form-layout-custom-layout.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/email-field';
 import '@vaadin/form-layout';
-import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import '@vaadin/split-layout';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-custom-layout')

--- a/frontend/demo/component/formlayout/form-layout-native-input.ts
+++ b/frontend/demo/component/formlayout/form-layout-native-input.ts
@@ -1,10 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/form-layout';
 import '@vaadin/form-layout/vaadin-form-item';
-
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-native-input')

--- a/frontend/demo/component/formlayout/form-layout-side.ts
+++ b/frontend/demo/component/formlayout/form-layout-side.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/form-layout';
 import '@vaadin/form-layout/vaadin-form-item';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('form-layout-side')

--- a/frontend/demo/component/grid/grid-basic.ts
+++ b/frontend/demo/component/grid/grid-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
+import '@vaadin/text-area';
 import { css, html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
-import '@vaadin/grid';
 import type { Grid, GridCellFocusEvent } from '@vaadin/grid';
-import '@vaadin/text-area';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-column-alignment.ts
+++ b/frontend/demo/component/grid/grid-column-alignment.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
+import { format } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
-import { format } from 'date-fns';
 
 @customElement('grid-column-alignment')
 export class Example extends LitElement {

--- a/frontend/demo/component/grid/grid-column-borders.ts
+++ b/frontend/demo/component/grid/grid-column-borders.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-column-filtering.ts
+++ b/frontend/demo/component/grid/grid-column-filtering.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-filter-column.js';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-column-freezing.ts
+++ b/frontend/demo/component/grid/grid-column-freezing.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/grid';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/grid/grid-column-grouping.ts
+++ b/frontend/demo/component/grid/grid-column-grouping.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-column-group.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-column-header-footer.ts
+++ b/frontend/demo/component/grid/grid-column-header-footer.ts
@@ -1,17 +1,16 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
+import '@vaadin/horizontal-layout';
+import '@vaadin/icon';
+import '@vaadin/icons';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/grid';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import {
   columnBodyRenderer,
   columnFooterRenderer,
   columnHeaderRenderer,
 } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
-import '@vaadin/horizontal-layout';
-import '@vaadin/icon';
-import '@vaadin/icons';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-column-reordering-resizing.ts
+++ b/frontend/demo/component/grid/grid-column-reordering-resizing.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-column-group.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-column-visibility.ts
+++ b/frontend/demo/component/grid/grid-column-visibility.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/context-menu';
-import type { ContextMenuItem, ContextMenuItemSelectedEvent } from '@vaadin/context-menu';
 import '@vaadin/grid';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { ContextMenuItem, ContextMenuItemSelectedEvent } from '@vaadin/context-menu';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-column-width.ts
+++ b/frontend/demo/component/grid/grid-column-width.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-selection-column.js';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/split-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-compact.ts
+++ b/frontend/demo/component/grid/grid-compact.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-content.ts
+++ b/frontend/demo/component/grid/grid-content.ts
@@ -1,15 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/button';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-selection-column.js';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-context-menu.ts
+++ b/frontend/demo/component/grid/grid-context-menu.ts
@@ -1,14 +1,13 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/context-menu';
-import { contextMenuRenderer } from '@vaadin/context-menu/lit.js';
-import type { ContextMenuLitRenderer } from '@vaadin/context-menu/lit.js';
 import '@vaadin/grid';
-import type { Grid } from '@vaadin/grid';
 import '@vaadin/item';
 import '@vaadin/list-box';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { ContextMenuLitRenderer } from '@vaadin/context-menu/lit.js';
+import { contextMenuRenderer } from '@vaadin/context-menu/lit.js';
+import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-data-provider.ts
+++ b/frontend/demo/component/grid/grid-data-provider.ts
@@ -1,15 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/text-field';
 import '@vaadin/icon';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
 import '@vaadin/grid/vaadin-grid-filter-column.js';
-import { getPeople } from 'Frontend/demo/domain/DataService';
-import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
 import type {
   Grid,
   GridDataProviderCallback,
@@ -18,6 +14,9 @@ import type {
   GridSorterDirection,
 } from '@vaadin/grid';
 import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
+import { getPeople } from 'Frontend/demo/domain/DataService';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 function matchesTerm(value: string, searchTerm: string) {
   return value.toLowerCase().includes(searchTerm.toLowerCase());

--- a/frontend/demo/component/grid/grid-drag-drop-filters.ts
+++ b/frontend/demo/component/grid/grid-drag-drop-filters.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-tree-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
 import type {
   Grid,
   GridDataProviderCallback,

--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridDragStartEvent } from '@vaadin/grid';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-dynamic-height.ts
+++ b/frontend/demo/component/grid/grid-dynamic-height.ts
@@ -1,16 +1,15 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/combo-box';
-import type { ComboBoxValueChangedEvent } from '@vaadin/combo-box';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { ComboBoxValueChangedEvent } from '@vaadin/combo-box';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-empty-state.ts
+++ b/frontend/demo/component/grid/grid-empty-state.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/grid';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('grid-empty-state')

--- a/frontend/demo/component/grid/grid-external-filtering.ts
+++ b/frontend/demo/component/grid/grid-external-filtering.ts
@@ -1,17 +1,16 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/button';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
-import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-header-footer-styling.ts
+++ b/frontend/demo/component/grid/grid-header-footer-styling.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/grid';
-import { columnBodyRenderer, columnFooterRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer, columnFooterRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-item-details-toggle.ts
+++ b/frontend/demo/component/grid/grid-item-details-toggle.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
-import { columnBodyRenderer, gridRowDetailsRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/form-layout';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { columnBodyRenderer, gridRowDetailsRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-item-details.ts
+++ b/frontend/demo/component/grid/grid-item-details.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
-import { gridRowDetailsRenderer } from '@vaadin/grid/lit.js';
-import type { GridActiveItemChangedEvent } from '@vaadin/grid';
 import '@vaadin/form-layout';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GridActiveItemChangedEvent } from '@vaadin/grid';
+import { gridRowDetailsRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-lazy-column-rendering.ts
+++ b/frontend/demo/component/grid/grid-lazy-column-rendering.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/grid';
+import type { GridBodyRenderer } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
-import type { GridBodyRenderer } from '@vaadin/grid';
 
 @customElement('grid-lazy-column-rendering')
 export class Example extends LitElement {

--- a/frontend/demo/component/grid/grid-multi-select-mode.ts
+++ b/frontend/demo/component/grid/grid-multi-select-mode.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-selection-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-multisort.ts
+++ b/frontend/demo/component/grid/grid-multisort.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-no-border.ts
+++ b/frontend/demo/component/grid/grid-no-border.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-no-row-border.ts
+++ b/frontend/demo/component/grid/grid-no-row-border.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-rich-content-sorting.ts
+++ b/frontend/demo/component/grid/grid-rich-content-sorting.ts
@@ -1,18 +1,17 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sorter.js';
-import { columnBodyRenderer, columnHeaderRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
+import { differenceInYears, format, parseISO } from 'date-fns';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer, columnHeaderRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
-import { differenceInYears, format, parseISO } from 'date-fns';
 
 @customElement('grid-rich-content-sorting')
 export class Example extends LitElement {

--- a/frontend/demo/component/grid/grid-row-reordering.ts
+++ b/frontend/demo/component/grid/grid-row-reordering.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { GridDragStartEvent, GridDropEvent } from '@vaadin/grid';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-row-stripes.ts
+++ b/frontend/demo/component/grid/grid-row-stripes.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-single-selection-mode.ts
+++ b/frontend/demo/component/grid/grid-single-selection-mode.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/grid';
 import type { GridActiveItemChangedEvent } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/grid/grid-sorting.ts
+++ b/frontend/demo/component/grid/grid-sorting.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-styling.ts
+++ b/frontend/demo/component/grid/grid-styling.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import type { GridItemModel } from '@vaadin/grid';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/grid/grid-tooltip-generator.ts
+++ b/frontend/demo/component/grid/grid-tooltip-generator.ts
@@ -1,15 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid';
-import type { GridEventContext } from '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
 import { differenceInYears, parseISO } from 'date-fns';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GridEventContext } from '@vaadin/grid';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/grid/grid-wrap-cell-content.ts
+++ b/frontend/demo/component/grid/grid-wrap-cell-content.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/grid';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/gridpro/grid-pro-basic.ts
+++ b/frontend/demo/component/gridpro/grid-pro-basic.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/gridpro/grid-pro-cell-editability.ts
+++ b/frontend/demo/component/gridpro/grid-pro-cell-editability.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { GridItemModel } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/gridpro/grid-pro-edit-column.ts
+++ b/frontend/demo/component/gridpro/grid-pro-edit-column.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid/vaadin-grid-column.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/gridpro/grid-pro-editors.ts
+++ b/frontend/demo/component/gridpro/grid-pro-editors.ts
@@ -1,16 +1,15 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/date-picker';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { format, parseISO } from 'date-fns';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { columnEditModeRenderer } from '@vaadin/grid-pro/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
-import { format, parseISO } from 'date-fns';
 
 @customElement('grid-pro-editors')
 export class Example extends LitElement {

--- a/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
+++ b/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid/vaadin-grid-column.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid/vaadin-grid-column.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
+++ b/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/gridpro/grid-pro-single-click.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-click.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/icons/icon-basic.ts
+++ b/frontend/demo/component/icons/icon-basic.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import '@vaadin/icons';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('icon-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/icons/icon-fonts.ts
+++ b/frontend/demo/component/icons/icon-fonts.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/horizontal-layout';
+import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/horizontal-layout';
-import '@vaadin/icon';
 
 @customElement('icon-fonts')
 export class Example extends LitElement {

--- a/frontend/demo/component/icons/icons-accessibility.ts
+++ b/frontend/demo/component/icons/icons-accessibility.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/icons';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('icons-accessibility')
 export class Example extends LitElement {

--- a/frontend/demo/component/icons/icons-color.ts
+++ b/frontend/demo/component/icons/icons-color.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/icon';
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/icon';
-import '@vaadin/horizontal-layout';
 import codeBranch from '../../../../src/main/resources/icons/code-branch.svg';
 
 @customElement('icons-color')

--- a/frontend/demo/component/icons/icons-color.ts
+++ b/frontend/demo/component/icons/icons-color.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/icon';
 import '@vaadin/horizontal-layout';
+import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/icons/icons-padding.ts
+++ b/frontend/demo/component/icons/icons-padding.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/icon';
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/icon';
-import '@vaadin/horizontal-layout';
 import codeBranch from '../../../../src/main/resources/icons/code-branch.svg';
 
 @customElement('icons-padding')

--- a/frontend/demo/component/icons/icons-padding.ts
+++ b/frontend/demo/component/icons/icons-padding.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/icon';
 import '@vaadin/horizontal-layout';
+import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/icons/icons-sizing.ts
+++ b/frontend/demo/component/icons/icons-sizing.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/icon';
+import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/icon';
-import '@vaadin/horizontal-layout';
 import codeBranch from '../../../../src/main/resources/icons/code-branch.svg';
 
 @customElement('icons-sizing')

--- a/frontend/demo/component/icons/icons-sizing.ts
+++ b/frontend/demo/component/icons/icons-sizing.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/icon';
 import '@vaadin/horizontal-layout';
+import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/icons/iconset-generator.ts
+++ b/frontend/demo/component/icons/iconset-generator.ts
@@ -1,5 +1,5 @@
-import { css, html, LitElement, render } from 'lit';
 import type { TemplateResult } from 'lit';
+import { css, html, LitElement, render } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { convertToEnumName, generateVaadinIconset } from './iconset-helpers';
 

--- a/frontend/demo/component/icons/lumo-icons.ts
+++ b/frontend/demo/component/icons/lumo-icons.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('lumo-icons')
 export class Example extends LitElement {

--- a/frontend/demo/component/icons/svg-sprites.ts
+++ b/frontend/demo/component/icons/svg-sprites.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/horizontal-layout';
+import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/horizontal-layout';
-import '@vaadin/icon';
 import solidSprite from '../../../../src/main/resources/icons/solid.svg';
 
 @customElement('svg-sprites')

--- a/frontend/demo/component/icons/svg-standalone.ts
+++ b/frontend/demo/component/icons/svg-standalone.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/icon';
 import codeBranchIcon from '../../../../src/main/resources/icons/code-branch.svg';
 
 @customElement('svg-standalone')

--- a/frontend/demo/component/icons/vaadin-icons.ts
+++ b/frontend/demo/component/icons/vaadin-icons.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('vaadin-icons')
 export class Example extends LitElement {

--- a/frontend/demo/component/listbox/list-box-basic.ts
+++ b/frontend/demo/component/listbox/list-box-basic.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/item';
 import '@vaadin/list-box';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-basic')

--- a/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
+++ b/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
@@ -1,15 +1,15 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/item';
 import '@vaadin/list-box';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vaadin-lumo-styles/typography';
 import '@vaadin/vertical-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-custom-item-presentation')
 export class Example extends LitElement {

--- a/frontend/demo/component/listbox/list-box-disabled-items.ts
+++ b/frontend/demo/component/listbox/list-box-disabled-items.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/item';
 import '@vaadin/list-box';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-disabled-items')

--- a/frontend/demo/component/listbox/list-box-multi-selection.ts
+++ b/frontend/demo/component/listbox/list-box-multi-selection.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/item';
 import '@vaadin/list-box';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-multi-selection')
 export class Example extends LitElement {

--- a/frontend/demo/component/listbox/list-box-separators.ts
+++ b/frontend/demo/component/listbox/list-box-separators.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/item';
 import '@vaadin/list-box';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-separators')

--- a/frontend/demo/component/listbox/list-box-single-selection.ts
+++ b/frontend/demo/component/listbox/list-box-single-selection.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/item';
 import '@vaadin/list-box';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('list-box-single-selection')

--- a/frontend/demo/component/login/login-additional-information.ts
+++ b/frontend/demo/component/login/login-additional-information.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import '@vaadin/login';
 import type { LoginOverlay } from '@vaadin/login';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/login/login-basic.ts
+++ b/frontend/demo/component/login/login-basic.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/login/vaadin-login-form.js';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/login/vaadin-login-form.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-basic')

--- a/frontend/demo/component/login/login-internationalization.ts
+++ b/frontend/demo/component/login/login-internationalization.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/login/vaadin-login-form.js';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/login/vaadin-login-form.js';
 import type { LoginI18n } from '@vaadin/login';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/login/login-overlay-basic.ts
+++ b/frontend/demo/component/login/login-overlay-basic.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/login';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-overlay-basic')

--- a/frontend/demo/component/login/login-overlay-custom-form-area.ts
+++ b/frontend/demo/component/login/login-overlay-custom-form-area.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/integer-field';
 import '@vaadin/login';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-overlay-custom-form-area')

--- a/frontend/demo/component/login/login-overlay-footer.ts
+++ b/frontend/demo/component/login/login-overlay-footer.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/login';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-overlay-footer')

--- a/frontend/demo/component/login/login-overlay-header.ts
+++ b/frontend/demo/component/login/login-overlay-header.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/login';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-overlay-header')

--- a/frontend/demo/component/login/login-overlay-internationalization.ts
+++ b/frontend/demo/component/login/login-overlay-internationalization.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/login';
 import type { LoginI18n } from '@vaadin/login';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -1,8 +1,8 @@
+import '@vaadin/login/vaadin-login-form.js';
 import { css, html, LitElement, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/login/vaadin-login-form.js';
 import type { LoginI18n } from '@vaadin/login';
+import { applyTheme } from 'Frontend/generated/theme';
 import img from '../../../../src/main/resources/images/starry-sky.png';
 
 @customElement('login-overlay-mockup')

--- a/frontend/demo/component/login/login-rich-content.ts
+++ b/frontend/demo/component/login/login-rich-content.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/login/vaadin-login-form.js';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-rich-content')

--- a/frontend/demo/component/login/login-validation.ts
+++ b/frontend/demo/component/login/login-validation.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/login';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('login-validation')

--- a/frontend/demo/component/login/react/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/react/login-overlay-mockup.ts
@@ -1,8 +1,8 @@
+import '@vaadin/login/vaadin-login-form.js';
 import { css, html, LitElement, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
-import '@vaadin/login/vaadin-login-form.js';
 import type { LoginI18n } from '@vaadin/login';
+import { applyTheme } from 'Frontend/generated/theme';
 import img from '../../../../../src/main/resources/images/starry-sky.png';
 
 @customElement('login-overlay-mockup')

--- a/frontend/demo/component/menubar/menu-bar-basic.ts
+++ b/frontend/demo/component/menubar/menu-bar-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import type { MenuBarItem, MenuBarItemSelectedEvent } from '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/menubar/menu-bar-checkable.ts
+++ b/frontend/demo/component/menubar/menu-bar-checkable.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import type { MenuBarItemSelectedEvent, SubMenuItem } from '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
+++ b/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/menu-bar';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-combo-buttons')

--- a/frontend/demo/component/menubar/menu-bar-custom-styling.ts
+++ b/frontend/demo/component/menubar/menu-bar-custom-styling.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-custom-styling')

--- a/frontend/demo/component/menubar/menu-bar-disabled.ts
+++ b/frontend/demo/component/menubar/menu-bar-disabled.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-disabled')

--- a/frontend/demo/component/menubar/menu-bar-dividers.ts
+++ b/frontend/demo/component/menubar/menu-bar-dividers.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-dividers')

--- a/frontend/demo/component/menubar/menu-bar-drop-down-indicators.ts
+++ b/frontend/demo/component/menubar/menu-bar-drop-down-indicators.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-drop-down-indicators')

--- a/frontend/demo/component/menubar/menu-bar-drop-down.ts
+++ b/frontend/demo/component/menubar/menu-bar-drop-down.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-drop-down')

--- a/frontend/demo/component/menubar/menu-bar-icon-only.ts
+++ b/frontend/demo/component/menubar/menu-bar-icon-only.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/menu-bar';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-icon-only')

--- a/frontend/demo/component/menubar/menu-bar-icons.ts
+++ b/frontend/demo/component/menubar/menu-bar-icons.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/menu-bar';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-icons')

--- a/frontend/demo/component/menubar/menu-bar-internationalization.ts
+++ b/frontend/demo/component/menubar/menu-bar-internationalization.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
+import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import type { MenuBarI18n } from '@vaadin/menu-bar';
-import '@vaadin/split-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-internationalization')

--- a/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
+++ b/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-open-on-hover')

--- a/frontend/demo/component/menubar/menu-bar-overflow.ts
+++ b/frontend/demo/component/menubar/menu-bar-overflow.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/menu-bar';
 import '@vaadin/split-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-overflow')

--- a/frontend/demo/component/menubar/menu-bar-right-aligned.ts
+++ b/frontend/demo/component/menubar/menu-bar-right-aligned.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-right-aligned')

--- a/frontend/demo/component/menubar/menu-bar-styles.ts
+++ b/frontend/demo/component/menubar/menu-bar-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/menu-bar';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/menu-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-styles')

--- a/frontend/demo/component/menubar/menu-bar-tooltip.ts
+++ b/frontend/demo/component/menubar/menu-bar-tooltip.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/menu-bar';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('menu-bar-tooltip')

--- a/frontend/demo/component/messages/message-basic.ts
+++ b/frontend/demo/component/messages/message-basic.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/message-input';
 import '@vaadin/message-list';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { MessageInputSubmitEvent } from '@vaadin/message-input';
 import type { MessageListItem } from '@vaadin/message-list';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('message-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/messages/message-input-component.ts
+++ b/frontend/demo/component/messages/message-input-component.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/message-input';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/message-input';
 import type { MessageInputSubmitEvent } from '@vaadin/message-input';
 import { Notification } from '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/messages/message-list-component.ts
+++ b/frontend/demo/component/messages/message-list-component.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/message-list';
+import { format, subDays, subMinutes } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/message-list';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import { format, subDays, subMinutes } from 'date-fns';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('message-list-component')
 export class Example extends LitElement {

--- a/frontend/demo/component/messages/message-list-with-theme-component.ts
+++ b/frontend/demo/component/messages/message-list-with-theme-component.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/message-list';
+import { format, subDays, subMinutes } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/message-list';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import { format, subDays, subMinutes } from 'date-fns';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('message-list-component-with-theme')
 export class Example extends LitElement {

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/multi-select-combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/multi-select-combo-box';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/multi-select-combo-box';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/multi-select-combo-box';
 import type { MultiSelectComboBoxI18n } from '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-item-class-name.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-item-class-name.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/multi-select-combo-box';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/multi-select-combo-box';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('multi-select-combo-box-item-class-name')

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/multi-select-combo-box';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/multi-select-combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/multi-select-combo-box';
-import type { MultiSelectComboBoxSelectedItemsChangedEvent } from '@vaadin/multi-select-combo-box';
 import '@vaadin/text-area';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { MultiSelectComboBoxSelectedItemsChangedEvent } from '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/multi-select-combo-box';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/notification/notification-content-length-do.ts
+++ b/frontend/demo/component/notification/notification-content-length-do.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
 import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/notification';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { html, LitElement } from 'lit';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {

--- a/frontend/demo/component/notification/notification-content-length-dont.ts
+++ b/frontend/demo/component/notification/notification-content-length-dont.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
 import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/notification';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { html, LitElement } from 'lit';
 import { applyTheme } from 'Frontend/generated/theme';
 
 export class Example extends LitElement {

--- a/frontend/demo/component/notification/notification-contrast.ts
+++ b/frontend/demo/component/notification/notification-contrast.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
 import { LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
 import { Notification } from '@vaadin/notification';
 
 @customElement('notification-contrast')

--- a/frontend/demo/component/notification/notification-error.ts
+++ b/frontend/demo/component/notification/notification-error.ts
@@ -1,14 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/notification';
-import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
-import { notificationRenderer } from '@vaadin/notification/lit.js';
-import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
+import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
+import { notificationRenderer } from '@vaadin/notification/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-error')

--- a/frontend/demo/component/notification/notification-keyboard-a11y.ts
+++ b/frontend/demo/component/notification/notification-keyboard-a11y.ts
@@ -1,12 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/notification';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
-import { notificationRenderer } from '@vaadin/notification/lit.js';
 import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
+import { notificationRenderer } from '@vaadin/notification/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-keyboard-a11y')

--- a/frontend/demo/component/notification/notification-link.ts
+++ b/frontend/demo/component/notification/notification-link.ts
@@ -1,14 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/notification';
-import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
-import { notificationRenderer } from '@vaadin/notification/lit.js';
-import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
+import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
+import { notificationRenderer } from '@vaadin/notification/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-link')

--- a/frontend/demo/component/notification/notification-popup.ts
+++ b/frontend/demo/component/notification/notification-popup.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/context-menu';
-import { contextMenuRenderer } from '@vaadin/context-menu/lit.js';
 import '@vaadin/icon';
-import { badge } from '@vaadin/vaadin-lumo-styles/badge.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { contextMenuRenderer } from '@vaadin/context-menu/lit.js';
+import { badge } from '@vaadin/vaadin-lumo-styles/badge.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-popup')

--- a/frontend/demo/component/notification/notification-position.ts
+++ b/frontend/demo/component/notification/notification-position.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
-import { Notification } from '@vaadin/notification';
 import type { NotificationPosition } from '@vaadin/notification';
+import { Notification } from '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-position')

--- a/frontend/demo/component/notification/notification-primary.ts
+++ b/frontend/demo/component/notification/notification-primary.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
 import { LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
 import { Notification } from '@vaadin/notification';
 
 @customElement('notification-primary')

--- a/frontend/demo/component/notification/notification-retry.ts
+++ b/frontend/demo/component/notification/notification-retry.ts
@@ -1,14 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/notification';
-import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
-import { notificationRenderer } from '@vaadin/notification/lit.js';
-import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
+import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
+import { notificationRenderer } from '@vaadin/notification/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-retry')

--- a/frontend/demo/component/notification/notification-rich-preview.ts
+++ b/frontend/demo/component/notification/notification-rich-preview.ts
@@ -1,12 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/notification';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-rich-preview')

--- a/frontend/demo/component/notification/notification-rich.ts
+++ b/frontend/demo/component/notification/notification-rich.ts
@@ -1,15 +1,15 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/notification';
-import { notificationRenderer } from '@vaadin/notification/lit.js';
-import type { Notification } from '@vaadin/notification';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import type { Notification } from '@vaadin/notification';
+import { notificationRenderer } from '@vaadin/notification/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-rich')

--- a/frontend/demo/component/notification/notification-static-helper.ts
+++ b/frontend/demo/component/notification/notification-static-helper.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
 import { Notification } from '@vaadin/notification';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/notification/notification-undo.ts
+++ b/frontend/demo/component/notification/notification-undo.ts
@@ -1,14 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/notification';
-import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
-import { notificationRenderer } from '@vaadin/notification/lit.js';
-import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
+import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
+import { notificationRenderer } from '@vaadin/notification/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-undo')

--- a/frontend/demo/component/notification/notification-warning.ts
+++ b/frontend/demo/component/notification/notification-warning.ts
@@ -1,14 +1,14 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { css, html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/notification';
-import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
-import { notificationRenderer } from '@vaadin/notification/lit.js';
-import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { NotificationOpenedChangedEvent } from '@vaadin/notification';
+import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
+import { notificationRenderer } from '@vaadin/notification/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('notification-warning')

--- a/frontend/demo/component/numberfield/number-field-basic-features.ts
+++ b/frontend/demo/component/numberfield/number-field-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/number-field';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-basic-features')

--- a/frontend/demo/component/numberfield/number-field-basic.ts
+++ b/frontend/demo/component/numberfield/number-field-basic.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/number-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-basic')

--- a/frontend/demo/component/numberfield/number-field-integer.ts
+++ b/frontend/demo/component/numberfield/number-field-integer.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/integer-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-integer')

--- a/frontend/demo/component/numberfield/number-field-readonly-and-disabled.ts
+++ b/frontend/demo/component/numberfield/number-field-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/number-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-readonly-and-disabled')

--- a/frontend/demo/component/numberfield/number-field-step-buttons.ts
+++ b/frontend/demo/component/numberfield/number-field-step-buttons.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/integer-field';
 import '@vaadin/form-layout';
 import '@vaadin/form-layout/vaadin-form-item.js';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/numberfield/number-field-step.ts
+++ b/frontend/demo/component/numberfield/number-field-step.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/number-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/number-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-step')

--- a/frontend/demo/component/numberfield/number-field-styles.ts
+++ b/frontend/demo/component/numberfield/number-field-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/number-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/number-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-styles')

--- a/frontend/demo/component/numberfield/number-field-validation.ts
+++ b/frontend/demo/component/numberfield/number-field-validation.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/integer-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/integer-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('number-field-validation')

--- a/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
+++ b/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/password-field';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { PasswordFieldValueChangedEvent } from '@vaadin/password-field';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/passwordfield/password-field-basic-features.ts
+++ b/frontend/demo/component/passwordfield/password-field-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/password-field';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('password-field-basic-features')

--- a/frontend/demo/component/passwordfield/password-field-basic.ts
+++ b/frontend/demo/component/passwordfield/password-field-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/password-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('password-field-basic')

--- a/frontend/demo/component/passwordfield/password-field-helper.ts
+++ b/frontend/demo/component/passwordfield/password-field-helper.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/password-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('input-field-helper')

--- a/frontend/demo/component/passwordfield/password-field-readonly-and-disabled.ts
+++ b/frontend/demo/component/passwordfield/password-field-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/password-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('password-field-readonly-and-disabled')

--- a/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts
+++ b/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/password-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('password-field-reveal-button-hidden')

--- a/frontend/demo/component/passwordfield/password-field-styles.ts
+++ b/frontend/demo/component/passwordfield/password-field-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/password-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('password-field-styles')

--- a/frontend/demo/component/passwordfield/password-field-validation.ts
+++ b/frontend/demo/component/passwordfield/password-field-validation.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/password-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('password-field-validation')

--- a/frontend/demo/component/popover/popover-anchored-dialog.ts
+++ b/frontend/demo/component/popover/popover-anchored-dialog.ts
@@ -1,7 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/checkbox-group';
 import '@vaadin/grid';
@@ -9,6 +6,8 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/popover';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { CheckboxChangeEvent } from '@vaadin/checkbox';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';

--- a/frontend/demo/component/popover/popover-arrow.ts
+++ b/frontend/demo/component/popover/popover-arrow.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/popover';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/popover/popover-dropdown-field.ts
+++ b/frontend/demo/component/popover/popover-dropdown-field.ts
@@ -1,7 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/date-picker';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
@@ -9,12 +6,14 @@ import '@vaadin/popover';
 import '@vaadin/select';
 import '@vaadin/text-field';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
+import { formatISO, subMonths, subWeeks, subYears } from 'date-fns';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { DatePickerChangeEvent } from '@vaadin/date-picker';
 import type { PopoverOpenedChangedEvent, PopoverTrigger } from '@vaadin/popover';
-import type { SelectChangeEvent } from '@vaadin/select';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
+import type { SelectChangeEvent } from '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
-import { formatISO, subMonths, subWeeks, subYears } from 'date-fns';
 
 @customElement('popover-dropdown-field')
 export class Example extends LitElement {

--- a/frontend/demo/component/popover/popover-interactive-tooltip.ts
+++ b/frontend/demo/component/popover/popover-interactive-tooltip.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/integer-field';
 import '@vaadin/popover';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { PopoverTrigger } from '@vaadin/popover';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/popover/popover-modal.ts
+++ b/frontend/demo/component/popover/popover-modal.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/popover';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/popover/popover-notification-panel.ts
+++ b/frontend/demo/component/popover/popover-notification-panel.ts
@@ -1,7 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
@@ -9,11 +6,13 @@ import '@vaadin/message-list';
 import '@vaadin/popover';
 import '@vaadin/tabsheet';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
+import { format, subMinutes } from 'date-fns';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { MessageListItem } from '@vaadin/message-list';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
-import { format, subMinutes } from 'date-fns';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('popover-notifications-panel')
 export class Example extends LitElement {

--- a/frontend/demo/component/popover/popover-positioning.ts
+++ b/frontend/demo/component/popover/popover-positioning.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/popover';
 import '@vaadin/select';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { PopoverPosition } from '@vaadin/popover';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
 import type { SelectChangeEvent } from '@vaadin/select';

--- a/frontend/demo/component/popover/popover-user-menu.ts
+++ b/frontend/demo/component/popover/popover-user-menu.ts
@@ -1,16 +1,15 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/popover';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('popover-user-menu')
 export class Example extends LitElement {

--- a/frontend/demo/component/progressbar/progress-bar-basic.ts
+++ b/frontend/demo/component/progressbar/progress-bar-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/progress-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-basic')

--- a/frontend/demo/component/progressbar/progress-bar-completion-time.ts
+++ b/frontend/demo/component/progressbar/progress-bar-completion-time.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/progress-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-completion-time')

--- a/frontend/demo/component/progressbar/progress-bar-custom-range.ts
+++ b/frontend/demo/component/progressbar/progress-bar-custom-range.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/progress-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-custom-range')

--- a/frontend/demo/component/progressbar/progress-bar-determinate.ts
+++ b/frontend/demo/component/progressbar/progress-bar-determinate.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/progress-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-determinate')

--- a/frontend/demo/component/progressbar/progress-bar-indeterminate.ts
+++ b/frontend/demo/component/progressbar/progress-bar-indeterminate.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/progress-bar';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-indeterminate')

--- a/frontend/demo/component/progressbar/progress-bar-label.ts
+++ b/frontend/demo/component/progressbar/progress-bar-label.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/progress-bar';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-label')

--- a/frontend/demo/component/progressbar/progress-bar-theme-variants.ts
+++ b/frontend/demo/component/progressbar/progress-bar-theme-variants.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/progress-bar';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('progress-bar-theme-variants')

--- a/frontend/demo/component/radiobutton/radio-button-basic.ts
+++ b/frontend/demo/component/radiobutton/radio-button-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/radio-group';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-basic')

--- a/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts
+++ b/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/checkbox';
 import '@vaadin/radio-group';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-checkbox-alternative')

--- a/frontend/demo/component/radiobutton/radio-button-custom-option.ts
+++ b/frontend/demo/component/radiobutton/radio-button-custom-option.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/radio-group';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import { getCards } from 'Frontend/demo/domain/DataService';
 import type Card from 'Frontend/generated/com/vaadin/demo/domain/Card';

--- a/frontend/demo/component/radiobutton/radio-button-default-value.ts
+++ b/frontend/demo/component/radiobutton/radio-button-default-value.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/radio-group';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-default-value')

--- a/frontend/demo/component/radiobutton/radio-button-disabled.ts
+++ b/frontend/demo/component/radiobutton/radio-button-disabled.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/radio-group';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-disabled')

--- a/frontend/demo/component/radiobutton/radio-button-group-basic-features.ts
+++ b/frontend/demo/component/radiobutton/radio-button-group-basic-features.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/radio-group';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-group-basic-features')

--- a/frontend/demo/component/radiobutton/radio-button-group-labels.ts
+++ b/frontend/demo/component/radiobutton/radio-button-group-labels.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/radio-group';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-group-labels')

--- a/frontend/demo/component/radiobutton/radio-button-group-styles.ts
+++ b/frontend/demo/component/radiobutton/radio-button-group-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/radio-group';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-group-styles')

--- a/frontend/demo/component/radiobutton/radio-button-horizontal.ts
+++ b/frontend/demo/component/radiobutton/radio-button-horizontal.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/radio-group';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-horizontal')

--- a/frontend/demo/component/radiobutton/radio-button-presentation.ts
+++ b/frontend/demo/component/radiobutton/radio-button-presentation.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/radio-group';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { getCards } from 'Frontend/demo/domain/DataService';
 import type Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/radiobutton/radio-button-readonly.ts
+++ b/frontend/demo/component/radiobutton/radio-button-readonly.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/radio-group';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-readonly')

--- a/frontend/demo/component/radiobutton/radio-button-vertical.ts
+++ b/frontend/demo/component/radiobutton/radio-button-vertical.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/radio-group';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('radio-button-vertical')

--- a/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
@@ -1,11 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/rich-text-editor';
-
-import templates from '../../../../src/main/resources/data/templates.json';
 import { applyTheme } from 'Frontend/generated/theme';
+import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
@@ -1,11 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/rich-text-editor';
-
-import templates from '../../../../src/main/resources/data/templates.json';
 import { applyTheme } from 'Frontend/generated/theme';
+import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-min-max-height')
 export class Example extends LitElement {

--- a/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
@@ -1,11 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/rich-text-editor';
-
-import templates from '../../../../src/main/resources/data/templates.json';
 import { applyTheme } from 'Frontend/generated/theme';
+import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-readonly')
 export class Example extends LitElement {

--- a/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
@@ -1,14 +1,13 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/rich-text-editor';
+import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
-import '@vaadin/rich-text-editor';
 import type {
   RichTextEditor,
   RichTextEditorHtmlValueChangedEvent,
   RichTextEditorValueChangedEvent,
 } from '@vaadin/rich-text-editor';
-import '@vaadin/text-area';
 import type { TextAreaChangeEvent } from '@vaadin/text-area';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
@@ -1,11 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/rich-text-editor';
-
-import templates from '../../../../src/main/resources/data/templates.json';
 import { applyTheme } from 'Frontend/generated/theme';
+import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-theme-compact')
 export class Example extends LitElement {

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
@@ -1,11 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/rich-text-editor';
-
-import templates from '../../../../src/main/resources/data/templates.json';
 import { applyTheme } from 'Frontend/generated/theme';
+import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-no-border')
 export class Example extends LitElement {

--- a/frontend/demo/component/scroller/scroller-basic.ts
+++ b/frontend/demo/component/scroller/scroller-basic.ts
@@ -1,7 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/date-picker';
 import '@vaadin/icon';
@@ -10,6 +7,8 @@ import '@vaadin/scroller';
 import '@vaadin/text-area';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('scroller-basic')

--- a/frontend/demo/component/scroller/scroller-both.ts
+++ b/frontend/demo/component/scroller/scroller-both.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/scroller';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/scroller';
-import img from '../../../../src/main/resources/images/reindeer.jpg';
 import { applyTheme } from 'Frontend/generated/theme';
+import img from '../../../../src/main/resources/images/reindeer.jpg';
 
 @customElement('scroller-both')
 export class Example extends LitElement {

--- a/frontend/demo/component/scroller/scroller-mobile.ts
+++ b/frontend/demo/component/scroller/scroller-mobile.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { css, html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/scroller';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('scroller-mobile')

--- a/frontend/demo/component/select/select-basic-features.ts
+++ b/frontend/demo/component/select/select-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/select';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-basic-features')

--- a/frontend/demo/component/select/select-basic.ts
+++ b/frontend/demo/component/select/select-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-basic')

--- a/frontend/demo/component/select/select-complex-value-label.ts
+++ b/frontend/demo/component/select/select-complex-value-label.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/select';
 import type { SelectItem } from '@vaadin/select';
-import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-complex-value-label')
 export class Example extends LitElement {

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -1,14 +1,13 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/item';
 import '@vaadin/list-box';
 import '@vaadin/select';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { selectRenderer } from '@vaadin/select/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
-import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { getPeople } from 'Frontend/demo/domain/DataService';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 const formatPersonFullName = (person: Person) => `${person.firstName} ${person.lastName}`;
 

--- a/frontend/demo/component/select/select-disabled.ts
+++ b/frontend/demo/component/select/select-disabled.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-disabled')

--- a/frontend/demo/component/select/select-dividers.ts
+++ b/frontend/demo/component/select/select-dividers.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-dividers')

--- a/frontend/demo/component/select/select-empty-selection-caption.ts
+++ b/frontend/demo/component/select/select-empty-selection-caption.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
 import '@vaadin/item';
 import '@vaadin/list-box';
 import '@vaadin/select';

--- a/frontend/demo/component/select/select-empty-selection.ts
+++ b/frontend/demo/component/select/select-empty-selection.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
 import '@vaadin/item';
 import '@vaadin/list-box';
 import '@vaadin/select';

--- a/frontend/demo/component/select/select-no-vertical-overlap.ts
+++ b/frontend/demo/component/select/select-no-vertical-overlap.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-no-vertical-overlap')

--- a/frontend/demo/component/select/select-overlay-width.ts
+++ b/frontend/demo/component/select/select-overlay-width.ts
@@ -1,14 +1,13 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/item';
 import '@vaadin/list-box';
 import '@vaadin/select';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { SelectItem } from '@vaadin/select';
-import { applyTheme } from 'Frontend/generated/theme';
-import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { getPeople } from 'Frontend/demo/domain/DataService';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+import { applyTheme } from 'Frontend/generated/theme';
 
 const formatPersonFullName = (person: Person) => `${person.firstName} ${person.lastName}`;
 

--- a/frontend/demo/component/select/select-placeholder.ts
+++ b/frontend/demo/component/select/select-placeholder.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-placeholder')

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/item';
 import '@vaadin/list-box';
 import '@vaadin/select';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { selectRenderer } from '@vaadin/select/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';

--- a/frontend/demo/component/select/select-readonly-and-disabled.ts
+++ b/frontend/demo/component/select/select-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/select';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-readonly-and-disabled')

--- a/frontend/demo/component/select/select-styles.ts
+++ b/frontend/demo/component/select/select-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('select-styles')

--- a/frontend/demo/component/side-nav/side-nav-basic.ts
+++ b/frontend/demo/component/side-nav/side-nav-basic.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/side-nav';
 import '@vaadin/icon';
 import '@vaadin/icons';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('side-nav-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/side-nav/side-nav-hierarchy.ts
+++ b/frontend/demo/component/side-nav/side-nav-hierarchy.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/side-nav';
 import '@vaadin/icon';
 import '@vaadin/icons';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('side-nav-hierarchy')
 export class Example extends LitElement {

--- a/frontend/demo/component/side-nav/side-nav-labelled.ts
+++ b/frontend/demo/component/side-nav/side-nav-labelled.ts
@@ -1,13 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/side-nav';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/vertical-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('side-nav-labelled')
 export class Example extends LitElement {

--- a/frontend/demo/component/side-nav/side-nav-styling.ts
+++ b/frontend/demo/component/side-nav/side-nav-styling.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/side-nav';
 import '@vaadin/icon';
 import '@vaadin/icons';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('side-nav-styling')
 export class Example extends LitElement {

--- a/frontend/demo/component/side-nav/side-nav-suffix.ts
+++ b/frontend/demo/component/side-nav/side-nav-suffix.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/side-nav';
 import '@vaadin/icon';
 import '@vaadin/icons';
-import { applyTheme } from 'Frontend/generated/theme';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('side-nav-suffix')
 export class Example extends LitElement {

--- a/frontend/demo/component/splitlayout/split-layout-basic.ts
+++ b/frontend/demo/component/splitlayout/split-layout-basic.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/split-layout';
-import { applyTheme } from 'Frontend/generated/theme';
 import './master-content';
 import './detail-content';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('split-layout-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts
+++ b/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/split-layout';
-import { applyTheme } from 'Frontend/generated/theme';
 import './master-content';
 import './detail-content';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('split-layout-initial-splitter-position')
 export class Example extends LitElement {

--- a/frontend/demo/component/splitlayout/split-layout-min-max-size.ts
+++ b/frontend/demo/component/splitlayout/split-layout-min-max-size.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/split-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('split-layout-min-max-size')

--- a/frontend/demo/component/splitlayout/split-layout-orientation.ts
+++ b/frontend/demo/component/splitlayout/split-layout-orientation.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/split-layout';
-import { applyTheme } from 'Frontend/generated/theme';
 import './master-content';
 import './detail-content';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('split-layout-orientation')
 export class Example extends LitElement {

--- a/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts
+++ b/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/split-layout';
-import { applyTheme } from 'Frontend/generated/theme';
 import './master-content';
 import './detail-content';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('split-layout-theme-minimal')
 export class Example extends LitElement {

--- a/frontend/demo/component/splitlayout/split-layout-theme-small.ts
+++ b/frontend/demo/component/splitlayout/split-layout-theme-small.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/split-layout';
-import { applyTheme } from 'Frontend/generated/theme';
 import './master-content';
 import './detail-content';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('split-layout-theme-small')
 export class Example extends LitElement {

--- a/frontend/demo/component/splitlayout/split-layout-toggle.ts
+++ b/frontend/demo/component/splitlayout/split-layout-toggle.ts
@@ -1,13 +1,13 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/split-layout';
-import { applyTheme } from 'Frontend/generated/theme';
 import './master-content';
 import './detail-content';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('split-layout-toggle')
 export class Example extends LitElement {

--- a/frontend/demo/component/spreadsheet/spreadsheet-imports.ts
+++ b/frontend/demo/component/spreadsheet/spreadsheet-imports.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init';
-
 import '@vaadin/charts';
 import '@vaadin/icon';
 import '@vaadin/icons';

--- a/frontend/demo/component/tabs/tabs-badges.ts
+++ b/frontend/demo/component/tabs/tabs-badges.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 import { badge } from '@vaadin/vaadin-lumo-styles/badge.js';
 
 @customElement('tabs-badges')

--- a/frontend/demo/component/tabs/tabs-basic.ts
+++ b/frontend/demo/component/tabs/tabs-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-content.ts
+++ b/frontend/demo/component/tabs/tabs-content.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/tabs';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { TabsSelectedChangedEvent } from '@vaadin/tabs';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/tabs/tabs-focus-ring.ts
+++ b/frontend/demo/component/tabs/tabs-focus-ring.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-focus-ring')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-hide-scroll-buttons.ts
+++ b/frontend/demo/component/tabs/tabs-hide-scroll-buttons.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-hide-scroll-buttons')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-horizontal.ts
+++ b/frontend/demo/component/tabs/tabs-horizontal.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-horizontal')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-icons-horizontal.ts
+++ b/frontend/demo/component/tabs/tabs-icons-horizontal.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tabs';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 @customElement('tabs-icons-horizontal')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-icons-vertical.ts
+++ b/frontend/demo/component/tabs/tabs-icons-vertical.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tabs';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 @customElement('tabs-icons-vertical')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-states.ts
+++ b/frontend/demo/component/tabs/tabs-states.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-states')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-theme-centered.ts
+++ b/frontend/demo/component/tabs/tabs-theme-centered.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-theme-centered')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-theme-equal-width.ts
+++ b/frontend/demo/component/tabs/tabs-theme-equal-width.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-theme-equal-width')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-theme-minimal.ts
+++ b/frontend/demo/component/tabs/tabs-theme-minimal.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-theme-minimal')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-theme-small.ts
+++ b/frontend/demo/component/tabs/tabs-theme-small.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-theme-small')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabs-vertical.ts
+++ b/frontend/demo/component/tabs/tabs-vertical.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tabs';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tabs';
 
 @customElement('tabs-vertical')
 export class Example extends LitElement {

--- a/frontend/demo/component/tabs/tabsheet-basic.ts
+++ b/frontend/demo/component/tabs/tabsheet-basic.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/tabs';
 import '@vaadin/tabsheet';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tabsheet-basic')

--- a/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
+++ b/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/tabs';
 import '@vaadin/tabsheet';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { TabSheetSelectedChangedEvent } from '@vaadin/tabsheet';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts
+++ b/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tabs';
 import '@vaadin/tabsheet';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tabsheet-prefix-suffix')

--- a/frontend/demo/component/tabs/tabsheet-theme-bordered.ts
+++ b/frontend/demo/component/tabs/tabsheet-theme-bordered.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/tabs';
 import '@vaadin/tabsheet';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 @customElement('tabsheet-theme-bordered')
 export class Example extends LitElement {

--- a/frontend/demo/component/textarea/text-area-auto-height.ts
+++ b/frontend/demo/component/textarea/text-area-auto-height.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/text-area';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/text-area';
-import templates from '../../../../src/main/resources/data/templates.json';
 import { applyTheme } from 'Frontend/generated/theme';
+import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('text-area-auto-height')
 export class Example extends LitElement {

--- a/frontend/demo/component/textarea/text-area-basic-features.ts
+++ b/frontend/demo/component/textarea/text-area-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/text-area';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-basic-features')

--- a/frontend/demo/component/textarea/text-area-basic.ts
+++ b/frontend/demo/component/textarea/text-area-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/text-area';
 import type { TextAreaValueChangedEvent } from '@vaadin/text-area';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/textarea/text-area-height.ts
+++ b/frontend/demo/component/textarea/text-area-height.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/text-area';
-import templates from '../../../../src/main/resources/data/templates.json';
 import { applyTheme } from 'Frontend/generated/theme';
+import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('text-area-height')
 export class Example extends LitElement {

--- a/frontend/demo/component/textarea/text-area-helper.ts
+++ b/frontend/demo/component/textarea/text-area-helper.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/text-area';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/text-area';
 import type { TextAreaValueChangedEvent } from '@vaadin/text-area';
-import templates from '../../../../src/main/resources/data/templates.json';
 import { applyTheme } from 'Frontend/generated/theme';
+import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('text-area-helper-2')
 export class Example extends LitElement {

--- a/frontend/demo/component/textarea/text-area-readonly-and-disabled.ts
+++ b/frontend/demo/component/textarea/text-area-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/text-area';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-readonly-and-disabled')

--- a/frontend/demo/component/textarea/text-area-styles.ts
+++ b/frontend/demo/component/textarea/text-area-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/text-area';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-styles')

--- a/frontend/demo/component/textarea/text-area-validation.ts
+++ b/frontend/demo/component/textarea/text-area-validation.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/text-area';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-area-validation')

--- a/frontend/demo/component/textfield/text-field-basic-features.ts
+++ b/frontend/demo/component/textfield/text-field-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/text-field';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-basic-features')

--- a/frontend/demo/component/textfield/text-field-basic.ts
+++ b/frontend/demo/component/textfield/text-field-basic.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-basic')

--- a/frontend/demo/component/textfield/text-field-readonly-and-disabled.ts
+++ b/frontend/demo/component/textfield/text-field-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-readonly-and-disabled')

--- a/frontend/demo/component/textfield/text-field-styles.ts
+++ b/frontend/demo/component/textfield/text-field-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/text-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-styles')

--- a/frontend/demo/component/textfield/text-field-validation.ts
+++ b/frontend/demo/component/textfield/text-field-validation.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/text-field';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('text-field-validation')

--- a/frontend/demo/component/timepicker/time-picker-auto-open.ts
+++ b/frontend/demo/component/timepicker/time-picker-auto-open.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-auto-open')

--- a/frontend/demo/component/timepicker/time-picker-basic-features.ts
+++ b/frontend/demo/component/timepicker/time-picker-basic-features.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/time-picker';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-basic-features')

--- a/frontend/demo/component/timepicker/time-picker-basic.ts
+++ b/frontend/demo/component/timepicker/time-picker-basic.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-basic')

--- a/frontend/demo/component/timepicker/time-picker-custom-parser.ts
+++ b/frontend/demo/component/timepicker/time-picker-custom-parser.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-custom-parser')

--- a/frontend/demo/component/timepicker/time-picker-custom-validation.ts
+++ b/frontend/demo/component/timepicker/time-picker-custom-validation.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/time-picker';
 import { Binder, field } from '@vaadin/hilla-lit-form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/timepicker/time-picker-minutes-step.ts
+++ b/frontend/demo/component/timepicker/time-picker-minutes-step.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-minutes-step')

--- a/frontend/demo/component/timepicker/time-picker-readonly-and-disabled.ts
+++ b/frontend/demo/component/timepicker/time-picker-readonly-and-disabled.ts
@@ -1,9 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/time-picker';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-readonly-and-disabled')

--- a/frontend/demo/component/timepicker/time-picker-seconds-step.ts
+++ b/frontend/demo/component/timepicker/time-picker-seconds-step.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-seconds-step')

--- a/frontend/demo/component/timepicker/time-picker-styles.ts
+++ b/frontend/demo/component/timepicker/time-picker-styles.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('time-picker-styles')

--- a/frontend/demo/component/timepicker/time-picker-validation.ts
+++ b/frontend/demo/component/timepicker/time-picker-validation.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import '@vaadin/time-picker';
 import type { TimePickerChangeEvent } from '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/tooltip/tooltip-basic.ts
+++ b/frontend/demo/component/tooltip/tooltip-basic.ts
@@ -1,11 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/text-field';
 import '@vaadin/tooltip';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tooltip-basic')

--- a/frontend/demo/component/tooltip/tooltip-html-element.ts
+++ b/frontend/demo/component/tooltip/tooltip-html-element.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/tooltip';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tooltip-html-element')

--- a/frontend/demo/component/tooltip/tooltip-manual.ts
+++ b/frontend/demo/component/tooltip/tooltip-manual.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/text-field';
 import '@vaadin/tooltip';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tooltip-manual')

--- a/frontend/demo/component/tooltip/tooltip-positioning.ts
+++ b/frontend/demo/component/tooltip/tooltip-positioning.ts
@@ -1,12 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/app-layout';
 import '@vaadin/app-layout/vaadin-drawer-toggle.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/tabs';
 import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('tooltip-positioning')

--- a/frontend/demo/component/tree-grid/tree-grid-basic.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-basic.ts
@@ -1,10 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/grid';
+import '@vaadin/grid/vaadin-grid-tree-column.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/grid';
 import type { GridDataProviderCallback, GridDataProviderParams } from '@vaadin/grid';
-import '@vaadin/grid/vaadin-grid-tree-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/tree-grid/tree-grid-column.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-column.ts
@@ -1,12 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/grid';
-import type { GridDataProviderCallback, GridDataProviderParams } from '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-tree-column.js';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GridDataProviderCallback, GridDataProviderParams } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -1,19 +1,18 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/avatar';
 import '@vaadin/button';
 import '@vaadin/grid';
-import type { GridDataProviderCallback, GridDataProviderParams } from '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-tree-toggle.js';
-import type { GridTreeToggleExpandedChangedEvent } from '@vaadin/grid/vaadin-grid-tree-toggle.js';
-import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GridDataProviderCallback, GridDataProviderParams } from '@vaadin/grid';
+import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+import type { GridTreeToggleExpandedChangedEvent } from '@vaadin/grid/vaadin-grid-tree-toggle.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/tree-grid/tree-grid-scroll-to-index.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-scroll-to-index.ts
@@ -1,20 +1,19 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/grid';
 import '@vaadin/button';
 import '@vaadin/integer-field';
 import '@vaadin/horizontal-layout';
-import type { IntegerFieldChangeEvent } from '@vaadin/integer-field';
+import '@vaadin/grid/vaadin-grid-tree-column.js';
+import { html, LitElement } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
 import type {
   Grid,
+  GridActiveItemChangedEvent,
+  GridBodyRenderer,
   GridDataProviderCallback,
   GridDataProviderParams,
-  GridBodyRenderer,
-  GridActiveItemChangedEvent,
 } from '@vaadin/grid';
-import '@vaadin/grid/vaadin-grid-tree-column.js';
+import type { IntegerFieldChangeEvent } from '@vaadin/integer-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/upload/react/upload-demo-mock-files.ts
+++ b/frontend/demo/component/upload/react/upload-demo-mock-files.ts
@@ -1,5 +1,5 @@
-import { createFakeUploadFiles, mockErrorXhrGenerator } from './upload-demo-helpers';
 import { Upload } from '@vaadin/upload';
+import { createFakeUploadFiles, mockErrorXhrGenerator } from './upload-demo-helpers';
 
 declare module '@vaadin/upload' {
   // eslint-disable-next-line @typescript-eslint/no-shadow

--- a/frontend/demo/component/upload/upload-all-files.ts
+++ b/frontend/demo/component/upload/upload-all-files.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
-import { createFakeFilesUploadAllFiles } from './upload-demo-mock-files'; // hidden-source-line
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import '@vaadin/upload';
 import type { Upload } from '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
+import { createFakeFilesUploadAllFiles } from './upload-demo-mock-files'; // hidden-source-line
 
 @customElement('upload-all-files')
 export class Example extends LitElement {

--- a/frontend/demo/component/upload/upload-auto-upload-disabled.ts
+++ b/frontend/demo/component/upload/upload-auto-upload-disabled.ts
@@ -1,11 +1,11 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
-import { createFakeFilesUploadAutoUploadDisabled } from './upload-demo-mock-files'; // hidden-source-line
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import '@vaadin/upload';
 import type { Upload } from '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
+import { createFakeFilesUploadAutoUploadDisabled } from './upload-demo-mock-files'; // hidden-source-line
 
 @customElement('upload-auto-upload-disabled')
 export class Example extends LitElement {

--- a/frontend/demo/component/upload/upload-basic.ts
+++ b/frontend/demo/component/upload/upload-basic.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
-import { createFakeFilesUploadBasic } from './upload-demo-mock-files'; // hidden-source-line
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
+import { createFakeFilesUploadBasic } from './upload-demo-mock-files'; // hidden-source-line
 
 @customElement('upload-basic')
 export class Example extends LitElement {

--- a/frontend/demo/component/upload/upload-button-theme-variant.ts
+++ b/frontend/demo/component/upload/upload-button-theme-variant.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/button';
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
-import '@vaadin/button';
 import { Notification } from '@vaadin/notification';
-import '@vaadin/upload';
 import type {
   Upload,
   UploadFileRejectEvent,

--- a/frontend/demo/component/upload/upload-clear-button.ts
+++ b/frontend/demo/component/upload/upload-clear-button.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { createFakeUploadFiles } from './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
+import { createFakeUploadFiles } from './upload-demo-helpers'; // hidden-source-line
 
 function createFakeFiles() {
   return createFakeUploadFiles([

--- a/frontend/demo/component/upload/upload-demo-mock-files.ts
+++ b/frontend/demo/component/upload/upload-demo-mock-files.ts
@@ -1,5 +1,5 @@
-import { createFakeUploadFiles, mockErrorXhrGenerator } from './upload-demo-helpers';
 import { Upload } from '@vaadin/upload';
+import { createFakeUploadFiles, mockErrorXhrGenerator } from './upload-demo-helpers';
 
 // Used by `upload-basic.ts`
 export function createFakeFilesUploadBasic() {

--- a/frontend/demo/component/upload/upload-drag-and-drop.ts
+++ b/frontend/demo/component/upload/upload-drag-and-drop.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/form-layout';
+import '@vaadin/upload';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/form-layout';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
-import '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
 
 const layoutSteps: FormLayoutResponsiveStep[] = [

--- a/frontend/demo/component/upload/upload-drop-label.ts
+++ b/frontend/demo/component/upload/upload-drop-label.ts
@@ -1,10 +1,10 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/upload';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('upload-drop-label')

--- a/frontend/demo/component/upload/upload-error-messages.ts
+++ b/frontend/demo/component/upload/upload-error-messages.ts
@@ -1,12 +1,12 @@
 import 'Frontend/demo/init'; // hidden-source-line
-/* prettier-ignore */ import {createFakeFilesUploadErrorMessagesA, createFakeFilesUploadErrorMessagesB} from './upload-demo-mock-files'; // hidden-source-line
+import '@vaadin/form-layout';
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import '@vaadin/form-layout';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
-import '@vaadin/upload';
 import type { Upload } from '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
+/* prettier-ignore */ import {createFakeFilesUploadErrorMessagesA, createFakeFilesUploadErrorMessagesB} from './upload-demo-mock-files'; // hidden-source-line
 
 const layoutSteps: FormLayoutResponsiveStep[] = [
   { minWidth: 0, columns: 1, labelsPosition: 'top' },

--- a/frontend/demo/component/upload/upload-file-count.ts
+++ b/frontend/demo/component/upload/upload-file-count.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/upload';
 import { css, html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
-import '@vaadin/upload';
 import type { Upload, UploadFileRejectEvent } from '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/upload/upload-file-format.ts
+++ b/frontend/demo/component/upload/upload-file-format.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/upload';
 import { css, html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
-import '@vaadin/upload';
 import type { Upload, UploadFileRejectEvent } from '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/upload/upload-file-size.ts
+++ b/frontend/demo/component/upload/upload-file-size.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/upload';
 import { css, html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
-import '@vaadin/upload';
 import type { Upload, UploadFileRejectEvent } from '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/upload/upload-helper.ts
+++ b/frontend/demo/component/upload/upload-helper.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/upload';
 import { css, html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
-import '@vaadin/upload';
 import type { Upload, UploadFileRejectEvent } from '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/upload/upload-internationalization.ts
+++ b/frontend/demo/component/upload/upload-internationalization.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/upload';
 import type { UploadI18n } from '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/upload/upload-labelling.ts
+++ b/frontend/demo/component/upload/upload-labelling.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
-import '@vaadin/upload';
 import type { Upload, UploadFileRejectEvent } from '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/upload/upload-retry-button.ts
+++ b/frontend/demo/component/upload/upload-retry-button.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { createFakeUploadFiles } from './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
+import { createFakeUploadFiles } from './upload-demo-helpers'; // hidden-source-line
 
 function createFakeFiles() {
   return createFakeUploadFiles([

--- a/frontend/demo/component/upload/upload-start-button.ts
+++ b/frontend/demo/component/upload/upload-start-button.ts
@@ -1,9 +1,9 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { createFakeUploadFiles } from './upload-demo-helpers'; // hidden-source-line
+import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/upload';
 import { applyTheme } from 'Frontend/generated/theme';
+import { createFakeUploadFiles } from './upload-demo-helpers'; // hidden-source-line
 
 function createFakeFiles() {
   return createFakeUploadFiles([

--- a/frontend/demo/component/virtuallist/virtual-list-basic.ts
+++ b/frontend/demo/component/virtuallist/virtual-list-basic.ts
@@ -1,16 +1,15 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement, css } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { live } from 'lit/directives/live.js';
 import '@vaadin/avatar';
 import '@vaadin/details';
-import type { Details } from '@vaadin/details';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import '@vaadin/virtual-list';
-import { virtualListRenderer } from '@vaadin/virtual-list/lit.js';
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
+import type { Details } from '@vaadin/details';
 import type { VirtualListLitRenderer } from '@vaadin/virtual-list/lit.js';
+import { virtualListRenderer } from '@vaadin/virtual-list/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/domain/DataService.ts
+++ b/frontend/demo/domain/DataService.ts
@@ -1,6 +1,6 @@
+import type Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import type Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
 import type RawReport from 'Frontend/generated/com/vaadin/demo/domain/Report';
 import type ServiceHealth from 'Frontend/generated/com/vaadin/demo/domain/ServiceHealth';
 import type UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermissions';

--- a/frontend/demo/flow/application/events/events-basic.ts
+++ b/frontend/demo/flow/application/events/events-basic.ts
@@ -1,7 +1,7 @@
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 
 @customElement('fusion-application-events-basic')
 // tag::snippet[]

--- a/frontend/demo/flow/application/images/icons-basic.ts
+++ b/frontend/demo/flow/application/images/icons-basic.ts
@@ -1,10 +1,10 @@
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 @customElement('fusion-application-icons-basic')
 export class IconsBasic extends LitElement {

--- a/frontend/demo/flow/application/routing/index.ts
+++ b/frontend/demo/flow/application/routing/index.ts
@@ -1,6 +1,6 @@
 // tag::snippet[]
-import { Router } from '@vaadin/router';
 import { Flow } from '@vaadin/flow-frontend';
+import { Router } from '@vaadin/router';
 
 // Get automatically generated routes to server-side views
 const { serverSideRoutes } = new Flow({

--- a/frontend/demo/flow/application/routing/routing-basic.ts
+++ b/frontend/demo/flow/application/routing/routing-basic.ts
@@ -1,10 +1,10 @@
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/form-layout';
 import '@vaadin/password-field';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 @customElement('routing-login')
 export class LoginView extends LitElement {

--- a/frontend/demo/flow/application/routing/routing-registration.ts
+++ b/frontend/demo/flow/application/routing/routing-registration.ts
@@ -1,6 +1,6 @@
+import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
 
 @customElement('routing-registration')
 export class RegistrationView extends LitElement {

--- a/frontend/demo/flow/application/ui/ui-menu-basic.ts
+++ b/frontend/demo/flow/application/ui/ui-menu-basic.ts
@@ -1,8 +1,8 @@
 import '../../../init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/horizontal-layout';
 import '@vaadin/tabs';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 @customElement('fusion-application-ui-menu')
 export class UiMenu extends LitElement {

--- a/frontend/demo/flow/binding/binding-overview.ts
+++ b/frontend/demo/flow/binding/binding-overview.ts
@@ -1,7 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/form-layout';
 import '@vaadin/form-layout/vaadin-form-item.js';
@@ -10,6 +7,8 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 @customElement('binding-overview')
 export class DataBindingExample extends LitElement {

--- a/frontend/demo/foundation/icons-preview.ts
+++ b/frontend/demo/foundation/icons-preview.ts
@@ -1,9 +1,9 @@
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
-import { Iconset } from '@vaadin/icon/vaadin-iconset.js';
-import { LitElement, html } from 'lit';
+import { html, LitElement } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
+import { Iconset } from '@vaadin/icon/vaadin-iconset.js';
 
 type VaadinIconset = Iconset & { _icons: string[] };
 
@@ -120,13 +120,12 @@ export class IconsPreview extends LitElement {
       />
       <ul>
         ${this.iconNames?.map(
-          (name: string) =>
-            html`
-              <li class="docs-icon-preview icon-${name}">
-                <vaadin-icon icon="${name}"></vaadin-icon>
-                <span class="docs-icon-preview-name">${name}</span>
-              </li>
-            `
+          (name: string) => html`
+            <li class="docs-icon-preview icon-${name}">
+              <vaadin-icon icon="${name}"></vaadin-icon>
+              <span class="docs-icon-preview-name">${name}</span>
+            </li>
+          `
         )}
       </ul>
     `;

--- a/frontend/demo/foundation/lumo-tokens.ts
+++ b/frontend/demo/foundation/lumo-tokens.ts
@@ -1,6 +1,7 @@
 // Import all Lumo CSS custom properties into the global style scope
 // tag::color[]
 import '@vaadin/vaadin-lumo-styles/color.js';
+// end::color[]
 // tag::typography[]
 import '@vaadin/vaadin-lumo-styles/typography.js';
 // end::typography[]
@@ -15,9 +16,8 @@ import '@vaadin/vaadin-lumo-styles/style.js';
 // end::style[]
 // tag::utility-classes[]
 import '@vaadin/vaadin-lumo-styles/utility.js';
-// end::color[]
-import { color } from '@vaadin/vaadin-lumo-styles/color.js'; // hidden-source-line
 // end::utility-classes[]
+import { color } from '@vaadin/vaadin-lumo-styles/color.js'; // hidden-source-line
 import { utility } from '@vaadin/vaadin-lumo-styles/utility.js'; // hidden-source-line
 import { applyTheme } from 'Frontend/generated/theme'; // hidden-source-line
 import { includeModule } from './include-module'; // hidden-source-line

--- a/frontend/demo/foundation/lumo-tokens.ts
+++ b/frontend/demo/foundation/lumo-tokens.ts
@@ -1,8 +1,6 @@
 // Import all Lumo CSS custom properties into the global style scope
 // tag::color[]
 import '@vaadin/vaadin-lumo-styles/color.js';
-// end::color[]
-import { color } from '@vaadin/vaadin-lumo-styles/color.js'; // hidden-source-line
 // tag::typography[]
 import '@vaadin/vaadin-lumo-styles/typography.js';
 // end::typography[]
@@ -17,10 +15,12 @@ import '@vaadin/vaadin-lumo-styles/style.js';
 // end::style[]
 // tag::utility-classes[]
 import '@vaadin/vaadin-lumo-styles/utility.js';
+// end::color[]
+import { color } from '@vaadin/vaadin-lumo-styles/color.js'; // hidden-source-line
 // end::utility-classes[]
 import { utility } from '@vaadin/vaadin-lumo-styles/utility.js'; // hidden-source-line
-import { includeModule } from './include-module'; // hidden-source-line
 import { applyTheme } from 'Frontend/generated/theme'; // hidden-source-line
+import { includeModule } from './include-module'; // hidden-source-line
 // prettier-ignore
 includeModule(color, (css) => `[theme~="dark"] ${css.split("[theme~='dark']")[1].split('}')[0]} }`); // hidden-source-line
 // prettier-ignore

--- a/frontend/demo/foundation/material-tokens.ts
+++ b/frontend/demo/foundation/material-tokens.ts
@@ -1,11 +1,11 @@
 // Import all Material CSS custom properties into the global style scope
 // tag::color[]
 import '@vaadin/vaadin-material-styles/color';
+// end::color[]
 // tag::typography[]
 import '@vaadin/vaadin-material-styles/typography';
-// end::color[]
-import { colorDark } from '@vaadin/vaadin-material-styles/color'; // hidden-source-line
 // end::typography[]
+import { colorDark } from '@vaadin/vaadin-material-styles/color'; // hidden-source-line
 import { includeModule } from './include-module'; // hidden-source-line
 // prettier-ignore
 includeModule(colorDark, (css) => css.replace(':host', 'html[theme~="dark"]').replace('background-color: var(--material-background-color);', '').replace('color: var(--material-body-text-color);', '')); // hidden-source-line

--- a/frontend/demo/foundation/material-tokens.ts
+++ b/frontend/demo/foundation/material-tokens.ts
@@ -1,10 +1,10 @@
 // Import all Material CSS custom properties into the global style scope
 // tag::color[]
 import '@vaadin/vaadin-material-styles/color';
-// end::color[]
-import { colorDark } from '@vaadin/vaadin-material-styles/color'; // hidden-source-line
 // tag::typography[]
 import '@vaadin/vaadin-material-styles/typography';
+// end::color[]
+import { colorDark } from '@vaadin/vaadin-material-styles/color'; // hidden-source-line
 // end::typography[]
 import { includeModule } from './include-module'; // hidden-source-line
 // prettier-ignore

--- a/frontend/demo/fusion/application/basic/my-view.ts
+++ b/frontend/demo/fusion/application/basic/my-view.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
 import { Notification } from '@vaadin/notification';
 
 // tag::snippet[]

--- a/frontend/demo/fusion/application/basic/reactive-view.ts
+++ b/frontend/demo/fusion/application/basic/reactive-view.ts
@@ -1,8 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
+import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import '@vaadin/button';
 
 // tag::snippet[]
 @customElement('reactive-view')

--- a/frontend/demo/fusion/application/events/click-view.ts
+++ b/frontend/demo/fusion/application/events/click-view.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import '@vaadin/button';
 import { Notification } from '@vaadin/notification';
 
 // tag::snippet[]

--- a/frontend/demo/fusion/application/events/value-changed-view.ts
+++ b/frontend/demo/fusion/application/events/value-changed-view.ts
@@ -1,8 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 
 // tag::snippet[]
 @customElement('value-changed-view')

--- a/frontend/demo/fusion/authentication/auth.ts
+++ b/frontend/demo/fusion/authentication/auth.ts
@@ -7,9 +7,9 @@ import {
   logout as logoutImpl,
   type LogoutOptions,
 } from '@vaadin/hilla-frontend';
-import type UserInfo from 'Frontend/generated/com/vaadin/demo/fusion/security/authentication/UserInfo';
 // end::impl[]
 // tag::userinfo[]
+import type UserInfo from 'Frontend/generated/com/vaadin/demo/fusion/security/authentication/UserInfo';
 import { UserInfoService } from 'Frontend/generated/endpoints';
 // end::userinfo[]
 // tag::basic[]

--- a/frontend/demo/fusion/authentication/auth.ts
+++ b/frontend/demo/fusion/authentication/auth.ts
@@ -7,10 +7,10 @@ import {
   logout as logoutImpl,
   type LogoutOptions,
 } from '@vaadin/hilla-frontend';
+import type UserInfo from 'Frontend/generated/com/vaadin/demo/fusion/security/authentication/UserInfo';
 // end::impl[]
 // tag::userinfo[]
 import { UserInfoService } from 'Frontend/generated/endpoints';
-import type UserInfo from 'Frontend/generated/com/vaadin/demo/fusion/security/authentication/UserInfo';
 // end::userinfo[]
 // tag::basic[]
 

--- a/frontend/demo/fusion/authentication/handle-session-expiration/login-overlay.ts
+++ b/frontend/demo/fusion/authentication/handle-session-expiration/login-overlay.ts
@@ -1,13 +1,13 @@
 import { LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import type { LoginResult } from '@vaadin/hilla-frontend';
 import { Router } from '@vaadin/router';
-import { LoginResult } from '@vaadin/hilla-frontend';
 
 @customElement('login-view')
 export class LoginView extends LitElement {
   private returnUrl = '/';
 
-  // @ts-ignore
+  // @ts-expect-error
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private onSuccess = (_: LoginResult) => {
     Router.go(this.returnUrl);

--- a/frontend/demo/fusion/authentication/login-view.ts
+++ b/frontend/demo/fusion/authentication/login-view.ts
@@ -1,9 +1,9 @@
+import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { LoginResult } from '@vaadin/hilla-frontend';
-import { login } from './auth';
 import type { AfterEnterObserver, RouterLocation } from '@vaadin/router';
-import '@vaadin/login';
+import { login } from './auth';
 
 @customElement('login-view')
 export class LoginView extends LitElement implements AfterEnterObserver {

--- a/frontend/demo/fusion/authentication/main-view.ts
+++ b/frontend/demo/fusion/authentication/main-view.ts
@@ -1,8 +1,8 @@
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { isAuthorizedViewRoute, routes } from './routes';
 import { Router } from '@vaadin/router';
+import { isAuthorizedViewRoute, routes } from './routes';
 
 export const router = new Router(document.querySelector('#outlet'));
 

--- a/frontend/demo/fusion/authentication/protected-view.ts
+++ b/frontend/demo/fusion/authentication/protected-view.ts
@@ -1,6 +1,10 @@
-import { BeforeEnterObserver, PreventAndRedirectCommands, RouterLocation } from '@vaadin/router';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import type {
+  BeforeEnterObserver,
+  PreventAndRedirectCommands,
+  RouterLocation,
+} from '@vaadin/router';
 import { isLoggedIn } from './auth';
 
 @customElement('protected-view')

--- a/frontend/demo/fusion/authentication/routes.ts
+++ b/frontend/demo/fusion/authentication/routes.ts
@@ -1,4 +1,4 @@
-import { Route, Router } from '@vaadin/router';
+import type { Route, Router } from '@vaadin/router';
 import { isUserInRole } from './auth';
 
 // Enable declaring additional data on the routes

--- a/frontend/demo/fusion/components/color-picker-view.ts
+++ b/frontend/demo/fusion/components/color-picker-view.ts
@@ -1,10 +1,8 @@
+import '@vaadin/text-field';
+import 'vanilla-colorful';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-
-import '@vaadin/text-field';
 import type { TextField } from '@vaadin/text-field';
-
-import 'vanilla-colorful';
 
 @customElement('color-picker-view')
 export class ColorPickerView extends LitElement {

--- a/frontend/demo/fusion/components/greeting-view.ts
+++ b/frontend/demo/fusion/components/greeting-view.ts
@@ -1,8 +1,7 @@
-import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-
 import '@vaadin/checkbox';
 import '@vaadin/combo-box';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 import type { ComboBoxValueChangedEvent } from '@vaadin/combo-box';
 
 @customElement('greeting-view')

--- a/frontend/demo/fusion/errorhandling/catch-error.ts
+++ b/frontend/demo/fusion/errorhandling/catch-error.ts
@@ -1,5 +1,4 @@
 import { EndpointError } from '@vaadin/hilla-frontend';
-
 import { DataEndpoint } from 'Frontend/generated/endpoints';
 
 export async function callEndpoint() {
@@ -7,8 +6,8 @@ export async function callEndpoint() {
     await DataEndpoint.getViewData();
   } catch (error) {
     if (error instanceof EndpointError) {
-      console.warn((error as EndpointError).message); // "Not implemented"
-      console.warn((error as EndpointError).type); // "com.vaadin.hilla.exception.EndpointException"
+      console.warn(error.message); // "Not implemented"
+      console.warn(error.type); // "com.vaadin.hilla.exception.EndpointException"
     }
   }
 }

--- a/frontend/demo/fusion/errorhandling/catch-invalid-args.ts
+++ b/frontend/demo/fusion/errorhandling/catch-invalid-args.ts
@@ -1,5 +1,4 @@
 import { EndpointValidationError } from '@vaadin/hilla-frontend';
-
 import { DateEndpoint } from 'Frontend/generated/endpoints';
 
 export async function callEndpoint() {
@@ -10,12 +9,10 @@ export async function callEndpoint() {
     // handle result...
   } catch (error) {
     if (error instanceof EndpointValidationError) {
-      (error as EndpointValidationError).validationErrorData.forEach(
-        ({ parameterName, message }) => {
-          console.warn(parameterName); // "date"
-          console.warn(message); // "Unable to deserialize an endpoint method parameter into type 'java.time.LocalDate'"
-        }
-      );
+      error.validationErrorData.forEach(({ parameterName, message }) => {
+        console.warn(parameterName); // "date"
+        console.warn(message); // "Unable to deserialize an endpoint method parameter into type 'java.time.LocalDate'"
+      });
     } else {
       // handle other error types...
     }

--- a/frontend/demo/fusion/forms/contact-form.ts
+++ b/frontend/demo/fusion/forms/contact-form.ts
@@ -1,17 +1,13 @@
-import { html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
-
 import '@vaadin/button';
 import '@vaadin/upload';
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { readAsDataURL } from 'promise-file-reader';
+import { Binder } from '@vaadin/hilla-lit-form';
 import type { UploadBeforeEvent } from '@vaadin/upload';
-
-import Contact from 'Frontend/generated/com/vaadin/demo/fusion/forms/Contact';
+import type Contact from 'Frontend/generated/com/vaadin/demo/fusion/forms/Contact';
 import ContactModel from 'Frontend/generated/com/vaadin/demo/fusion/forms/ContactModel';
 import { ContactEndpoint } from 'Frontend/generated/endpoints';
-
-import { Binder } from '@vaadin/hilla-lit-form';
-
-import { readAsDataURL } from 'promise-file-reader';
 
 @customElement('contact-form')
 export class ContactForm extends LitElement {
@@ -21,6 +17,7 @@ export class ContactForm extends LitElement {
   set contact(value: Contact) {
     this.binder.read(value);
   }
+
   render() {
     return html`
       <img src="${this.binder.model.avatarBase64.valueOf()}" alt="contact's avatar" />

--- a/frontend/demo/fusion/forms/dialogs/newsletter-dialog.ts
+++ b/frontend/demo/fusion/forms/dialogs/newsletter-dialog.ts
@@ -1,20 +1,19 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { Binder, field, ObjectModel } from '@vaadin/hilla-lit-form';
-import NewsletterSubscriptionModel from 'Frontend/generated/com/vaadin/demo/fusion/forms/dialogs/NewsletterSubscriptionModel';
-import { NewsletterEndpoint } from 'Frontend/generated/endpoints';
-import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/checkbox';
 import '@vaadin/dialog';
 import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
-import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+import { html, LitElement } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
 import type { Dialog, DialogOpenedChangedEvent } from '@vaadin/dialog';
+import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+import { Binder, field, ObjectModel } from '@vaadin/hilla-lit-form';
 import { Notification } from '@vaadin/notification';
+import NewsletterSubscriptionModel from 'Frontend/generated/com/vaadin/demo/fusion/forms/dialogs/NewsletterSubscriptionModel';
+import { NewsletterEndpoint } from 'Frontend/generated/endpoints';
 
-// @ts-ignore // hidden-source-line
+// @ts-expect-error // hidden-source-line
 NewsletterSubscriptionModel.createEmptyValue = ObjectModel.createEmptyValue; // hidden-source-line
 
 @customElement('newsletter-dialog')

--- a/frontend/demo/fusion/forms/field-strategy/my-binder.ts
+++ b/frontend/demo/fusion/forms/field-strategy/my-binder.ts
@@ -1,5 +1,9 @@
+import type {
+  AbstractModel,
+  DetachedModelConstructor,
+  FieldStrategy,
+} from '@vaadin/hilla-lit-form';
 import { Binder, StringModel } from '@vaadin/hilla-lit-form';
-import type { AbstractModel, DetachedModelConstructor, FieldStrategy } from '@vaadin/hilla-lit-form';
 import { MyTextFieldStrategy } from './my-text-field-strategy';
 
 export class MyBinder<M extends AbstractModel> extends Binder<M> {

--- a/frontend/demo/fusion/forms/field-strategy/my-form.ts
+++ b/frontend/demo/fusion/forms/field-strategy/my-form.ts
@@ -1,9 +1,9 @@
+import './my-text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { field } from '@vaadin/hilla-lit-form';
-import './my-text-field';
-import { MyBinder } from './my-binder';
 import SamplePersonModel from 'Frontend/generated/com/vaadin/demo/fusion/forms/fieldstrategy/SamplePersonModel';
+import { MyBinder } from './my-binder';
 
 @customElement('person-form-view')
 export class PersonFormViewElement extends LitElement {
@@ -20,5 +20,5 @@ export class PersonFormViewElement extends LitElement {
       </vaadin-form-layout>
     `;
   }
-  //...
+  // ...
 }

--- a/frontend/demo/fusion/forms/field-strategy/my-text-field-strategy.ts
+++ b/frontend/demo/fusion/forms/field-strategy/my-text-field-strategy.ts
@@ -3,9 +3,9 @@ import type { FieldStrategy } from '@vaadin/hilla-lit-form';
 import type { MyTextField } from './my-text-field';
 
 export class MyTextFieldStrategy implements FieldStrategy {
-  public element: MyTextField;
+  element: MyTextField;
 
-  public constructor(element: MyTextField) {
+  constructor(element: MyTextField) {
     this.element = element;
   }
 
@@ -20,6 +20,7 @@ export class MyTextFieldStrategy implements FieldStrategy {
   set errorMessage(errorMessage: string) {
     this.element.error = errorMessage;
   }
+
   // ...
   // end::snippet[]
   validate = async () => [];
@@ -40,15 +41,15 @@ export class MyTextFieldStrategy implements FieldStrategy {
     }
   }
 
-  public get validity() {
+  get validity() {
     return new ValidityState();
   }
 
-  public checkValidity() {
+  checkValidity() {
     return true;
   }
 
-  public removeEventListeners() {}
+  removeEventListeners() {}
   // tag::snippet[]
 }
 // end::snippet[]

--- a/frontend/demo/fusion/forms/field-strategy/my-text-field.ts
+++ b/frontend/demo/fusion/forms/field-strategy/my-text-field.ts
@@ -1,7 +1,7 @@
-import { html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
 import '@vaadin/custom-field';
 import '@vaadin/text-field';
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import type { CustomFieldValueChangedEvent } from '@vaadin/custom-field';
 
 // tag::snippet[]
@@ -15,7 +15,7 @@ export class MyTextField extends LitElement {
   @property({ type: Boolean }) hasError = false;
   @property({ type: String }) error = '';
 
-  //...
+  // ...
   // end::snippet[]
 
   render() {

--- a/frontend/demo/fusion/lit-basics/data-binding.ts
+++ b/frontend/demo/fusion/lit-basics/data-binding.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from 'lit';
+import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 @customElement('data-binding-view')

--- a/frontend/demo/fusion/lit-basics/light-dom.ts
+++ b/frontend/demo/fusion/lit-basics/light-dom.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from 'lit';
+import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 @customElement('my-component')

--- a/frontend/demo/fusion/lit-basics/minimal.ts
+++ b/frontend/demo/fusion/lit-basics/minimal.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from 'lit';
+import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 @customElement('my-component') // <1>

--- a/frontend/demo/fusion/lit-basics/shadow-dom.ts
+++ b/frontend/demo/fusion/lit-basics/shadow-dom.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from 'lit';
+import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 @customElement('my-component')

--- a/frontend/demo/fusion/reactive/reactive-view.ts
+++ b/frontend/demo/fusion/reactive/reactive-view.ts
@@ -1,10 +1,10 @@
-import { Subscription } from '@vaadin/hilla-frontend';
 import '@vaadin/button';
 import '@vaadin/notification';
 import '@vaadin/text-field';
-import { ReactiveEndpoint } from 'Frontend/generated/endpoints';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import type { Subscription } from '@vaadin/hilla-frontend';
+import { ReactiveEndpoint } from 'Frontend/generated/endpoints';
 
 @customElement('reactive-view')
 export class ReactiveView extends LitElement {

--- a/frontend/demo/init-flow-components.ts
+++ b/frontend/demo/init-flow-components.ts
@@ -10,7 +10,6 @@
 // General Flow modules
 import '@vaadin/flow-frontend/dndConnector.js';
 import '@vaadin/flow-frontend/flow-component-renderer.js';
-
 // Flow component specific modules
 import '@vaadin/flow-frontend/cookieConsentConnector.js';
 import '@vaadin/flow-frontend/comboBoxConnector.js';
@@ -27,9 +26,7 @@ import '@vaadin/flow-frontend/selectConnector.js';
 import '@vaadin/flow-frontend/vaadin-time-picker/timepickerConnector.js';
 import '@vaadin/flow-frontend/virtualListConnector.js';
 import '@vaadin/flow-frontend/tooltip.js';
-
 // Lit renderer
 import '@vaadin/flow-frontend/lit-renderer.js';
-
 // Legacy template renderer
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';

--- a/frontend/demo/init.ts
+++ b/frontend/demo/init.ts
@@ -1,6 +1,5 @@
 // Legacy Polymer-based dom-module styling
 import '@vaadin/polymer-legacy-adapter/style-modules.js';
-
 import './init-flow-namespace';
 import './init-flow-components';
 import '../generated/vaadin-featureflags';

--- a/frontend/demo/pwa/offline/ts-view-with-endpoint.ts
+++ b/frontend/demo/pwa/offline/ts-view-with-endpoint.ts
@@ -1,5 +1,4 @@
 import { EndpointError } from '@vaadin/hilla-frontend';
-
 // Import the remote endpoint
 import { DataEndpoint } from 'Frontend/generated/endpoints';
 

--- a/frontend/demo/react-example.ts
+++ b/frontend/demo/react-example.ts
@@ -1,8 +1,8 @@
+import 'Frontend/demo/init';
+import type { CSSResult } from 'lit';
 import React, { type ComponentClass, type FunctionComponent } from 'react';
 import { createRoot } from 'react-dom/client';
 import { applyTheme } from 'Frontend/generated/theme';
-import type { CSSResult } from 'lit';
-import 'Frontend/demo/init';
 
 export function reactExample(
   Example: ComponentClass<any> | FunctionComponent<any>,

--- a/frontend/demo/services/CrudService.ts
+++ b/frontend/demo/services/CrudService.ts
@@ -1,7 +1,7 @@
+import type { CrudService } from '@vaadin/hilla-react-crud';
 import type FilterUnion from 'Frontend/generated/com/vaadin/hilla/crud/filter/FilterUnion';
 import Matcher from 'Frontend/generated/com/vaadin/hilla/crud/filter/PropertyStringFilter/Matcher';
 import type Pageable from 'Frontend/generated/com/vaadin/hilla/mappedtypes/Pageable';
-import type { CrudService } from '@vaadin/hilla-react-crud';
 import Direction from 'Frontend/generated/org/springframework/data/domain/Sort/Direction';
 
 type AbstractEntity = { id?: any };

--- a/frontend/demo/services/EmployeeService.ts
+++ b/frontend/demo/services/EmployeeService.ts
@@ -1,6 +1,6 @@
-import Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
-import Gender from '../../generated/com/vaadin/demo/fusion/crud/Employee/Gender';
 import { CrudMockService } from 'Frontend/demo/services/CrudService';
+import type Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';
+import Gender from '../../generated/com/vaadin/demo/fusion/crud/Employee/Gender';
 
 const employeeData: Employee[] = [
   {

--- a/frontend/demo/services/ProductService.ts
+++ b/frontend/demo/services/ProductService.ts
@@ -1,5 +1,5 @@
 import type Product from 'Frontend/generated/com/vaadin/demo/fusion/crud/Product.js';
-import Supplier from 'Frontend/generated/com/vaadin/demo/fusion/crud/Supplier.js';
+import type Supplier from 'Frontend/generated/com/vaadin/demo/fusion/crud/Supplier.js';
 import { CrudMockService } from './CrudService.js';
 
 const productData: Product[] = [

--- a/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
+++ b/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
@@ -1,16 +1,15 @@
 import 'Frontend/demo/init'; // hidden-source-line
-
-import { css, html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
 import '@vaadin/button';
 import '@vaadin/icon';
 import '@vaadin/icons';
 import '@vaadin/text-field';
 import '@vaadin/text-area';
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { Notification } from '@vaadin/notification';
+import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
 import { applyTheme } from 'Frontend/generated/theme';
 import template from './dashboard-template.json';
-import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
-import { Notification } from '@vaadin/notification';
 
 @customElement('new-relic-dashboard-generator')
 export class DashboardGenerator extends LitElement {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "eslint": "^8.49.0",
         "eslint-config-vaadin": "1.0.0-alpha.18",
         "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-simple-import-sort": "^12.0.0",
         "glob": "10.4.5",
         "husky": "^8.0.0",
         "lint-staged": "^13.0.3",
@@ -7490,6 +7491,16 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -19001,6 +19012,13 @@
         "prettier-linter-helpers": "^1.0.0",
         "synckit": "^0.9.1"
       }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint": "^8.49.0",
     "eslint-config-vaadin": "1.0.0-alpha.18",
     "eslint-plugin-prettier": "^5.0.0",
+    "eslint-plugin-simple-import-sort": "^12.0.0",
     "glob": "10.4.5",
     "husky": "^8.0.0",
     "lint-staged": "^13.0.3",
@@ -214,6 +215,6 @@
       "workbox-core": "7.1.0",
       "workbox-precaching": "7.1.0"
     },
-    "hash": "bbd32a1de9be13c8f468c3ae1700221f70ba93d507e7950e66a4448c762e4660"
+    "hash": "e05dbbaba77a6e376af3abd88d15e47248fd2ec3e2c6962b3a5dc58783e65c36"
   }
 }


### PR DESCRIPTION
Adds the `simple-import-sort` ESLint plugin and sorts imports in the `frontend/demo` folder.