### PR TITLE
Add note about ACME certificates

### DIFF
--- a/articles/control-center/application-deployment/index.adoc
+++ b/articles/control-center/application-deployment/index.adoc
@@ -85,6 +85,11 @@ In the [guibutton]*Deploy* panel on the right-hand side (as shown in the screens
 - *Hostname*: Set the external URL to access your application (e.g., `https://app.example.com`). For more information on how to choose a proper hostname, refer to the <<hostname-guidelines, Hostname Guidelines>>.
 - *Features*: Enable additional features like Identity Management and Localization if required.
 
+[NOTE]
+====
+Control Center utilizes https://cert-manager.io/[cert-manager] to generate and sign certificates for https. It can also be used to generate valid ACME (Let's Encrypt) certificates and auto-renew them. For more information on how to do this, refer to the https://cert-manager.io/docs/configuration/acme/[cert-manager documentation].
+====
+
 Once all fields are completed, click [guibutton]*Deploy*.
 
 Control Center now deploys your application to the Kubernetes cluster, creates the necessary resources, and handles configurations such as load balancing and service discovery.


### PR DESCRIPTION
This adds a note to the application deployment page for Control Center. It informs the reader that it is possible to create ACME certificates and then links to the cert-manager documentation.