### PR TITLE
chore: reorder example groups

### DIFF
--- a/dspublisher/config/default.json
+++ b/dspublisher/config/default.json
@@ -4,5 +4,9 @@
     "lit": true,
     "react": true
   },
-  "useEsbuild": true
+  "exampleGroupOrder": [
+    "Flow",
+    "React",
+    "Lit"
+  ]
 }

--- a/dspublisher/config/production.json
+++ b/dspublisher/config/production.json
@@ -4,6 +4,9 @@
     "lit": true,
     "react": true
   },
-  "useStandardDecorators": true,
-  "useEsbuild": true
+  "exampleGroupOrder": [
+    "Flow",
+    "React",
+    "Lit"
+  ]
 }

--- a/dspublisher/dspublisher-scripts.js
+++ b/dspublisher/dspublisher-scripts.js
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const DSP_VERSION = '3.0.0-alpha.6';
+const DSP_VERSION = '3.0.0-alpha.7';
 
 async function checkPreConditions() {
   try {

--- a/src/main/java/com/vaadin/dspublisher/licensecheck/Check.java
+++ b/src/main/java/com/vaadin/dspublisher/licensecheck/Check.java
@@ -6,7 +6,7 @@ import com.vaadin.pro.licensechecker.LicenseChecker;
 public class Check {
     public static void main(String[] args) {
         try {
-            LicenseChecker.checkLicense("vaadin-dspublisher", "3.0.0-alpha.6",
+            LicenseChecker.checkLicense("vaadin-dspublisher", "3.0.0-alpha.7",
                     (BuildType) null);
         } catch (Exception e) {
             System.exit(1);


### PR DESCRIPTION
Configures DSP to show Flow and React examples first. Also updates DSP to a new version that has that feature, and removes obsolete config options.

Closes https://github.com/vaadin/docs/issues/3351