### PR TITLE
fix: use correct tag name in form-layout colspan TS example

### DIFF
--- a/frontend/demo/component/formlayout/form-layout-colspan.ts
+++ b/frontend/demo/component/formlayout/form-layout-colspan.ts
@@ -8,7 +8,7 @@ import { customElement } from 'lit/decorators.js';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import { applyTheme } from 'Frontend/generated/theme';
 
-@customElement('form-layout-custom-layout')
+@customElement('form-layout-colspan')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();


### PR DESCRIPTION
Fix for the following error on the Form Layout page:

```
Uncaught (in promise) NotSupportedError: Failed to execute 'define' on 'CustomElementRegistry': the name "form-layout-custom-layout" has already been used with this registry
    at chunk-CJV2DPYP.js?v=e35ab810:13:20
    at __decorateClass (form-layout-colspan.ts:7:57)
    at form-layout-colspan.ts:45:11
```