### PR TITLE
docs: use single quote in inline React examples

### DIFF
--- a/articles/flow/integrations/hilla.adoc
+++ b/articles/flow/integrations/hilla.adoc
@@ -193,14 +193,14 @@ The following example illustrates how to use `window.Vaadin.documentTitleSignal`
 [source,javascript]
 ----
 import { createMenuItems, useViewConfig } from '@vaadin/hilla-file-router/runtime.js';
-import { effect, Signal, signal } from "@vaadin/hilla-react-signals";
+import { effect, Signal, signal } from '@vaadin/hilla-react-signals';
 
 // define Signal<string> type for the window.Vaadin
 const vaadin = window.Vaadin as {
     documentTitleSignal: Signal<string>;
 };
 // initialize signal with empty string
-vaadin.documentTitleSignal = signal("");
+vaadin.documentTitleSignal = signal('');
 // keep document title in sync with the signal
 effect(() =>  document.title = vaadin.documentTitleSignal.value);
 

--- a/articles/flow/integrations/react.adoc
+++ b/articles/flow/integrations/react.adoc
@@ -216,8 +216,8 @@ customElements.define('react-router-layout', ReactRouterLayoutElement);
 
 When integrating React components into Vaadin applications, one common requirement is to enable these components to participate in Vaadin's data binding and form handling. This can be accomplished by wrapping the React component in a Vaadin component that extends `AbstractSinglePropertyField`. This allows the React component to be used like any other field in Vaadin, making it compatible with the `Binder` API.
 
-This integration process involves two main parts: creating a Java class for the server-side adapter component; and developing a client-side adapter using TypeScript and React. 
- 
+This integration process involves two main parts: creating a Java class for the server-side adapter component; and developing a client-side adapter using TypeScript and React.
+
 This process is demonstrated in the next sections using a simple React text input component as an example.
 
 === Create Client-Side React Component
@@ -229,7 +229,7 @@ First, define your React component. For this example, assume a simple text input
 // File: frontend/react-text-input.tsx
 
 import React, { useState } from 'react';
-import {ReactAdapterElement, type RenderHooks} from "Frontend/generated/flow/ReactAdapter";
+import { ReactAdapterElement, type RenderHooks } from 'Frontend/generated/flow/ReactAdapter';
 
 class ReactTextInputElement extends ReactAdapterElement {
     constructor() {
@@ -237,7 +237,7 @@ class ReactTextInputElement extends ReactAdapterElement {
     }
 
     protected override render(hooks: RenderHooks): React.ReactElement | null {
-        const [value, setValue] = hooks.useState<string>("value");
+        const [value, setValue] = hooks.useState<string>('value');
 
         const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
             setValue(event.target.value);

--- a/articles/getting-started/tutorial/hilla/first-view.adoc
+++ b/articles/getting-started/tutorial/hilla/first-view.adoc
@@ -61,7 +61,7 @@ In your IDE, create the file and copy-paste the following contents into it:
 .@index.tsx
 [source,tsx]
 ----
-import { useParams } from "react-router-dom"
+import { useParams } from 'react-router-dom';
 
 export default function ChannelView() {
     const { channelId } = useParams()
@@ -86,10 +86,10 @@ In your IDE, replace the contents of [filename]`@index.tsx` with the following:
 .@index.tsx
 [source,tsx]
 ----
-import { useParams } from "react-router-dom"
-import { VerticalLayout } from "@vaadin/react-components/VerticalLayout";
-import { MessageList } from "@vaadin/react-components/MessageList";
-import { MessageInput } from "@vaadin/react-components/MessageInput";
+import { useParams } from 'react-router-dom';
+import { MessageInput } from '@vaadin/react-components/MessageInput';
+import { MessageList } from '@vaadin/react-components/MessageList';
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout';
 
 export default function ChannelView() {
     const { channelId } = useParams()
@@ -263,13 +263,13 @@ You are going to call this method and store the result inside a *signal*. For no
 .@index.tsx
 [source,tsx]
 ----
-import { useNavigate, useParams } from "react-router-dom"
-import { VerticalLayout } from "@vaadin/react-components/VerticalLayout";
-import { MessageList } from "@vaadin/react-components/MessageList";
-import { MessageInput } from "@vaadin/react-components/MessageInput";
-import { useSignal } from "@vaadin/hilla-react-signals";
-import Channel from "Frontend/generated/com/example/application/chat/Channel";
-import { ChatService } from "Frontend/generated/endpoints";
+import { useNavigate, useParams } from 'react-router-dom';
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { MessageInput } from '@vaadin/react-components/MessageInput';
+import { MessageList } from '@vaadin/react-components/MessageList';
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout';
+import Channel from 'Frontend/generated/com/example/application/chat/Channel';
+import { ChatService } from 'Frontend/generated/endpoints';
 
 export default function ChannelView() {
     const { channelId } = useParams()
@@ -280,7 +280,7 @@ export default function ChannelView() {
     async function updateChannel() {
         channel.value = channelId ? await ChatService.channel(channelId) : undefined // <3>
         if (!channel.value) {
-            navigate("/") // <4>
+            navigate('/') // <4>
         } else {
             document.title = channel.value.name // <5>
         }
@@ -304,14 +304,14 @@ Next, you want to call this function whenever the [variablename]`channelId` para
 .@index.tsx
 [source,tsx]
 ----
-import { useNavigate, useParams } from "react-router-dom"
-import { VerticalLayout } from "@vaadin/react-components/VerticalLayout";
-import { MessageList } from "@vaadin/react-components/MessageList";
-import { MessageInput } from "@vaadin/react-components/MessageInput";
-import { useSignal } from "@vaadin/hilla-react-signals";
-import Channel from "Frontend/generated/com/example/application/chat/Channel";
-import { useEffect } from "react";
-import { ChatService } from "Frontend/generated/endpoints";
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { MessageInput } from '@vaadin/react-components/MessageInput';
+import { MessageList } from '@vaadin/react-components/MessageList';
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout';
+import Channel from 'Frontend/generated/com/example/application/chat/Channel';
+import { ChatService } from 'Frontend/generated/endpoints';
 
 export default function ChannelView() {
     const { channelId } = useParams()
@@ -321,7 +321,7 @@ export default function ChannelView() {
     async function updateChannel() {
         channel.value = channelId ? await ChatService.channel(channelId) : undefined
         if (!channel.value) {
-            navigate("/")
+            navigate('/')
         } else {
             document.title = channel.value.name
         }
@@ -362,7 +362,7 @@ Add the function to the channel view, like this:
 [source,tsx]
 ----
 ...
-import { Notification } from "@vaadin/react-components/Notification"
+import { Notification } from '@vaadin/react-components/Notification';
 
 export default function ChannelView() {
     ...
@@ -373,14 +373,14 @@ export default function ChannelView() {
     // tag::snippet[]
     async function postMessage(message: string) {
         if (!channel.value) { // <1>
-            throw new Error("No channel to post to")
+            throw new Error('No channel to post to')
         }
         try {
             await ChatService.postMessage(channel.value.id, message) // <2>
         } catch (_) {
-            Notification.show("Failed to send the message. Please try again later.", { // <3>
-                theme: "error",
-                position: "bottom-end"
+            Notification.show('Failed to send the message. Please try again later.', { // <3>
+                theme: 'error',
+                position: 'bottom-end'
             })
         }
     }
@@ -425,7 +425,7 @@ The first thing you need to do is create a signal that holds the messages that y
 [source,tsx]
 ----
 ...
-import Message from "Frontend/generated/com/example/application/chat/Message";
+import Message from 'Frontend/generated/com/example/application/chat/Message';
 
 export default function ChannelView() {
     const { channelId } = useParams()
@@ -469,7 +469,7 @@ When you subscribe, you will get a [classname]`Subscription` object that you can
 [source,tsx]
 ----
 ...
-import { Subscription } from "@vaadin/hilla-frontend";
+import { Subscription } from '@vaadin/hilla-frontend';
 
 export default function ChannelView() {
     const { channelId } = useParams()

--- a/articles/getting-started/tutorial/hilla/layout.adoc
+++ b/articles/getting-started/tutorial/hilla/layout.adoc
@@ -39,9 +39,9 @@ To create a layout for the views, start with a file named [filename]`@layout.tsx
 .@layout.tsx
 [source,tsx]
 ----
-import { AppLayout, DrawerToggle, Tooltip } from "@vaadin/react-components";
-import { Suspense } from "react";
-import { Outlet } from "react-router-dom";
+import { AppLayout, DrawerToggle, Tooltip } from '@vaadin/react-components';
+import { Suspense } from 'react';
+import { Outlet } from 'react-router-dom';
 
 export default function MainLayout() {
     return (
@@ -80,10 +80,10 @@ Start by updating the imports at the top of the [filename]`@layout.tsx` file as 
 .@layout.tsx
 [source,tsx]
 ----
-import { createMenuItems } from "@vaadin/hilla-file-router/runtime.js";
-import { AppLayout, DrawerToggle, Icon, SideNav, SideNavItem, Tooltip } from "@vaadin/react-components";
-import { Suspense } from "react";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { createMenuItems } from '@vaadin/hilla-file-router/runtime.js';
+import { AppLayout, DrawerToggle, Icon, SideNav, SideNavItem, Tooltip } from '@vaadin/react-components';
+import { Suspense } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 ...
 ----
 
@@ -145,7 +145,7 @@ To handle this situation, you have to declare a signal that will contain the cur
 [source,tsx]
 ----
 ...
-import { effect, signal } from "@vaadin/hilla-react-signals";
+import { effect, signal } from '@vaadin/hilla-react-signals';
 
 export const pageTitle = signal<string>(""); // <1>
 effect(() => {
@@ -186,7 +186,7 @@ Finally, you need to update the lobby and channel views to set their page titles
 [source,tsx]
 ----
 ...
-import { pageTitle } from "./@layout";
+import { pageTitle } from './@layout';
 
 export default function LobbyView() {
     pageTitle.value = "Lobby"
@@ -201,7 +201,7 @@ Then, do the same with the channel view. Open [filename]`views/channel/{channelI
 ----
 ...
 // tag::snippet[]
-import { pageTitle } from "Frontend/views/@layout";
+import { pageTitle } from 'Frontend/views/@layout';
 // end::snippet[]
 
 export default function ChannelView() {

--- a/articles/getting-started/tutorial/hilla/reconnects.adoc
+++ b/articles/getting-started/tutorial/hilla/reconnects.adoc
@@ -21,9 +21,9 @@ In your IDE, create a new directory [directoryname]`src/main/frontend/util` and 
 .ConnectionUtil.ts
 [source,ts]
 ----
-import {signal} from "@vaadin/hilla-react-signals";
-import connectClient from "Frontend/generated/connect-client.default";
-import {State} from "@vaadin/hilla-frontend";
+import { signal } from '@vaadin/hilla-react-signals';
+import connectClient from 'Frontend/generated/connect-client.default';
+import { State } from '@vaadin/hilla-frontend';
 
 export const connectionActive = signal(connectClient.fluxConnection.state == State.ACTIVE); // <1>
 
@@ -45,7 +45,7 @@ In the channel view, you have already declared a function [functionname]`subscri
 ----
 ...
 // tag::snippet[]
-import { connectionActive } from "Frontend/util/ConnectionUtil"; // <1>
+import { connectionActive } from 'Frontend/util/ConnectionUtil'; // <1>
 // end::snippet[]
 
 ...

--- a/articles/getting-started/tutorial/hilla/second-view.adoc
+++ b/articles/getting-started/tutorial/hilla/second-view.adoc
@@ -21,11 +21,11 @@ Recall from the first view, that if a user tried to access a channel that doesn'
 .@index.tsx
 [source,tsx]
 ----
-import { Button } from "@vaadin/react-components/Button"
-import { HorizontalLayout } from "@vaadin/react-components/HorizontalLayout"
-import { TextField } from "@vaadin/react-components/TextField"
-import { VerticalLayout } from "@vaadin/react-components/VerticalLayout";
-import { VirtualList } from "@vaadin/react-components/VirtualList";
+import { Button } from '@vaadin/react-components/Button';
+import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout';
+import { TextField } from '@vaadin/react-components/TextField';
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout';
+import { VirtualList } from '@vaadin/react-components/VirtualList';
 
 export default function LobbyView() {
     return <VerticalLayout>
@@ -83,8 +83,8 @@ The first thing you need to do is to create a signal that holds the channels. Fu
 ----
 ...
 // tag::snippet[]
-import { useSignal } from "@vaadin/hilla-react-signals";
-import Channel from "Frontend/generated/com/example/application/chat/Channel";
+import { useSignal } from '@vaadin/hilla-react-signals';
+import Channel from 'Frontend/generated/com/example/application/chat/Channel';
 // end::snippet[]
 
 export default function LobbyView() {
@@ -113,7 +113,7 @@ Next, you are going to create the function that fetches the channels from the se
 ----
 ...
 // tag::snippet[]
-import { ChatService } from "Frontend/generated/endpoints";
+import { ChatService } from 'Frontend/generated/endpoints';
 // end::snippet[]
 
 export default function LobbyView() {
@@ -137,7 +137,7 @@ Finally, you need to call this function inside a React effect, like this:
 .@index.tsx
 [source,tsx]
 ----
-import { useEffect } from "react";
+import { useEffect } from 'react';
 
 export default function LobbyView() {
     ...
@@ -162,7 +162,7 @@ You are now going to add a simple renderer to the virtual list. It will render a
 [source,tsx]
 ----
 ...
-import { Link } from "react-router-dom";
+import { Link } from 'react-router-dom';
 
 export default function LobbyView() {
     ...
@@ -196,9 +196,9 @@ Next, inside the [filename]`src/main/frontend/views/@index.tsx` file, locate the
 ._AddChannelComponent.tsx
 [source,tsx]
 ----
-import { Button } from "@vaadin/react-components/Button"
-import { HorizontalLayout } from "@vaadin/react-components/HorizontalLayout"
-import { TextField } from "@vaadin/react-components/TextField"
+import { Button } from '@vaadin/react-components/Button';
+import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout';
+import { TextField } from '@vaadin/react-components/TextField';
 
 export default function AddChannelComponent() {
     return <HorizontalLayout className="w-full" theme="spacing">
@@ -215,7 +215,7 @@ Finally, add the newly created `AddChannelComponent` to the `LobbyView`, like th
 ----
 ...
 // tag::snippet[]
-import AddChannelComponent from "./_AddChannelComponent";
+import AddChannelComponent from './_AddChannelComponent';
 // end::snippet[]
 
 export default function LobbyView() {
@@ -249,7 +249,7 @@ In your IDE, make the following additions to [filename]`_AddChannelComponent.tsx
 ----
 ...
 // tag::snippet[]
-import Channel from "Frontend/generated/com/example/application/chat/Channel"
+import Channel from 'Frontend/generated/com/example/application/chat/Channel';
 
 export type AddChannelComponentProps = {
     onChannelCreated?: (channel: Channel) => void // <1>

--- a/articles/getting-started/views/index.adoc
+++ b/articles/getting-started/views/index.adoc
@@ -76,11 +76,15 @@ Add a new view to your application. The view should be a small, but fully functi
 .`todo.tsx`
 [source,tsx]
 ----
-import { useSignal } from "@vaadin/hilla-react-signals";
-import { Checkbox, HorizontalLayout, VerticalLayout } from "@vaadin/react-components";
-import { TextField } from "@vaadin/react-components/TextField.js";
-import { Button } from "@vaadin/react-components/Button.js";
-import { ViewConfig } from "@vaadin/hilla-file-router/types.js";
+import { useSignal } from '@vaadin/hilla-react-signals';
+import type { ViewConfig } from '@vaadin/hilla-file-router/types.js';
+import {
+  Button,
+  Checkbox,
+  HorizontalLayout,
+  TextField,
+  VerticalLayout,
+} from '@vaadin/react-components';
 
 export const config: ViewConfig = { // <1>
     menu: { order: 1, icon: 'line-awesome/svg/tasks-solid.svg' },

--- a/articles/hilla/guides/flow-integration.adoc
+++ b/articles/hilla/guides/flow-integration.adoc
@@ -55,11 +55,11 @@ To add the exported web component to a Hilla view, import the `reactElement` fun
 .TSX
 [source,jsx]
 ----
-import { VerticalLayout } from "@vaadin/react-components/VerticalLayout";
-import { reactElement } from "Frontend/generated/flow/Flow"; // <1>
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout';
+import { reactElement } from 'Frontend/generated/flow/Flow'; // <1>
 
 function MyFlowComponent() {
-  return reactElement("my-flow-component"); // <2>
+  return reactElement('my-flow-component'); // <2>
 }
 
 export default function HillaView() {
@@ -87,13 +87,13 @@ You can use this when the exported web component exposes properties to the clien
 .Custom Properties for Flow WebComponent
 [source,jsx]
 ----
-import { VerticalLayout } from "@vaadin/react-components/VerticalLayout";
-import { reactElement } from "Frontend/generated/flow/Flow";
-import React from "react";
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout';
+import { reactElement } from 'Frontend/generated/flow/Flow';
+import React from 'react';
 
 function MyFlowComponent() {
   // Create element with property hellomsg
-  return reactElement("my-flow-component", {
+  return reactElement('my-flow-component', {
     hellomsg: 'Hi from the client!'
   });
 }
@@ -115,9 +115,9 @@ You can also link the properties to the React component properties using a custo
 .Custom Properties with Attribute Link
 [source,jsx]
 ----
-import { VerticalLayout } from "@vaadin/react-components/VerticalLayout";
-import { reactElement } from "Frontend/generated/flow/Flow";
-import React from "react";
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout';
+import { reactElement } from 'Frontend/generated/flow/Flow';
+import React from 'react';
 
 type MyProperties = {
   hellomsg: string
@@ -125,7 +125,7 @@ type MyProperties = {
 
 function MyFlowComponent(props: MyProperties) {
   // Create element with property hellomsg
-  return reactElement("my-flow-component", {
+  return reactElement('my-flow-component', {
     hellomsg: props.hellomsg
   });
 }
@@ -200,9 +200,9 @@ The [methodname]`reactElement` accepts an `onload` callback function as the thir
 .Loading Indicator Example
 [source,jsx]
 ----
-import { VerticalLayout } from "@vaadin/react-components/VerticalLayout";
-import { reactElement } from "Frontend/generated/flow/Flow";
-import React from "react";
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout';
+import { reactElement } from 'Frontend/generated/flow/Flow';
+import React from 'react';
 
 type MyProperties = {
   hellomsg: string
@@ -210,9 +210,9 @@ type MyProperties = {
 
 function MyFlowComponent(props: MyProperties) {
   // Create element with property hellomsg
-  return reactElement("my-flow-component",
+  return reactElement('my-flow-component',
     undefined,
-    () => document.getElementById("loading")?.remove()
+    () => document.getElementById('loading')?.remove()
   );
 }
 

--- a/articles/hilla/guides/routing.adoc
+++ b/articles/hilla/guides/routing.adoc
@@ -204,7 +204,7 @@ To customize the route to a route, in your view source file, export an object na
 [source,tsx]
 .`src/main/frontend/views/about.tsx`
 ----
-import { ViewConfig } from "@vaadin/hilla-file-router/types.js";
+import type { ViewConfig } from '@vaadin/hilla-file-router/types.js';
 
 export default function AboutView() {
   return (
@@ -223,7 +223,7 @@ To access this metadata from within a component, you can use the `useRouteMetada
 
 [source,tsx]
 ----
-import { useRouteMetadata } from "Frontend/util/routing";
+import { useRouteMetadata } from 'Frontend/util/routing';
 
 export default function MainLayout() {
   const metadata = useRouteMetadata();
@@ -245,7 +245,7 @@ Under the hood, the route metadata is passed through using the `.handle` React R
 
 [source,ts]
 ----
-import { useMatches } from "react-router-dom";
+import { useMatches } from 'react-router-dom';
 
 export default function MainLayout() {
   const matches = useMatches();

--- a/articles/hilla/guides/testing.adoc
+++ b/articles/hilla/guides/testing.adoc
@@ -86,14 +86,14 @@ Now, create a basic test for this view in a file named, [filename]`frontend/test
 
 [source,tsx]
 ----
-import { describe, it, expect } from "vitest";
-import { TodoView } from "Frontend/views/TodoView";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from 'vitest';
+import { TodoView } from 'Frontend/views/TodoView';
+import { render, screen } from '@testing-library/react';
 
-describe("TodoView", () => {
-  it("should render", () => {
+describe('TodoView', () => {
+  it('should render', () => {
     render(<TodoView />);
-    expect(screen.getByText("My Todos")).to.exist;
+    expect(screen.getByText('My Todos')).to.exist;
   });
 });
 ----
@@ -116,15 +116,15 @@ Now you can explore how to add a feature to the view and test it with user inter
 
 [source,tsx]
 ----
-import { Button } from "@vaadin/react-components/Button.js";
+import { Button } from '@vaadin/react-components/Button.js';
 import {
   TextField,
   TextFieldValueChangedEvent,
-} from "@vaadin/react-components/TextField.js";
-import { useSignal } from "@vaadin/hilla-react-signals";
+} from '@vaadin/react-components/TextField.js';
+import { useSignal } from '@vaadin/hilla-react-signals';
 
 export function TodoView() {
-  const newTodo = useSignal("");
+  const newTodo = useSignal('');
   const todos = useSignal<Array<string>>([]);
 
   return (
@@ -141,7 +141,7 @@ export function TodoView() {
         <Button
           onClick={() => {
             todos.value = [...todos, newTodo];
-            newTodo = "";
+            newTodo = '';
           }}
         >
           Add todo
@@ -161,25 +161,25 @@ Next, add a test that interacts with the view. For testing interactions, import 
 
 [source,tsx]
 ----
-import { userEvent } from "@testing-library/user-event";
+import { userEvent } from '@testing-library/user-event';
 
-describe("TodoView", () => {
+describe('TodoView', () => {
   ...
 
-  it("should add a todo", async () => {
+  it('should add a todo', async () => {
     render(<TodoView />);
 
     // Change the value of the text field
-    const textField = screen.getByLabelText("New todo");
+    const textField = screen.getByLabelText('New todo');
     await userEvent.click(textField);
-    await userEvent.type(textField, "Read testing guide");
+    await userEvent.type(textField, 'Read testing guide');
 
     // Click the add todo button
-    const button = screen.getByText("Add todo");
+    const button = screen.getByText('Add todo');
     await userEvent.click(button);
 
     // Rerender and check that the todo is shown
-    expect(screen.getByText("Read testing guide")).to.exist;
+    expect(screen.getByText('Read testing guide')).to.exist;
   });
 });
 ----
@@ -223,7 +223,7 @@ Now, update the click handler of the button in `TodoView` to call the service:
 [source,tsx]
 ----
 /* Add new import for generated service client */
-import { TodoService } from "Frontend/generated/endpoints";
+import { TodoService } from 'Frontend/generated/endpoints';
 
 ...
 
@@ -231,7 +231,7 @@ import { TodoService } from "Frontend/generated/endpoints";
   onClick={() => {
     TodoService.addTodo(newTodo);
     setTodos([...todos, newTodo]);
-    setNewTodo("");
+    setNewTodo('');
   }}
 >
   Add todo
@@ -243,17 +243,17 @@ Next, add a test to verify that the service is called correctly. Set up a test e
 [source,tsx]
 ----
 /* Update imports from vitest */
-import { afterEach, beforeEach, describe, expect, it, type SpyInstance, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type SpyInstance, vi } from 'vitest';
 
 /* Add new import for generated service client */
-import { TodoService } from "Frontend/generated/endpoints";
+import { TodoService } from 'Frontend/generated/endpoints';
 
-describe("TodoView", () => {
+describe('TodoView', () => {
   /* Add test setup and teardown */
   let addTodoSpy: SpyInstance;
 
   beforeEach(() => {
-    addTodoSpy = vi.spyOn(TodoService, "addTodo");
+    addTodoSpy = vi.spyOn(TodoService, 'addTodo');
     addTodoSpy.mockReturnValue(Promise.resolve());
   });
 
@@ -263,17 +263,17 @@ describe("TodoView", () => {
 
   ...
 
-  it("should call service when adding todo", async () => {
+  it('should call service when adding todo', async () => {
     render(<TodoView />);
 
-    const textField = screen.getByLabelText("New todo");
+    const textField = screen.getByLabelText('New todo');
     await userEvent.click(textField);
-    await userEvent.type(textField, "Read testing guide");
+    await userEvent.type(textField, 'Read testing guide');
 
-    const button = screen.getByText("Add todo");
+    const button = screen.getByText('Add todo');
     await userEvent.click(button);
 
-    expect(addTodoSpy).toHaveBeenCalledWith("Read testing guide");
+    expect(addTodoSpy).toHaveBeenCalledWith('Read testing guide');
   });
 });
 

--- a/articles/hilla/lit/guides/forms/binder-validation.adoc
+++ b/articles/hilla/lit/guides/forms/binder-validation.adoc
@@ -182,8 +182,8 @@ import { useForm } from '@vaadin/hilla-react-form';
 import EmployeeModel from 'Frontend/generated/com/example/application/EmployeeModel';
 import { EmployeeEndpoint } from 'Frontend/generated/endpoints';
 
-import { Button } from "@vaadin/react-components/Button.js";
-import { PasswordField } from "@vaadin/react-components/PasswordField.js";
+import { Button } from '@vaadin/react-components/Button.js';
+import { PasswordField } from '@vaadin/react-components/PasswordField.js';
 
 export default function ProfileView() {
   const { model, submit, field } = useForm(EmployeeModel, {

--- a/articles/hilla/lit/guides/forms/binding-arrays.adoc
+++ b/articles/hilla/lit/guides/forms/binding-arrays.adoc
@@ -41,7 +41,7 @@ ifdef::hilla-react[]
 ----
 import { useForm } from '@vaadin/hilla-react-form';
 import GroupModel from '.../GroupModel';
-import { TextField } from "@vaadin/react-components/TextField.js";
+import { TextField } from '@vaadin/react-components/TextField.js';
 
 export default function GroupFormView() {
 
@@ -151,8 +151,8 @@ ifdef::hilla-react[]
 ----
 import { useForm } from '@vaadin/hilla-react-form';
 import GroupModel from '.../GroupModel';
-import { TextField } from "@vaadin/react-components/TextField.js";
-import {Button} from "@vaadin/react-components/Button.js";
+import { Button } from '@vaadin/react-components/Button.js';
+import { TextField } from '@vaadin/react-components/TextField.js';
 
 export default function GroupFormView() {
 

--- a/articles/hilla/lit/guides/forms/form-images.adoc
+++ b/articles/hilla/lit/guides/forms/form-images.adoc
@@ -38,11 +38,10 @@ ifdef::hilla-react[]
 import ContactModel from 'Frontend/generated/com/vaadin/demo/fusion/forms/ContactModel';
 import { ContactEndpoint } from 'Frontend/generated/endpoints';
 import { useForm } from '@vaadin/hilla-react-form';
-import { useEffect } from "react";
-import { Upload } from "@vaadin/react-components/Upload.js";
-import { UploadBeforeEvent } from "@vaadin/upload";
-import { readAsDataURL } from "promise-file-reader";
-import { Button } from "@vaadin/react-components/Button.js";
+import { useEffect } from 'react';
+import { Button } from '@vaadin/react-components/Button.js';
+import { Upload, type UploadBeforeEvent } from '@vaadin/react-components/Upload.js';
+import { readAsDataURL } from 'promise-file-reader';
 
 
 export default function ContactForm() {

--- a/articles/hilla/lit/guides/forms/reference.adoc
+++ b/articles/hilla/lit/guides/forms/reference.adoc
@@ -29,7 +29,7 @@ ifdef::hilla-react[]
 .Using the Field Directive
 [source,tsx]
 ----
-import {TextField} from "@vaadin/react-components/TextField.js";
+import { TextField } from '@vaadin/react-components/TextField.js';
 ...
 const { model, field } = useForm(PersonModel);
 ...
@@ -63,7 +63,7 @@ ifdef::hilla-react[]
 [source,tsx]
 ----
 import { useForm, useFormPart } from '@vaadin/hilla-react-form';
-import {StringModel} from "@vaadin/hilla-lit-form";
+import { StringModel } from '@vaadin/hilla-lit-form';
 ...
 interface FullNameProps {
     fullNameModel: StringModel;
@@ -260,7 +260,7 @@ Array models are iterable. Iterating yields binder nodes for entries:
 ifdef::hilla-react[]
 [source,tsx]
 ----
-import {TextField} from "@vaadin/react-components/TextField.js";
+import { TextField } from '@vaadin/react-components/TextField.js';
 
 interface PersonProps {
   model: PersonModel;

--- a/articles/hilla/lit/guides/forms/vaadin-components.adoc
+++ b/articles/hilla/lit/guides/forms/vaadin-components.adoc
@@ -121,12 +121,12 @@ No extra action is needed to configure the Vaadin components that represent Text
 ifdef::hilla-react[]
 [source,tsx]
 ----
-import {TextField} from "@vaadin/react-components/TextField.js";
-import {PasswordField} from "@vaadin/react-components/PasswordField.js";
-import {IntegerField} from "@vaadin/react-components/IntegerField";
-import {NumberField} from "@vaadin/react-components/NumberField.js";
-import {EmailField} from "@vaadin/react-components/EmailField.js";
-import {TextArea} from "@vaadin/react-components/TextArea.js";
+import { EmailField } from '@vaadin/react-components/EmailField.js';
+import { IntegerField } from '@vaadin/react-components/IntegerField';
+import { NumberField } from '@vaadin/react-components/NumberField.js';
+import { PasswordField } from '@vaadin/react-components/PasswordField.js';
+import { TextArea } from '@vaadin/react-components/TextArea.js';
+import { TextField } from '@vaadin/react-components/TextField.js';
 
 ...
 const { model, field } = useForm(MyEntityModel);
@@ -199,8 +199,8 @@ vaadin-checkbox[invalid], vaadin-radio-button[invalid] {
 
 [source,tsx]
 ----
-import {Checkbox} from "@vaadin/react-components/Checkbox.js";
-import {RadioButton} from "@vaadin/react-components/RadioButton.js";
+import { Checkbox } from '@vaadin/react-components/Checkbox.js';
+import { RadioButton } from '@vaadin/react-components/RadioButton.js';
 
 import './my-styles.module.css';
 ...
@@ -248,7 +248,7 @@ The `{vaadin-select}` can be bound to a boolean, as in the following snippet:
 ifdef::hilla-react[]
 [source,tsx]
 ----
-import {Select} from "@vaadin/react-components/Select.js";
+import { Select } from '@vaadin/react-components/Select.js';
 ...
 const { model, field } = useForm(MyEntityModel);
 const selectItems = [{label: "True", value: "true"}, {label: "False", value: "false"}];
@@ -348,12 +348,12 @@ For a single selection, you should use `{vaadin-combo-box}`, `{vaadin-radio-grou
 ifdef::hilla-react[]
 [source,tsx]
 ----
-import {ComboBox} from "@vaadin/react-components/ComboBox.js";
-import {useEffect} from "react";
-import {RadioGroup} from "@vaadin/react-components/RadioGroup.js";
-import {RadioButton} from "@vaadin/react-components/RadioButton.js";
-import {ListBox} from "@vaadin/react-components/ListBox.js";
-import {Item} from "@vaadin/react-components/Item.js";
+import { useEffect } from 'react';
+import { ComboBox } from '@vaadin/react-components/ComboBox.js';
+import { Item } from '@vaadin/react-components/Item.js';
+import { ListBox } from '@vaadin/react-components/ListBox.js';
+import { RadioButton } from '@vaadin/react-components/RadioButton.js';
+import { RadioGroup } from '@vaadin/react-components/RadioGroup.js';
 ...
 const { model, field } = useForm(MyEntityModel);
 const myOptions = useSignal<Array<MyEntity>>([]);
@@ -437,9 +437,9 @@ To select items by index, you should use the `{vaadin-select}` component. This a
 ifdef::hilla-react[]
 [source,tsx]
 ----
-import {useEffect} from "react";
-import {useSignal} from "@vaadin/hilla-react-signals";
-import {Select} from "@vaadin/react-components/Select.js";
+import { useEffect } from 'react';
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { Select } from '@vaadin/react-components/Select.js';
 ...
 const { model, field } = useForm(MyEntityModel);
 const myOptions = useSignal<Array<MyEntity>>([]);
@@ -493,9 +493,9 @@ The Vaadin components for multiple selection are `{vaadin-checkbox-group}` and `
 ifdef::hilla-react[]
 [source,tsx]
 ----
-import {CheckboxGroup} from "@vaadin/react-components/CheckboxGroup.js";
-import {Checkbox} from "@vaadin/react-components/Checkbox.js";
-import {MultiSelectComboBox} from "@vaadin/react-components/MultiSelectComboBox.js";
+import { CheckboxGroup } from '@vaadin/react-components/CheckboxGroup.js';
+import { Checkbox } from '@vaadin/react-components/Checkbox.js';
+import { MultiSelectComboBox } from '@vaadin/react-components/MultiSelectComboBox.js';
 ...
 const { model, field } = useForm(MyEntityModel);
 const myOptions = useSignal<Array<MyEntity>>([]);
@@ -552,9 +552,9 @@ Use `{vaadin-date-picker}` to bind to Java [classname]`LocalDate`, `{vaadin-time
 ifdef::hilla-react[]
 [source,tsx]
 ----
-import { DatePicker } from "@vaadin/react-components/DatePicker.js";
-import { TimePicker } from "@vaadin/react-components/TimePicker.js";
-import {DateTimePicker} from "@vaadin/react-components/DateTimePicker.js";
+import { DatePicker } from '@vaadin/react-components/DatePicker.js';
+import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
+import { TimePicker } from '@vaadin/react-components/TimePicker.js';
 ...
 return (
   <>
@@ -602,8 +602,8 @@ Hilla provides the `{vaadin-custom-field}`, which can be used to wrap one or mul
 ifdef::hilla-react[]
 [source,tsx]
 ----
-import {CustomField} from "@vaadin/react-components/CustomField.js";
-import {TextField} from "@vaadin/react-components/TextField.js";
+import { CustomField } from '@vaadin/react-components/CustomField.js';
+import { TextField } from '@vaadin/react-components/TextField.js';
 
 ...
 return (

--- a/articles/hilla/lit/guides/reactive-endpoints.adoc
+++ b/articles/hilla/lit/guides/reactive-endpoints.adoc
@@ -95,10 +95,10 @@ Create the [filename]`frontend/views/reactive/ReactiveView.tsx` file to add a ne
 
 [source,typescript]
 ----
-import { Subscription } from "@vaadin/hilla-frontend";
-import { Button } from "@vaadin/react-components/Button.js";
-import { TextField } from "@vaadin/react-components/TextField.js";
-import { getClockCancellable } from "Frontend/generated/ReactiveEndpoint";
+import { Subscription } from '@vaadin/hilla-frontend';
+import { Button } from '@vaadin/react-components/Button.js';
+import { TextField } from '@vaadin/react-components/TextField.js';
+import { getClockCancellable } from 'Frontend/generated/ReactiveEndpoint';
 
 export default function ReactiveView() {
   const serverTime = useSignal("");

--- a/articles/hilla/lit/guides/upgrading/index.adoc
+++ b/articles/hilla/lit/guides/upgrading/index.adoc
@@ -224,8 +224,8 @@ Change `@hilla/react-components/` to `@vaadin/react-components/`:
 
 [source,diff]
 ----
-- import { TextField } from "@hilla/react-components/TextField.js";
-+ import { TextField } from "@vaadin/react-components/TextField.js";
+- import { TextField } from '@hilla/react-components/TextField.js';
++ import { TextField } from '@vaadin/react-components/TextField.js';
 ----
 
 

--- a/articles/hilla/lit/start/basics/index.adoc
+++ b/articles/hilla/lit/start/basics/index.adoc
@@ -505,7 +505,7 @@ Open the `frontend/views/todo/TodoView.tsx` file and replace its contents with t
 ----
 import type Todo from 'Frontend/generated/com/example/application/Todo'; // <1>
 import { useEffect } from 'react';
-import { useSignal } from "@vaadin/hilla-react-signals";
+import { useSignal } from '@vaadin/hilla-react-signals';
 import { useForm } from '@vaadin/hilla-react-form';
 import { Button } from '@vaadin/react-components/Button.js';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';
@@ -697,9 +697,9 @@ Open the `frontend/views/todo/TodoView.tsx` file and replace its contents with t
 [source,typescript]
 ----
 import Todo from 'Frontend/generated/com/example/application/Todo';
-import TodoModel from "Frontend/generated/com/example/application/TodoModel";
+import TodoModel from 'Frontend/generated/com/example/application/TodoModel';
 import { useEffect } from 'react';
-import { useSignal } from "@vaadin/hilla-react-signals";
+import { useSignal } from '@vaadin/hilla-react-signals';
 import { useForm } from '@vaadin/hilla-react-form';
 import { Button } from '@vaadin/react-components/Button.js';
 import { Checkbox } from '@vaadin/react-components/Checkbox.js';

--- a/articles/hilla/tutorial/index.adoc
+++ b/articles/hilla/tutorial/index.adoc
@@ -193,11 +193,11 @@ With the backend completed, you can start building the UI. Change the contents o
 [source,tsx]
 ----
 import ContactRecord from 'Frontend/generated/com/example/application/services/CRMService/ContactRecord';
-import {useEffect} from 'react';
-import {useSignal} from "@vaadin/hilla-react-signals";
-import {CRMService} from "Frontend/generated/endpoints";
-import {Grid} from "@vaadin/react-components/Grid";
-import {GridColumn} from "@vaadin/react-components/GridColumn";
+import { useEffect } from 'react';
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { CRMService } from 'Frontend/generated/endpoints';
+import { Grid } from '@vaadin/react-components/Grid';
+import { GridColumn } from '@vaadin/react-components/GridColumn';
 
 export default function ContactsView() {
     const contacts = useSignal<ContactRecord[]>([]);
@@ -238,16 +238,16 @@ For a complete CRM, users need to be able to edit contacts. Create a new compone
 .ContactForm.tsx
 [source,tsx]
 ----
-import {TextField} from "@vaadin/react-components/TextField";
-import {EmailField} from "@vaadin/react-components/EmailField";
-import {Select, SelectItem} from "@vaadin/react-components/Select";
-import {Button} from "@vaadin/react-components/Button";
-import {useForm} from "@vaadin/hilla-react-form";
-import ContactRecordModel from "Frontend/generated/com/example/application/services/CRMService/ContactRecordModel";
-import {CRMService} from "Frontend/generated/endpoints";
-import {useEffect} from "react";
-import {useSignal} from "@vaadin/hilla-react-signals";
-import ContactRecord from "Frontend/generated/com/example/application/services/CRMService/ContactRecord";
+import { useEffect } from 'react';
+import { useForm } from '@vaadin/hilla-react-form';
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { Button } from '@vaadin/react-components/Button';
+import { EmailField } from '@vaadin/react-components/EmailField';
+import { Select, SelectItem } from '@vaadin/react-components/Select';
+import { TextField } from '@vaadin/react-components/TextField';
+import ContactRecord from 'Frontend/generated/com/example/application/services/CRMService/ContactRecord';
+import ContactRecordModel from 'Frontend/generated/com/example/application/services/CRMService/ContactRecordModel';
+import { CRMService } from 'Frontend/generated/endpoints';
 
 interface ContactFormProps {
     contact?: ContactRecord | null;
@@ -273,7 +273,7 @@ export default function ContactForm({contact, onSubmit}: ContactFormProps) {
         const companyItems = companies.map(company => {
             return {
                 label: company.name,
-                value: company.id + ""
+                value: company.id + ''
             };
         });
         companies.value = companyItems;
@@ -308,12 +308,12 @@ Change `ContactsView.tsx` with the following content:
 [source,tsx]
 ----
 import ContactRecord from 'Frontend/generated/com/example/application/services/CRMService/ContactRecord';
-import {useEffect} from 'react';
-import {useSignal} from "@vaadin/hilla-react-signals";
-import {CRMService} from "Frontend/generated/endpoints";
-import {Grid} from "@vaadin/react-components/Grid";
-import {GridColumn} from "@vaadin/react-components/GridColumn";
-import ContactForm from "Frontend/views/contacts/ContactForm";
+import { useEffect } from 'react';
+import { useSignal } from '@vaadin/hilla-react-signals';
+import { CRMService } from 'Frontend/generated/endpoints';
+import { Grid } from '@vaadin/react-components/Grid';
+import { GridColumn } from '@vaadin/react-components/GridColumn';
+import ContactForm from 'Frontend/views/contacts/ContactForm';
 
 export default function ContactsView() {
     const contacts = useSignal<ContactRecord[]>([]);


### PR DESCRIPTION
Updated inline code examples to use single quotes (mostly in imports). Also changed `{Button}` to `{ Button }` etc. 