### PR TITLE
[Control Center] Remove numbered comments from code examples

### DIFF
--- a/articles/control-center/getting-started/index.adoc
+++ b/articles/control-center/getting-started/index.adoc
@@ -50,15 +50,17 @@ Granting administrator privileges enables automatic installation of required dep
 
 For use in a development environment, you might install Control Center like so:
 
+// IMPORTANT: Do not add numbered comments in the code block below. It causes and error in the command (see https://github.com/vaadin/control-center/issues/633).
 .Terminal
 [.linenums,source,bash]
 ----
-helm install control-center oci://docker.io/vaadin/control-center \ // <1>
-    -n control-center --create-namespace \ // <2>
-    --set serviceAccount.clusterAdmin=true \ // <3>
-    --set service.type=LoadBalancer --set service.port=8000 \ // <4>
-    --wait // <5>
+helm install control-center oci://docker.io/vaadin/control-center \
+    -n control-center --create-namespace \
+    --set serviceAccount.clusterAdmin=true \
+    --set service.type=LoadBalancer --set service.port=8000 \
+    --wait
 ----
+// IMPORTANT: Do not add numbered comments in the code block above.
 
 <1> This installs Control Center.
 <2> This creates a dedicated namespace to isolate Control Center from other applications.
@@ -73,14 +75,16 @@ For use in a production environment, you'll need to install manually the require
 
 Once you've installed the dependencies, you can install Control Center like this:
 
+// IMPORTANT: Do not add numbered comments in the code block below. It causes and error in the command (see https://github.com/vaadin/control-center/issues/633).
 .Terminal
 [.linenums,source,bash]
 ----
-helm install control-center oci://docker.io/vaadin/control-center \ // <1>
-    -n control-center --create-namespace \ // <2>
-    -f values-ingress.yaml \ // <3>
-    --wait // <4>
+helm install control-center oci://docker.io/vaadin/control-center \
+    -n control-center --create-namespace \
+    -f values-ingress.yaml \
+    --wait
 ----
+// IMPORTANT: Do not add numbered comments in the code block above.
 
 <1> This installs Control Center.
 <2> This creates a dedicated namespace to isolate Control Center from other applications.
@@ -151,7 +155,7 @@ image::images/welcome-step.png[Welcome Step]
 
 === Configure Keycloak Hostname
 
-Keycloak is the identity provider used by Control Center. Therefore, you'll need to configure the hostname for it. It needs a hostname that is accessible from within the Kubernetes cluster and from a web browser running outside the cluster. 
+Keycloak is the identity provider used by Control Center. Therefore, you'll need to configure the hostname for it. It needs a hostname that is accessible from within the Kubernetes cluster and from a web browser running outside the cluster.
 
 The hostname allows your applications and users to authenticate securely via Keycloak. This is necessary for both secure authentication and browser accessibility. Applications in the cluster need to access Keycloak to authenticate users, securely. At the same time, since authentication often involves redirects to Keycloak's login page, your browser must be able to reach Keycloak using a resolvable hostname.
 

--- a/articles/control-center/getting-started/index.adoc
+++ b/articles/control-center/getting-started/index.adoc
@@ -50,7 +50,7 @@ Granting administrator privileges enables automatic installation of required dep
 
 For use in a development environment, you might install Control Center like so:
 
-// IMPORTANT: Do not add numbered comments in the code block below. It causes and error in the command (see https://github.com/vaadin/control-center/issues/633).
+// IMPORTANT: Do not add numbered comments in the code block below. It causes an error in the command (see https://github.com/vaadin/control-center/issues/633).
 .Terminal
 [.linenums,source,bash]
 ----
@@ -75,7 +75,7 @@ For use in a production environment, you'll need to install manually the require
 
 Once you've installed the dependencies, you can install Control Center like this:
 
-// IMPORTANT: Do not add numbered comments in the code block below. It causes and error in the command (see https://github.com/vaadin/control-center/issues/633).
+// IMPORTANT: Do not add numbered comments in the code block below. It causes an error in the command (see https://github.com/vaadin/control-center/issues/633).
 .Terminal
 [.linenums,source,bash]
 ----


### PR DESCRIPTION
This removes the numbered comments erroneously added into code examples during the language check for #3887 .