### PR TITLE
Fix copy & paste issue

### DIFF
--- a/articles/control-center/getting-started/index.adoc
+++ b/articles/control-center/getting-started/index.adoc
@@ -24,10 +24,10 @@ To deploy Control Center to your Kubernetes cluster, run the following Helm comm
 .Terminal
 [source,bash]
 ----
-helm install control-center oci://docker.io/vaadin/control-center \  # (1)
-    -n control-center --create-namespace \  # (2)
-    --set serviceAccount.clusterAdmin=true \  # (3)
-    --set service.type=LoadBalancer --set service.port=8000 \  # (4)
+helm install control-center oci://docker.io/vaadin/control-center  # (1)
+    -n control-center --create-namespace  # (2)
+    --set serviceAccount.clusterAdmin=true  # (3)
+    --set service.type=LoadBalancer --set service.port=8000  # (4)
     --wait  # (5)
 ----
 


### PR DESCRIPTION
Copying the current text results in an error:

```
vesanieminen@ code % helm install control-center oci://docker.io/vaadin/control-center \  
    -n control-center --create-namespace \
    --set serviceAccount.clusterAdmin=true \
    --set service.type=LoadBalancer --set service.port=8000 \
    --wait
Error: INSTALLATION FAILED: expected at most two arguments, unexpected arguments:  
zsh: command not found: -n
zsh: command not found: --set
zsh: command not found: --set
zsh: command not found: --wait
```


