### PR TITLE
docs: fix broken cross-references in Classic Components

### DIFF
--- a/articles/tools/modernization-toolkit/classic-components.adoc
+++ b/articles/tools/modernization-toolkit/classic-components.adoc
@@ -114,7 +114,7 @@ Unlike in the previous implementation, the layouts use `flexbox`, since this pro
 
 === FormLayout
 
-The Classic FormLayout resembles, as much as possible, the Vaadin 7 or 8 version of FormLayout. It shows all components added to it in a table with two columns. The left column contains the component's caption -- except for Checkbox. The components themselves appear stacked in the right column. 
+The Classic FormLayout resembles, as much as possible, the Vaadin 7 or 8 version of FormLayout. It shows all components added to it in a table with two columns. The left column contains the component's caption -- except for Checkbox. The components themselves appear stacked in the right column.
 
 If a component is marked as required, an asterisk is appended to its caption. As with `HorizontalLayout` and `VerticalLayout`, `FlowLayout` extends from the common superclass [classname]`AbstractOrderedLayout` and a selection of methods in classes with the same names from the V8 inheritance hierarchy.
 
@@ -249,7 +249,7 @@ The Classic Components version of the class is in the `com.vaadin.classic.v8.ser
 | [methodname]`ErrorHandler getErrorHandler()`
 
 [methodname]`void setErrorHandler(ErrorHandler errorHandler)`
-| **Migrate**. Flow doesn't have a component-level error handler. Migrate to use [methodname]`VaadinSession::setErrorHandler()` instead. Or, depending the type of error, you could use an <<../routing/exceptions#, error view>> instead.
+| **Migrate**. Flow doesn't have a component-level error handler. Migrate to use [methodname]`VaadinSession::setErrorHandler()` instead. Or, depending the type of error, you could use an <<{articles}/flow/routing/exceptions#, error view>> instead.
 
 | [methodname]`Collection<?> getListeners(Class<?> eventType)`
 | **Remove/Migrate**. No replacement available in Flow. Use the [methodname]`fireEvent()` API from [classname]`ComponentEventBus` or [classname]`ComponentUtil` to notify all listeners.
@@ -294,7 +294,7 @@ The Classic Components version of the class is in the `com.vaadin.classic.v8.ui`
 | **Migrate**. You need to first check whether the component implements [interfacename]`com.vaadin.flow.component.Focusable`, and then call [methodname]`focus()` on it.
 
 | [methodname]`protected ActionManager getActionManager()`
-| **Migrate**. Not supported by Classic Components. See <<../create-ui/shortcut#, how to add shortcuts>> in Flow.
+| **Migrate**. Not supported by Classic Components. See <<{articles}/flow/create-ui/shortcut#, how to add shortcuts>> in Flow.
 
 | [methodname]`ErrorMessage getComponentError()`
 


### PR DESCRIPTION
Discovered these when building docs locally:

```
Broken cross reference /tools/routing/exceptions in C:\Users\serhii\docs\articles\tools\modernization-toolkit\classic-components.adoc
Broken cross reference /tools/create-ui/shortcut in C:\Users\serhii\docs\articles\tools\modernization-toolkit\classic-components.adoc
```