### PR TITLE
docs: enhance dialog component documentation with positioning and sizing details

### DIFF
--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -279,7 +279,7 @@ Modal dialogs don't benefit from being draggable, as their modality curtain (the
 
 == Size
 
-The Dialog size can be set with the width and height on the Dialog itself (__since V24.6 for React and Lit__). You can also set the size of the content of Dialog, whereby the Dialog scales to accommodate it In both cases, the Dialog can also be made resizable.
+The Dialog size can be set with the width and height on the Dialog itself (__since V24.6 for React and Lit__). You can also set the size of the content of Dialog, whereby the Dialog scales to accommodate it. In both cases, the Dialog can also be made resizable.
 
 [.example]
 --


### PR DESCRIPTION
Create new "Position" and "Size" sections and move "Draggable" and "Rezizable" sections to the corresponding ones. 

Also add code snippets showing the new API for programmatically sizing and positioning. 