### PR TITLE
refactor: make image imports in TS examples work with Astro

### DIFF
--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -6,7 +6,7 @@ import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
-import companyLogo from '../../../../src/main/resources/images/company-logo.png';
+import companyLogo from '../../../../src/main/resources/images/company-logo.png?url';
 
 @customElement('avatar-image')
 export class Example extends LitElement {

--- a/frontend/demo/component/avatar/react/avatar-image.tsx
+++ b/frontend/demo/component/avatar/react/avatar-image.tsx
@@ -5,7 +5,7 @@ import { useSignal } from '@vaadin/hilla-react-signals';
 import { Avatar, HorizontalLayout } from '@vaadin/react-components';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import companyLogo from '../../../../../src/main/resources/images/company-logo.png';
+import companyLogo from '../../../../../src/main/resources/images/company-logo.png?url';
 
 function Example() {
   useSignals(); // hidden-source-line

--- a/frontend/demo/component/button/button-images.ts
+++ b/frontend/demo/component/button/button-images.ts
@@ -3,7 +3,7 @@ import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import img from '../../../../src/main/resources/images/vaadin-logo-dark.png';
+import img from '../../../../src/main/resources/images/vaadin-logo-dark.png?url';
 
 @customElement('button-images')
 export class Example extends LitElement {

--- a/frontend/demo/component/button/react/button-images.tsx
+++ b/frontend/demo/component/button/react/button-images.tsx
@@ -1,7 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { Button } from '@vaadin/react-components/Button.js';
-import img from '../../../../../src/main/resources/images/vaadin-logo-dark.png';
+import img from '../../../../../src/main/resources/images/vaadin-logo-dark.png?url';
 
 function Example() {
   return (

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -3,7 +3,7 @@ import { css, html, LitElement, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { LoginI18n } from '@vaadin/login';
 import { applyTheme } from 'Frontend/generated/theme';
-import img from '../../../../src/main/resources/images/starry-sky.png';
+import img from '../../../../src/main/resources/images/starry-sky.png?url';
 
 @customElement('login-overlay-mockup')
 export class LoginOverlayMockupElement extends LitElement {

--- a/frontend/demo/component/login/react/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/react/login-overlay-mockup.ts
@@ -3,7 +3,7 @@ import { css, html, LitElement, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { LoginI18n } from '@vaadin/login';
 import { applyTheme } from 'Frontend/generated/theme';
-import img from '../../../../../src/main/resources/images/starry-sky.png';
+import img from '../../../../../src/main/resources/images/starry-sky.png?url';
 
 @customElement('login-overlay-mockup')
 export class LoginOverlayMockupElement extends LitElement {

--- a/frontend/demo/component/scroller/react/scroller-both.tsx
+++ b/frontend/demo/component/scroller/react/scroller-both.tsx
@@ -1,7 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { Scroller } from '@vaadin/react-components/Scroller.js';
-import img from '../../../../../src/main/resources/images/reindeer.jpg';
+import img from '../../../../../src/main/resources/images/reindeer.jpg?url';
 
 function Example() {
   return (

--- a/frontend/demo/component/scroller/scroller-both.ts
+++ b/frontend/demo/component/scroller/scroller-both.ts
@@ -3,7 +3,7 @@ import '@vaadin/scroller';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
-import img from '../../../../src/main/resources/images/reindeer.jpg';
+import img from '../../../../src/main/resources/images/reindeer.jpg?url';
 
 @customElement('scroller-both')
 export class Example extends LitElement {

--- a/frontend/types.d.ts
+++ b/frontend/types.d.ts
@@ -1,9 +1,9 @@
-declare module '*.png' {
+declare module '*.png?url' {
   const value: string;
   export = value;
 }
 
-declare module '*.jpg' {
+declare module '*.jpg?url' {
   const value: string;
   export = value;
 }


### PR DESCRIPTION
Same as #3803 but for `.jpg` and `.png` imports.

The reason why this is needed is the fact that without `?url`, Astro processes imports and returns `ImageMetadata` object instead of just `src` (which is what Vite does) - see https://github.com/withastro/astro/issues/5924 (the issue was closed as intended).