### PR TITLE
fix: update import for disable on click functions

### DIFF
--- a/frontend/demo/init-flow-components.ts
+++ b/frontend/demo/init-flow-components.ts
@@ -11,12 +11,12 @@
 import '@vaadin/flow-frontend/dndConnector.js';
 import '@vaadin/flow-frontend/flow-component-renderer.js';
 // Flow component specific modules
-import '@vaadin/flow-frontend/buttonFunctions.js';
 import '@vaadin/flow-frontend/cookieConsentConnector.js';
 import '@vaadin/flow-frontend/comboBoxConnector.js';
 import '@vaadin/flow-frontend/contextMenuConnector.js';
 import '@vaadin/flow-frontend/contextMenuTargetConnector.js';
 import '@vaadin/flow-frontend/datepickerConnector.js';
+import '@vaadin/flow-frontend/disableOnClickFunctions.js';
 import '@vaadin/flow-frontend/gridConnector.js';
 import '@vaadin/flow-frontend/vaadin-grid-flow-selection-column.js';
 import '@vaadin/flow-frontend/gridProConnector.js';


### PR DESCRIPTION
This file was moved in https://github.com/vaadin/flow-components/pull/6815 released in the latest 24.6 alpha.