### PR TITLE
chore: add Notification to avoid error with Astro DSP

### DIFF
--- a/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationPosition.java
@@ -29,14 +29,17 @@ public class NotificationPosition extends Div {
     // tag::createButton[]
     private Button createButton(Notification.Position position) {
         Button button = new Button(position.getClientName());
-        button.addClickListener(event -> show(position));
+        button.addClickListener(event -> {
+            Notification notification = show(position);
+            add(notification); // hidden-source-line
+        });
         return button;
     }
     // end::createButton[]
 
     // tag::show[]
-    private void show(Notification.Position position) {
-        Notification.show(position.getClientName(), 5000, position);
+    private Notification show(Notification.Position position) {
+        return Notification.show(position.getClientName(), 5000, position);
     }
     // end::show[]
 

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationRich.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationRich.java
@@ -31,6 +31,8 @@ public class NotificationRich extends HorizontalLayout {
             btn.setEnabled(false);
 
             Notification notification = notificationSupplier.get();
+            btn.getParent().get().getElement() // hidden-source-line
+                    .appendChild(notification.getElement()); // hidden-source-line
             notification.setPosition(Notification.Position.MIDDLE);
             notification.setDuration(5000);
             notification.open();

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationStaticHelper.java
@@ -17,6 +17,7 @@ public class NotificationStaticHelper extends Div {
             Notification notification = Notification
                     .show("Financial report generated");
             notification.setPosition(Notification.Position.MIDDLE);
+            add(notification); // hidden-source-line
             // end::snippet[]
         });
 


### PR DESCRIPTION
This is a workaround for a problem with some Notification Java examples in Astro based DSP.

Steps to reproduce the problem:

- Open the "Notification" page
- Go to other component page
- Return to the "Notification" page
- Click a button to show notification

There is a following error in the console originating from `setText()` method:

```
FlowClient.js:74 Uncaught TypeError: Cannot set properties of undefined (setting 'textContent')
    at _Notification.renderer (eval at Ut (FlowClient.js:1049:101), <anonymous>:3:94)
    at _Notification.requestContentUpdate (chunk-TD75QAJX.js:593:10)
    at Object.eval (eval at Ut (FlowClient.js:1049:101), <anonymous>:3:11
```

Seems like an edge case of auto-adding mechanism. When adding to UI manually there is no error.

