### PR TITLE
[Control Center] Improve "manual installation" documentation

### DIFF
--- a/articles/control-center/getting-started/dependency-installation.adoc
+++ b/articles/control-center/getting-started/dependency-installation.adoc
@@ -1,25 +1,27 @@
 ---
-title: Manual Installation of Dependencies
+title: Installation of Dependencies
 description: Learn how to manually install Control Center's dependencies.
 order: 20
 ---
 
 
-= Manual Installation
+= Installation of Dependencies
 
 This guide explains how to install the required dependencies of Control Center without utilizing cluster-wide administrator permissions.
-
-Control Center must already be installed in your cluster before you can proceed with the installation of dependencies. If you haven't done this yet, see the <<index#,Getting Started>> guide for instructions.
 
 
 == NGINX Ingress Controller
 
-https://docs.nginx.com/nginx-ingress-controller[NGINX] is an ingress controller that manages external access to services in your cluster. You can install it by running the following command:
+The https://kubernetes.github.io/ingress-nginx/[Ingress NGINX Controller] manages external access to services in your cluster. You can install it by running the following command:
 
 .Terminal
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.11.3/deploy/static/provider/cloud/deploy.yaml
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx \
+  --create-namespace \
+  --version 4.11.3
 ----
 
 
@@ -30,7 +32,12 @@ https://cert-manager.io[Cert-Manager] is a Kubernetes add-on that automates the 
 .Terminal
 [source,bash]
 ----
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml
+helm upgrade --install cert-manager cert-manager \
+  --repo https://charts.jetstack.io \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true \
+  --version v1.16.1
 ----
 
 
@@ -41,13 +48,23 @@ https://cloudnative-pg.io[CloudNativePG] is a PostgreSQL database that Control C
 .Terminal
 [source,bash]
 ----
-kubectl apply --server-side -f https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/releases/cnpg-1.24.0.yaml
+helm upgrade --install cnpg cloudnative-pg \
+  --repo https://cloudnative-pg.github.io/charts \
+  --namespace cnpg-system \
+  --create-namespace \
+  --version v0.22.1
 ----
 
 
 == Keycloak
 
 https://www.keycloak.org[Keycloak] is an open-source identity and access management solution that Control Center uses for authentication. You can install it by running the following commands:
+
+.Terminal
+[source,bash]
+----
+kubectl create namespace control-center
+----
 
 .Terminal
 [source,bash]

--- a/articles/control-center/getting-started/index.adoc
+++ b/articles/control-center/getting-started/index.adoc
@@ -43,6 +43,9 @@ To deploy Control Center to a Kubernetes cluster, run one of the following Helm 
 
 === Development Environment
 
+[NOTE]
+Granting administrator privileges enables automatic installation of required dependencies. If you choose not to grant these privileges, though, you'll need to first install the prerequisite resources before installing Control Center. See the <<dependency-installation.adoc#,Installation of Dependencies>> section for details on how to do this.
+
 For use in a development environment, you might install Control Center like so:
 
 .Terminal
@@ -61,13 +64,12 @@ helm install control-center oci://docker.io/vaadin/control-center \
 <4> Configures service settings for a load balancer on port `8000`. Change the port if necessary for your environment.
 <5> This says for Helm to wait until Control Center is fully deployed.
 
-[NOTE]
-Granting administrator privileges enables automatic installation of required dependencies. If you choose not to grant these privileges, though, you'll need to manually install the necessary resources. See the <<manual-installation#,Manual Installation>> section for details on how to do this.
-
 
 === Production Environment
 
-For use in a production environment, you could install Control Center like this:
+For use in a production environment, you'll need to manually install the required dependencies. See the <<dependency-installation.adoc#,Installation of Dependencies>> section for details on how to do this.
+
+Then you could install Control Center like this:
 
 .Terminal
 [.linenums,source,bash]
@@ -82,9 +84,6 @@ helm install control-center oci://docker.io/vaadin/control-center \
 <2> This creates a dedicated namespace to isolate Control Center from other applications.
 <3> Configures a custom ingress configuration (see below)
 <4> This instructs Helm to wait until Control Center is fully deployed.
-
-[IMPORTANT]
-Since this does not grant administrator privileges, you'll need to manually install the required dependencies. See the <<manual-installation#,Manual Installation>> section for details on how to do this.
 
 This is an example of a custom ingress configuration:
 


### PR DESCRIPTION
- [x] Renames "Manual Installation" page to "Installation of Dependencies".
- [x] Changes the dependency installation commands to use Helm.
- [x] Moves the admonitions in the "Getting Started" to be above the CC Helm commands.

The Keycloak commands need to remain in the documentation until we update the Helm charts to include the Keycloak Operator (https://github.com/vaadin/control-center/issues/721).

Fixes https://github.com/vaadin/control-center/issues/720