### PR TITLE
Removed a confusing since tag

### DIFF
--- a/articles/components/_styling-section-theming-props.adoc
+++ b/articles/components/_styling-section-theming-props.adoc
@@ -1,5 +1,4 @@
 // tag::style-properties[]
-[role="since:com.vaadin:vaadin@V24.3"]
 == Style Properties
 The following style properties can be used in CSS stylesheets to customize the appearance of this component.
 


### PR DESCRIPTION
It is hard for the user to figure out where this tag is related to, to some component or to the actual feature. In 24 series, most users are already in 24.3 or newer today, so probably best to remove altogether.


