### PR TITLE
[Control Center] Clarify instructions for local clusters

### DIFF
--- a/articles/control-center/application-deployment/index.adoc
+++ b/articles/control-center/application-deployment/index.adoc
@@ -62,7 +62,7 @@ The `my-app:dev` tag is important because it's used later when deploying the app
 [TIP]
 It's common to use the application version to tag a release build (e.g., `my-app:1.0`). It's also common to use the tag `latest`, representing the most recent release. Using this tag forces Kubernetes always to pull the image from the registry, which requires the image to be there.
 
-=== Remote Kubernetes Cluster
+=== Publish to Container Registry
 
 If you're deploying to a remote Kubernetes cluster, you need to push the Docker image to a container registry. This allows the Kubernetes cluster to pull the image from the registry when deploying the application. To do this, make sure you have a Docker account, and that the image is tagged with a proper namespace (e.g., `company/my-app:dev`).
 
@@ -72,9 +72,9 @@ If you're deploying to a remote Kubernetes cluster, you need to push the Docker 
 docker push company/my-app:dev
 ----
 
-=== Local Kubernetes Cluster
+=== Local Development
 
-If you're using a local Kubernetes cluster, you may need to perform an extra step to allow the image to be accessible there. This is not necessary when using Kubernetes on Docker Desktop, as it can pull the image from the local Docker daemon.
+If you're using a local Kubernetes cluster for development, you may need to perform an additional step to allow an unpublished image to be accessible there. This is not necessary when using Kubernetes on Docker Desktop, as it can pull the image from the local Docker daemon.
 
 [.example]
 --

--- a/articles/control-center/application-deployment/index.adoc
+++ b/articles/control-center/application-deployment/index.adoc
@@ -59,17 +59,47 @@ docker build -t my-app:dev .
 
 The `my-app:dev` tag is important because it's used later when deploying the application in Control Center.
 
-If you're working with a local Kubernetes cluster (e.g., Minikube or Docker Desktop), there is no need to push the image to a container registry. However, if you're deploying to a remote cluster, the image needs to be pushed to a registry like Docker Hub:
+[TIP]
+It's common to use the application version to tag a release build (e.g., `my-app:1.0`). It's also common to use the tag `latest`, representing the most recent release. Using this tag forces Kubernetes always to pull the image from the registry, which requires the image to be there.
 
-[source,shell]
+=== Remote Kubernetes Cluster
+
+If you're deploying to a remote Kubernetes cluster, you need to push the Docker image to a container registry. This allows the Kubernetes cluster to pull the image from the registry when deploying the application. To do this, make sure you have a Docker account, and that the image is tagged with a proper namespace (e.g., `company/my-app:dev`).
+
+.Terminal
+[source,bash]
 ----
 docker push company/my-app:dev
 ----
 
-Make sure you have a Docker account, and that the image is tagged with a proper namespace (e.g., `company/my-app:dev`).
+=== Local Kubernetes Cluster
 
-[TIP]
-It's common to use the application version to tag a release build (e.g., `my-app:1.0`). It's also common to use the tag `latest`, representing the most recent release. Using this tag forces Kubernetes always to pull the image from the registry, which requires the image to be there.
+If you're using a local Kubernetes cluster, you may need to perform an extra step to allow the image to be accessible there. This is not necessary when using Kubernetes on Docker Desktop, as it can pull the image from the local Docker daemon.
+
+[.example]
+--
+
+.Terminal
+[source,bash]
+----
+<source-info group="minikube"></source-info>
+minikube image load my-app:dev
+----
+
+.Terminal
+[source,bash]
+----
+<source-info group="KiND"></source-info>
+kind load docker-image my-app:dev
+----
+
+.Terminal
+[source,bash]
+----
+<source-info group="k3s"></source-info>
+k3d image import my-app:dev -c your-cluster-name
+----
+--
 
 
 == Deploy with Control Center


### PR DESCRIPTION
Adds specific instructions for using local Kubernetes clusters such as minikube, KiND and k3s.

Fixes https://github.com/vaadin/control-center/issues/634