### PR TITLE
Make some improvements to the Control Center getting started page

### DIFF
--- a/articles/control-center/getting-started/index.adoc
+++ b/articles/control-center/getting-started/index.adoc
@@ -24,11 +24,11 @@ To deploy Control Center to your Kubernetes cluster, run the following Helm comm
 .Terminal
 [source,bash]
 ----
-helm install control-center oci://docker.io/vaadin/control-center \  // <1>
-    -n control-center --create-namespace \  // <2>
-    --set serviceAccount.clusterAdmin=true \  // <3>
-    --set service.type=LoadBalancer --set service.port=8000 \  // <4>
-    --wait  // <5>
+helm install control-center oci://docker.io/vaadin/control-center \  # (1)
+    -n control-center --create-namespace \  # (2)
+    --set serviceAccount.clusterAdmin=true \  # (3)
+    --set service.type=LoadBalancer --set service.port=8000 \  # (4)
+    --wait  # (5)
 ----
 
 <1> This installs Control Center.
@@ -54,10 +54,8 @@ The wizard requires a passkey to proceed. Run the following command to retrieve 
 .Terminal
 [source,bash]
 ----
-kubectl -n control-center get secret control-center-passkey -o jsonpath='{.data.passkey}' | base64 --decode
+kubectl -n control-center get secret control-center-passkey -o go-template='"{{ .data.passkey | base64decode }}"'
 ----
-
-On Windows, you might need to remove `| base64 --decode` and use a separate tool to decode the base64 output.
 
 image::images/welcome-step.png[Welcome Step]
 


### PR DESCRIPTION
This improves the look of the code references (now rendering as encircled numbers). It also changes the command to get the passkey so that it aligns with the instructions Control Center gives the user.