### PR TITLE
docs: binder record limitations; mention records as items

### DIFF
--- a/articles/flow/binding-data/components-binder-load.adoc
+++ b/articles/flow/binding-data/components-binder-load.adoc
@@ -229,5 +229,10 @@ For writing a record, the `writeRecord` method should be used. Calling this meth
 Person editedPerson = binder.writeRecord();
 ----
 
+=== Limitations
+
+Custom methods which return computed values but do not have a corresponding property in the record are not handled by the Binder, but their value can still be bound manually if needed.
+
+For Binder to be able to write a record, it is required to have a field binding for all properties of the record.
 
 [discussion-id]`33EBA0BC-10B8-4DB4-922C-71AA8B0A446C`

--- a/articles/flow/binding-data/data-provider.adoc
+++ b/articles/flow/binding-data/data-provider.adoc
@@ -25,7 +25,7 @@ grid.setItems(
 );
 ----
 
-All listing components in Vaadin have many overloaded [methodname]`setItems()` methods to define the items to display. Items can be basic objects (e.g., strings or numbers), or they can be plain-old Java objects (POJO), such as Data Transfer Objects (DTO) and JPA entities.
+All listing components in Vaadin have many overloaded [methodname]`setItems()` methods to define the items to display. Items can be basic objects (e.g., strings or numbers), Java Records, or plain-old Java objects (POJO), such as Data Transfer Objects (DTO) and JPA entities.
 
 The easiest way to bind items to a component is to provide a [classname]`List` of objects to be shown in the component.
 


### PR DESCRIPTION
Documenting limitations mentioned in https://github.com/vaadin/flow/issues/20318