### PR TITLE
[Control Center] Add a page detailing the options for the helm command

### DIFF
--- a/articles/control-center/getting-started/helm-values.adoc
+++ b/articles/control-center/getting-started/helm-values.adoc
@@ -1,0 +1,157 @@
+---
+title: Helm Values
+description: Learn how to configure Control Center using Helm values.
+order: 30
+---
+
+
+= Helm Values
+
+This page explains how to configure Control Center using Helm values. The following table lists the available values and their descriptions. You can set these values when you install Control Center using Helm. Below is an example where the domain, user email (both required), and application host (optional) are set:
+
+.Terminal
+[source,bash]
+----
+helm install control-center oci://docker.io/vaadin/control-center \
+    -n control-center --create-namespace \
+    --set domain=mydomain.com \
+    --set user.email=example@mydomain.com \
+    --set app.host=cc.mydomain.com \
+    -f values-ingress.yaml \
+    --wait
+----
+
+[cols="m,1,m,4",options="header"]
+|===
+| Value | Required | Default | Description
+
+| domain | Yes | | The domain name of the Control Center installation. This is used to determine the host names for Control Center and Keycloak.
+
+| user.email | Yes | | The email address of the Control Center administrator user.
+
+| nameOverride | No | | Replace every occurrence of "control-center".
+
+| fullnameOverride | No |
+a| The full name is generated as:
+
+* if the release name is "control-center", the full name is "control-center"
+* if the release name is "foo", the full name is "foo-control-center"
+
+This value overrides the full name.
+
+| serviceAccount.create | No | true | Specifies whether a service account should be created.
+
+| serviceAccount.automount | No | true | Specifies whether to automount the service account token.
+
+| serviceAccount.name | No | | The name of the service account to use.
+
+| serviceAccount.annotations | No | | Annotations to add to the service account.
+
+| app.host | No | | The host name of the Control Center application. If none is specified, `control.${domain}` will be used.
+
+| app.tlsSecret | No | | The name of the secret with the keystore for the Control Center application.
+
+| app.image.repository | No | vaadin/control-center | The image repository to use for the Control Center application.
+
+| app.image.pullPolicy | No | | The pull policy to use for the image. If none is specified, the Kubernetes default is used.
+
+| app.image.tag | No | | The image tag to use for the Control Center application. If none is specified, the chart's appVersion will be used.
+
+| app.imagePullSecrets | No | | The image pull secrets to use for the Control Center application.
+
+| app.podLabels | No | | Additional labels to add to the Control Center application pods.
+
+| app.podAnnotations | No | | Additional annotations to add to the Control Center application pods.
+
+| app.podSecurityContext | No | | The security context for the Control Center application pods.
+
+| app.securityContext | No | | The security context for the Control Center application deployment.
+
+| app.replicaCount | No | 1 | The number of replicas for the Control Center application.
+
+| app.autoscaling.enabled | No | false | Specifies whether autoscaling should be enabled for the Control Center application.
+
+| app.autoscaling.minReplicas | No | 1 | The minimum number of replicas for the Control Center application.
+
+| app.autoscaling.maxReplicas | No | 100 | The maximum number of replicas for the Control Center application.
+
+| app.autoscaling.targetCPUUtilizationPercentage | No | 80 | The target CPU utilization percentage for the Control Center application.
+
+| app.autoscaling.targetMemoryUtilizationPercentage | No | 90 | The target memory utilization percentage for the Control Center application.
+
+| app.resources | No | | The resource to allocate for the Control Center application containers.
+
+| livenessProbe.httpGet.path | No | /actuator/health/liveness | The path to use for the liveness probe for the Control Center application.
+
+| livenessProbe.httpGet.port | No | http | The port to use for the liveness probe.
+
+| readinessProbe.httpGet.path | No | /actuator/health/readiness | The path to use for the readiness probe for the Control Center application.
+
+| readinessProbe.httpGet.port | No | http | The port to use for the readiness probe.
+
+| app.volumes | No | | The volume definitions for the Control Center application.
+
+| app.volumeMounts | No | | The volume mounts for the Control Center application.
+
+| app.nodeSelector | No | | The custom node selectors for the Control Center application.
+
+| app.tolerations | No | | The custom tolerations for the Control Center application.
+
+| app.affinity | No | | The custom affinity for the Control Center application.
+
+| app.service.type | No | ClusterIP | The type of service to create for the Control Center application.
+
+| app.service.port | No | 80 | The port to expose for the Control Center application.
+
+| app.service.targetPort | No | 8080 | The port for the Control Center application containers.
+
+| app.ingress.enabled | No | true | Specifies whether to create an Ingress for the Control Center application.
+
+| app.ingress.annotations | No | | The annotations to add to the Ingress.
+
+| app.ingress.hosts | No | | The hosts to add to the Ingress. If none is specified, `app.host` will be used.
+
+| app.ingress.tls | No | | The TLS configuration for the Ingress.
+
+| postgres.replicaCount | No | 1 | The number of replicas for the PostgreSQL database.
+
+| postgres.storage.size | No | 1Gi | The storage size for the PostgreSQL database.
+
+| keycloak.image.repository | No | vaadin/control-center-keycloak | The image repository to use for the Keycloak instance.
+
+| keycloak.image.tag | No | | The image tag to use for the Keycloak instance. If none is specified, the chart's appVersion will be used.
+
+| keycloak.resources | No | | The resources to allocate for the Keycloak containers.
+
+| keycloak.host | No | | The hosts for the Keycloak instance. If none is specified, `auth.${domain}` will be used.
+
+| keycloak.tlsSecret | No | | The name of the secret with the keystore for the Keycloak instance.
+
+| acme.enabled | No | false | Specifies whether to enable ACME for the Ingress. When enabled, certificates will be automatically requested from Let's Encrypt using CertManager. This requires public DNS records for the Ingress hosts.
+
+| acme.server | No | \https://acme-v02.api.letsencrypt.org/directory | The ACME server to use.
+
+| keycloak-operator.enabled | No | true | Specifies whether to enable the Keycloak Operator.
+
+| keycloak-operator.image.repository | No | quay.io/keycloak/keycloak-operator | The image repository to use for the Keycloak Operator.
+
+| cloudnative-pg.enabled | No | true | Specifies whether to enable Cloud Native PostgreSQL Operator.
+
+| cloudnative-pg.crds.create | No | false | Specifies whether to create the CRDs for the Operator.
+
+| ingress-nginx.enabled | No | true | Specifies whether to enable the Ingress NGINX Controller.
+
+| ingress-nginx.controller.scope.enabled | No | true | Specifies whether to enable the scope for the Ingress NGINX Controller.
+
+| cert-manager.enabled | No | true | Specifies whether to enable CertManager.
+
+| cert-manager.enableCertificateOwnerRef | No | true | Specifies whether to enable the certificate owner reference for CertManager.
+
+| external-dns.enabled | No | false | Specifies whether to enable ExternalDNS
+
+| external-dns.namespaced | No | true | Specifies whether ExternalDNS should be namespaced.
+
+| external-dns.txtOwnerId | No | control-center | The TXT owner ID for ExternalDNS.
+
+| external-dns.sources | No | [ingress] | The sources for ExternalDNS.
+|===


### PR DESCRIPTION
This adds a page explaining the options that can be used when installing Control Center using the helm command.

Fixes https://github.com/vaadin/control-center/issues/759