### PR TITLE
chore: add simple-import-sort ESLint plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,9 @@
     "ecmaVersion": 2021,
     "project": "./tsconfig.json"
   },
+  "plugins": [
+    "simple-import-sort"
+  ],
   "extends": [
     "vaadin/typescript-requiring-type-checking",
     "vaadin/lit",
@@ -34,6 +37,27 @@
     "prefer-destructuring": "off",
     "radix": "off",
     "require-unicode-regexp": "off",
-    "sort-keys": "off"
+    "sort-keys": "off",
+    "simple-import-sort/imports": [
+      "error",
+      {
+        "groups": [
+          [
+            // Side-effects group
+            "^\\u0000",
+            // External group
+            "^",
+            // Vaadin group
+            "^@vaadin",
+            // Frontend group
+            "^Frontend",
+            // Parent group
+            "^\\.\\.",
+            // Sibling group
+            "^\\."
+          ]
+        ]
+      }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "eslint": "^8.49.0",
         "eslint-config-vaadin": "1.0.0-alpha.18",
         "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-simple-import-sort": "^12.0.0",
         "glob": "10.4.5",
         "husky": "^8.0.0",
         "lint-staged": "^13.0.3",
@@ -7490,6 +7491,16 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -19001,6 +19012,13 @@
         "prettier-linter-helpers": "^1.0.0",
         "synckit": "^0.9.1"
       }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint": "^8.49.0",
     "eslint-config-vaadin": "1.0.0-alpha.18",
     "eslint-plugin-prettier": "^5.0.0",
+    "eslint-plugin-simple-import-sort": "^12.0.0",
     "glob": "10.4.5",
     "husky": "^8.0.0",
     "lint-staged": "^13.0.3",
@@ -214,6 +215,6 @@
       "workbox-core": "7.1.0",
       "workbox-precaching": "7.1.0"
     },
-    "hash": "bbd32a1de9be13c8f468c3ae1700221f70ba93d507e7950e66a4448c762e4660"
+    "hash": "35a3d0aa910014be01bed61b19ae15c3f4f3f8b21c219b9d0f647537681ec634"
   }
 }


### PR DESCRIPTION
Adds the `simple-import-sort` ESLint plugin to ensure the consistent import order in JS/TS examples. The plugin configuration is based on that in the `web-components` repo.