### PR TITLE
fix: use correct tag name in form-layout colspan TS example (v23)

### DIFF
--- a/frontend/demo/component/formlayout/form-layout-colspan.ts
+++ b/frontend/demo/component/formlayout/form-layout-colspan.ts
@@ -8,7 +8,7 @@ import '@vaadin/text-field';
 import '@vaadin/time-picker';
 import { applyTheme } from 'Frontend/generated/theme';
 
-@customElement('form-layout-custom-layout')
+@customElement('form-layout-colspan')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();


### PR DESCRIPTION
Same as #3866 but for `v23` branch.