### PR TITLE
refactor: make image imports in TS examples work with Astro

### DIFF
--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -6,7 +6,7 @@ import '@vaadin/horizontal-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import companyLogo from '../../../../src/main/resources/images/company-logo.png';
+import companyLogo from '../../../../src/main/resources/images/company-logo.png?url';
 
 @customElement('avatar-image')
 export class Example extends LitElement {

--- a/frontend/demo/component/button/button-images.ts
+++ b/frontend/demo/component/button/button-images.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import '@vaadin/button';
 import { applyTheme } from 'Frontend/generated/theme';
-import img from '../../../../src/main/resources/images/vaadin-logo-dark.png';
+import img from '../../../../src/main/resources/images/vaadin-logo-dark.png?url';
 
 @customElement('button-images')
 export class Example extends LitElement {

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -3,7 +3,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 import '@vaadin/login/vaadin-login-form.js';
 import type { LoginI18n } from '@vaadin/login';
-import img from '../../../../src/main/resources/images/starry-sky.png';
+import img from '../../../../src/main/resources/images/starry-sky.png?url';
 
 @customElement('login-overlay-mockup')
 export class LoginOverlayMockupElement extends LitElement {

--- a/frontend/demo/component/scroller/scroller-both.ts
+++ b/frontend/demo/component/scroller/scroller-both.ts
@@ -3,7 +3,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import '@vaadin/scroller';
-import img from '../../../../src/main/resources/images/reindeer.jpg';
+import img from '../../../../src/main/resources/images/reindeer.jpg?url';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('scroller-both')

--- a/frontend/types.d.ts
+++ b/frontend/types.d.ts
@@ -1,9 +1,9 @@
-declare module '*.png' {
+declare module '*.png?url' {
   const value: string;
   export = value;
 }
 
-declare module '*.jpg' {
+declare module '*.jpg?url' {
   const value: string;
   export = value;
 }


### PR DESCRIPTION
Same as #3849 but for `v23` branch which also has a few `.png` and `.jpg` imports.