### PR TITLE
refactor: remove unused React import

### DIFF
--- a/frontend/demo/auth/LoginView.tsx
+++ b/frontend/demo/auth/LoginView.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import type { ViewConfig } from '@vaadin/hilla-file-router/types.js';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/accordion/react/accordion-basic.tsx
+++ b/frontend/demo/component/accordion/react/accordion-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Accordion, AccordionPanel, VerticalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/accordion/react/accordion-content.tsx
+++ b/frontend/demo/component/accordion/react/accordion-content.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Accordion, AccordionPanel, VerticalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/accordion/react/accordion-disabled-panels.tsx
+++ b/frontend/demo/component/accordion/react/accordion-disabled-panels.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Accordion, AccordionPanel, VerticalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/accordion/react/accordion-filled-panels.tsx
+++ b/frontend/demo/component/accordion/react/accordion-filled-panels.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Accordion, AccordionPanel, VerticalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/accordion/react/accordion-reverse-panels.tsx
+++ b/frontend/demo/component/accordion/react/accordion-reverse-panels.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Accordion, AccordionPanel, VerticalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/accordion/react/accordion-small-panels.tsx
+++ b/frontend/demo/component/accordion/react/accordion-small-panels.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Accordion, AccordionPanel, VerticalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/accordion/react/accordion-summary.tsx
+++ b/frontend/demo/component/accordion/react/accordion-summary.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useForm } from '@vaadin/hilla-react-form';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/app-layout/react/app-layout-basic.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-basic.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   AppLayout,
   DrawerToggle,

--- a/frontend/demo/component/app-layout/react/app-layout-bottom-navbar.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-bottom-navbar.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   AppLayout,
   type AppLayoutElement,

--- a/frontend/demo/component/app-layout/react/app-layout-drawer.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-drawer.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   AppLayout,
   DrawerToggle,

--- a/frontend/demo/component/app-layout/react/app-layout-height-auto.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-height-auto.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { AppLayout, Grid, GridColumn } from '@vaadin/react-components';

--- a/frontend/demo/component/app-layout/react/app-layout-height-full.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-height-full.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { css } from 'lit'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/app-layout/react/app-layout-navbar-placement-side.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-navbar-placement-side.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   AppLayout,
   DrawerToggle,

--- a/frontend/demo/component/app-layout/react/app-layout-navbar-placement.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-navbar-placement.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   AppLayout,
   DrawerToggle,

--- a/frontend/demo/component/app-layout/react/app-layout-navbar.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-navbar.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   AppLayout,
   HorizontalLayout,

--- a/frontend/demo/component/app-layout/react/app-layout-secondary-navigation.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-secondary-navigation.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   AppLayout,
   DrawerToggle,

--- a/frontend/demo/component/auto-crud/react/auto-crud-basic.tsx
+++ b/frontend/demo/component/auto-crud/react/auto-crud-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 // tag::snippet[]
 import { AutoCrud } from '@vaadin/hilla-react-crud';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line

--- a/frontend/demo/component/auto-crud/react/auto-crud-customized-form.tsx
+++ b/frontend/demo/component/auto-crud/react/auto-crud-customized-form.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoCrud } from '@vaadin/hilla-react-crud';
 import { TextArea } from '@vaadin/react-components/TextArea';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line

--- a/frontend/demo/component/auto-crud/react/auto-crud-customized-grid.tsx
+++ b/frontend/demo/component/auto-crud/react/auto-crud-customized-grid.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoCrud } from '@vaadin/hilla-react-crud';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line
 import type Employee from 'Frontend/generated/com/vaadin/demo/fusion/crud/Employee';

--- a/frontend/demo/component/auto-form/react/auto-form-basic.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoForm } from '@vaadin/hilla-react-crud';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line
 import EmployeeModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/EmployeeModel';

--- a/frontend/demo/component/auto-form/react/auto-form-custom-renderer-alt.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-custom-renderer-alt.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoForm, type AutoFormLayoutRendererProps } from '@vaadin/hilla-react-crud';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';

--- a/frontend/demo/component/auto-form/react/auto-form-custom-renderer.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-custom-renderer.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoForm, type AutoFormLayoutRendererProps } from '@vaadin/hilla-react-crud';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';

--- a/frontend/demo/component/auto-form/react/auto-form-delete-after-delete.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-delete-after-delete.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { AutoForm } from '@vaadin/hilla-react-crud';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/auto-form/react/auto-form-edit-new-modes.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-edit-new-modes.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { AutoForm } from '@vaadin/hilla-react-crud';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/auto-form/react/auto-form-field-colspan.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-field-colspan.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoForm } from '@vaadin/hilla-react-crud';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line
 import EmployeeModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/EmployeeModel';

--- a/frontend/demo/component/auto-form/react/auto-form-field-custom-label.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-field-custom-label.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoForm } from '@vaadin/hilla-react-crud';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line
 import EmployeeModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/EmployeeModel';

--- a/frontend/demo/component/auto-form/react/auto-form-field-custom-renderer.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-field-custom-renderer.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoForm } from '@vaadin/hilla-react-crud';
 import { TextArea } from '@vaadin/react-components/TextArea.js';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line

--- a/frontend/demo/component/auto-form/react/auto-form-field-visibility.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-field-visibility.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoForm } from '@vaadin/hilla-react-crud';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line
 import EmployeeModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/EmployeeModel';

--- a/frontend/demo/component/auto-form/react/auto-form-on-errors.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-on-errors.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoForm } from '@vaadin/hilla-react-crud';
 import { Notification } from '@vaadin/react-components/Notification.js';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line

--- a/frontend/demo/component/auto-form/react/auto-form-responsive-steps.tsx
+++ b/frontend/demo/component/auto-form/react/auto-form-responsive-steps.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { AutoForm } from '@vaadin/hilla-react-crud';
 import { autoGridHostStyles } from 'Frontend/demo/component/auto-grid/react/auto-grid-host-styles'; // hidden-source-line
 import EmployeeModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/EmployeeModel';

--- a/frontend/demo/component/auto-grid/react/auto-grid-basic.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 // tag::snippet[]
 import { AutoGrid } from '@vaadin/hilla-react-crud';
 // tag::apply-backend[]

--- a/frontend/demo/component/auto-grid/react/auto-grid-column-options.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-column-options.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { AutoGrid } from '@vaadin/hilla-react-crud';
 import type Product from 'Frontend/generated/com/vaadin/demo/fusion/crud/Product';
 import ProductModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/ProductModel';

--- a/frontend/demo/component/auto-grid/react/auto-grid-custom-columns.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-custom-columns.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { AutoGrid } from '@vaadin/hilla-react-crud';
 import { GridColumn } from '@vaadin/react-components/GridColumn';
 import type Product from 'Frontend/generated/com/vaadin/demo/fusion/crud/Product';

--- a/frontend/demo/component/auto-grid/react/auto-grid-filtering.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-filtering.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { AutoGrid } from '@vaadin/hilla-react-crud';
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/auto-grid/react/auto-grid-selection.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-selection.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { AutoGrid } from '@vaadin/hilla-react-crud';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/auto-grid/react/auto-grid-visible-columns.tsx
+++ b/frontend/demo/component/auto-grid/react/auto-grid-visible-columns.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { AutoGrid } from '@vaadin/hilla-react-crud';
 import ProductModel from 'Frontend/generated/com/vaadin/demo/fusion/crud/ProductModel';
 import { ProductService } from 'Frontend/generated/endpoints';

--- a/frontend/demo/component/avatar/react/avatar-abbreviation.tsx
+++ b/frontend/demo/component/avatar/react/avatar-abbreviation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Avatar, HorizontalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/avatar/react/avatar-basic.tsx
+++ b/frontend/demo/component/avatar/react/avatar-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components';

--- a/frontend/demo/component/avatar/react/avatar-group-basic.tsx
+++ b/frontend/demo/component/avatar/react/avatar-group-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { AvatarGroup } from '@vaadin/react-components';

--- a/frontend/demo/component/avatar/react/avatar-group-bg-color.tsx
+++ b/frontend/demo/component/avatar/react/avatar-group-bg-color.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { AvatarGroup } from '@vaadin/react-components';

--- a/frontend/demo/component/avatar/react/avatar-group-internationalisation.tsx
+++ b/frontend/demo/component/avatar/react/avatar-group-internationalisation.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { AvatarGroup, type AvatarGroupI18n } from '@vaadin/react-components';

--- a/frontend/demo/component/avatar/react/avatar-group-max-items.tsx
+++ b/frontend/demo/component/avatar/react/avatar-group-max-items.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { AvatarGroup } from '@vaadin/react-components';

--- a/frontend/demo/component/avatar/react/avatar-image.tsx
+++ b/frontend/demo/component/avatar/react/avatar-image.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar, HorizontalLayout } from '@vaadin/react-components';

--- a/frontend/demo/component/avatar/react/avatar-menu-bar.tsx
+++ b/frontend/demo/component/avatar/react/avatar-menu-bar.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar, MenuBar } from '@vaadin/react-components';

--- a/frontend/demo/component/avatar/react/avatar-name.tsx
+++ b/frontend/demo/component/avatar/react/avatar-name.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components';

--- a/frontend/demo/component/avatar/react/avatar-sizes.tsx
+++ b/frontend/demo/component/avatar/react/avatar-sizes.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar, HorizontalLayout } from '@vaadin/react-components';

--- a/frontend/demo/component/badge/react/badge-basic.tsx
+++ b/frontend/demo/component/badge/react/badge-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout';
 
 function Example() {

--- a/frontend/demo/component/badge/react/badge-color.tsx
+++ b/frontend/demo/component/badge/react/badge-color.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout, VerticalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/badge/react/badge-counter.tsx
+++ b/frontend/demo/component/badge/react/badge-counter.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab, Tabs } from '@vaadin/react-components';
 
 const badgeStyle = {

--- a/frontend/demo/component/badge/react/badge-highlight.tsx
+++ b/frontend/demo/component/badge/react/badge-highlight.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid, GridColumn } from '@vaadin/react-components';

--- a/frontend/demo/component/badge/react/badge-icons-only-table.tsx
+++ b/frontend/demo/component/badge/react/badge-icons-only-table.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid, GridColumn, type GridColumnElement, Icon } from '@vaadin/react-components';

--- a/frontend/demo/component/badge/react/badge-icons-only.tsx
+++ b/frontend/demo/component/badge/react/badge-icons-only.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout, Icon } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/badge/react/badge-icons.tsx
+++ b/frontend/demo/component/badge/react/badge-icons.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout, Icon, VerticalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/badge/react/badge-interactive.tsx
+++ b/frontend/demo/component/badge/react/badge-interactive.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/badge/react/badge-shape.tsx
+++ b/frontend/demo/component/badge/react/badge-shape.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/badge/react/badge-size.tsx
+++ b/frontend/demo/component/badge/react/badge-size.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-expanding-items.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-expanding-items.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button, HorizontalLayout, RadioButton, RadioGroup } from '@vaadin/react-components';

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button, HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-individual-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-individual-alignment.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout, TextArea } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-margin.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-margin.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button, HorizontalLayout, RadioButton, RadioGroup } from '@vaadin/react-components';

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-padding.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-padding.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-spacing-variants.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-spacing-variants.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button, HorizontalLayout, RadioButton, RadioGroup } from '@vaadin/react-components';

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-spacing.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-spacing.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button, HorizontalLayout, RadioButton, RadioGroup } from '@vaadin/react-components';

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-vertical-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-vertical-alignment.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TextArea } from '@vaadin/react-components';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button, HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-margin.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-margin.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button, RadioButton, RadioGroup, VerticalLayout } from '@vaadin/react-components';

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-padding.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-padding.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button, RadioButton, RadioGroup, VerticalLayout } from '@vaadin/react-components';

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-spacing-variants.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-spacing-variants.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button, RadioButton, RadioGroup, VerticalLayout } from '@vaadin/react-components';

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-spacing.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-spacing.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-horizontal-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-horizontal-alignment.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button, VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-individual-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-individual-alignment.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button, VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-vertical-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-vertical-alignment.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button, VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button, VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 

--- a/frontend/demo/component/board/react/ExampleChart.tsx
+++ b/frontend/demo/component/board/react/ExampleChart.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Chart } from '@vaadin/react-components-pro/Chart.js';

--- a/frontend/demo/component/board/react/ExampleIndicator.tsx
+++ b/frontend/demo/component/board/react/ExampleIndicator.tsx
@@ -1,5 +1,5 @@
 import '@vaadin/icons';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 

--- a/frontend/demo/component/board/react/ExampleStatistics.tsx
+++ b/frontend/demo/component/board/react/ExampleStatistics.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { getServiceHealth } from 'Frontend/demo/domain/DataService';

--- a/frontend/demo/component/board/react/board-basic.tsx
+++ b/frontend/demo/component/board/react/board-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Board } from '@vaadin/react-components-pro/Board.js';
 import { BoardRow } from '@vaadin/react-components-pro/BoardRow.js';
 import boardStyles from './board-styles';

--- a/frontend/demo/component/board/react/board-breakpoints.tsx
+++ b/frontend/demo/component/board/react/board-breakpoints.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
 import { Board } from '@vaadin/react-components-pro/Board.js';
 import { BoardRow } from '@vaadin/react-components-pro/BoardRow.js';

--- a/frontend/demo/component/board/react/board-column-span.tsx
+++ b/frontend/demo/component/board/react/board-column-span.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Board } from '@vaadin/react-components-pro/Board.js';
 import { BoardRow } from '@vaadin/react-components-pro/BoardRow.js';
 import boardStyles from './board-styles';

--- a/frontend/demo/component/board/react/board-column-wrapping.tsx
+++ b/frontend/demo/component/board/react/board-column-wrapping.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
 import { Board } from '@vaadin/react-components-pro/Board.js';
 import { BoardRow } from '@vaadin/react-components-pro/BoardRow.js';

--- a/frontend/demo/component/board/react/board-nested.tsx
+++ b/frontend/demo/component/board/react/board-nested.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Board } from '@vaadin/react-components-pro/Board.js';
 import { BoardRow } from '@vaadin/react-components-pro/BoardRow.js';
 import boardStyles from './board-styles';

--- a/frontend/demo/component/button/react/button-basic.tsx
+++ b/frontend/demo/component/button/react/button-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/button/react/button-contrast.tsx
+++ b/frontend/demo/component/button/react/button-contrast.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/button/react/button-dialog.tsx
+++ b/frontend/demo/component/button/react/button-dialog.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { EmailField } from '@vaadin/react-components/EmailField.js';
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';

--- a/frontend/demo/component/button/react/button-disable-long-action.tsx
+++ b/frontend/demo/component/button/react/button-disable-long-action.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/button/react/button-disabled.tsx
+++ b/frontend/demo/component/button/react/button-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/button/react/button-error.tsx
+++ b/frontend/demo/component/button/react/button-error.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/button/react/button-focus.tsx
+++ b/frontend/demo/component/button/react/button-focus.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 
 function Example() {

--- a/frontend/demo/component/button/react/button-form.tsx
+++ b/frontend/demo/component/button/react/button-form.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { EmailField } from '@vaadin/react-components/EmailField.js';
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';

--- a/frontend/demo/component/button/react/button-grid.tsx
+++ b/frontend/demo/component/button/react/button-grid.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js'; // hidden-source-line

--- a/frontend/demo/component/button/react/button-icons.tsx
+++ b/frontend/demo/component/button/react/button-icons.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
@@ -10,13 +9,13 @@ function Example() {
   return (
     <HorizontalLayout theme="spacing">
       {/* tag::snippet[] */}
-      {/* Icon button using an aria-label to provide a textual alternative 
+      {/* Icon button using an aria-label to provide a textual alternative
           to screen readers  */}
       <Button theme="icon" aria-label="Add item">
         <Icon icon="vaadin:plus" />
       </Button>
 
-      {/* Icon button using a tooltip to provide a textual description of 
+      {/* Icon button using a tooltip to provide a textual description of
           the action that it triggers */}
       <Button theme="icon" aria-label="Close">
         <Icon icon="vaadin:close-small" />

--- a/frontend/demo/component/button/react/button-images.tsx
+++ b/frontend/demo/component/button/react/button-images.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import img from '../../../../../src/main/resources/images/vaadin-logo-dark.png';
 

--- a/frontend/demo/component/button/react/button-labels.tsx
+++ b/frontend/demo/component/button/react/button-labels.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/button/react/button-sizes.tsx
+++ b/frontend/demo/component/button/react/button-sizes.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/button/react/button-styles.tsx
+++ b/frontend/demo/component/button/react/button-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/button/react/button-success.tsx
+++ b/frontend/demo/component/button/react/button-success.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/button/react/button-tertiary-inline.tsx
+++ b/frontend/demo/component/button/react/button-tertiary-inline.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 
 function Example() {

--- a/frontend/demo/component/button/react/button-warning.tsx
+++ b/frontend/demo/component/button/react/button-warning.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/charts/react/charts-area.tsx
+++ b/frontend/demo/component/charts/react/charts-area.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Chart } from '@vaadin/react-components-pro/Chart.js';
 import { ChartSeries } from '@vaadin/react-components-pro/ChartSeries.js';
 

--- a/frontend/demo/component/charts/react/charts-column.tsx
+++ b/frontend/demo/component/charts/react/charts-column.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Chart } from '@vaadin/react-components-pro/Chart.js';
 import { ChartSeries } from '@vaadin/react-components-pro/ChartSeries.js';
 

--- a/frontend/demo/component/charts/react/charts-overview.tsx
+++ b/frontend/demo/component/charts/react/charts-overview.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import type { Options, PointOptionsObject, SeriesOptionsType } from 'highcharts';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/charts/react/charts-pie.tsx
+++ b/frontend/demo/component/charts/react/charts-pie.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Chart } from '@vaadin/react-components-pro/Chart.js';
 import { ChartSeries } from '@vaadin/react-components-pro/ChartSeries.js';
 

--- a/frontend/demo/component/charts/react/charts-polar.tsx
+++ b/frontend/demo/component/charts/react/charts-polar.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Chart } from '@vaadin/react-components-pro/Chart.js';
 import { ChartSeries } from '@vaadin/react-components-pro/ChartSeries.js';
 

--- a/frontend/demo/component/checkbox/react/checkbox-adjacent-groups.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-adjacent-groups.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';

--- a/frontend/demo/component/checkbox/react/checkbox-basic.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 
 function Example() {

--- a/frontend/demo/component/checkbox/react/checkbox-disabled.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
 

--- a/frontend/demo/component/checkbox/react/checkbox-group-basic-features.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-group-basic-features.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/checkbox/react/checkbox-group-basic.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-group-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';

--- a/frontend/demo/component/checkbox/react/checkbox-group-styles.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-group-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
 

--- a/frontend/demo/component/checkbox/react/checkbox-horizontal.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-horizontal.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
 

--- a/frontend/demo/component/checkbox/react/checkbox-indeterminate.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-indeterminate.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';

--- a/frontend/demo/component/checkbox/react/checkbox-labeling.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-labeling.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 
 function Example() {

--- a/frontend/demo/component/checkbox/react/checkbox-readonly.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-readonly.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
 

--- a/frontend/demo/component/checkbox/react/checkbox-required.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-required.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Required } from '@vaadin/hilla-lit-form';
 import { useForm, useFormPart } from '@vaadin/hilla-react-form';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/checkbox/react/checkbox-vertical.tsx
+++ b/frontend/demo/component/checkbox/react/checkbox-vertical.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
 

--- a/frontend/demo/component/combobox/react/combo-box-auto-open.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-auto-open.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/combobox/react/combo-box-basic-features.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-basic-features.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/combobox/react/combo-box-basic.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/combobox/react/combo-box-custom-entry-1.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-custom-entry-1.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';
 
 function Example() {

--- a/frontend/demo/component/combobox/react/combo-box-custom-entry-2.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-custom-entry-2.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/combobox/react/combo-box-filtering-1.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-filtering-1.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/combobox/react/combo-box-filtering-2.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-filtering-2.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ComboBox, type ComboBoxFilterChangedEvent } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/combobox/react/combo-box-item-class-name.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-item-class-name.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';
 
 function Example() {

--- a/frontend/demo/component/combobox/react/combo-box-popup-width.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-popup-width.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/combobox/react/combo-box-presentation.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-presentation.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import type { ComboBoxFilterChangedEvent } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/combobox/react/combo-box-readonly-and-disabled.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/combobox/react/combo-box-styles.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';
 
 function Example() {

--- a/frontend/demo/component/combobox/react/combo-box-validation.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';
 
 function Example() {

--- a/frontend/demo/component/confirmdialog/react/confirm-dialog-basic.tsx
+++ b/frontend/demo/component/confirmdialog/react/confirm-dialog-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/confirmdialog/react/confirm-dialog-cancel-button.tsx
+++ b/frontend/demo/component/confirmdialog/react/confirm-dialog-cancel-button.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/confirmdialog/react/confirm-dialog-confirm-button.tsx
+++ b/frontend/demo/component/confirmdialog/react/confirm-dialog-confirm-button.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/confirmdialog/react/confirm-dialog-reject-button.tsx
+++ b/frontend/demo/component/confirmdialog/react/confirm-dialog-reject-button.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/contextmenu/react/context-menu-basic.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ContextMenu } from '@vaadin/react-components/ContextMenu.js';

--- a/frontend/demo/component/contextmenu/react/context-menu-best-practices.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-best-practices.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ContextMenu } from '@vaadin/react-components/ContextMenu.js';

--- a/frontend/demo/component/contextmenu/react/context-menu-checkable.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-checkable.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/contextmenu/react/context-menu-classname.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-classname.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/contextmenu/react/context-menu-disabled.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-disabled.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { ContextMenu } from '@vaadin/react-components/ContextMenu.js';
 import { Grid, type GridElement } from '@vaadin/react-components/Grid.js';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';

--- a/frontend/demo/component/contextmenu/react/context-menu-dividers.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-dividers.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ContextMenu } from '@vaadin/react-components/ContextMenu.js';

--- a/frontend/demo/component/contextmenu/react/context-menu-hierarchical.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-hierarchical.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { ContextMenu } from '@vaadin/react-components/ContextMenu.js';
 import { Grid, type GridElement } from '@vaadin/react-components/Grid.js';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';

--- a/frontend/demo/component/contextmenu/react/context-menu-left-click.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-left-click.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ContextMenu } from '@vaadin/react-components/ContextMenu.js';

--- a/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/cookieconsent/react/cookie-consent-basic.tsx
+++ b/frontend/demo/component/cookieconsent/react/cookie-consent-basic.tsx
@@ -1,6 +1,5 @@
 import './example-cleanup'; // hidden-source-line
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { CookieConsent } from '@vaadin/react-components-pro/CookieConsent.js';
 
 function Example() {

--- a/frontend/demo/component/cookieconsent/react/cookie-consent-localization.tsx
+++ b/frontend/demo/component/cookieconsent/react/cookie-consent-localization.tsx
@@ -1,6 +1,5 @@
 import './example-cleanup'; // hidden-source-line
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { CookieConsent } from '@vaadin/react-components-pro/CookieConsent.js';
 
 function Example() {

--- a/frontend/demo/component/cookieconsent/react/cookie-consent-theming.tsx
+++ b/frontend/demo/component/cookieconsent/react/cookie-consent-theming.tsx
@@ -1,6 +1,6 @@
 import './example-cleanup'; // hidden-source-line
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { CookieConsent } from '@vaadin/react-components-pro/CookieConsent.js';
 
 function Example() {

--- a/frontend/demo/component/crud/react/crud-basic.tsx
+++ b/frontend/demo/component/crud/react/crud-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Crud } from '@vaadin/react-components-pro/Crud.js';

--- a/frontend/demo/component/crud/react/crud-columns.tsx
+++ b/frontend/demo/component/crud/react/crud-columns.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Crud } from '@vaadin/react-components-pro/Crud.js';

--- a/frontend/demo/component/crud/react/crud-editor-aside.tsx
+++ b/frontend/demo/component/crud/react/crud-editor-aside.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Crud } from '@vaadin/react-components-pro/Crud.js';

--- a/frontend/demo/component/crud/react/crud-editor-bottom.tsx
+++ b/frontend/demo/component/crud/react/crud-editor-bottom.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Crud } from '@vaadin/react-components-pro/Crud.js';

--- a/frontend/demo/component/crud/react/crud-editor-content.tsx
+++ b/frontend/demo/component/crud/react/crud-editor-content.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/crud/react/crud-grid-replacement.tsx
+++ b/frontend/demo/component/crud/react/crud-grid-replacement.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/crud/react/crud-hidden-toolbar.tsx
+++ b/frontend/demo/component/crud/react/crud-hidden-toolbar.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Crud } from '@vaadin/react-components-pro/Crud.js';

--- a/frontend/demo/component/crud/react/crud-item-initialization.tsx
+++ b/frontend/demo/component/crud/react/crud-item-initialization.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Crud, type CrudNewEvent } from '@vaadin/react-components-pro/Crud.js';

--- a/frontend/demo/component/crud/react/crud-localization.tsx
+++ b/frontend/demo/component/crud/react/crud-localization.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/crud/react/crud-open-editor.tsx
+++ b/frontend/demo/component/crud/react/crud-open-editor.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid, type GridElement } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/crud/react/crud-sorting-filtering.tsx
+++ b/frontend/demo/component/crud/react/crud-sorting-filtering.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Crud } from '@vaadin/react-components-pro/Crud.js';

--- a/frontend/demo/component/crud/react/crud-toolbar.tsx
+++ b/frontend/demo/component/crud/react/crud-toolbar.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/custom-field/react/custom-field-basic.tsx
+++ b/frontend/demo/component/custom-field/react/custom-field-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { differenceInDays, isAfter, parseISO } from 'date-fns';
 import { useForm, useFormPart } from '@vaadin/hilla-react-form';
 import { CustomField } from '@vaadin/react-components/CustomField.js';

--- a/frontend/demo/component/custom-field/react/custom-field-native-input.tsx
+++ b/frontend/demo/component/custom-field/react/custom-field-native-input.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { CustomField } from '@vaadin/react-components/CustomField.js';

--- a/frontend/demo/component/custom-field/react/custom-field-size-variants.tsx
+++ b/frontend/demo/component/custom-field/react/custom-field-size-variants.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { CustomField } from '@vaadin/react-components/CustomField.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Select } from '@vaadin/react-components/Select.js';

--- a/frontend/demo/component/datepicker/react/date-picker-auto-open.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-auto-open.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datepicker/react/date-picker-basic-features.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-basic-features.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DatePicker } from '@vaadin/react-components/DatePicker';
 import { Icon } from '@vaadin/react-components/Icon';
 import { Tooltip } from '@vaadin/react-components/Tooltip';

--- a/frontend/demo/component/datepicker/react/date-picker-basic.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datepicker/react/date-picker-custom-functions.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-custom-functions.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import dateFnsFormat from 'date-fns/format';
 import dateFnsParse from 'date-fns/parse';

--- a/frontend/demo/component/datepicker/react/date-picker-custom-validation.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-custom-validation.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useForm, useFormPart } from '@vaadin/hilla-react-form';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';

--- a/frontend/demo/component/datepicker/react/date-picker-date-format-indicator.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-date-format-indicator.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datepicker/react/date-picker-date-range.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-date-range.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';

--- a/frontend/demo/component/datepicker/react/date-picker-individual-input-fields.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-individual-input-fields.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import getDaysInMonth from 'date-fns/getDaysInMonth';
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/datepicker/react/date-picker-initial-position.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-initial-position.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { formatISO, lastDayOfYear } from 'date-fns';
 import { useComputed } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/datepicker/react/date-picker-internationalization.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-internationalization.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { DatePicker, type DatePickerElement } from '@vaadin/react-components/DatePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datepicker/react/date-picker-readonly-and-disabled.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/datepicker/react/date-picker-styles.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datepicker/react/date-picker-validation.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { addDays, formatISO, isAfter, isBefore, parse } from 'date-fns';
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/datepicker/react/date-picker-week-numbers.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-week-numbers.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { DatePicker, type DatePickerElement } from '@vaadin/react-components/DatePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-auto-open.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-auto-open.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-basic-features.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-basic-features.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';
 

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-basic.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-custom-validation.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-custom-validation.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useForm, useFormPart } from '@vaadin/hilla-react-form';
 import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-initial-position.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-initial-position.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import addMonths from 'date-fns/addMonths';
 import formatISO from 'date-fns/formatISO';
 import startOfMonth from 'date-fns/startOfMonth';

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-input-format.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-input-format.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import dateFnsFormat from 'date-fns/format';
 import dateFnsParse from 'date-fns/parse';
 import type { DatePickerDate } from '@vaadin/date-picker';

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-internationalization.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-internationalization.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   DateTimePicker,
   type DateTimePickerElement,

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-minutes-step.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-minutes-step.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-range.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-range.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-readonly-and-disabled.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-seconds-step.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-seconds-step.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-styles.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
 
 function Example() {

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-validation.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { addDays, format, isAfter, isBefore, parseISO } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-week-numbers.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-week-numbers.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   DateTimePicker,
   type DateTimePickerElement,

--- a/frontend/demo/component/details/react/details-basic.tsx
+++ b/frontend/demo/component/details/react/details-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Details } from '@vaadin/react-components/Details.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 

--- a/frontend/demo/component/details/react/details-content.tsx
+++ b/frontend/demo/component/details/react/details-content.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Details } from '@vaadin/react-components/Details.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 

--- a/frontend/demo/component/details/react/details-disabled.tsx
+++ b/frontend/demo/component/details/react/details-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Details } from '@vaadin/react-components/Details.js';
 
 function Example() {

--- a/frontend/demo/component/details/react/details-filled.tsx
+++ b/frontend/demo/component/details/react/details-filled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Details } from '@vaadin/react-components/Details.js';
 
 function Example() {

--- a/frontend/demo/component/details/react/details-reverse.tsx
+++ b/frontend/demo/component/details/react/details-reverse.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Details } from '@vaadin/react-components/Details.js';
 
 function Example() {

--- a/frontend/demo/component/details/react/details-small.tsx
+++ b/frontend/demo/component/details/react/details-small.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Details } from '@vaadin/react-components/Details.js';
 
 function Example() {

--- a/frontend/demo/component/details/react/details-summary.tsx
+++ b/frontend/demo/component/details/react/details-summary.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { ComboBox } from '@vaadin/react-components/ComboBox.js';

--- a/frontend/demo/component/dialog/react/dialog-basic.tsx
+++ b/frontend/demo/component/dialog/react/dialog-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/dialog/react/dialog-closing.tsx
+++ b/frontend/demo/component/dialog/react/dialog-closing.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/dialog/react/dialog-draggable.tsx
+++ b/frontend/demo/component/dialog/react/dialog-draggable.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/dialog/react/dialog-footer.tsx
+++ b/frontend/demo/component/dialog/react/dialog-footer.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/dialog/react/dialog-header.tsx
+++ b/frontend/demo/component/dialog/react/dialog-header.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/dialog/react/dialog-no-padding.tsx
+++ b/frontend/demo/component/dialog/react/dialog-no-padding.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/dialog/react/dialog-resizable.tsx
+++ b/frontend/demo/component/dialog/react/dialog-resizable.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/emailfield/react/email-field-basic-features.tsx
+++ b/frontend/demo/component/emailfield/react/email-field-basic-features.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { EmailField } from '@vaadin/react-components/EmailField.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/emailfield/react/email-field-basic.tsx
+++ b/frontend/demo/component/emailfield/react/email-field-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { EmailField } from '@vaadin/react-components/EmailField.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/emailfield/react/email-field-readonly-and-disabled.tsx
+++ b/frontend/demo/component/emailfield/react/email-field-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { EmailField } from '@vaadin/react-components/EmailField.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 

--- a/frontend/demo/component/emailfield/react/email-field-styles.tsx
+++ b/frontend/demo/component/emailfield/react/email-field-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { EmailField } from '@vaadin/react-components/EmailField.js';
 
 function Example() {

--- a/frontend/demo/component/emailfield/react/email-field-validation.tsx
+++ b/frontend/demo/component/emailfield/react/email-field-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { EmailField } from '@vaadin/react-components/EmailField.js';
 
 function Example() {

--- a/frontend/demo/component/formlayout/react/form-layout-basic.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';
 import { PasswordField } from '@vaadin/react-components/PasswordField.js';
 import { TextField } from '@vaadin/react-components/TextField.js';

--- a/frontend/demo/component/formlayout/react/form-layout-colspan.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-colspan.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';
 import { TextField } from '@vaadin/react-components/TextField.js';

--- a/frontend/demo/component/formlayout/react/form-layout-custom-field.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-custom-field.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed } from '@vaadin/hilla-react-signals';
 import { CustomField } from '@vaadin/react-components/CustomField.js';

--- a/frontend/demo/component/formlayout/react/form-layout-custom-layout.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-custom-layout.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { EmailField } from '@vaadin/react-components/EmailField.js';
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';

--- a/frontend/demo/component/formlayout/react/form-layout-native-input.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-native-input.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { FormItem } from '@vaadin/react-components/FormItem.js';
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';
 

--- a/frontend/demo/component/formlayout/react/form-layout-side.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-side.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { FormItem } from '@vaadin/react-components/FormItem.js';
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';
 import { TextField } from '@vaadin/react-components/TextField.js';

--- a/frontend/demo/component/grid/react/grid-basic.tsx
+++ b/frontend/demo/component/grid/react/grid-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-cell-focus.tsx
+++ b/frontend/demo/component/grid/react/grid-cell-focus.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid, type GridCellFocusEvent, type GridElement } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-column-alignment.tsx
+++ b/frontend/demo/component/grid/react/grid-column-alignment.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { format } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/grid/react/grid-column-borders.tsx
+++ b/frontend/demo/component/grid/react/grid-column-borders.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/grid/react/grid-column-filtering.tsx
+++ b/frontend/demo/component/grid/react/grid-column-filtering.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/grid/react/grid-column-freezing.tsx
+++ b/frontend/demo/component/grid/react/grid-column-freezing.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/grid/react/grid-column-grouping.tsx
+++ b/frontend/demo/component/grid/react/grid-column-grouping.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-column-header-footer.tsx
+++ b/frontend/demo/component/grid/react/grid-column-header-footer.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-column-reordering-resizing.tsx
+++ b/frontend/demo/component/grid/react/grid-column-reordering-resizing.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-column-visibility.tsx
+++ b/frontend/demo/component/grid/react/grid-column-visibility.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/grid/react/grid-column-width.tsx
+++ b/frontend/demo/component/grid/react/grid-column-width.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-compact.tsx
+++ b/frontend/demo/component/grid/react/grid-compact.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-content.tsx
+++ b/frontend/demo/component/grid/react/grid-content.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/grid/react/grid-context-menu.tsx
+++ b/frontend/demo/component/grid/react/grid-context-menu.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/grid/react/grid-data-provider.tsx
+++ b/frontend/demo/component/grid/react/grid-data-provider.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/grid/react/grid-drag-drop-filters.tsx
+++ b/frontend/demo/component/grid/react/grid-drag-drop-filters.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/grid/react/grid-drag-rows-between-grids.tsx
+++ b/frontend/demo/component/grid/react/grid-drag-rows-between-grids.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid, type GridDragStartEvent } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-dynamic-height.tsx
+++ b/frontend/demo/component/grid/react/grid-dynamic-height.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/grid/react/grid-empty-state.tsx
+++ b/frontend/demo/component/grid/react/grid-empty-state.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Grid } from '@vaadin/react-components/Grid.js';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';
 

--- a/frontend/demo/component/grid/react/grid-external-filtering.tsx
+++ b/frontend/demo/component/grid/react/grid-external-filtering.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/grid/react/grid-header-footer-styling.tsx
+++ b/frontend/demo/component/grid/react/grid-header-footer-styling.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-item-details-toggle.tsx
+++ b/frontend/demo/component/grid/react/grid-item-details-toggle.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/grid/react/grid-item-details.tsx
+++ b/frontend/demo/component/grid/react/grid-item-details.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { FormLayout } from '@vaadin/react-components/FormLayout.js';

--- a/frontend/demo/component/grid/react/grid-lazy-column-rendering.tsx
+++ b/frontend/demo/component/grid/react/grid-lazy-column-rendering.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-multi-select-mode.tsx
+++ b/frontend/demo/component/grid/react/grid-multi-select-mode.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-multisort.tsx
+++ b/frontend/demo/component/grid/react/grid-multisort.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-no-border.tsx
+++ b/frontend/demo/component/grid/react/grid-no-border.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/grid/react/grid-no-row-border.tsx
+++ b/frontend/demo/component/grid/react/grid-no-row-border.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/grid/react/grid-rich-content-sorting.tsx
+++ b/frontend/demo/component/grid/react/grid-rich-content-sorting.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { format, parseISO } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/grid/react/grid-row-reordering.tsx
+++ b/frontend/demo/component/grid/react/grid-row-reordering.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/grid/react/grid-row-stripes.tsx
+++ b/frontend/demo/component/grid/react/grid-row-stripes.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/grid/react/grid-single-selection-mode.tsx
+++ b/frontend/demo/component/grid/react/grid-single-selection-mode.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-sorting.tsx
+++ b/frontend/demo/component/grid/react/grid-sorting.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-styling.tsx
+++ b/frontend/demo/component/grid/react/grid-styling.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Grid, type GridCellPartNameGenerator } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/grid/react/grid-tooltip-generator.tsx
+++ b/frontend/demo/component/grid/react/grid-tooltip-generator.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { differenceInYears, parseISO } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/grid/react/grid-wrap-cell-content.tsx
+++ b/frontend/demo/component/grid/react/grid-wrap-cell-content.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/gridpro/react/grid-pro-basic.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { GridPro } from '@vaadin/react-components-pro/GridPro.js';

--- a/frontend/demo/component/gridpro/react/grid-pro-cell-editability.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-cell-editability.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import type { GridItemModel } from '@vaadin/react-components/Grid.js';

--- a/frontend/demo/component/gridpro/react/grid-pro-edit-column.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-edit-column.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';

--- a/frontend/demo/component/gridpro/react/grid-pro-editors.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-editors.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { format, parseISO } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/gridpro/react/grid-pro-enter-next-row.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-enter-next-row.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { GridPro } from '@vaadin/react-components-pro/GridPro.js';

--- a/frontend/demo/component/gridpro/react/grid-pro-highlight-editable-cells.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-highlight-editable-cells.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';

--- a/frontend/demo/component/gridpro/react/grid-pro-highlight-read-only-cells.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-highlight-read-only-cells.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';

--- a/frontend/demo/component/gridpro/react/grid-pro-prevent-save.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-prevent-save.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Notification } from '@vaadin/notification';

--- a/frontend/demo/component/gridpro/react/grid-pro-single-cell-edit.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-single-cell-edit.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { GridPro } from '@vaadin/react-components-pro/GridPro.js';

--- a/frontend/demo/component/gridpro/react/grid-pro-single-click.tsx
+++ b/frontend/demo/component/gridpro/react/grid-pro-single-click.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { GridPro } from '@vaadin/react-components-pro/GridPro.js';

--- a/frontend/demo/component/icons/react/icon-basic.tsx
+++ b/frontend/demo/component/icons/react/icon-basic.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 

--- a/frontend/demo/component/icons/react/icon-fonts.tsx
+++ b/frontend/demo/component/icons/react/icon-fonts.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 

--- a/frontend/demo/component/icons/react/icons-accessibility.tsx
+++ b/frontend/demo/component/icons/react/icons-accessibility.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 

--- a/frontend/demo/component/icons/react/icons-color.tsx
+++ b/frontend/demo/component/icons/react/icons-color.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import codeBranch from '../../../../../src/main/resources/icons/code-branch.svg';

--- a/frontend/demo/component/icons/react/icons-padding.tsx
+++ b/frontend/demo/component/icons/react/icons-padding.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import codeBranch from '../../../../../src/main/resources/icons/code-branch.svg';

--- a/frontend/demo/component/icons/react/icons-sizing.tsx
+++ b/frontend/demo/component/icons/react/icons-sizing.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import codeBranch from '../../../../../src/main/resources/icons/code-branch.svg';

--- a/frontend/demo/component/icons/react/lumo-icons.tsx
+++ b/frontend/demo/component/icons/react/lumo-icons.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';

--- a/frontend/demo/component/icons/react/svg-sprites.tsx
+++ b/frontend/demo/component/icons/react/svg-sprites.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import spriteIcons from '../../../../../src/main/resources/icons/solid.svg';

--- a/frontend/demo/component/icons/react/svg-standalone.tsx
+++ b/frontend/demo/component/icons/react/svg-standalone.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import codeBranchIcon from '../../../../../src/main/resources/icons/code-branch.svg';
 

--- a/frontend/demo/component/icons/react/vaadin-icons.tsx
+++ b/frontend/demo/component/icons/react/vaadin-icons.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';

--- a/frontend/demo/component/listbox/react/list-box-basic.tsx
+++ b/frontend/demo/component/listbox/react/list-box-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Item } from '@vaadin/react-components/Item.js';
 import { ListBox } from '@vaadin/react-components/ListBox.js';
 

--- a/frontend/demo/component/listbox/react/list-box-custom-item-presentation.tsx
+++ b/frontend/demo/component/listbox/react/list-box-custom-item-presentation.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/listbox/react/list-box-disabled-items.tsx
+++ b/frontend/demo/component/listbox/react/list-box-disabled-items.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Item } from '@vaadin/react-components/Item.js';
 import { ListBox } from '@vaadin/react-components/ListBox.js';
 

--- a/frontend/demo/component/listbox/react/list-box-multi-selection.tsx
+++ b/frontend/demo/component/listbox/react/list-box-multi-selection.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Item } from '@vaadin/react-components/Item.js';

--- a/frontend/demo/component/listbox/react/list-box-separators.tsx
+++ b/frontend/demo/component/listbox/react/list-box-separators.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Item } from '@vaadin/react-components/Item.js';
 import { ListBox } from '@vaadin/react-components/ListBox.js';
 

--- a/frontend/demo/component/listbox/react/list-box-single-selection.tsx
+++ b/frontend/demo/component/listbox/react/list-box-single-selection.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Item } from '@vaadin/react-components/Item.js';
 import { ListBox } from '@vaadin/react-components/ListBox.js';
 

--- a/frontend/demo/component/login/react/login-additional-information.tsx
+++ b/frontend/demo/component/login/react/login-additional-information.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { LoginOverlay, type LoginOverlayElement } from '@vaadin/react-components/LoginOverlay.js';
 
 function Example() {

--- a/frontend/demo/component/login/react/login-basic.tsx
+++ b/frontend/demo/component/login/react/login-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { LoginForm } from '@vaadin/react-components/LoginForm.js';
 import { loginHostStyles } from './login-host-styles'; // hidden-source-line
 

--- a/frontend/demo/component/login/react/login-internationalization.tsx
+++ b/frontend/demo/component/login/react/login-internationalization.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { LoginForm } from '@vaadin/react-components/LoginForm.js';
 import { loginHostStyles } from './login-host-styles'; // hidden-source-line
 

--- a/frontend/demo/component/login/react/login-overlay-basic.tsx
+++ b/frontend/demo/component/login/react/login-overlay-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/login/react/login-overlay-custom-form-area.tsx
+++ b/frontend/demo/component/login/react/login-overlay-custom-form-area.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { IntegerField } from '@vaadin/react-components/IntegerField.js';
 import { LoginOverlay } from '@vaadin/react-components/LoginOverlay.js';
 import { applyTheme } from 'Frontend/generated/theme';

--- a/frontend/demo/component/login/react/login-overlay-footer.tsx
+++ b/frontend/demo/component/login/react/login-overlay-footer.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { LoginOverlay } from '@vaadin/react-components/LoginOverlay.js';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/login/react/login-overlay-header.tsx
+++ b/frontend/demo/component/login/react/login-overlay-header.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { LoginOverlay } from '@vaadin/react-components/LoginOverlay.js';
 import { applyTheme } from 'Frontend/generated/theme';
 

--- a/frontend/demo/component/login/react/login-overlay-internationalization.tsx
+++ b/frontend/demo/component/login/react/login-overlay-internationalization.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { LoginOverlay } from '@vaadin/react-components/LoginOverlay.js';
 
 function Example() {

--- a/frontend/demo/component/login/react/login-rich-content.tsx
+++ b/frontend/demo/component/login/react/login-rich-content.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { LoginForm } from '@vaadin/react-components/LoginForm.js';
 
 function Example() {

--- a/frontend/demo/component/login/react/login-validation.tsx
+++ b/frontend/demo/component/login/react/login-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { LoginOverlay } from '@vaadin/react-components/LoginOverlay.js';
 
 // tag::snippet[]

--- a/frontend/demo/component/menubar/react/menu-bar-basic.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';

--- a/frontend/demo/component/menubar/react/menu-bar-checkable.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-checkable.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/menubar/react/menu-bar-combo-buttons.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-combo-buttons.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 

--- a/frontend/demo/component/menubar/react/menu-bar-custom-styling.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-custom-styling.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {

--- a/frontend/demo/component/menubar/react/menu-bar-disabled.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {

--- a/frontend/demo/component/menubar/react/menu-bar-dividers.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-dividers.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {

--- a/frontend/demo/component/menubar/react/menu-bar-drop-down-indicators.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-drop-down-indicators.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {

--- a/frontend/demo/component/menubar/react/menu-bar-drop-down.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-drop-down.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {

--- a/frontend/demo/component/menubar/react/menu-bar-icon-only.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-icon-only.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 

--- a/frontend/demo/component/menubar/react/menu-bar-icons.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-icons.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 

--- a/frontend/demo/component/menubar/react/menu-bar-internationalization.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-internationalization.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MenuBar, type MenuBarI18n } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {

--- a/frontend/demo/component/menubar/react/menu-bar-open-on-hover.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-open-on-hover.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {

--- a/frontend/demo/component/menubar/react/menu-bar-overflow.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-overflow.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
 

--- a/frontend/demo/component/menubar/react/menu-bar-right-aligned.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-right-aligned.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {

--- a/frontend/demo/component/menubar/react/menu-bar-styles.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 

--- a/frontend/demo/component/menubar/react/menu-bar-tooltip.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-tooltip.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { MenuBar } from '@vaadin/react-components/MenuBar.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/messages/react/message-basic.tsx
+++ b/frontend/demo/component/messages/react/message-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import type { MessageListItem } from '@vaadin/message-list';

--- a/frontend/demo/component/messages/react/message-input-component.tsx
+++ b/frontend/demo/component/messages/react/message-input-component.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import {
   MessageInput,
   type MessageInputSubmitEvent,

--- a/frontend/demo/component/messages/react/message-list-component.tsx
+++ b/frontend/demo/component/messages/react/message-list-component.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { format, subDays, subMinutes } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/messages/react/message-list-with-theme-component.tsx
+++ b/frontend/demo/component/messages/react/message-list-with-theme-component.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { format, subDays, subMinutes } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-auto-expand.tsx
+++ b/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-auto-expand.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { MultiSelectComboBox } from '@vaadin/react-components/MultiSelectComboBox.js';

--- a/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-basic.tsx
+++ b/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { MultiSelectComboBox } from '@vaadin/react-components/MultiSelectComboBox.js';

--- a/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-i18n.tsx
+++ b/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-i18n.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { MultiSelectComboBox } from '@vaadin/react-components/MultiSelectComboBox.js';

--- a/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-item-class-name.tsx
+++ b/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-item-class-name.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { MultiSelectComboBox } from '@vaadin/react-components/MultiSelectComboBox.js';
 
 function Example() {

--- a/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-read-only.tsx
+++ b/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-read-only.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { MultiSelectComboBox } from '@vaadin/react-components/MultiSelectComboBox.js';

--- a/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-selected-items-on-top.tsx
+++ b/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-selected-items-on-top.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { MultiSelectComboBox } from '@vaadin/react-components/MultiSelectComboBox.js';

--- a/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-selection-change.tsx
+++ b/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-selection-change.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';

--- a/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-selection.tsx
+++ b/frontend/demo/component/multi-select-combo-box/react/multi-select-combo-box-selection.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { MultiSelectComboBox } from '@vaadin/react-components/MultiSelectComboBox.js';

--- a/frontend/demo/component/notification/react/notification-basic.tsx
+++ b/frontend/demo/component/notification/react/notification-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 
 function Example() {

--- a/frontend/demo/component/notification/react/notification-contrast.tsx
+++ b/frontend/demo/component/notification/react/notification-contrast.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 
 function Example() {

--- a/frontend/demo/component/notification/react/notification-error.tsx
+++ b/frontend/demo/component/notification/react/notification-error.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/notification/react/notification-keyboard-a11y.tsx
+++ b/frontend/demo/component/notification/react/notification-keyboard-a11y.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/notification/react/notification-link.tsx
+++ b/frontend/demo/component/notification/react/notification-link.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/notification/react/notification-popup.tsx
+++ b/frontend/demo/component/notification/react/notification-popup.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { ContextMenu } from '@vaadin/react-components/ContextMenu.js';
 import { Icon } from '@vaadin/react-components/Icon.js';

--- a/frontend/demo/component/notification/react/notification-position.tsx
+++ b/frontend/demo/component/notification/react/notification-position.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { Notification, type NotificationPosition } from '@vaadin/react-components/Notification.js';
 import exampleStyles from './notification-position-example-styles'; // hidden-source-line

--- a/frontend/demo/component/notification/react/notification-primary.tsx
+++ b/frontend/demo/component/notification/react/notification-primary.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 
 function Example() {

--- a/frontend/demo/component/notification/react/notification-retry.tsx
+++ b/frontend/demo/component/notification/react/notification-retry.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/notification/react/notification-rich.tsx
+++ b/frontend/demo/component/notification/react/notification-rich.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/notification/react/notification-static-helper.tsx
+++ b/frontend/demo/component/notification/react/notification-static-helper.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { Notification } from '@vaadin/react-components/Notification.js';
 

--- a/frontend/demo/component/notification/react/notification-success.tsx
+++ b/frontend/demo/component/notification/react/notification-success.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 
 function Example() {

--- a/frontend/demo/component/notification/react/notification-undo.tsx
+++ b/frontend/demo/component/notification/react/notification-undo.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/notification/react/notification-warning.tsx
+++ b/frontend/demo/component/notification/react/notification-warning.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/numberfield/react/number-field-basic-features.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-basic-features.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { NumberField } from '@vaadin/react-components/NumberField.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/numberfield/react/number-field-basic.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { NumberField } from '@vaadin/react-components/NumberField.js';
 

--- a/frontend/demo/component/numberfield/react/number-field-integer.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-integer.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { IntegerField } from '@vaadin/react-components/IntegerField.js';
 

--- a/frontend/demo/component/numberfield/react/number-field-readonly-and-disabled.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { NumberField } from '@vaadin/react-components/NumberField.js';
 

--- a/frontend/demo/component/numberfield/react/number-field-step-buttons.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-step-buttons.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { FormItem } from '@vaadin/react-components/FormItem.js';
 import { FormLayout, type FormLayoutResponsiveStep } from '@vaadin/react-components/FormLayout.js';
 import { IntegerField } from '@vaadin/react-components/IntegerField';

--- a/frontend/demo/component/numberfield/react/number-field-step.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-step.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { NumberField } from '@vaadin/react-components/NumberField.js';
 
 function Example() {

--- a/frontend/demo/component/numberfield/react/number-field-styles.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { NumberField } from '@vaadin/react-components/NumberField.js';
 
 function Example() {

--- a/frontend/demo/component/numberfield/react/number-field-validation.tsx
+++ b/frontend/demo/component/numberfield/react/number-field-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { IntegerField } from '@vaadin/react-components/IntegerField';
 
 function Example() {

--- a/frontend/demo/component/passwordfield/react/password-field-advanced-helper.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-advanced-helper.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Icon } from '@vaadin/react-components/Icon.js';

--- a/frontend/demo/component/passwordfield/react/password-field-basic-features.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-basic-features.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { PasswordField } from '@vaadin/react-components/PasswordField.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/passwordfield/react/password-field-basic.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { PasswordField } from '@vaadin/react-components/PasswordField.js';
 
 function Example() {

--- a/frontend/demo/component/passwordfield/react/password-field-helper.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-helper.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { PasswordField } from '@vaadin/react-components/PasswordField.js';
 
 function Example() {

--- a/frontend/demo/component/passwordfield/react/password-field-readonly-and-disabled.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { PasswordField } from '@vaadin/react-components/PasswordField.js';
 

--- a/frontend/demo/component/passwordfield/react/password-field-reveal-button-hidden.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-reveal-button-hidden.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { PasswordField } from '@vaadin/react-components/PasswordField.js';
 
 function Example() {

--- a/frontend/demo/component/passwordfield/react/password-field-styles.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { PasswordField } from '@vaadin/react-components/PasswordField.js';
 
 function Example() {

--- a/frontend/demo/component/passwordfield/react/password-field-validation.tsx
+++ b/frontend/demo/component/passwordfield/react/password-field-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { PasswordField } from '@vaadin/react-components/PasswordField.js';
 
 function Example() {

--- a/frontend/demo/component/popover/react/popover-anchored-dialog.tsx
+++ b/frontend/demo/component/popover/react/popover-anchored-dialog.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/popover/react/popover-arrow.tsx
+++ b/frontend/demo/component/popover/react/popover-arrow.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button, Icon, Popover } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/popover/react/popover-dropdown-field.tsx
+++ b/frontend/demo/component/popover/react/popover-dropdown-field.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { formatISO, subMonths, subWeeks, subYears } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/popover/react/popover-interactive-tooltip.tsx
+++ b/frontend/demo/component/popover/react/popover-interactive-tooltip.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { IntegerField, Popover } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/popover/react/popover-modal.tsx
+++ b/frontend/demo/component/popover/react/popover-modal.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button, Popover, TextField } from '@vaadin/react-components';
 
 function Example() {

--- a/frontend/demo/component/popover/react/popover-notification-panel.tsx
+++ b/frontend/demo/component/popover/react/popover-notification-panel.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { format, subMinutes } from 'date-fns';
 import { useSignal } from '@vaadin/hilla-react-signals';

--- a/frontend/demo/component/popover/react/popover-positioning.tsx
+++ b/frontend/demo/component/popover/react/popover-positioning.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/popover/react/popover-user-menu.tsx
+++ b/frontend/demo/component/popover/react/popover-user-menu.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/progressbar/react/progress-bar-basic.tsx
+++ b/frontend/demo/component/progressbar/react/progress-bar-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ProgressBar } from '@vaadin/react-components/ProgressBar.js';
 
 function Example() {

--- a/frontend/demo/component/progressbar/react/progress-bar-completion-time.tsx
+++ b/frontend/demo/component/progressbar/react/progress-bar-completion-time.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ProgressBar } from '@vaadin/react-components/ProgressBar.js';
 
 function Example() {

--- a/frontend/demo/component/progressbar/react/progress-bar-custom-range.tsx
+++ b/frontend/demo/component/progressbar/react/progress-bar-custom-range.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ProgressBar } from '@vaadin/react-components/ProgressBar.js';
 
 function Example() {

--- a/frontend/demo/component/progressbar/react/progress-bar-determinate.tsx
+++ b/frontend/demo/component/progressbar/react/progress-bar-determinate.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ProgressBar } from '@vaadin/react-components/ProgressBar.js';
 
 function Example() {

--- a/frontend/demo/component/progressbar/react/progress-bar-indeterminate.tsx
+++ b/frontend/demo/component/progressbar/react/progress-bar-indeterminate.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ProgressBar } from '@vaadin/react-components/ProgressBar.js';
 
 function Example() {

--- a/frontend/demo/component/progressbar/react/progress-bar-label.tsx
+++ b/frontend/demo/component/progressbar/react/progress-bar-label.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { ProgressBar } from '@vaadin/react-components/ProgressBar.js';
 

--- a/frontend/demo/component/progressbar/react/progress-bar-theme-variants.tsx
+++ b/frontend/demo/component/progressbar/react/progress-bar-theme-variants.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { ProgressBar } from '@vaadin/react-components/ProgressBar.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 

--- a/frontend/demo/component/radiobutton/react/radio-button-basic.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 

--- a/frontend/demo/component/radiobutton/react/radio-button-checkbox-alternative.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-checkbox-alternative.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';

--- a/frontend/demo/component/radiobutton/react/radio-button-custom-option.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-custom-option.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';

--- a/frontend/demo/component/radiobutton/react/radio-button-default-value.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-default-value.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 

--- a/frontend/demo/component/radiobutton/react/radio-button-disabled.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 

--- a/frontend/demo/component/radiobutton/react/radio-button-group-basic-features.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-group-basic-features.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/radiobutton/react/radio-button-group-labels.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-group-labels.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';

--- a/frontend/demo/component/radiobutton/react/radio-button-group-styles.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-group-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 

--- a/frontend/demo/component/radiobutton/react/radio-button-horizontal.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-horizontal.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 

--- a/frontend/demo/component/radiobutton/react/radio-button-presentation.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-presentation.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';

--- a/frontend/demo/component/radiobutton/react/radio-button-readonly.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-readonly.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 

--- a/frontend/demo/component/radiobutton/react/radio-button-vertical.tsx
+++ b/frontend/demo/component/radiobutton/react/radio-button-vertical.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 

--- a/frontend/demo/component/richtexteditor/react/rich-text-editor-basic.tsx
+++ b/frontend/demo/component/richtexteditor/react/rich-text-editor-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { RichTextEditor } from '@vaadin/react-components-pro/RichTextEditor.js';

--- a/frontend/demo/component/richtexteditor/react/rich-text-editor-min-max-height.tsx
+++ b/frontend/demo/component/richtexteditor/react/rich-text-editor-min-max-height.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { RichTextEditor } from '@vaadin/react-components-pro/RichTextEditor.js';

--- a/frontend/demo/component/richtexteditor/react/rich-text-editor-readonly.tsx
+++ b/frontend/demo/component/richtexteditor/react/rich-text-editor-readonly.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { RichTextEditor } from '@vaadin/react-components-pro/RichTextEditor.js';
 import templates from '../../../../../src/main/resources/data/templates.json';
 

--- a/frontend/demo/component/richtexteditor/react/rich-text-editor-set-get-value.tsx
+++ b/frontend/demo/component/richtexteditor/react/rich-text-editor-set-get-value.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { TextArea, type TextAreaChangeEvent } from '@vaadin/react-components/TextArea.js';

--- a/frontend/demo/component/richtexteditor/react/rich-text-editor-theme-compact.tsx
+++ b/frontend/demo/component/richtexteditor/react/rich-text-editor-theme-compact.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { RichTextEditor } from '@vaadin/react-components-pro/RichTextEditor.js';

--- a/frontend/demo/component/richtexteditor/react/rich-text-editor-theme-no-border.tsx
+++ b/frontend/demo/component/richtexteditor/react/rich-text-editor-theme-no-border.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { RichTextEditor } from '@vaadin/react-components-pro/RichTextEditor.js';

--- a/frontend/demo/component/scroller/react/scroller-basic.tsx
+++ b/frontend/demo/component/scroller/react/scroller-basic.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { DatePicker } from '@vaadin/react-components/DatePicker.js';
 import { Icon } from '@vaadin/react-components/Icon.js';

--- a/frontend/demo/component/scroller/react/scroller-both.tsx
+++ b/frontend/demo/component/scroller/react/scroller-both.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Scroller } from '@vaadin/react-components/Scroller.js';
 import img from '../../../../../src/main/resources/images/reindeer.jpg';
 

--- a/frontend/demo/component/scroller/react/scroller-mobile.tsx
+++ b/frontend/demo/component/scroller/react/scroller-mobile.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';

--- a/frontend/demo/component/select/react/select-basic-features.tsx
+++ b/frontend/demo/component/select/react/select-basic-features.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { Select } from '@vaadin/react-components/Select.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/select/react/select-basic.tsx
+++ b/frontend/demo/component/select/react/select-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Select } from '@vaadin/react-components/Select.js';
 
 function Example() {

--- a/frontend/demo/component/select/react/select-complex-value-label.tsx
+++ b/frontend/demo/component/select/react/select-complex-value-label.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Select, type SelectItem } from '@vaadin/react-components/Select.js';

--- a/frontend/demo/component/select/react/select-custom-renderer-label.tsx
+++ b/frontend/demo/component/select/react/select-custom-renderer-label.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Item } from '@vaadin/react-components/Item.js';

--- a/frontend/demo/component/select/react/select-disabled.tsx
+++ b/frontend/demo/component/select/react/select-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Select } from '@vaadin/react-components/Select.js';
 
 // tag::snippet[]

--- a/frontend/demo/component/select/react/select-dividers.tsx
+++ b/frontend/demo/component/select/react/select-dividers.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Select } from '@vaadin/react-components/Select.js';
 
 // tag::snippet[]

--- a/frontend/demo/component/select/react/select-no-vertical-overlap.tsx
+++ b/frontend/demo/component/select/react/select-no-vertical-overlap.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Select } from '@vaadin/react-components/Select.js';
 
 function Example() {

--- a/frontend/demo/component/select/react/select-overlay-width.tsx
+++ b/frontend/demo/component/select/react/select-overlay-width.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Select, type SelectItem } from '@vaadin/react-components/Select.js';

--- a/frontend/demo/component/select/react/select-placeholder.tsx
+++ b/frontend/demo/component/select/react/select-placeholder.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Select } from '@vaadin/react-components/Select.js';
 
 function Example() {

--- a/frontend/demo/component/select/react/select-presentation.tsx
+++ b/frontend/demo/component/select/react/select-presentation.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Item } from '@vaadin/react-components/Item.js';

--- a/frontend/demo/component/select/react/select-readonly-and-disabled.tsx
+++ b/frontend/demo/component/select/react/select-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Select } from '@vaadin/react-components/Select.js';
 

--- a/frontend/demo/component/select/react/select-styles.tsx
+++ b/frontend/demo/component/select/react/select-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Select } from '@vaadin/react-components/Select.js';
 
 function Example() {

--- a/frontend/demo/component/side-nav/react/side-nav-basic.tsx
+++ b/frontend/demo/component/side-nav/react/side-nav-basic.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { SideNav, type SideNavElement } from '@vaadin/react-components/SideNav.js';
 import { SideNavItem } from '@vaadin/react-components/SideNavItem.js';

--- a/frontend/demo/component/side-nav/react/side-nav-hierarchy.tsx
+++ b/frontend/demo/component/side-nav/react/side-nav-hierarchy.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { SideNav, type SideNavElement } from '@vaadin/react-components/SideNav.js';
 import { SideNavItem } from '@vaadin/react-components/SideNavItem.js';

--- a/frontend/demo/component/side-nav/react/side-nav-labelled.tsx
+++ b/frontend/demo/component/side-nav/react/side-nav-labelled.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { SideNav, type SideNavElement } from '@vaadin/react-components/SideNav.js';
 import { SideNavItem } from '@vaadin/react-components/SideNavItem.js';

--- a/frontend/demo/component/side-nav/react/side-nav-router.tsx
+++ b/frontend/demo/component/side-nav/react/side-nav-router.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { SideNav } from '@vaadin/react-components/SideNav.js';
 import { SideNavItem } from '@vaadin/react-components/SideNavItem.js';

--- a/frontend/demo/component/side-nav/react/side-nav-styling.tsx
+++ b/frontend/demo/component/side-nav/react/side-nav-styling.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { SideNav, type SideNavElement } from '@vaadin/react-components/SideNav.js';
 import { SideNavItem } from '@vaadin/react-components/SideNavItem.js';

--- a/frontend/demo/component/side-nav/react/side-nav-suffix.tsx
+++ b/frontend/demo/component/side-nav/react/side-nav-suffix.tsx
@@ -1,6 +1,6 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { SideNav, type SideNavElement } from '@vaadin/react-components/SideNav.js';
 import { SideNavItem } from '@vaadin/react-components/SideNavItem.js';

--- a/frontend/demo/component/splitlayout/react/detail-content.tsx
+++ b/frontend/demo/component/splitlayout/react/detail-content.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type DetailContentProps = {
   style?: React.CSSProperties;
 };

--- a/frontend/demo/component/splitlayout/react/master-content.tsx
+++ b/frontend/demo/component/splitlayout/react/master-content.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type MasterContentProps = {
   style?: React.CSSProperties;
 };

--- a/frontend/demo/component/splitlayout/react/split-layout-basic.tsx
+++ b/frontend/demo/component/splitlayout/react/split-layout-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout';
 import DetailContent from './detail-content';
 import MasterContent from './master-content';

--- a/frontend/demo/component/splitlayout/react/split-layout-initial-splitter-position.tsx
+++ b/frontend/demo/component/splitlayout/react/split-layout-initial-splitter-position.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
 import DetailContent from './detail-content';
 import MasterContent from './master-content';

--- a/frontend/demo/component/splitlayout/react/split-layout-min-max-size.tsx
+++ b/frontend/demo/component/splitlayout/react/split-layout-min-max-size.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
 import DetailContent from './detail-content';
 import MasterContent from './master-content';

--- a/frontend/demo/component/splitlayout/react/split-layout-orientation.tsx
+++ b/frontend/demo/component/splitlayout/react/split-layout-orientation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
 import DetailContent from './detail-content';
 import MasterContent from './master-content';

--- a/frontend/demo/component/splitlayout/react/split-layout-theme-minimal.tsx
+++ b/frontend/demo/component/splitlayout/react/split-layout-theme-minimal.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
 import DetailContent from './detail-content';
 import MasterContent from './master-content';

--- a/frontend/demo/component/splitlayout/react/split-layout-theme-small.tsx
+++ b/frontend/demo/component/splitlayout/react/split-layout-theme-small.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
 import DetailContent from './detail-content';
 import MasterContent from './master-content';

--- a/frontend/demo/component/splitlayout/react/split-layout-toggle.tsx
+++ b/frontend/demo/component/splitlayout/react/split-layout-toggle.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/tabs/react/tabs-badges.tsx
+++ b/frontend/demo/component/tabs/react/tabs-badges.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-basic.tsx
+++ b/frontend/demo/component/tabs/react/tabs-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-content.tsx
+++ b/frontend/demo/component/tabs/react/tabs-content.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Tab } from '@vaadin/react-components/Tab.js';

--- a/frontend/demo/component/tabs/react/tabs-focus-ring.tsx
+++ b/frontend/demo/component/tabs/react/tabs-focus-ring.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-hide-scroll-buttons.tsx
+++ b/frontend/demo/component/tabs/react/tabs-hide-scroll-buttons.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-horizontal.tsx
+++ b/frontend/demo/component/tabs/react/tabs-horizontal.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-icons-horizontal.tsx
+++ b/frontend/demo/component/tabs/react/tabs-icons-horizontal.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';

--- a/frontend/demo/component/tabs/react/tabs-icons-vertical.tsx
+++ b/frontend/demo/component/tabs/react/tabs-icons-vertical.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';

--- a/frontend/demo/component/tabs/react/tabs-states.tsx
+++ b/frontend/demo/component/tabs/react/tabs-states.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-theme-centered.tsx
+++ b/frontend/demo/component/tabs/react/tabs-theme-centered.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-theme-equal-width.tsx
+++ b/frontend/demo/component/tabs/react/tabs-theme-equal-width.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-theme-minimal.tsx
+++ b/frontend/demo/component/tabs/react/tabs-theme-minimal.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-theme-small.tsx
+++ b/frontend/demo/component/tabs/react/tabs-theme-small.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabs-vertical.tsx
+++ b/frontend/demo/component/tabs/react/tabs-vertical.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 

--- a/frontend/demo/component/tabs/react/tabsheet-basic.tsx
+++ b/frontend/demo/component/tabs/react/tabsheet-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TabSheet, TabSheetTab } from '@vaadin/react-components/TabSheet.js';
 
 function Example() {

--- a/frontend/demo/component/tabs/react/tabsheet-lazy-initialization.tsx
+++ b/frontend/demo/component/tabs/react/tabsheet-lazy-initialization.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import {

--- a/frontend/demo/component/tabs/react/tabsheet-prefix-suffix.tsx
+++ b/frontend/demo/component/tabs/react/tabsheet-prefix-suffix.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { TabSheet, TabSheetTab } from '@vaadin/react-components/TabSheet.js';

--- a/frontend/demo/component/tabs/react/tabsheet-theme-bordered.tsx
+++ b/frontend/demo/component/tabs/react/tabsheet-theme-bordered.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TabSheet, TabSheetTab } from '@vaadin/react-components/TabSheet.js';
 
 function Example() {

--- a/frontend/demo/component/textarea/react/text-area-auto-height.tsx
+++ b/frontend/demo/component/textarea/react/text-area-auto-height.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TextArea } from '@vaadin/react-components/TextArea.js';
 import templates from '../../../../../src/main/resources/data/templates.json';
 

--- a/frontend/demo/component/textarea/react/text-area-basic-features.tsx
+++ b/frontend/demo/component/textarea/react/text-area-basic-features.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { TextArea } from '@vaadin/react-components/TextArea.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/textarea/react/text-area-basic.tsx
+++ b/frontend/demo/component/textarea/react/text-area-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { TextArea } from '@vaadin/react-components/TextArea.js';

--- a/frontend/demo/component/textarea/react/text-area-height.tsx
+++ b/frontend/demo/component/textarea/react/text-area-height.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TextArea } from '@vaadin/react-components/TextArea.js';
 import templates from '../../../../../src/main/resources/data/templates.json';
 

--- a/frontend/demo/component/textarea/react/text-area-helper.tsx
+++ b/frontend/demo/component/textarea/react/text-area-helper.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { TextArea } from '@vaadin/react-components/TextArea.js';

--- a/frontend/demo/component/textarea/react/text-area-readonly-and-disabled.tsx
+++ b/frontend/demo/component/textarea/react/text-area-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { TextArea } from '@vaadin/react-components/TextArea.js';
 

--- a/frontend/demo/component/textarea/react/text-area-styles.tsx
+++ b/frontend/demo/component/textarea/react/text-area-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TextArea } from '@vaadin/react-components/TextArea.js';
 
 function Example() {

--- a/frontend/demo/component/textarea/react/text-area-validation.tsx
+++ b/frontend/demo/component/textarea/react/text-area-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TextArea } from '@vaadin/react-components/TextArea.js';
 
 function Example() {

--- a/frontend/demo/component/textfield/react/text-field-basic-features.tsx
+++ b/frontend/demo/component/textfield/react/text-field-basic-features.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { TextField } from '@vaadin/react-components/TextField.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/textfield/react/text-field-basic.tsx
+++ b/frontend/demo/component/textfield/react/text-field-basic.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { TextField } from '@vaadin/react-components/TextField.js';
 

--- a/frontend/demo/component/textfield/react/text-field-readonly-and-disabled.tsx
+++ b/frontend/demo/component/textfield/react/text-field-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { TextField } from '@vaadin/react-components/TextField.js';
 

--- a/frontend/demo/component/textfield/react/text-field-styles.tsx
+++ b/frontend/demo/component/textfield/react/text-field-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TextField } from '@vaadin/react-components/TextField.js';
 
 function Example() {

--- a/frontend/demo/component/textfield/react/text-field-validation.tsx
+++ b/frontend/demo/component/textfield/react/text-field-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TextField } from '@vaadin/react-components/TextField.js';
 
 function Example() {

--- a/frontend/demo/component/timepicker/react/time-picker-auto-open.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-auto-open.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TimePicker } from '@vaadin/react-components/TimePicker.js';
 
 const Example = () => (

--- a/frontend/demo/component/timepicker/react/time-picker-basic-features.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-basic-features.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { TimePicker } from '@vaadin/react-components/TimePicker.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/timepicker/react/time-picker-basic.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TimePicker } from '@vaadin/react-components/TimePicker.js';
 
 function Example() {

--- a/frontend/demo/component/timepicker/react/time-picker-custom-validation.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-custom-validation.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useForm, useFormPart } from '@vaadin/hilla-react-form';
 import { TimePicker } from '@vaadin/react-components/TimePicker.js';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';

--- a/frontend/demo/component/timepicker/react/time-picker-minutes-step.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-minutes-step.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TimePicker } from '@vaadin/react-components/TimePicker.js';
 
 function Example() {

--- a/frontend/demo/component/timepicker/react/time-picker-readonly-and-disabled.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-readonly-and-disabled.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { TimePicker } from '@vaadin/react-components/TimePicker.js';
 

--- a/frontend/demo/component/timepicker/react/time-picker-seconds-step.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-seconds-step.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TimePicker } from '@vaadin/react-components/TimePicker.js';
 
 function Example() {

--- a/frontend/demo/component/timepicker/react/time-picker-styles.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-styles.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { TimePicker } from '@vaadin/react-components/TimePicker.js';
 
 function Example() {

--- a/frontend/demo/component/timepicker/react/time-picker-validation.tsx
+++ b/frontend/demo/component/timepicker/react/time-picker-validation.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import type { TimePickerChangeEvent } from '@vaadin/react-components/TimePicker.js';

--- a/frontend/demo/component/tooltip/react/tooltip-basic.tsx
+++ b/frontend/demo/component/tooltip/react/tooltip-basic.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { TextField } from '@vaadin/react-components/TextField.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';

--- a/frontend/demo/component/tooltip/react/tooltip-html-element.tsx
+++ b/frontend/demo/component/tooltip/react/tooltip-html-element.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';
 
 function Example() {

--- a/frontend/demo/component/tooltip/react/tooltip-manual.tsx
+++ b/frontend/demo/component/tooltip/react/tooltip-manual.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/tooltip/react/tooltip-positioning.tsx
+++ b/frontend/demo/component/tooltip/react/tooltip-positioning.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { AppLayout } from '@vaadin/react-components/AppLayout.js';
 import { DrawerToggle } from '@vaadin/react-components/DrawerToggle.js';
 import { Icon } from '@vaadin/react-components/Icon.js';

--- a/frontend/demo/component/tree-grid/react/tree-grid-basic.tsx
+++ b/frontend/demo/component/tree-grid/react/tree-grid-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import {
   Grid,
   type GridDataProviderCallback,

--- a/frontend/demo/component/tree-grid/react/tree-grid-column.tsx
+++ b/frontend/demo/component/tree-grid/react/tree-grid-column.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/tree-grid/react/tree-grid-rich-content.tsx
+++ b/frontend/demo/component/tree-grid/react/tree-grid-rich-content.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/component/tree-grid/react/tree-grid-scroll-to-index.tsx
+++ b/frontend/demo/component/tree-grid/react/tree-grid-scroll-to-index.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/upload/react/upload-all-files.tsx
+++ b/frontend/demo/component/upload/react/upload-all-files.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';

--- a/frontend/demo/component/upload/react/upload-auto-upload-disabled.tsx
+++ b/frontend/demo/component/upload/react/upload-auto-upload-disabled.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed } from '@vaadin/hilla-react-signals';
 import { Upload, type UploadElement } from '@vaadin/react-components/Upload.js';

--- a/frontend/demo/component/upload/react/upload-basic.tsx
+++ b/frontend/demo/component/upload/react/upload-basic.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed } from '@vaadin/hilla-react-signals';
 import { Upload } from '@vaadin/react-components/Upload.js';

--- a/frontend/demo/component/upload/react/upload-button-theme-variant.tsx
+++ b/frontend/demo/component/upload/react/upload-button-theme-variant.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
 import { Notification } from '@vaadin/react-components/Notification.js';
 import { Upload } from '@vaadin/react-components/Upload.js';

--- a/frontend/demo/component/upload/react/upload-clear-button.tsx
+++ b/frontend/demo/component/upload/react/upload-clear-button.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed } from '@vaadin/hilla-react-signals';
 import { Upload } from '@vaadin/react-components/Upload.js';

--- a/frontend/demo/component/upload/react/upload-drag-and-drop.tsx
+++ b/frontend/demo/component/upload/react/upload-drag-and-drop.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { FormLayout, type FormLayoutResponsiveStep } from '@vaadin/react-components/FormLayout.js';
 import { Upload } from '@vaadin/react-components/Upload.js';
 

--- a/frontend/demo/component/upload/react/upload-drop-label.tsx
+++ b/frontend/demo/component/upload/react/upload-drop-label.tsx
@@ -1,6 +1,5 @@
 import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
 import { Upload } from '@vaadin/react-components/Upload.js';
 

--- a/frontend/demo/component/upload/react/upload-error-messages.tsx
+++ b/frontend/demo/component/upload/react/upload-error-messages.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed } from '@vaadin/hilla-react-signals';
 import { FormLayout, type FormLayoutResponsiveStep } from '@vaadin/react-components/FormLayout.js';

--- a/frontend/demo/component/upload/react/upload-file-count.tsx
+++ b/frontend/demo/component/upload/react/upload-file-count.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 import { Upload } from '@vaadin/react-components/Upload.js';
 

--- a/frontend/demo/component/upload/react/upload-file-format.tsx
+++ b/frontend/demo/component/upload/react/upload-file-format.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 import { Upload } from '@vaadin/react-components/Upload.js';
 

--- a/frontend/demo/component/upload/react/upload-file-size.tsx
+++ b/frontend/demo/component/upload/react/upload-file-size.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 import { Upload } from '@vaadin/react-components/Upload.js';
 

--- a/frontend/demo/component/upload/react/upload-helper.tsx
+++ b/frontend/demo/component/upload/react/upload-helper.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 import { Upload } from '@vaadin/react-components/Upload.js';
 

--- a/frontend/demo/component/upload/react/upload-internationalization.tsx
+++ b/frontend/demo/component/upload/react/upload-internationalization.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Upload } from '@vaadin/react-components/Upload.js';
 
 function Example() {

--- a/frontend/demo/component/upload/react/upload-labelling.tsx
+++ b/frontend/demo/component/upload/react/upload-labelling.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Notification } from '@vaadin/react-components/Notification.js';
 import type { UploadFileRejectEvent } from '@vaadin/react-components/Upload.js';
 import { Upload } from '@vaadin/react-components/Upload.js';

--- a/frontend/demo/component/upload/react/upload-retry-button.tsx
+++ b/frontend/demo/component/upload/react/upload-retry-button.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { Upload } from '@vaadin/react-components/Upload.js';
 import { createFakeUploadFiles } from './upload-demo-helpers';
 

--- a/frontend/demo/component/upload/react/upload-start-button.tsx
+++ b/frontend/demo/component/upload/react/upload-start-button.tsx
@@ -1,5 +1,4 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useComputed } from '@vaadin/hilla-react-signals';
 import { Upload } from '@vaadin/react-components/Upload.js';

--- a/frontend/demo/component/virtuallist/react/virtual-list-basic.tsx
+++ b/frontend/demo/component/virtuallist/react/virtual-list-basic.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar } from '@vaadin/react-components/Avatar.js';

--- a/frontend/demo/fusion/forms/formchange/CompanyOfficeView.tsx
+++ b/frontend/demo/fusion/forms/formchange/CompanyOfficeView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import { useForm } from '@vaadin/hilla-react-form';
 import { useSignal } from '@vaadin/hilla-react-signals';


### PR DESCRIPTION
The React import is no longer required as of [React 17](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports). Our examples seem to work correctly without it as well.