### PR TITLE
fix: set responsiveSteps initially to avoid warning

### DIFF
--- a/frontend/demo/component/crud/crud-editor-content.ts
+++ b/frontend/demo/component/crud/crud-editor-content.ts
@@ -27,16 +27,15 @@ export class Example extends LitElement {
   private professions: string[] = [];
 
   @state()
-  private responsiveSteps: FormLayoutResponsiveStep[] = [];
+  private responsiveSteps: FormLayoutResponsiveStep[] = [
+    { minWidth: 0, columns: 1 },
+    { minWidth: '30em', columns: 2 },
+  ];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();
     this.items = people;
     this.professions = [...new Set(people.map((i) => i.profession))];
-    this.responsiveSteps = [
-      { minWidth: 0, columns: 1 },
-      { minWidth: '30em', columns: 2 },
-    ];
   }
 
   protected override render() {

--- a/frontend/demo/component/crud/react/crud-editor-content.tsx
+++ b/frontend/demo/component/crud/react/crud-editor-content.tsx
@@ -14,23 +14,22 @@ function Example() {
   useSignals(); // hidden-source-line
   const items = useSignal<Person[]>([]);
   const professions = useSignal<string[]>([]);
-  const responsiveSteps = useSignal<FormLayoutResponsiveStep[]>([]);
+  const responsiveSteps: FormLayoutResponsiveStep[] = [
+    { minWidth: 0, columns: 1 },
+    { minWidth: '30em', columns: 2 },
+  ];
 
   useEffect(() => {
     getPeople().then(({ people }) => {
       items.value = people;
       professions.value = [...new Set(people.map((i) => i.profession))];
-      responsiveSteps.value = [
-        { minWidth: 0, columns: 1 },
-        { minWidth: '30em', columns: 2 },
-      ];
     });
   }, []);
 
   return (
     // tag::snippet[]
     <Crud include="firstName, lastName, email, profession" items={items.value}>
-      <FormLayout slot="form" style={{ maxWidth: '480px' }} responsiveSteps={responsiveSteps.value}>
+      <FormLayout slot="form" style={{ maxWidth: '480px' }} responsiveSteps={responsiveSteps}>
         <TextField label="First name" {...crudPath('firstName')} required />
         <TextField label="Last name" {...crudPath('lastName')} required />
         <EmailField label="Email" {...crudPath('email')} required data-colspan="2" />


### PR DESCRIPTION
This fixes the warning I noticed on the CRUD page by not setting empty array to responsive steps by default:

```
Invalid empty "responsiveSteps" array, at least one item is required. Using default 'responsiveSteps' instead.
```

This would also make the logic aligned with other examples where `responsiveSteps` is always set initially.