### PR TITLE
fix(gradle): replace outdated properties from hilla to vaadin

### DIFF
--- a/articles/hilla/lit/reference/gradle.adoc
+++ b/articles/hilla/lit/reference/gradle.adoc
@@ -358,14 +358,14 @@ At the command line:
 [source,bash,subs="+attributes"]
 ----
 <source-info group="Windows"></source-info>
-gradlew -Philla.productionMode=true build
+gradlew -Pvaadin.productionMode=true build
 ----
 
 .terminal
 [source,bash,subs="+attributes"]
 ----
 <source-info group="macOS / Linux"></source-info>
-./gradlew -Philla.productionMode=true build
+./gradlew -Pvaadin.productionMode=true build
 ----
 --
 


### PR DESCRIPTION
The currently documented properties are outdated and no longer work