### PR TITLE
docs: update outdated Hilla SSO kit npm package name

### DIFF
--- a/articles/tools/sso/getting-started/hilla.adoc
+++ b/articles/tools/sso/getting-started/hilla.adoc
@@ -466,7 +466,7 @@ The `SingleSignOnContext` provided by the SSO Kit Client handles the back-channe
 .frontend/store/app-store.ts
 [source,typescript]
 ----
-import ssoContext from "@vaadin/sso-kit-client-lit";
+import ssoContext from '@vaadin/sso-kit-client-lit';
 
 // Store the logged out state in the AppStore class.
 isLoggedOut = false;

--- a/articles/tools/sso/getting-started/hilla.adoc
+++ b/articles/tools/sso/getting-started/hilla.adoc
@@ -211,7 +211,7 @@ The `SsoProvider` provides the single sign-on context to the application. Import
 .frontend/App.tsx
 [source,typescript]
 ----
-import { SsoProvider } from "@hilla/sso-kit-client-react";
+import { SsoProvider } from '@vaadin/sso-kit-client-react';
 
 return (
   <SsoProvider>
@@ -231,7 +231,7 @@ As an example, add two buttons to the drawer footer -- one to sign in, and anoth
 [source,typescript]
 ----
 import '@vaadin/button';
-import ssoContext from "@hilla/sso-kit-client-lit";
+import ssoContext from '@vaadin/sso-kit-client-lit';
 
 // Replace the `footer` in the rendered `html`.
 <footer slot="drawer">
@@ -250,7 +250,7 @@ As an example, add two buttons to the drawer footer -- one to sign in, and anoth
 [source,typescript]
 ----
 import { Button } from '@vaadin/react-components/Button.js';
-import { useSsoContext } from "@hilla/sso-kit-client-react";
+import { useSsoContext } from '@vaadin/sso-kit-client-react';
 
 // Get the authenticated state, the login and logout functions in the MenuOnLeftLayout function.
 const {authenticated, login, logout} = useSsoContext();
@@ -282,8 +282,8 @@ ifdef::hilla-lit[]
 .frontend/routes.ts
 [source,typescript]
 ----
-import type { ProtectedRoute } from '@hilla/sso-kit-client-lit';
-import ssoContext from "@hilla/sso-kit-client-lit";
+import type { ProtectedRoute } from '@vaadin/sso-kit-client-lit';
+import ssoContext from '@vaadin/sso-kit-client-lit';
 
 // Enrich the ViewRoute type with ProtectedRoute.
 export type ViewRoute = Route & ProtectedRoute & {
@@ -325,7 +325,7 @@ In the [filename]`frontend/routes.tsx` file, enrich the `ViewRouteObject` type w
 .frontend/routes.tsx
 [source,typescript]
 ----
-import { AccessProps, protectRoutes } from "@hilla/sso-kit-client-react";
+import { AccessProps, protectRoutes } from '@vaadin/sso-kit-client-react';
 
 // Enrich the ViewRouteObject type with AccessProps.
 export type ViewRouteObject = (IndexViewRouteObject | NonIndexViewRouteObject) & AccessProps;
@@ -377,8 +377,8 @@ ifdef::hilla-lit[]
 [source,typescript]
 ----
 import { property } from 'lit/decorators.js';
-import { User } from "@hilla/sso-kit-client-lit";
-import ssoContext from "@hilla/sso-kit-client-lit";
+import { User } from '@vaadin/sso-kit-client-lit';
+import ssoContext from '@vaadin/sso-kit-client-lit';
 
 // Add a property for the user.
 @property()
@@ -402,7 +402,7 @@ ifdef::hilla-react[]
 .frontend/views/about/AboutView.tsx
 [source,typescript]
 ----
-import { useSsoContext } from "@hilla/sso-kit-client-react";
+import { useSsoContext } from '@vaadin/sso-kit-client-react';
 
 // Gather the user from the SSO context.
 const { user } = useSsoContext();
@@ -466,7 +466,7 @@ The `SingleSignOnContext` provided by the SSO Kit Client handles the back-channe
 .frontend/store/app-store.ts
 [source,typescript]
 ----
-import ssoContext from "@hilla/sso-kit-client-lit";
+import ssoContext from "@vaadin/sso-kit-client-lit";
 
 // Store the logged out state in the AppStore class.
 isLoggedOut = false;
@@ -508,8 +508,8 @@ The `useSsoContext` hook provided by the SSO Kit Client handles the back-channel
 ----
 import { ConfirmDialog } from '@vaadin/react-components/ConfirmDialog.js';
 import { useEffect } from 'react';
-import { useSignal } from "@vaadin/hilla-react-signals";
-import { useSsoContext } from "@hilla/sso-kit-client-react";
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { useSsoContext } from '@vaadin/sso-kit-client-react';
 
 const { onBackChannelLogout } = useSsoContext();
 


### PR DESCRIPTION
The npm scope was changed from `@hilla` to `@vaadin` in the latest version: https://github.com/vaadin/sso-kit/commit/b3b1a4068ce60164dca8d7fd4d8c553dcf956b7a
Updated inline code examples to use correct npm package name. Also changed to use single quotes.