### PR TITLE
chore: Example how to use arbitrary hidden component for setDragImage

### DIFF
--- a/articles/flow/create-ui/dnd/drag-source.adoc
+++ b/articles/flow/create-ui/dnd/drag-source.adoc
@@ -1,13 +1,13 @@
 ---
 title: Drag Source
-description: Making any component draggable, and configuring the drag operation.
+description: Making any component draggable and configuring the drag operation.
 order: 20
 ---
 
 
 = Creating a Drag Source
 
-With the [classname]`DragSource` class, you can make any component draggable by the user, and configure the drag operation. By default, the entire component is made draggable, instead of a small part of it. The [classname]`DragSource` class is a configuration object for the dragged item and contains static methods for configuring the given component instance.
+With the [classname]`DragSource` class, you can make any component draggable by the user, and configure the drag operation for it. By default, the entire component is made draggable, instead of a small part of it. The [classname]`DragSource` class is a configuration object for the dragged item and contains static methods for configuring the given component instance.
 
 [source,java]
 ----
@@ -28,7 +28,7 @@ add(box1, box2);
 
 The [classname]`DragSource` configuration object doesn't itself store any data, as it's a convenience proxy that facilitates making a component draggable. Creating a new [classname]`DragSource` instance of a component doesn't reset any previous configuration, but any changes override the previous configuration.
 
-When a component is set draggable on the server side, the `draggable` attribute is assigned to its topmost element on the browser, making it draggable. When the user starts to drag the component, the root element of the component gets the `v-dragged` class name in the browser. This can be used to highlight the dragged component to the user.
+When a component is set as draggable on the server side, the `draggable` attribute is assigned to its topmost element on the browser, thus making it draggable. When the user starts to drag the component, the root element of the component gets the [classname]`v-dragged` class name in the browser. This can be used to highlight the dragged component to the user.
 
 [source,css]
 ----
@@ -41,7 +41,7 @@ When a component is set draggable on the server side, the `draggable` attribute 
 
 == Exposing Drag Source API to a Component
 
-As the [interfacename]`DragSource` is an interface, it can also be used as a "mix-in interface". It provides an easy way to add its API to your custom component. This is convenient when you want to reuse the component in many places for drag operations.
+As the [interfacename]`DragSource` is an interface, it can also be used as a "mix-in interface". It provides an easy way to add its API to your custom component. This is convenient when you want to reuse the component in many places for drag operation.
 
 [source,java]
 ----
@@ -59,7 +59,7 @@ public class CardComponent extends Div implements DragSource<CardComponent>, Has
 == Assigning Server-Side Data to Drag Source
 
 It's possible to set any Java object as the server-side drag data for the drag
-source. This data is provided on the [classname]`DropEvent` when the drop occurs on a valid drop target, if it's inside the same UI (browser window / tab) as the drag source component.
+source. This data is provided on the [classname]`DropEvent` when the drop occurs on a valid drop target -- if it's inside the same UI (i.e., browser window or tab) as the drag source component.
 
 [source,java]
 ----
@@ -78,7 +78,7 @@ It isn't possible to configure the client-side drag data, the `dataTransfer` obj
 
 == Drag Start & End Events
 
-The [interfacename]`DragSource` provides a way to react when the user starts and stops dragging a component. The [classname]`DragStartEvent` is fired when the drag starts in the browser, which means that you can't cancel the drag. You should avoid doing any heavy synchronous processing there, since this blocks the user from dragging the component further in the browser. It has a negative effect on the UX.
+The [interfacename]`DragSource` provides a way to react when the user starts and stops dragging a component. The [classname]`DragStartEvent` is fired when the drag starts in the browser, which means that you can't cancel the drag. You should avoid doing any heavy synchronous processing there, since this blocks the user from dragging the component further in the browser. That would have a negative effect on the UX.
 
 [source,java]
 ----
@@ -95,7 +95,7 @@ card1.addDragStartListener(event -> {
 });
 ----
 
-When the user stops dragging the component by either dropping it or by canceling the drag with, for example, the escape key, the [classname]`DragEndEvent` is fired. The [methodname]`isSuccessful()` method returns `true` if the drop occurred on a drop target that accepted the drop, but only for Chrome and Firefox (see the note after the sample).
+When the user stops dragging the component by either dropping it or by canceling the drag with, for example, the escape key, the [classname]`DragEndEvent` is fired. The [methodname]`isSuccessful()` method returns `true` if the drop occurred on a drop target that accepted the drop, but only for Chrome and Firefox (see the note after the example below).
 
 [source,java]
 ----
@@ -111,7 +111,7 @@ card1.addDragEndListener(event -> {
 
 .Handling Drag End in Edge & Safari
 [NOTE]
-Edge and Safari don't report whether the drop occurred successfully or not in the [classname]`DragEnd` event. You need to take this into account if your users are using any of these browsers, and do any logic in the [classname]`DropEvent` handler of the [classname]`DropTarget` instead. For Chrome and Firefox, it works correctly.
+Edge and Safari don't report whether the drop occurred successfully in the [classname]`DragEnd` event. You'll need to take this into account if your users are using any of these browsers, and do any logic in the [classname]`DropEvent` handler of the [classname]`DropTarget`, instead. For Chrome and Firefox, it works correctly.
 
 
 === Effect Allowed & Drop Effect
@@ -129,7 +129,7 @@ When the drop effect is `MOVE`, you should move or remove the drag source compon
 
 === Customizing the Draggable Element
 
-You can customize the element that is made draggable by overriding the [methodname]`getDraggableElement()` method in the [interfacename]`DragSource` interface. This is useful if it isn't the whole component that's to be draggable, but only a part of it.
+You can customize the element that is made draggable by overriding the [methodname]`getDraggableElement()` method in the [interfacename]`DragSource` interface. This is useful if it's not the whole component that's to be draggable, but only a part of it.
 
 [source,java]
 ----
@@ -177,10 +177,9 @@ Any optional coordinates define the offset of the pointer location from the top 
 card.setDragImage(new Image("/cards/queen_of_hearts.png", "Queen of Hearts"), 20, 0);
 ----
 
-Other components can be used as well, but support may vary between browsers. If a given component is a visible element in the viewport, the browser can show it as a drag image. Otherwise, the component must be added to the DOM as an off-screen element specifically for this purpose. Vaadin handles this automatically if the component is not already attached before being set as a drag image.
-If the default behavior does not meet your requirements, you can override it by manually adding the component to the DOM and applying your desired styling before invoking the [methodname]`setDragImage()` method.
+Other components can be used as well, but support may vary between browsers. If a given component is a visible element in the viewport, the browser can show it as a drag image. Otherwise, the component must be added to the DOM as an off-screen element specifically for this purpose. Vaadin handles this if the component is not already attached before being set as a drag image. If the default behavior doesn't meet your requirements, you can override it by adding the component to the DOM and applying your desired styling before invoking the [methodname]`setDragImage()` method.
 
-The following example demonstrates manually adding an off-screen component as a drag image:
+The following example demonstrates the addition of an off-screen component as a drag image:
 
 [source,java]
 ----
@@ -194,6 +193,6 @@ add(dragImage);
 dragSource.setDragImage(dragImage);
 ----
 
-For more information about the drag image, see link:https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setDragImage[HTML5 drag and drop API].
+For more information about the drag image, see link:https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setDragImage[HTML5 Drag & Drop API].
 
 [discussion-id]`4FFD51BA-4736-44BD-8FCF-0E534A19FB8D`


### PR DESCRIPTION
This documents a workaround while the https://github.com/vaadin/flow/pull/20490 is being investigated why it doesn't work on Mac.