### PR TITLE
chore: add workaround to rewrite JSCompiler_renameProperty

### DIFF
--- a/vite.dspublisher.ts
+++ b/vite.dspublisher.ts
@@ -1,5 +1,6 @@
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
+import MagicString from 'magic-string';
 import type { UserConfig } from 'vite';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -41,7 +42,28 @@ const config: UserConfig = {
       },
     },
   },
-  plugins: [themePlugin],
+  plugins: [
+    themePlugin,
+    {
+      name: 'vite-plugin-rewrite-polymer-global',
+      transform(code, id) {
+        // Workaround esbuild issue with chunked code running in wrong order
+        // See https://github.com/vitejs/vite/issues/5142
+        if (id.includes('.js') && code.includes('JSCompiler_renameProperty')) {
+          const ms = new MagicString(code);
+          ms.replaceAll(/JSCompiler_renameProperty\(([^,]+),[^)]+\)/g, '$1');
+
+          return {
+            code: ms.toString(),
+            map: ms.generateMap({
+              file: id,
+              includeContent: true,
+            }),
+          };
+        }
+      },
+    },
+  ],
 };
 
 export default config;


### PR DESCRIPTION
Added a workaround similar to the one included to v23 branch to avoid following errors:

```
Uncaught (in promise) ReferenceError: JSCompiler_renameProperty is not defined
    at get observedAttributes (chunk-GOCCCYYU.js?v=034aa3b9:3713:17)
    at defineCustomElement
```

I thought it was only happening with legacy Polymer elements but we also reproduced it in V24.
In particular, can be reproduced on the Board page http://localhost:8000/components/board 