### PR TITLE
fix: add Flow button JS import to init-flow-components

### DIFF
--- a/frontend/demo/init-flow-components.ts
+++ b/frontend/demo/init-flow-components.ts
@@ -11,6 +11,7 @@
 import '@vaadin/flow-frontend/dndConnector.js';
 import '@vaadin/flow-frontend/flow-component-renderer.js';
 // Flow component specific modules
+import '@vaadin/flow-frontend/buttonFunctions.js';
 import '@vaadin/flow-frontend/cookieConsentConnector.js';
 import '@vaadin/flow-frontend/comboBoxConnector.js';
 import '@vaadin/flow-frontend/contextMenuConnector.js';


### PR DESCRIPTION
This should fix the following error on the Button page:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'initDisableOnClick')
    at Button.eval (eval at rE (FlowClient-CFpeFTrH.js:3:42450), <anonymous>:3:54)
```