### PR TITLE
fix: use tr element in thead to fix hydration warning

### DIFF
--- a/frontend/demo/component/board/example-statistics.ts
+++ b/frontend/demo/component/board/example-statistics.ts
@@ -104,10 +104,12 @@ export class ExampleStatistics extends LitElement {
       <div class="table">
         <table>
           <thead>
-            <th></th>
-            <th>City</th>
-            <th>Input</th>
-            <th>Output</th>
+            <tr>
+              <th></th>
+              <th>City</th>
+              <th>Input</th>
+              <th>Output</th>
+            </tr>
           </thead>
           <tbody>
             ${repeat(

--- a/frontend/demo/component/board/react/ExampleStatistics.tsx
+++ b/frontend/demo/component/board/react/ExampleStatistics.tsx
@@ -34,10 +34,12 @@ function ExampleStatistics() {
       <div className="table">
         <table>
           <thead>
-            <th></th>
-            <th>City</th>
-            <th>Input</th>
-            <th>Output</th>
+            <tr>
+              <th></th>
+              <th>City</th>
+              <th>Input</th>
+              <th>Output</th>
+            </tr>
           </thead>
           <tbody>
             {serviceHealth.value.map(({ id, city, input, output }) => (


### PR DESCRIPTION
This fixes the hydration warning on the Board component page due to incorrect HTML tags usage:

```
Warning: validateDOMNesting(...): <th> cannot appear as a child of <thead>.
    at th
    at thead
    at table
    at div
    at div
    at ExampleStatistics
```