### PR TITLE
refactor: cleanup dsp vite dirname workaround

### DIFF
--- a/vite.dspublisher.ts
+++ b/vite.dspublisher.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import type { UserConfig } from 'vite';
@@ -7,16 +6,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const allFlowImportsPath = resolve(__dirname, 'frontend/generated/flow/generated-flow-imports.js');
-const generatedPath = resolve(__dirname, 'vite.generated.ts');
 
-// Read and modify vite.generated.ts to include __dirname if not present
-const viteGenerated = fs.readFileSync(generatedPath, 'utf-8');
-if (!viteGenerated.includes('const __dirname')) {
-  const dirnameConst = `import { fileURLToPath } from 'node:url';
-     const __dirname = path.dirname(fileURLToPath(import.meta.url));`;
-  fs.writeFileSync(generatedPath, `${dirnameConst}\n${viteGenerated}`);
-}
-
+// vite.generated.ts accesses __dirname without declaring it.
+// Workaround the error by setting it on the global object.
+globalThis.__dirname = __dirname;
 const { vaadinConfig } = await import('./vite.generated');
 
 const vaadin = vaadinConfig({


### PR DESCRIPTION
`vite.dspublisher.ts` needs to import `vite.generated.ts` to adopt some of its configuration. `vite.generated.ts` accesses `__dirname`, which doesn't resolve with Astro's Vite config without the variable being defined first. This results in an error (`"__dirname is not defined"`) getting thrown on import by default.

The current workaround modifies the `vite.generated.ts` file to define `const __dirname` before importing it. This PR refactors `vite.dspublisher.ts` to use a less intrusive workaround that instead declares `__dirname` in the global object. 