### PR TITLE
fix: remove extra div elements to fix hydration warning

### DIFF
--- a/articles/styling/lumo/utility-classes.adoc
+++ b/articles/styling/lumo/utility-classes.adoc
@@ -1619,17 +1619,17 @@ Classes for setting the display property of an element. Determines whether the e
 |===
 | Preview | CSS Class Name / Java Constant
 
-| +++<span class="border block rounded-m"><span class="item block text-center">1</span><span class="item block text-center">2</span><span class="item block text-center">3</span><div>+++
+| +++<span class="border block rounded-m"><span class="item block text-center">1</span><span class="item block text-center">2</span><span class="item block text-center">3</span>+++
 | *`block` / `BLOCK`*
-| +++<span class="border block rounded-m"><span class="item inline text-center">1</span><span class="item inline text-center">2</span><span class="item inline text-center">3</span><div>+++
+| +++<span class="border block rounded-m"><span class="item inline text-center">1</span><span class="item inline text-center">2</span><span class="item inline text-center">3</span>+++
 | *`inline` / `INLINE`*
-| +++<span class="border block rounded-m"><span class="item inline-block text-center">1</span><span class="item inline-block text-center">2</span><span class="item inline-block text-center">3</span><div>+++
+| +++<span class="border block rounded-m"><span class="item inline-block text-center">1</span><span class="item inline-block text-center">2</span><span class="item inline-block text-center">3</span>+++
 | *`inline-block` / `INLINE_BLOCK`*
-| +++<span class="border flex rounded-m"><span class="item flex flex-auto">1</span><span class="item flex flex-auto">2</span><span class="item flex flex-auto">3</span><div>+++
+| +++<span class="border flex rounded-m"><span class="item flex flex-auto">1</span><span class="item flex flex-auto">2</span><span class="item flex flex-auto">3</span>+++
 | *`flex` / `FLEX`*
-| +++<span class="border inline-flex rounded-m"><span class="item flex flex-auto">1</span><span class="item flex flex-auto">2</span><span class="item flex flex-auto">3</span><div>+++
+| +++<span class="border inline-flex rounded-m"><span class="item flex flex-auto">1</span><span class="item flex flex-auto">2</span><span class="item flex flex-auto">3</span>+++
 | *`inline-flex` / `INLINE_FLEX`*
-| +++<span class="border block rounded-m h-xs"><span class="item hidden">1</span><span class="item hidden">2</span><span class="item hidden">3</span><div>+++
+| +++<span class="border block rounded-m h-xs"><span class="item hidden">1</span><span class="item hidden">2</span><span class="item hidden">3</span>+++
 | *`hidden` / `HIDDEN`*
 | +++<span class="border grid rounded-m gap-s p-s grid-cols-3"><span class="item flex">1</span><span class="item flex">2</span><span class="item flex">3</span><span class="item flex">4</span><span class="item flex">5</span><span class="item flex">6</span><span class="item flex">7</span><span class="item flex">8</span><span class="item flex">9</span></span>+++
 | *`grid` / `GRID`*


### PR DESCRIPTION
Removed a few unused `<div>` elements that trigger hydration warning on the Lumo Utility Classes page:

```
Warning: Expected server HTML to contain a matching <div> in <span>.
    at div
    at span
    at p
    at td
    at tr
    at tbody
    at table
```