### PR TITLE
Added feature flag and feedback link versions of preview feature admonition

### DIFF
--- a/articles/_preview-banner.adoc
+++ b/articles/_preview-banner.adoc
@@ -53,6 +53,15 @@ ifndef::preview-feature[]
 :preview-feature: This feature
 endif::[]
 
+:feature-flag-docs-link: <<{articles}/flow/configuration/feature-flags#,feature flag>>
+
+ifdef::feedback-url[]
+:feedback-link: {feedback-url}[provide feedback,window=_blank]
+endif::[]
+ifndef::feedback-url[]
+:feedback-link: provde feedback
+endif::[]
+
 ifndef::preview-banner-content[]
 :preview-banner-content: {preview-feature} is a preview feature. This means that it is not yet ready for production usage and may have limitations or bugs. We encourage you to try it out and provide feedback to help us improve it.
 endif::[]
@@ -61,5 +70,15 @@ endif::[]
 [.preview.skip-search-index]
 [NOTE]
 ====
+
+// Normal Preview Feature admonition
+ifndef::feature-flag[]
 {preview-banner-content}
+endif::[]
+
+// Preview Feature behind a Feature Flag
+ifdef::feature-flag[]
+This is a preview version of {preview-feature}. It needs to be enabled with the {feature-flag-docs-link} `{feature-flag}`. Preview versions may lack some planned features, and breaking changes may be introduced in any Vaadin version. We encourage you to try it out and {feedback-link} to help us improve it.
+endif::[]
+
 ====

--- a/articles/_preview-banner.adoc
+++ b/articles/_preview-banner.adoc
@@ -66,7 +66,7 @@ ifndef::preview-banner-content[]
 :preview-banner-content: {preview-feature} is a preview feature. This means that it is not yet ready for production usage and may have limitations or bugs. We encourage you to try it out and provide feedback to help us improve it.
 endif::[]
 
-.Preview feature
+.Preview Feature
 [.preview.skip-search-index]
 [NOTE]
 ====


### PR DESCRIPTION
Looks like so:

<img width="723" alt="Screen Shot 2024-11-28 at 19 25 20" src="https://github.com/user-attachments/assets/9b77d53e-227b-470c-bdf8-6f1791ca6983">

Usage:
```
:preview-feature: Dashboard
:feature-flag: com.vaadin.experimental.dashboardComponent
:feedback-url: https://vaadin.com/forum/t/vaadin-slider-element/167827
include::{articles}/_preview-banner.adoc[opts=optional]
```

- If `feature-flag` is omitted, the normal Preview admonition is rendered instead.
- If `feedback-url` is omitted, the paragraph is rendered without a link.