### PR TITLE
fix: add endpoint mocks alias to dsp vite config

### DIFF
--- a/frontend/demo/services/mocks.ts
+++ b/frontend/demo/services/mocks.ts
@@ -1,6 +1,7 @@
 // This module should export all mock services used in live examples
-// During the webpack build, the `Frontend/generated/endpoints` import is replaced with this module
+// During the build, the `Frontend/generated/endpoints` import is replaced with this module
 import EmployeeService from 'Frontend/demo/services/EmployeeService';
 import ProductService from 'Frontend/demo/services/ProductService';
+export * from 'Frontend/generated/endpoints.js';
 
 export { EmployeeService, ProductService };

--- a/vite.dspublisher.ts
+++ b/vite.dspublisher.ts
@@ -11,9 +11,9 @@ const generatedPath = resolve(__dirname, 'vite.generated.ts');
 
 // Read and modify vite.generated.ts to include __dirname if not present
 const viteGenerated = fs.readFileSync(generatedPath, 'utf-8');
-const dirnameConst = `import { fileURLToPath } from 'node:url';
-     const __dirname = path.dirname(fileURLToPath(import.meta.url));`;
 if (!viteGenerated.includes('const __dirname')) {
+  const dirnameConst = `import { fileURLToPath } from 'node:url';
+     const __dirname = path.dirname(fileURLToPath(import.meta.url));`;
   fs.writeFileSync(generatedPath, `${dirnameConst}\n${viteGenerated}`);
 }
 
@@ -27,9 +27,12 @@ const vaadin = vaadinConfig({
 // Get the theme plugin from vaadinConfig
 const themePlugin = vaadin.plugins?.find((plugin: any) => plugin.name === 'vaadin:theme');
 
+const endpointMocks = resolve(__dirname, 'frontend', 'demo', 'services', 'mocks.js');
+
 const config: UserConfig = {
   resolve: {
     alias: {
+      'Frontend/generated/endpoints': endpointMocks,
       ...vaadin.resolve?.alias,
       'all-flow-imports-or-empty':
         process.env.DOCS_IMPORT_EXAMPLE_RESOURCES === 'true' ? allFlowImportsPath : 'lit',
@@ -41,9 +44,6 @@ const config: UserConfig = {
     /* dev-mode proxy config */
     proxy: {
       '/vaadin': {
-        target: 'http://localhost:8080',
-      },
-      '/connect': {
         target: 'http://localhost:8080',
       },
     },


### PR DESCRIPTION
Alias `Frontend/generated/endpoints` in the dsp Vite config similarly to how it's currently in the [dsp webpack config](https://github.com/vaadin/docs/blob/284e7766058094fb7f49cb4a3dca4e5c966733f5/webpack.dspublisher.js#L93-L98).

Also, remove the `/connect` proxy setup since it's unused.

Fixes https://github.com/orgs/vaadin/projects/75/views/1?pane=issue&itemId=83263680