### PR TITLE
chore: fix some typos, remove trailing whitespaces

### DIFF
--- a/articles/building-apps/application-layer/application-services.adoc
+++ b/articles/building-apps/application-layer/application-services.adoc
@@ -103,7 +103,7 @@ In both of these cases, the user interface and the entities are likely to change
 
 === Data Transfer Objects
 
-Sometimes, it is not a good idea for the application services to return the entities themselves. 
+Sometimes, it is not a good idea for the application services to return the entities themselves.
 
 For instance, the domain model may contain business logic that must be called within some context that is not available in the presentation layer. It might require access to other services, or run inside a transaction.
 
@@ -129,7 +129,7 @@ public class CustomerCrudService {
     CustomerCrudService(CustomerRepository repository) {
         this.repository = repository;
     }
-    
+
     // In this example, CustomerForm is a Java record.
 
     public CustomerForm save(CustomerForm customerForm) {
@@ -160,7 +160,7 @@ Application services act as the main entry point into the application from the u
 
 image::images/cross-cutting-concerns.png[A call from the presentation layer goes through three boundaries]
 
-You can implement cross-cutting concerns in two ways. You can use Aspect Oriented Programming (AOP), which is what Spring uses for its cross-cutting concerns. For instance, this is how you would run the `save` method inside a transaction using AOP: 
+You can implement cross-cutting concerns in two ways. You can use Aspect Oriented Programming (AOP), which is what Spring uses for its cross-cutting concerns. For instance, this is how you would run the `save` method inside a transaction using AOP:
 
 [source,java]
 ----
@@ -269,7 +269,7 @@ For example, on this diagram, the presentation layer interacts with three differ
 
 image::images/domain-application-services.png[The presentation calls three different application service components]
 
-Bounded contexts are often associated with <<{articles}/building-apps/architecture/microservices#,microservices>>. However, you can also use them when you're building <<{articles}/building-apps/architecture/monoliths#,modular monliths>>. This is the recommended approach in Vaadin applications.
+Bounded contexts are often associated with <<{articles}/building-apps/architecture/microservices#,microservices>>. However, you can also use them when you're building <<{articles}/building-apps/architecture/monoliths#,modular monoliths>>. This is the recommended approach in Vaadin applications.
 
 In <<{articles}/building-apps/project-structure/single-module#,single-module projects>>, you should place the bounded contexts into their own packages. The three contexts from the example above would correspond to the following Java packages:
 
@@ -277,6 +277,6 @@ In <<{articles}/building-apps/project-structure/single-module#,single-module pro
 * `com.example.application.om.services` (Order Management)
 * `com.example.application.crm.services` (Customer Relations Management)
 
-In <<{articles}/building-apps/project-structure/multi-module#,multi-module projects>>, you should place the bounded contexts into their own Maven modules. 
+In <<{articles}/building-apps/project-structure/multi-module#,multi-module projects>>, you should place the bounded contexts into their own Maven modules.
 
 You may even want to split a single bounded context into multiple Maven modules. For instance, you might want to have the application services and the domain model in two separate modules.

--- a/articles/building-apps/application-layer/persistence/repositories/index.adoc
+++ b/articles/building-apps/application-layer/persistence/repositories/index.adoc
@@ -132,7 +132,7 @@ One way of solving this problem is to introduce _query specifications_. A query 
 [source,java]
 ----
 public interface CustomerRepository extends Repository<CustomerId, Customer> {
-    Page<Customer> findBySpecification(CustomerSpecification specification, 
+    Page<Customer> findBySpecification(CustomerSpecification specification,
         PageRequest pageRequest);
 }
 ----
@@ -144,8 +144,8 @@ You would then use the query method like this:
 var result = customerRepository.findBySpecification(
     CustomerSpecification.nameEquals("ACME")
         .and(CustomerSpecification.countryEquals(Country.US)
-            .or(CustomerSpecificaiton.countryEquals(Country.FI))
-        ), 
+            .or(CustomerSpecification.countryEquals(Country.FI))
+        ),
     PageRequest.ofSize(10)
 );
 ...
@@ -164,9 +164,9 @@ Query specifications are useful when you are interested in fetching whole entiti
 [source,java]
 ----
 public interface CustomerRepository extends Repository<CustomerId, Customer> {
-    Page<Customer> findBySpecification(CustomerSpecification specification, 
+    Page<Customer> findBySpecification(CustomerSpecification specification,
         PageRequest pageRequest);
-    
+
 // tag::snippet[]
     Page<CustomerListItem> findListItemsBySpecification(
         CustomerSpecification specification,
@@ -192,12 +192,12 @@ public interface CustomerListQuery {
 }
 ----
 
-Query objects read from the same data source as the repositories. You can create as many query objects as you need without cluttering your repositories. 
+Query objects read from the same data source as the repositories. You can create as many query objects as you need without cluttering your repositories.
 
 The query objects do not have to be tied to a particular entity. Summary views, for example, often need complex queries that join data from different types of entities together. Putting queries like that in repositories can be difficult. Either you can't find a single repository that feels like a good candidate, or you have multiple candidates to choose from. Creating a separate query object solves this problem.
 
 [NOTE]
-If you know the Command Query Responsibility Segregation (CQRS) architectural pattern, the idea of query objects may sound familiar. However, there is a big difference: Whereas CQRS uses different data models for writing and reading, query objects and repositories operate on the same data model, using the same data source. 
+If you know the Command Query Responsibility Segregation (CQRS) architectural pattern, the idea of query objects may sound familiar. However, there is a big difference: Whereas CQRS uses different data models for writing and reading, query objects and repositories operate on the same data model, using the same data source.
 
 // TODO Add link to using CQRS in Vaadin app, when that page has been written sometime in the future.
 

--- a/articles/building-apps/application-layer/persistence/repositories/pluggable.adoc
+++ b/articles/building-apps/application-layer/persistence/repositories/pluggable.adoc
@@ -107,19 +107,19 @@ public abstract sealed class Order {
     public void setOrderId(OrderId orderId) {
         this.orderId = orderId;
     }
-    
+
     public static final class DraftOrder extends Order {
         ...
     }
-    
+
     public static final class PendingOrder extends Order {
         ...
     }
-    
+
     public static final class CancelledOrder extends Order {
         ...
     }
-    
+
     public static final class CompletedOrder extends Order {
         ...
     }
@@ -292,7 +292,7 @@ Declare repository interfaces for each entity you want to persist, for example l
 
 [source,java]
 ----
-public interface ProductRepositiory extends Repository<ProductId, Product> {    
+public interface ProductRepository extends Repository<ProductId, Product> {
 }
 ----
 

--- a/articles/building-apps/architecture/monoliths.adoc
+++ b/articles/building-apps/architecture/monoliths.adoc
@@ -1,6 +1,6 @@
 ---
 title: Monoliths
-description: Essential concepts, as well as advantages and disadvantages of developing and using monlithic applications.
+description: Essential concepts, as well as advantages and disadvantages of developing and using monolithic applications.
 order: 40
 ---
 

--- a/articles/components/notification/styling.adoc
+++ b/articles/components/notification/styling.adoc
@@ -1,6 +1,6 @@
 ---
 title: Styling
-description: Styling API reference for the Notfication component.
+description: Styling API reference for the Notification component.
 order: 50
 ---
 

--- a/articles/flow/advanced/custom-instantiators.adoc
+++ b/articles/flow/advanced/custom-instantiators.adoc
@@ -100,7 +100,7 @@ import org.apache.deltaspike.core.api.provider.BeanManagerProvider;
 public class CustomInstantiatorFactory implements InstantiatorFactory {
 
     @Override
-    public Instantiator createInstantitor(VaadinService vaadinService) {
+    public Instantiator createInstantiator(VaadinService vaadinService) {
         BeanManager beanManager = BeanManagerProvider.getInstance().getBeanManager();
         return new CustomInstantiator(beanManager, service);
     }

--- a/articles/flow/create-ui/shortcut.adoc
+++ b/articles/flow/create-ui/shortcut.adoc
@@ -35,7 +35,7 @@ Instead of clicking the button, the user can use the kbd:[Enter] key to perform 
 
 Focus shortcuts place the focus on a `Focusable` component, like an input field. You can add a focus shortcut using the [methodname]`addFocusShortcut()` method.
 
-The example here is using the [methodname]`addFocusShortcut()` method to add a focus shortcut to a `TextTield`:
+The example here is using the [methodname]`addFocusShortcut()` method to add a focus shortcut to a `TextField`:
 
 [source,java]
 ----

--- a/articles/flow/testing/end-to-end/advanced-concepts.adoc
+++ b/articles/flow/testing/end-to-end/advanced-concepts.adoc
@@ -56,7 +56,7 @@ Sometimes, you might want to disable this behavior. You can do so with [methodna
 
 == Profiling Test Execution Time
 
-You might not only be interested in the fact that an application works, but also how long it takes. Profiling the test execution time consistentcy isn't trivial. A test environment can have different kinds of latency and interference.
+You might not only be interested in the fact that an application works, but also how long it takes. Profiling the test execution time consistency isn't trivial. A test environment can have different kinds of latency and interference.
 
 For example, in a distributed setup, timing results taken on the test server would include the latencies among the test server, the grid hub, a grid node running the browser, and the web server running the application. In such a setup, you could also expect interference among multiple test nodes, which all might make requests to a shared application server and possibly also shared virtual machine resources.
 

--- a/articles/flow/tutorial/project-setup.adoc
+++ b/articles/flow/tutorial/project-setup.adoc
@@ -2,7 +2,7 @@
 title: Project Setup
 order: 30
 page-title: Import, Run pass:[&] Debug a Maven Spring Boot Project in IntelliJ
-description: Tutorial on openning and debugging a Vaadin project and configure for better auto-complete support.
+description: Tutorial on opening and debugging a Vaadin project and configure for better auto-complete support.
 ---
 
 

--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -744,7 +744,7 @@ Number Field's default width now matches that of other text input components. Th
 
 === RichTextEditor
 
-`RichTextEditor::setvalue` and `getValue` now use HTML format by default, instead of Delta. Applications using the Delta format must be refactored to use the `RichTextEditor.asDelta()` API (e.g., `rte.asDelta().getValue()` and `binder.forField(rte.asDelta())`).
+`RichTextEditor::setValue` and `getValue` now use HTML format by default, instead of Delta. Applications using the Delta format must be refactored to use the `RichTextEditor.asDelta()` API (e.g., `rte.asDelta().getValue()` and `binder.forField(rte.asDelta())`).
 
 To help avoid using the wrong setter, `RichTextEditor.setValue(String)` now throws an exception if the value looks like it's in Delta format (i.e., it starts with a `[` or `{` bracket). To set an HTML value starting with the above characters, either wrap the value in an HTML tag, or use the `RichTextEditor.asHtml()` API, which doesn't check for them.
 


### PR DESCRIPTION
Fixed some typos detected by `cspell` and also removed trailing whtiespaces.