### PR TITLE
[Control Center] Improve the passkey command

### DIFF
--- a/articles/control-center/getting-started/index.adoc
+++ b/articles/control-center/getting-started/index.adoc
@@ -73,7 +73,7 @@ The wizard requires a passkey to proceed. Run the following command to retrieve 
 .Terminal
 [source,bash]
 ----
-kubectl -n control-center get secret control-center-passkey -o go-template='"{{ .data.passkey | base64decode }}"'
+kubectl -n control-center get secret control-center-passkey -o go-template="{{ .data.passkey | base64decode | println }}"
 ----
 
 [.device]


### PR DESCRIPTION
Part of https://github.com/vaadin/control-center/issues/658

Improves the command to retrieve the Control Center passkey. It now works for Windows Command Prompt, Windows PowerShell, and Mac Terminal.