### PR TITLE
fix: add version information for Hilla paper cuts

### DIFF
--- a/articles/hilla/lit/reference/type-conversion.adoc
+++ b/articles/hilla/lit/reference/type-conversion.adoc
@@ -309,7 +309,7 @@ public class MyBean {
 }
 ----
 
-
+[role="since:com.vaadin:vaadin@V24.5"]
 === JsonNode
 
 The `JsonNode` Jackson type can be used to receive any kind of JSON object in Java. The `JsonNode` type is a tree model for JSON objects, and it can be used to navigate through the JSON object. The `JsonNode` type is converted to a TypeScript object with the type `unknown`. This means that the client-side code must correctly handle the type.
@@ -366,7 +366,7 @@ By default, the [classname]`ObjectMapper` converts Java's date time to a string 
 - `java.time.LocalDate` of `00:00:00 January 1st, 2019` => `'2019-01-01'`
 - `java.time.LocalDateTime` of `00:00:00 January 1st, 2019` => `'2019-01-01T00:00:00'`
 
-
+[role="since:com.vaadin:vaadin@V24.5"]
 === JsonNode
 
 The `JsonNode` type in Java allows to send an arbitrary JSON to the client. It's converted to `unknown` in TypeScript. This means that the client-side code must handle correctly the type.
@@ -530,6 +530,7 @@ public class Sale {
 }
 ----
 
+[role="since:com.vaadin:vaadin@V24.5"]
 === `@JsonCreator` & `@JsonValue` Annotations (Domain Objects)
 
 The `@JsonCreator` and `@JsonValue` annotations are powerful tools in the Jackson JSON library that allow you to create domain objects, also known as single-value objects.


### PR DESCRIPTION
As a follow-up to https://github.com/vaadin/docs/pull/3670, this PR adds missing version information to new features.