### PR TITLE
docs: document npm.excludeWebComponents property

### DIFF
--- a/articles/flow/configuration/development-mode/index.adoc
+++ b/articles/flow/configuration/development-mode/index.adoc
@@ -137,6 +137,49 @@ Vaadin allows this to prevent the frontend development bundle from being re-buil
 -Dvaadin.skip.dev.bundle=true
 ----
 
+[role="since:com.vaadin:vaadin@V24.6"]
+[#exclude-vaadin-components]
+== Optimize bundle and package.json by excluding all Vaadin components
+
+If Vaadin’s pro and core components are not used, they can be excluded from `package.json` with the `vaadin.npm.excludeWebComponents` property and from the project’s dependencies.
+
+Here is an example of excluding both pro and core components by adding exclusions to the `vaadin-core` dependency in the Maven project's `pom.xml`. Use the `vaadin-core` artifactId, not `vaadin`:
+
+.pom.xml
+[source,xml]
+----
+<dependency>
+	<groupId>com.vaadin</groupId>
+	<artifactId>vaadin-core</artifactId>
+	<exclusions>
+            <exclusion>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-core-components</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.vaadin</groupId>
+                <artifactId>copilot</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-icons-flow</artifactId>
+            </exclusion>
+	</exclusions>
+</dependency>
+----
+
+Also `copilot` is excluded. This is recommended because Copilot depends on core components and would not work without them.
+
+Vaadin's Lumo and Material themes are not excluded. `vaadin-icons-flow` is excluded in the example because it's otherwise included by Lumo theme dependency.
+
+Set `vaadin.npm.excludeWebComponents` <<../properties.adoc#,configuration property>> to `true` to exclude pro and core components, including `hilla-auto-crud`, from `package.json`. Material and Lumo themes are not excluded.
+
+Use `npmExcludeWebComponents` Vaadin Plugin property when building with Maven/Gradle.
+
+When property is set to `true`, Vaadin's pro and core components are not installed by npm. If project has dependencies to uninstalled components, there will be error saying `Failed to find the following imports in the node_modules tree` with a list of missing resources. These remaining dependencies can be removed from the project's dependencies.
+
+Notice that production bundle size may not change with this property as production bundle is already optimized by including only used components.
+
 == Topics
 
 section_outline::[]

--- a/articles/flow/configuration/maven.adoc
+++ b/articles/flow/configuration/maven.adoc
@@ -67,6 +67,9 @@ The Node.js version to be used when Node.js is installed automatically. Should b
 `nodeAutoUpdate`::
 Flag to enable automatic update of the Node.js version installed in `~/.vaadin` if it's older than the default or defined `nodeVersion`. Note: any installed version below `should work` is automatically updated regardless of this flag. Defaults to `false`.
 
+`npmExcludeWebComponents`::
+Excludes all Vaadin pro and core components from the `package.json`. Material and Lumo themes are preserved. Excluded packages aren't installed by npm which makes development bundles smaller. This property alone doesn't remove any Maven dependencies. See <<development-mode/index.adoc#exclude-vaadin-components, Optimize bundle and package.json by excluding all Vaadin components>> for more information. Defaults to `false`.
+
 `npmFolder`::
 The folder where the [filename]`package.json` file is located. Defaults to `${project.basedir}`.
 

--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -167,6 +167,10 @@ The following table contains the properties that are defined in the [classname]`
 |5000 ms (i.e., 5 seconds)
 |Sets the maximum time in `milliseconds` that the client waits for predecessors of an out-of-sequence message, before considering them missing and requesting a full state resynchronization from the server. For example, when a server sends adjacent `XmlHttpRequest` responses and pushes messages over a low-bandwidth connection, the client may receive the messages out of sequence. Increase this value if your application experiences excessive resynchronization requests. However, be aware that it degrades the UX with flickering and loss of client-side-only states, such as scroll position.
 
+|`npm.excludeWebComponents`
+|false
+|Excludes all Vaadin pro and core components from the `package.json`. Material and Lumo themes are preserved. Excluded packages aren't installed by npm which makes development bundles smaller. This property alone doesn't remove any Maven/Gradle dependencies. Supported also as a Vaadin Plugin property `npmExcludeWebComponents`. See <<development-mode/index.adoc#exclude-vaadin-components, Optimize bundle and package.json by excluding all Vaadin components>> for more information.
+
 |`pnpm.enable`
 |`false`
 |Enables `pnpm`, instead of `npm`, to resolve and download frontend dependencies. It's set by default to `false` since `npm` is used typically. Set it to `true` to enable `pnpm`. See <<development-mode/npm-pnpm-bun#, Switching Between npm, pnpm and bun>> for more information.


### PR DESCRIPTION
As npm.excludeWebComponents is mainly useful for development mode, added new section in development-mode/index.adoc. Updated also properties.adoc and maven.adoc with the new property.

RelatedTo: vaadin/flow#19948


