### PR TITLE
chore: Add a link to example project for application theme

### DIFF
--- a/articles/styling/application-theme.adoc
+++ b/articles/styling/application-theme.adoc
@@ -215,4 +215,6 @@ Embedded application theming is covered in a separate section:
 
 - <<../flow/integrations/embedding/theming#, Theming Embedded Applications>>.
 
+An example project that demonstrates the application theme in action can be found https://github.com/vaadin/custom-theme-demo[here].
+
 [discussion-id]`e5e984e4-6a4f-40ab-a6fc-665166a2d8c5`


### PR DESCRIPTION
I've just renewed this example project, IMO it may be useful for new evaluators to try the theme feature, https://github.com/vaadin/custom-theme-demo