### PR TITLE
Remove TODO from advanced-javascript.asciidoc

### DIFF
--- a/articles/framework/advanced/advanced-javascript.asciidoc
+++ b/articles/framework/advanced/advanced-javascript.asciidoc
@@ -17,8 +17,7 @@ code.
 You can make JavaScript calls from the server-side with the
 [methodname]#execute()# method in the [classname]#JavaScript# class. You can get
 a [classname]#JavaScript# instance from the current [classname]#Page# object
-with [methodname]#getJavaScript()#. 
-//TODO Check that the API is so.
+with [methodname]#getJavaScript()#.
 
 
 [source, java]


### PR DESCRIPTION
This has finally been checked and the API is indeed so.


