### PR TITLE
chore: align order for tools section subfolders

### DIFF
--- a/articles/tools/ai-form-filler/index.adoc
+++ b/articles/tools/ai-form-filler/index.adoc
@@ -1,6 +1,7 @@
 ---
 title: AI Form Filler
 description: Use ChatGPT to fill forms with a natural language input source.
+order: 110
 ---
 
 

--- a/articles/tools/appsec/index.adoc
+++ b/articles/tools/appsec/index.adoc
@@ -2,7 +2,7 @@
 title: AppSec Kit
 description: Identify and manage vulnerabilities in third-party dependencies.
 section-nav: commercial
-order: 10
+order: 40
 ---
 
 

--- a/articles/tools/azure-cloud/index.adoc
+++ b/articles/tools/azure-cloud/index.adoc
@@ -2,7 +2,7 @@
 title: Azure Cloud Kit
 description: Deploy your Vaadin application to Azure Cloud.
 section-nav: commercial
-order: 20
+order: 50
 ---
 
 

--- a/articles/tools/collaboration/index.adoc
+++ b/articles/tools/collaboration/index.adoc
@@ -1,7 +1,7 @@
 ---
 title: Collaboration Kit
 description: Add real-time collaboration features to your Vaadin application.
-order: 30
+order: 60
 section-nav: badge-flow
 ---
 

--- a/articles/tools/copilot/index.adoc
+++ b/articles/tools/copilot/index.adoc
@@ -1,7 +1,7 @@
 ---
 title: Copilot
 description: Introduction to Vaadin Copilot, a visual, AI-empowered development tool.
-order: 1
+order: 10
 ---
 
 

--- a/articles/tools/designer/index.adoc
+++ b/articles/tools/designer/index.adoc
@@ -1,6 +1,7 @@
 ---
 title: Designer
 section-nav: commercial
+order: 130
 ---
 
 

--- a/articles/tools/dspublisher/index.adoc
+++ b/articles/tools/dspublisher/index.adoc
@@ -1,6 +1,7 @@
 ---
 title: Design System Publisher
 section-nav: commercial
+order: 120
 ---
 
 = Design System Publisher

--- a/articles/tools/kubernetes/index.adoc
+++ b/articles/tools/kubernetes/index.adoc
@@ -2,7 +2,7 @@
 title: Kubernetes Kit
 description: Deploy your Vaadin application to Kubernetes, an open-source system for automating deployment, scaling, and management of containerized applications, and enable scalability, high availability, and rolling updates for your application.
 section-nav: commercial
-order: 40
+order: 70
 ---
 
 

--- a/articles/tools/modernization-toolkit/index.adoc
+++ b/articles/tools/modernization-toolkit/index.adoc
@@ -2,7 +2,7 @@
 title: Modernization Toolkit
 description: Get your modernization project done faster.
 section-nav: commercial
-order: 3
+order: 30
 ---
 
 

--- a/articles/tools/mpr/index.adoc
+++ b/articles/tools/mpr/index.adoc
@@ -1,6 +1,7 @@
 ---
 title: Multiplatform Runtime
 section-nav: commercial badge-flow
+order: 140
 ---
 
 

--- a/articles/tools/observability/index.adoc
+++ b/articles/tools/observability/index.adoc
@@ -2,7 +2,7 @@
 title: Observability Kit
 description: Insights into Flow applications at runtime and in production by monitoring application health, detecting unhandled errors and performance issues, and observing user behavior.
 section-nav: commercial
-order: 50
+order: 80
 ---
 
 

--- a/articles/tools/sso/index.adoc
+++ b/articles/tools/sso/index.adoc
@@ -2,7 +2,7 @@
 title: SSO Kit
 description: Integrate Vaadin applications with third-party identity providers, and allow your users to benefit from single sign-on capabilities.
 section-nav: commercial
-order: 60
+order: 90
 ---
 
 

--- a/articles/tools/start/index.adoc
+++ b/articles/tools/start/index.adoc
@@ -1,6 +1,6 @@
 ---
 title: Start
-order: 2
+order: 20
 ---
 
 

--- a/articles/tools/swing/index.adoc
+++ b/articles/tools/swing/index.adoc
@@ -2,7 +2,7 @@
 title: Swing Kit
 description: Swing Kit is a tool designed to render Vaadin views inside Swing applications.
 section-nav: commercial
-order: 70
+order: 100
 ---
 
 


### PR DESCRIPTION
Some subfolders were missing order which caused them to be incorrectly sorted with the Astro version.