### PR TITLE
feat: add Vite config for Astro DSP to v23 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,6 +145,7 @@
         "@rollup/plugin-replace": "3.1.0",
         "@rollup/pluginutils": "4.1.0",
         "@types/iframe-resizer": "^3.5.9",
+        "@types/node": "^22.7.5",
         "async": "3.2.2",
         "commander": "^9.4.1",
         "eslint": "^8.33.0",
@@ -153,6 +154,7 @@
         "glob": "7.2.3",
         "husky": "^8.0.0",
         "lint-staged": "^13.0.3",
+        "magic-string": "0.26.5",
         "mkdirp": "1.0.4",
         "prettier": "^2.8.3",
         "rollup-plugin-brotli": "3.1.0",
@@ -2801,6 +2803,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.1.0",
       "dev": true,
@@ -2825,6 +2836,15 @@
         "json5": "^2.2.0",
         "magic-string": "^0.25.0",
         "string.prototype.matchall": "^4.0.6"
+      }
+    },
+    "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/@types/estree": {
@@ -2855,9 +2875,13 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.6.2",
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7608,11 +7632,15 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.9",
+      "version": "0.26.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.5.tgz",
+      "integrity": "sha512-yXUIYOOQnEHKHOftp5shMWpB9ImfgfDJpapa38j/qMtTj5QHWucvxP4lUtuRmHT9vAzvtpHkWKXW9xBwimXeNg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/map-obj": {
@@ -9868,6 +9896,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "dev": true,
@@ -10445,6 +10479,15 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/workbox-build/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
     },
     "node_modules/workbox-build/node_modules/source-map": {
       "version": "0.8.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "@rollup/plugin-replace": "3.1.0",
     "@rollup/pluginutils": "4.1.0",
     "@types/iframe-resizer": "^3.5.9",
+    "@types/node": "^22.7.5",
     "async": "3.2.2",
     "commander": "^9.4.1",
     "eslint": "^8.33.0",
@@ -149,6 +150,7 @@
     "glob": "7.2.3",
     "husky": "^8.0.0",
     "lint-staged": "^13.0.3",
+    "magic-string": "0.26.5",
     "mkdirp": "1.0.4",
     "prettier": "^2.8.3",
     "rollup-plugin-brotli": "3.1.0",
@@ -323,7 +325,7 @@
       "workbox-core": "6.5.4",
       "workbox-precaching": "6.5.4"
     },
-    "hash": "a9fa580a4a3a31cfe41f73b9029d7dca8ae2c4d71e3c210860b2739111d2a5ad"
+    "hash": "c25d05a61e7edd8e7010cc7314893757be03806dea9381f1e16e126bed150384"
   },
   "overrides": {
     "@vaadin/accordion": "$@vaadin/accordion",

--- a/vite.dspublisher.ts
+++ b/vite.dspublisher.ts
@@ -1,0 +1,59 @@
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import MagicString from 'magic-string';
+import type { UserConfig } from 'vite';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const allFlowImportsPath = resolve(__dirname, 'frontend/generated/flow/generated-flow-imports.js');
+const frontendFolder = resolve(__dirname, 'frontend');
+const jarResourcesFolder = resolve(__dirname, 'frontend/generated/jar-resources');
+const themeFolder = resolve(__dirname, 'frontend/themes/docs');
+
+const config: UserConfig = {
+  resolve: {
+    alias: {
+      'all-flow-imports-or-empty':
+        process.env.DOCS_IMPORT_EXAMPLE_RESOURCES === 'true' ? allFlowImportsPath : 'lit',
+      Frontend: frontendFolder,
+      '@vaadin/flow-frontend': jarResourcesFolder,
+      'themes/docs': themeFolder,
+    },
+  },
+  server: {
+    /* dev-mode proxy config */
+    proxy: {
+      '/vaadin': {
+        target: 'http://localhost:8080',
+      },
+    },
+  },
+  plugins: [
+    {
+      name: 'vite-plugin-rewrite-polymer-global',
+      transform(code, id) {
+        // Workaround esbuild issue with chunked code running in wrong order,
+        // which causes errors with Polymer legacy components e.g. <iron-icon>.
+        // See https://github.com/vitejs/vite/issues/5142
+        if (
+          id.includes('.js') &&
+          code.includes('JSCompiler_renameProperty')
+        ) {
+          const ms = new MagicString(code);
+          ms.replaceAll(/JSCompiler_renameProperty\(([^,]+),[^)]+\)/g, '$1');
+
+          return {
+            code: ms.toString(),
+            map: ms.generateMap({
+              file: id,
+              includeContent: true,
+            }),
+          };
+        }
+      },
+    },
+  ],
+};
+
+export default config;


### PR DESCRIPTION
Added Vite config for DSP3. 

Note, I had to pin `magic-string` as Vite 3 brings an older version without `replaceAll()` support.