### PR TITLE
refactor: make svg imports in icon examples vite-friendly

### DIFF
--- a/frontend/demo/component/icons/icons-color.ts
+++ b/frontend/demo/component/icons/icons-color.ts
@@ -4,7 +4,7 @@ import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import codeBranch from '../../../../src/main/resources/icons/code-branch.svg';
+import codeBranch from '../../../../src/main/resources/icons/code-branch.svg?url';
 
 @customElement('icons-color')
 export class Example extends LitElement {

--- a/frontend/demo/component/icons/icons-padding.ts
+++ b/frontend/demo/component/icons/icons-padding.ts
@@ -4,7 +4,7 @@ import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import codeBranch from '../../../../src/main/resources/icons/code-branch.svg';
+import codeBranch from '../../../../src/main/resources/icons/code-branch.svg?url';
 
 @customElement('icons-padding')
 export class Example extends LitElement {

--- a/frontend/demo/component/icons/icons-sizing.ts
+++ b/frontend/demo/component/icons/icons-sizing.ts
@@ -4,7 +4,7 @@ import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import codeBranch from '../../../../src/main/resources/icons/code-branch.svg';
+import codeBranch from '../../../../src/main/resources/icons/code-branch.svg?url';
 
 @customElement('icons-sizing')
 export class Example extends LitElement {

--- a/frontend/demo/component/icons/react/icons-color.tsx
+++ b/frontend/demo/component/icons/react/icons-color.tsx
@@ -2,7 +2,7 @@ import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-lin
 import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
-import codeBranch from '../../../../../src/main/resources/icons/code-branch.svg';
+import codeBranch from '../../../../../src/main/resources/icons/code-branch.svg?url';
 
 function Example() {
   return (

--- a/frontend/demo/component/icons/react/icons-padding.tsx
+++ b/frontend/demo/component/icons/react/icons-padding.tsx
@@ -2,7 +2,7 @@ import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-lin
 import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
-import codeBranch from '../../../../../src/main/resources/icons/code-branch.svg';
+import codeBranch from '../../../../../src/main/resources/icons/code-branch.svg?url';
 
 function Example() {
   return (

--- a/frontend/demo/component/icons/react/icons-sizing.tsx
+++ b/frontend/demo/component/icons/react/icons-sizing.tsx
@@ -2,7 +2,7 @@ import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-lin
 import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
-import codeBranch from '../../../../../src/main/resources/icons/code-branch.svg';
+import codeBranch from '../../../../../src/main/resources/icons/code-branch.svg?url';
 
 function Example() {
   return (

--- a/frontend/demo/component/icons/react/svg-sprites.tsx
+++ b/frontend/demo/component/icons/react/svg-sprites.tsx
@@ -2,7 +2,7 @@ import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-lin
 import React from 'react';
 import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
 import { Icon } from '@vaadin/react-components/Icon.js';
-import spriteIcons from '../../../../../src/main/resources/icons/solid.svg';
+import spriteIcons from '../../../../../src/main/resources/icons/solid.svg?url';
 
 function Example() {
   return (

--- a/frontend/demo/component/icons/react/svg-standalone.tsx
+++ b/frontend/demo/component/icons/react/svg-standalone.tsx
@@ -1,7 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
-import codeBranchIcon from '../../../../../src/main/resources/icons/code-branch.svg';
+import codeBranchIcon from '../../../../../src/main/resources/icons/code-branch.svg?url';
 
 function Example() {
   return (

--- a/frontend/demo/component/icons/svg-sprites.ts
+++ b/frontend/demo/component/icons/svg-sprites.ts
@@ -4,7 +4,7 @@ import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import solidSprite from '../../../../src/main/resources/icons/solid.svg';
+import solidSprite from '../../../../src/main/resources/icons/solid.svg?url';
 
 @customElement('svg-sprites')
 export class Example extends LitElement {

--- a/frontend/demo/component/icons/svg-standalone.ts
+++ b/frontend/demo/component/icons/svg-standalone.ts
@@ -3,7 +3,7 @@ import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import codeBranchIcon from '../../../../src/main/resources/icons/code-branch.svg';
+import codeBranchIcon from '../../../../src/main/resources/icons/code-branch.svg?url';
 
 @customElement('svg-standalone')
 export class Example extends LitElement {

--- a/frontend/types.d.ts
+++ b/frontend/types.d.ts
@@ -8,7 +8,7 @@ declare module '*.jpg' {
   export = value;
 }
 
-declare module '*.svg' {
+declare module '*.svg?url' {
   const value: string;
   export = value;
 }


### PR DESCRIPTION
Make the svg imports in icon examples Vite-friendly.
This is a required change in preparation for DSP3.

Confirmed that the change is also compatible with DSP2.