### PR TITLE
chore: remove obsolete Hilla workaround from v23 branch

### DIFF
--- a/frontend/demo/init.ts
+++ b/frontend/demo/init.ts
@@ -4,18 +4,6 @@ import '@vaadin/polymer-legacy-adapter/style-modules.js';
 import './init-flow-namespace';
 import './init-flow-components';
 import '../generated/vaadin-featureflags';
-// @ts-expect-error See workaround below
-import Appointment from 'Frontend/generated/com/vaadin/demo/domain/Appointment';
-import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
-import PersonModel from 'Frontend/generated/com/vaadin/demo/domain/PersonModel';
-// @ts-expect-error See workaround below
-import Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import AddressModel from 'Frontend/generated/com/vaadin/demo/domain/AddressModel';
-// @ts-expect-error See workaround below
-import Address from 'Frontend/generated/com/vaadin/demo/domain/Address';
-import CardModel from 'Frontend/generated/com/vaadin/demo/domain/CardModel';
-// @ts-expect-error See workaround below
-import Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
 import client from 'Frontend/generated/connect-client.default';
 import { applyTheme } from 'Frontend/generated/theme';
 
@@ -24,15 +12,6 @@ applyTheme(document);
 
 // @ts-expect-error Inserted by DS Publisher
 client.prefix = __VAADIN_CONNECT_PREFIX__; // eslint-disable-line no-undef
-
-// @ts-expect-error Workaround a Vaadin issue
-AppointmentModel.createEmptyValue = () => Appointment;
-// @ts-expect-error Workaround a Vaadin issue
-PersonModel.createEmptyValue = () => Person;
-// @ts-expect-error Workaround a Vaadin issue
-AddressModel.createEmptyValue = () => Address;
-// @ts-expect-error Workaround a Vaadin issue
-CardModel.createEmptyValue = () => Card;
 
 document.body.style.setProperty('--docs-example-render-font-family', 'var(--lumo-font-family)');
 document.body.style.setProperty('--docs-example-render-color', 'var(--lumo-body-text-color)');


### PR DESCRIPTION
This was first added in c6e10c30ea5ab2d66c0a2f2b15763f10a4baccc7 - back then there was an issue in Hilla.

Tested the `v23` branch and the workaround is no longer necessary since corresponding types e.g. `AppointmentModel` already declare correct type for the static `createEmptyValue()` method. Apparently it was fixed by https://github.com/vaadin/hilla/pull/656 which was included to Hilla 1.4 used by the `v23` branch (which also uses Vite 3 mentioned in the PR).

Note: the workaround is already removed from `latest` branch in https://github.com/vaadin/docs/pull/2384.