### PR TITLE
docs: add missing Popover CSS files to code snippets

### DIFF
--- a/articles/components/popover/index.adoc
+++ b/articles/components/popover/index.adoc
@@ -29,6 +29,11 @@ include::{root}/src/main/java/com/vaadin/demo/component/popover/PopoverNotificat
 ----
 include::{root}/frontend/demo/component/popover/react/popover-notification-panel.tsx[render,tags=snippet,indent=0,group=React]
 ----
+
+[source,css]
+----
+include::{root}/frontend/themes/docs/popover-notification-panel.css[]
+----
 --
 
 Popovers support focusable, interactive content, and can be used to build virtually any type of anchored overlays from custom drop-down fields and drop-down buttons to and interactive tooltips.
@@ -442,6 +447,11 @@ include::{root}/src/main/java/com/vaadin/demo/component/popover/PopoverUserMenu.
 ----
 include::{root}/frontend/demo/component/popover/react/popover-user-menu.tsx[render,tags=snippet,indent=0,group=React]
 ----
+
+[source,css]
+----
+include::{root}/frontend/themes/docs/popover-user-menu.css[]
+----
 --
 
 - Opens on click
@@ -470,6 +480,11 @@ include::{root}/src/main/java/com/vaadin/demo/component/popover/PopoverNotificat
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/popover/react/popover-notification-panel.tsx[render,tags=snippet,indent=0,group=React]
+----
+
+[source,css]
+----
+include::{root}/frontend/themes/docs/popover-notification-panel.css[]
 ----
 --
 


### PR DESCRIPTION
Added missing `.css` files to "user menu" and "notification panel" code examples.