### PR TITLE
refactor: use simple items in basic layouts examples

### DIFF
--- a/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
@@ -22,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="padding spacing">
-        <div class="layout-item" style="flex-grow: 1">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item" style="flex-grow: 1">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-expanding-items.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -23,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="padding spacing">
-        <vaadin-button style="flex-grow: 1">Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item" style="flex-grow: 1">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -23,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing padding" style="justify-content: center">
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-horizontal-alignment.ts
@@ -22,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing padding" style="justify-content: center">
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
@@ -1,6 +1,5 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
-import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -21,24 +20,17 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-    <!-- tag::snippet[] -->
+      <!-- tag::snippet[] -->
       <vaadin-horizontal-layout
         theme="spacing padding"
-        class="height-4xl" // hidden-source-line
+        class="height-4xl"
         style="align-items: stretch"
       >
-        <vaadin-text-area
-          label="Text area 1"
-          style="align-self: start"
-        ></vaadin-text-area>
-        <vaadin-text-area label="Text area 2"></vaadin-text-area>
-        <vaadin-text-area
-          label="Text area 3"
-          style="align-self: end"
-        ></vaadin-text-area>
+        <div class="layout-item" style="align-self: start">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item" style="align-self: end">Item 3</div>
       </vaadin-horizontal-layout>
-
-    <!-- end::snippet[] -->
+      <!-- end::snippet[] -->
     `;
   }
 }

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-individual-alignment.ts
@@ -26,9 +26,9 @@ export class Example extends LitElement {
         class="height-4xl"
         style="align-items: stretch"
       >
-        <div class="layout-item" style="align-self: start">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item" style="align-self: end">Item 3</div>
+        <div class="example-item" style="align-self: start">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item" style="align-self: end">Item 3</div>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
@@ -23,9 +23,9 @@ export class Example extends LitElement {
       <p>Horizontal layout without margin:</p>
       <div class="container">
         <vaadin-horizontal-layout theme="spacing padding">
-          <div class="layout-item">Item 1</div>
-          <div class="layout-item">Item 2</div>
-          <div class="layout-item">Item 3</div>
+          <div class="example-item">Item 1</div>
+          <div class="example-item">Item 2</div>
+          <div class="example-item">Item 3</div>
         </vaadin-horizontal-layout>
       </div>
 
@@ -34,9 +34,9 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <vaadin-horizontal-layout theme="margin spacing padding">
           <!-- end::snippet[] -->
-          <div class="layout-item">Item 1</div>
-          <div class="layout-item">Item 2</div>
-          <div class="layout-item">Item 3</div>
+          <div class="example-item">Item 1</div>
+          <div class="example-item">Item 2</div>
+          <div class="example-item">Item 3</div>
           <!-- tag::snippet[] -->
         </vaadin-horizontal-layout>
         <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-margin.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -24,9 +23,9 @@ export class Example extends LitElement {
       <p>Horizontal layout without margin:</p>
       <div class="container">
         <vaadin-horizontal-layout theme="spacing padding">
-          <vaadin-button>Button 1</vaadin-button>
-          <vaadin-button>Button 2</vaadin-button>
-          <vaadin-button>Button 3</vaadin-button>
+          <div class="layout-item">Item 1</div>
+          <div class="layout-item">Item 2</div>
+          <div class="layout-item">Item 3</div>
         </vaadin-horizontal-layout>
       </div>
 
@@ -35,9 +34,9 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <vaadin-horizontal-layout theme="margin spacing padding">
           <!-- end::snippet[] -->
-          <vaadin-button>Button 1</vaadin-button>
-          <vaadin-button>Button 2</vaadin-button>
-          <vaadin-button>Button 3</vaadin-button>
+          <div class="layout-item">Item 1</div>
+          <div class="layout-item">Item 2</div>
+          <div class="layout-item">Item 3</div>
           <!-- tag::snippet[] -->
         </vaadin-horizontal-layout>
         <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
@@ -22,18 +22,18 @@ export class Example extends LitElement {
     return html`
       <p>Horizontal layout without padding:</p>
       <vaadin-horizontal-layout theme="spacing">
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-horizontal-layout>
 
       <p>Horizontal layout with padding:</p>
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="padding spacing">
         <!-- end::snippet[] -->
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
         <!-- tag::snippet[] -->
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-padding.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -23,18 +22,18 @@ export class Example extends LitElement {
     return html`
       <p>Horizontal layout without padding:</p>
       <vaadin-horizontal-layout theme="spacing">
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-horizontal-layout>
 
       <p>Horizontal layout with padding:</p>
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="padding spacing">
         <!-- end::snippet[] -->
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
         <!-- tag::snippet[] -->
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
@@ -27,9 +27,9 @@ export class Example extends LitElement {
   protected override render() {
     return html`
       <vaadin-horizontal-layout theme="${this.themeVariant} padding" style="align-items: stretch">
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-horizontal-layout>
       <vaadin-radio-group
         label="Spacing variant"

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing-variants.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
@@ -28,9 +27,9 @@ export class Example extends LitElement {
   protected override render() {
     return html`
       <vaadin-horizontal-layout theme="${this.themeVariant} padding" style="align-items: stretch">
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-horizontal-layout>
       <vaadin-radio-group
         label="Spacing variant"

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -23,18 +22,18 @@ export class Example extends LitElement {
     return html`
       <p>Horizontal layout without spacing:</p>
       <vaadin-horizontal-layout theme="padding">
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-horizontal-layout>
 
       <p>Horizontal layout with spacing:</p>
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing padding">
         <!-- end::snippet[] -->
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
         <!-- tag::snippet[] -->
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-spacing.ts
@@ -22,18 +22,18 @@ export class Example extends LitElement {
     return html`
       <p>Horizontal layout without spacing:</p>
       <vaadin-horizontal-layout theme="padding">
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-horizontal-layout>
 
       <p>Horizontal layout with spacing:</p>
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing padding">
         <!-- end::snippet[] -->
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
         <!-- tag::snippet[] -->
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
@@ -26,9 +26,9 @@ export class Example extends LitElement {
         class="height-4xl"
         style="align-items: center"
       >
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-vertical-alignment.ts
@@ -1,6 +1,5 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
-import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -21,17 +20,17 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-    <!-- tag::snippet[] -->
+      <!-- tag::snippet[] -->
       <vaadin-horizontal-layout
         theme="spacing padding"
-        class="height-4xl" // hidden-source-line
+        class="height-4xl"
         style="align-items: center"
       >
-        <vaadin-text-area label="Text area 1"></vaadin-text-area>
-        <vaadin-text-area label="Text area 2"></vaadin-text-area>
-        <vaadin-text-area label="Text area 3"></vaadin-text-area>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-horizontal-layout>
-    <!-- end::snippet[] -->
+      <!-- end::snippet[] -->
     `;
   }
 }

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-wrapping.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-wrapping.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -23,22 +22,22 @@ export class Example extends LitElement {
     return html`
       <p>Horizontal layout without wrapping:</p>
       <vaadin-horizontal-layout theme="spacing margin padding" style="width: 350px;">
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
-        <vaadin-button>Button 4</vaadin-button>
-        <vaadin-button>Button 5</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
+        <div class="layout-item">Item 4</div>
+        <div class="layout-item">Item 5</div>
       </vaadin-horizontal-layout>
 
       <p>Horizontal layout with wrapping:</p>
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="wrap spacing margin padding" style="width: 350px;">
         <!-- end::snippet[] -->
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
-        <vaadin-button>Button 4</vaadin-button>
-        <vaadin-button>Button 5</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
+        <div class="layout-item">Item 4</div>
+        <div class="layout-item">Item 5</div>
         <!-- tag::snippet[] -->
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-wrapping.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout-wrapping.ts
@@ -22,22 +22,22 @@ export class Example extends LitElement {
     return html`
       <p>Horizontal layout without wrapping:</p>
       <vaadin-horizontal-layout theme="spacing margin padding" style="width: 350px;">
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
-        <div class="layout-item">Item 4</div>
-        <div class="layout-item">Item 5</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
+        <div class="example-item">Item 4</div>
+        <div class="example-item">Item 5</div>
       </vaadin-horizontal-layout>
 
       <p>Horizontal layout with wrapping:</p>
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="wrap spacing margin padding" style="width: 350px;">
         <!-- end::snippet[] -->
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
-        <div class="layout-item">Item 4</div>
-        <div class="layout-item">Item 5</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
+        <div class="example-item">Item 4</div>
+        <div class="example-item">Item 5</div>
         <!-- tag::snippet[] -->
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -23,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing padding">
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-horizontal-layout.ts
@@ -22,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-horizontal-layout theme="spacing padding">
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-horizontal-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
@@ -27,9 +26,9 @@ export class Example extends LitElement {
           <p>Vertical layout without margin:</p>
           <div class="container">
             <vaadin-vertical-layout theme="spacing padding" style="align-items: stretch">
-              <vaadin-button>Button 1</vaadin-button>
-              <vaadin-button>Button 2</vaadin-button>
-              <vaadin-button>Button 3</vaadin-button>
+              <div class="layout-item">Item 1</div>
+              <div class="layout-item">Item 2</div>
+              <div class="layout-item">Item 3</div>
             </vaadin-vertical-layout>
           </div>
         </div>
@@ -39,9 +38,9 @@ export class Example extends LitElement {
             <!-- tag::snippet[] -->
             <vaadin-vertical-layout theme="margin spacing padding" style="align-items: stretch">
               <!-- end::snippet[] -->
-              <vaadin-button>Button 1</vaadin-button>
-              <vaadin-button>Button 2</vaadin-button>
-              <vaadin-button>Button 3</vaadin-button>
+              <div class="layout-item">Item 1</div>
+              <div class="layout-item">Item 2</div>
+              <div class="layout-item">Item 3</div>
               <!-- tag::snippet[] -->
             </vaadin-vertical-layout>
             <!-- end::snippet[] -->
@@ -50,5 +49,4 @@ export class Example extends LitElement {
       </vaadin-horizontal-layout>
     `;
   }
-  // end::snippet[]
 }

--- a/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-margin.ts
@@ -26,9 +26,9 @@ export class Example extends LitElement {
           <p>Vertical layout without margin:</p>
           <div class="container">
             <vaadin-vertical-layout theme="spacing padding" style="align-items: stretch">
-              <div class="layout-item">Item 1</div>
-              <div class="layout-item">Item 2</div>
-              <div class="layout-item">Item 3</div>
+              <div class="example-item">Item 1</div>
+              <div class="example-item">Item 2</div>
+              <div class="example-item">Item 3</div>
             </vaadin-vertical-layout>
           </div>
         </div>
@@ -38,9 +38,9 @@ export class Example extends LitElement {
             <!-- tag::snippet[] -->
             <vaadin-vertical-layout theme="margin spacing padding" style="align-items: stretch">
               <!-- end::snippet[] -->
-              <div class="layout-item">Item 1</div>
-              <div class="layout-item">Item 2</div>
-              <div class="layout-item">Item 3</div>
+              <div class="example-item">Item 1</div>
+              <div class="example-item">Item 2</div>
+              <div class="example-item">Item 3</div>
               <!-- tag::snippet[] -->
             </vaadin-vertical-layout>
             <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
@@ -26,9 +25,9 @@ export class Example extends LitElement {
         <div style="width: 100%">
           <p>Vertical layout without padding:</p>
           <vaadin-vertical-layout theme="spacing" style="align-items: stretch">
-            <vaadin-button>Button 1</vaadin-button>
-            <vaadin-button>Button 2</vaadin-button>
-            <vaadin-button>Button 3</vaadin-button>
+            <div class="layout-item">Item 1</div>
+            <div class="layout-item">Item 2</div>
+            <div class="layout-item">Item 3</div>
           </vaadin-vertical-layout>
         </div>
         <div style="width: 100%">
@@ -36,9 +35,9 @@ export class Example extends LitElement {
           <!-- tag::snippet[] -->
           <vaadin-vertical-layout theme="padding spacing" style="align-items: stretch">
             <!-- end::snippet[] -->
-            <vaadin-button>Button 1</vaadin-button>
-            <vaadin-button>Button 2</vaadin-button>
-            <vaadin-button>Button 3</vaadin-button>
+            <div class="layout-item">Item 1</div>
+            <div class="layout-item">Item 2</div>
+            <div class="layout-item">Item 3</div>
             <!-- tag::snippet[] -->
           </vaadin-vertical-layout>
           <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-padding.ts
@@ -25,9 +25,9 @@ export class Example extends LitElement {
         <div style="width: 100%">
           <p>Vertical layout without padding:</p>
           <vaadin-vertical-layout theme="spacing" style="align-items: stretch">
-            <div class="layout-item">Item 1</div>
-            <div class="layout-item">Item 2</div>
-            <div class="layout-item">Item 3</div>
+            <div class="example-item">Item 1</div>
+            <div class="example-item">Item 2</div>
+            <div class="example-item">Item 3</div>
           </vaadin-vertical-layout>
         </div>
         <div style="width: 100%">
@@ -35,9 +35,9 @@ export class Example extends LitElement {
           <!-- tag::snippet[] -->
           <vaadin-vertical-layout theme="padding spacing" style="align-items: stretch">
             <!-- end::snippet[] -->
-            <div class="layout-item">Item 1</div>
-            <div class="layout-item">Item 2</div>
-            <div class="layout-item">Item 3</div>
+            <div class="example-item">Item 1</div>
+            <div class="example-item">Item 2</div>
+            <div class="example-item">Item 3</div>
             <!-- tag::snippet[] -->
           </vaadin-vertical-layout>
           <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
@@ -31,9 +31,9 @@ export class Example extends LitElement {
         class="height-4xl"
         style="align-items: stretch"
       >
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-vertical-layout>
       <vaadin-radio-group
         label="Spacing variant"

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
@@ -1,6 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/vertical-layout';
 import '@vaadin/radio-group';
+import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing-variants.ts
@@ -1,7 +1,6 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
-import '@vaadin/radio-group';
 import '@vaadin/vertical-layout';
+import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
@@ -32,9 +31,9 @@ export class Example extends LitElement {
         class="height-4xl"
         style="align-items: stretch"
       >
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-vertical-layout>
       <vaadin-radio-group
         label="Spacing variant"

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
@@ -25,9 +25,9 @@ export class Example extends LitElement {
         <div style="width: 100%">
           <p>Vertical layout without spacing:</p>
           <vaadin-vertical-layout theme="padding" style="align-items: stretch">
-            <div class="layout-item">Item 1</div>
-            <div class="layout-item">Item 2</div>
-            <div class="layout-item">Item 3</div>
+            <div class="example-item">Item 1</div>
+            <div class="example-item">Item 2</div>
+            <div class="example-item">Item 3</div>
           </vaadin-vertical-layout>
         </div>
         <div style="width: 100%">
@@ -35,9 +35,9 @@ export class Example extends LitElement {
           <!-- tag::snippet[] -->
           <vaadin-vertical-layout theme="spacing padding" style="align-items: stretch">
             <!-- end::snippet[] -->
-            <div class="layout-item">Item 1</div>
-            <div class="layout-item">Item 2</div>
-            <div class="layout-item">Item 3</div>
+            <div class="example-item">Item 1</div>
+            <div class="example-item">Item 2</div>
+            <div class="example-item">Item 3</div>
             <!-- tag::snippet[] -->
           </vaadin-vertical-layout>
           <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-spacing.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
@@ -26,9 +25,9 @@ export class Example extends LitElement {
         <div style="width: 100%">
           <p>Vertical layout without spacing:</p>
           <vaadin-vertical-layout theme="padding" style="align-items: stretch">
-            <vaadin-button>Button 1</vaadin-button>
-            <vaadin-button>Button 2</vaadin-button>
-            <vaadin-button>Button 3</vaadin-button>
+            <div class="layout-item">Item 1</div>
+            <div class="layout-item">Item 2</div>
+            <div class="layout-item">Item 3</div>
           </vaadin-vertical-layout>
         </div>
         <div style="width: 100%">
@@ -36,9 +35,9 @@ export class Example extends LitElement {
           <!-- tag::snippet[] -->
           <vaadin-vertical-layout theme="spacing padding" style="align-items: stretch">
             <!-- end::snippet[] -->
-            <vaadin-button>Button 1</vaadin-button>
-            <vaadin-button>Button 2</vaadin-button>
-            <vaadin-button>Button 3</vaadin-button>
+            <div class="layout-item">Item 1</div>
+            <div class="layout-item">Item 2</div>
+            <div class="layout-item">Item 3</div>
             <!-- tag::snippet[] -->
           </vaadin-vertical-layout>
           <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -23,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing padding" style="align-items: center">
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-vertical-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-horizontal-alignment.ts
@@ -22,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing padding" style="align-items: center">
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-vertical-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -23,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing padding" style="align-items: start">
-        <vaadin-button style="align-self: end" theme="primary">Button 1</vaadin-button>
-        <vaadin-button style="align-self: center"> Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item" style="align-self: end">Item 1</div>
+        <div class="layout-item" style="align-self: center">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-vertical-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-individual-alignment.ts
@@ -22,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing padding" style="align-items: start">
-        <div class="layout-item" style="align-self: end">Item 1</div>
-        <div class="layout-item" style="align-self: center">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item" style="align-self: end">Item 1</div>
+        <div class="example-item" style="align-self: center">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-vertical-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
@@ -26,9 +26,9 @@ export class Example extends LitElement {
         class="height-4xl"
         style="justify-content: center"
       >
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-vertical-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-vertical-alignment.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -21,15 +20,15 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-    <!-- tag::snippet[] -->
+      <!-- tag::snippet[] -->
       <vaadin-vertical-layout
         theme="spacing padding"
-        class="height-4xl" // hidden-source-line
+        class="height-4xl"
         style="justify-content: center"
       >
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-vertical-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-wrapping.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-wrapping.ts
@@ -28,10 +28,10 @@ export class Example extends LitElement {
             theme="spacing padding"
             style="align-items: stretch; height: 200px;"
           >
-            <div class="layout-item">Item 1</div>
-            <div class="layout-item">Item 2</div>
-            <div class="layout-item">Item 3</div>
-            <div class="layout-item">Item 4</div>
+            <div class="example-item">Item 1</div>
+            <div class="example-item">Item 2</div>
+            <div class="example-item">Item 3</div>
+            <div class="example-item">Item 4</div>
           </vaadin-vertical-layout>
         </div>
         <div style="width: 100%;">
@@ -42,10 +42,10 @@ export class Example extends LitElement {
             style="align-items: stretch; height: 200px;"
           >
             <!-- end::snippet[] -->
-            <div class="layout-item">Item 1</div>
-            <div class="layout-item">Item 2</div>
-            <div class="layout-item">Item 3</div>
-            <div class="layout-item">Item 4</div>
+            <div class="example-item">Item 1</div>
+            <div class="example-item">Item 2</div>
+            <div class="example-item">Item 3</div>
+            <div class="example-item">Item 4</div>
             <!-- tag::snippet[] -->
           </vaadin-vertical-layout>
           <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-wrapping.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout-wrapping.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/vertical-layout';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
@@ -29,10 +28,10 @@ export class Example extends LitElement {
             theme="spacing padding"
             style="align-items: stretch; height: 200px;"
           >
-            <vaadin-button>Button 1</vaadin-button>
-            <vaadin-button>Button 2</vaadin-button>
-            <vaadin-button>Button 3</vaadin-button>
-            <vaadin-button>Button 4</vaadin-button>
+            <div class="layout-item">Item 1</div>
+            <div class="layout-item">Item 2</div>
+            <div class="layout-item">Item 3</div>
+            <div class="layout-item">Item 4</div>
           </vaadin-vertical-layout>
         </div>
         <div style="width: 100%;">
@@ -43,10 +42,10 @@ export class Example extends LitElement {
             style="align-items: stretch; height: 200px;"
           >
             <!-- end::snippet[] -->
-            <vaadin-button>Button 1</vaadin-button>
-            <vaadin-button>Button 2</vaadin-button>
-            <vaadin-button>Button 3</vaadin-button>
-            <vaadin-button>Button 4</vaadin-button>
+            <div class="layout-item">Item 1</div>
+            <div class="layout-item">Item 2</div>
+            <div class="layout-item">Item 3</div>
+            <div class="layout-item">Item 4</div>
             <!-- tag::snippet[] -->
           </vaadin-vertical-layout>
           <!-- end::snippet[] -->

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts
@@ -1,5 +1,4 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -23,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing padding">
-        <vaadin-button>Button 1</vaadin-button>
-        <vaadin-button>Button 2</vaadin-button>
-        <vaadin-button>Button 3</vaadin-button>
+        <div class="layout-item">Item 1</div>
+        <div class="layout-item">Item 2</div>
+        <div class="layout-item">Item 3</div>
       </vaadin-vertical-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts
+++ b/frontend/demo/component/basiclayouts/basic-layouts-vertical-layout.ts
@@ -22,9 +22,9 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-vertical-layout theme="spacing padding">
-        <div class="layout-item">Item 1</div>
-        <div class="layout-item">Item 2</div>
-        <div class="layout-item">Item 3</div>
+        <div class="example-item">Item 1</div>
+        <div class="example-item">Item 2</div>
+        <div class="example-item">Item 3</div>
       </vaadin-vertical-layout>
       <!-- end::snippet[] -->
     `;

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-expanding-items.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-expanding-items.tsx
@@ -8,9 +8,9 @@ function Example() {
     <>
       {/* tag::snippet[] */}
       <HorizontalLayout theme="padding spacing">
-        <div className="layout-item" style={{ flexGrow: 1 }}>Item 1</div>
-        <div className="layout-item">Item 2</div>
-        <div className="layout-item">Item 3</div>
+        <div className="example-item" style={{ flexGrow: 1 }}>Item 1</div>
+        <div className="example-item">Item 2</div>
+        <div className="example-item">Item 3</div>
       </HorizontalLayout>
       {/* end::snippet[] */}
     </>

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-expanding-items.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-expanding-items.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
-import { Button, HorizontalLayout } from '@vaadin/react-components';
+import { HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -8,9 +8,9 @@ function Example() {
     <>
       {/* tag::snippet[] */}
       <HorizontalLayout theme="padding spacing">
-        <Button style={{ flexGrow: 1 }}>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
+        <div className="layout-item" style={{ flexGrow: 1 }}>Item 1</div>
+        <div className="layout-item">Item 2</div>
+        <div className="layout-item">Item 3</div>
       </HorizontalLayout>
       {/* end::snippet[] */}
     </>

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
@@ -7,9 +7,9 @@ function Example() {
   return (
     // tag::snippet[]
     <HorizontalLayout theme="spacing padding" style={{ justifyContent: 'center' }}>
-      <div className="layout-item">Item 1</div>
-      <div className="layout-item">Item 2</div>
-      <div className="layout-item">Item 3</div>
+      <div className="example-item">Item 1</div>
+      <div className="example-item">Item 2</div>
+      <div className="example-item">Item 3</div>
     </HorizontalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-horizontal-alignment.tsx
@@ -1,19 +1,15 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { Button, HorizontalLayout } from '@vaadin/react-components';
+import { HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
   return (
     // tag::snippet[]
-    <HorizontalLayout
-      theme="spacing padding"
-      className="height-4xl"
-      style={{ justifyContent: 'center' }}
-    >
-      <Button>Button 1</Button>
-      <Button>Button 2</Button>
-      <Button>Button 3</Button>
+    <HorizontalLayout theme="spacing padding" style={{ justifyContent: 'center' }}>
+      <div className="layout-item">Item 1</div>
+      <div className="layout-item">Item 2</div>
+      <div className="layout-item">Item 3</div>
     </HorizontalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-individual-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-individual-alignment.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { HorizontalLayout, TextArea } from '@vaadin/react-components';
+import { HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -9,11 +9,11 @@ function Example() {
     <HorizontalLayout
       theme="spacing padding"
       className="height-4xl"
-      style={{ alignItems: 'stretch', ...layoutExampleStyle }}
+      style={{ alignItems: 'stretch' }}
     >
-      <TextArea label="Text area 1" style={{ alignSelf: 'start' }} />
-      <TextArea label="Text area 2" />
-      <TextArea label="Text area 3" style={{ alignSelf: 'end' }} />
+      <div className="layout-item" style={{ alignSelf: 'start' }}>Item 1</div>
+      <div className="layout-item">Item 2</div>
+      <div className="layout-item" style={{ alignSelf: 'end' }}>Item 3</div>
     </HorizontalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-individual-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-individual-alignment.tsx
@@ -11,9 +11,9 @@ function Example() {
       className="height-4xl"
       style={{ alignItems: 'stretch' }}
     >
-      <div className="layout-item" style={{ alignSelf: 'start' }}>Item 1</div>
-      <div className="layout-item">Item 2</div>
-      <div className="layout-item" style={{ alignSelf: 'end' }}>Item 3</div>
+      <div className="example-item" style={{ alignSelf: 'start' }}>Item 1</div>
+      <div className="example-item">Item 2</div>
+      <div className="example-item" style={{ alignSelf: 'end' }}>Item 3</div>
     </HorizontalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-margin.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-margin.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
-import { Button, HorizontalLayout } from '@vaadin/react-components';
+import { HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -9,9 +9,9 @@ function Example() {
       <p>Horizontal layout without margin:</p>
       <div className="container">
         <HorizontalLayout theme="spacing padding">
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button>Button 3</Button>
+          <div className="layout-item">Item 1</div>
+          <div className="layout-item">Item 2</div>
+          <div className="layout-item">Item 3</div>
         </HorizontalLayout>
       </div>
 
@@ -20,9 +20,9 @@ function Example() {
         {/* tag::snippet[] */}
         <HorizontalLayout theme="margin spacing padding">
           {/* end::snippet[] */}
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button>Button 3</Button>
+          <div className="layout-item">Item 1</div>
+          <div className="layout-item">Item 2</div>
+          <div className="layout-item">Item 3</div>
           {/* tag::snippet[] */}
         </HorizontalLayout>
         {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-margin.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-margin.tsx
@@ -9,9 +9,9 @@ function Example() {
       <p>Horizontal layout without margin:</p>
       <div className="container">
         <HorizontalLayout theme="spacing padding">
-          <div className="layout-item">Item 1</div>
-          <div className="layout-item">Item 2</div>
-          <div className="layout-item">Item 3</div>
+          <div className="example-item">Item 1</div>
+          <div className="example-item">Item 2</div>
+          <div className="example-item">Item 3</div>
         </HorizontalLayout>
       </div>
 
@@ -20,9 +20,9 @@ function Example() {
         {/* tag::snippet[] */}
         <HorizontalLayout theme="margin spacing padding">
           {/* end::snippet[] */}
-          <div className="layout-item">Item 1</div>
-          <div className="layout-item">Item 2</div>
-          <div className="layout-item">Item 3</div>
+          <div className="example-item">Item 1</div>
+          <div className="example-item">Item 2</div>
+          <div className="example-item">Item 3</div>
           {/* tag::snippet[] */}
         </HorizontalLayout>
         {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-padding.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-padding.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
-import { Button, HorizontalLayout } from '@vaadin/react-components';
+import { HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -8,18 +8,18 @@ function Example() {
     <>
       <p>Horizontal layout without padding:</p>
       <HorizontalLayout theme="spacing">
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
+        <div className="layout-item">Item 1</div>
+        <div className="layout-item">Item 2</div>
+        <div className="layout-item">Item 3</div>
       </HorizontalLayout>
 
       <p>Horizontal layout with padding:</p>
       {/* tag::snippet[] */}
       <HorizontalLayout theme="padding spacing">
         {/* end::snippet[] */}
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
+        <div className="layout-item">Item 1</div>
+        <div className="layout-item">Item 2</div>
+        <div className="layout-item">Item 3</div>
         {/* tag::snippet[] */}
       </HorizontalLayout>
       {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-padding.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-padding.tsx
@@ -8,18 +8,18 @@ function Example() {
     <>
       <p>Horizontal layout without padding:</p>
       <HorizontalLayout theme="spacing">
-        <div className="layout-item">Item 1</div>
-        <div className="layout-item">Item 2</div>
-        <div className="layout-item">Item 3</div>
+        <div className="example-item">Item 1</div>
+        <div className="example-item">Item 2</div>
+        <div className="example-item">Item 3</div>
       </HorizontalLayout>
 
       <p>Horizontal layout with padding:</p>
       {/* tag::snippet[] */}
       <HorizontalLayout theme="padding spacing">
         {/* end::snippet[] */}
-        <div className="layout-item">Item 1</div>
-        <div className="layout-item">Item 2</div>
-        <div className="layout-item">Item 3</div>
+        <div className="example-item">Item 1</div>
+        <div className="example-item">Item 2</div>
+        <div className="example-item">Item 3</div>
         {/* tag::snippet[] */}
       </HorizontalLayout>
       {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-spacing.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-spacing.tsx
@@ -8,18 +8,18 @@ function Example() {
     <div>
       <p>Horizontal layout without spacing:</p>
       <HorizontalLayout theme="padding">
-        <div className="layout-item">Item 1</div>
-        <div className="layout-item">Item 2</div>
-        <div className="layout-item">Item 3</div>
+        <div className="example-item">Item 1</div>
+        <div className="example-item">Item 2</div>
+        <div className="example-item">Item 3</div>
       </HorizontalLayout>
 
       <p>Horizontal layout with spacing:</p>
       {/* tag::snippet[] */}
       <HorizontalLayout theme="spacing padding">
         {/* end::snippet[] */}
-        <div className="layout-item">Item 1</div>
-        <div className="layout-item">Item 2</div>
-        <div className="layout-item">Item 3</div>
+        <div className="example-item">Item 1</div>
+        <div className="example-item">Item 2</div>
+        <div className="example-item">Item 3</div>
         {/* tag::snippet[] */}
       </HorizontalLayout>
       {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-spacing.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-spacing.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
-import { Button, HorizontalLayout } from '@vaadin/react-components';
+import { HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -8,18 +8,18 @@ function Example() {
     <div>
       <p>Horizontal layout without spacing:</p>
       <HorizontalLayout theme="padding">
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
+        <div className="layout-item">Item 1</div>
+        <div className="layout-item">Item 2</div>
+        <div className="layout-item">Item 3</div>
       </HorizontalLayout>
 
       <p>Horizontal layout with spacing:</p>
       {/* tag::snippet[] */}
       <HorizontalLayout theme="spacing padding">
         {/* end::snippet[] */}
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
+        <div className="layout-item">Item 1</div>
+        <div className="layout-item">Item 2</div>
+        <div className="layout-item">Item 3</div>
         {/* tag::snippet[] */}
       </HorizontalLayout>
       {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-vertical-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-vertical-alignment.tsx
@@ -1,7 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { TextArea } from '@vaadin/react-components';
-import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout';
+import { HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -12,9 +11,9 @@ function Example() {
       className="height-4xl"
       style={{ alignItems: 'center' }}
     >
-      <TextArea label="Text area 1" />
-      <TextArea label="Text area 2" />
-      <TextArea label="Text area 3" />
+      <div className="layout-item">Item 1</div>
+      <div className="layout-item">Item 2</div>
+      <div className="layout-item">Item 3</div>
     </HorizontalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-vertical-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-vertical-alignment.tsx
@@ -11,9 +11,9 @@ function Example() {
       className="height-4xl"
       style={{ alignItems: 'center' }}
     >
-      <div className="layout-item">Item 1</div>
-      <div className="layout-item">Item 2</div>
-      <div className="layout-item">Item 3</div>
+      <div className="example-item">Item 1</div>
+      <div className="example-item">Item 2</div>
+      <div className="example-item">Item 3</div>
     </HorizontalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-wrapping.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-wrapping.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import { Button, HorizontalLayout } from '@vaadin/react-components';
+import { HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -10,11 +10,11 @@ function Example() {
         theme="spacing margin padding"
         style={{ alignItems: 'stretch', width: '350px' }}
       >
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
-        <Button>Button 4</Button>
-        <Button>Button 5</Button>
+        <div className="layout-item">Item 1</div>
+        <div className="layout-item">Item 2</div>
+        <div className="layout-item">Item 3</div>
+        <div className="layout-item">Item 4</div>
+        <div className="layout-item">Item 5</div>
       </HorizontalLayout>
       <p>Horizontal layout with wrapping:</p>
       {/* tag::snippet[] */}
@@ -23,11 +23,11 @@ function Example() {
         style={{ alignItems: 'stretch', width: '350px' }}
       >
         {/* end::snippet[] */}
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
-        <Button>Button 4</Button>
-        <Button>Button 5</Button>
+        <div className="layout-item">Item 1</div>
+        <div className="layout-item">Item 2</div>
+        <div className="layout-item">Item 3</div>
+        <div className="layout-item">Item 4</div>
+        <div className="layout-item">Item 5</div>
         {/* tag::snippet[] */}
       </HorizontalLayout>
       {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-wrapping.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout-wrapping.tsx
@@ -10,11 +10,11 @@ function Example() {
         theme="spacing margin padding"
         style={{ alignItems: 'stretch', width: '350px' }}
       >
-        <div className="layout-item">Item 1</div>
-        <div className="layout-item">Item 2</div>
-        <div className="layout-item">Item 3</div>
-        <div className="layout-item">Item 4</div>
-        <div className="layout-item">Item 5</div>
+        <div className="example-item">Item 1</div>
+        <div className="example-item">Item 2</div>
+        <div className="example-item">Item 3</div>
+        <div className="example-item">Item 4</div>
+        <div className="example-item">Item 5</div>
       </HorizontalLayout>
       <p>Horizontal layout with wrapping:</p>
       {/* tag::snippet[] */}
@@ -23,11 +23,11 @@ function Example() {
         style={{ alignItems: 'stretch', width: '350px' }}
       >
         {/* end::snippet[] */}
-        <div className="layout-item">Item 1</div>
-        <div className="layout-item">Item 2</div>
-        <div className="layout-item">Item 3</div>
-        <div className="layout-item">Item 4</div>
-        <div className="layout-item">Item 5</div>
+        <div className="example-item">Item 1</div>
+        <div className="example-item">Item 2</div>
+        <div className="example-item">Item 3</div>
+        <div className="example-item">Item 4</div>
+        <div className="example-item">Item 5</div>
         {/* tag::snippet[] */}
       </HorizontalLayout>
       {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout.tsx
@@ -1,15 +1,15 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { Button, HorizontalLayout } from '@vaadin/react-components';
+import { HorizontalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
   return (
     // tag::snippet[]
     <HorizontalLayout theme="spacing padding">
-      <Button>Button 1</Button>
-      <Button>Button 2</Button>
-      <Button>Button 3</Button>
+      <div className="layout-item">Item 1</div>
+      <div className="layout-item">Item 2</div>
+      <div className="layout-item">Item 3</div>
     </HorizontalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-horizontal-layout.tsx
@@ -7,9 +7,9 @@ function Example() {
   return (
     // tag::snippet[]
     <HorizontalLayout theme="spacing padding">
-      <div className="layout-item">Item 1</div>
-      <div className="layout-item">Item 2</div>
-      <div className="layout-item">Item 3</div>
+      <div className="example-item">Item 1</div>
+      <div className="example-item">Item 2</div>
+      <div className="example-item">Item 3</div>
     </HorizontalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-margin.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-margin.tsx
@@ -10,9 +10,9 @@ function Example() {
         <p>Vertical layout without margin:</p>
         <div className="container">
           <VerticalLayout theme="spacing padding" style={{ alignItems: 'stretch' }}>
-            <div className="layout-item">Item 1</div>
-            <div className="layout-item">Item 2</div>
-            <div className="layout-item">Item 3</div>
+            <div className="example-item">Item 1</div>
+            <div className="example-item">Item 2</div>
+            <div className="example-item">Item 3</div>
           </VerticalLayout>
         </div>
       </div>
@@ -22,9 +22,9 @@ function Example() {
           {/* tag::snippet[] */}
           <VerticalLayout theme="margin spacing padding" style={{ alignItems: 'stretch' }}>
             {/* end::snippet[] */}
-            <div className="layout-item">Item 1</div>
-            <div className="layout-item">Item 2</div>
-            <div className="layout-item">Item 3</div>
+            <div className="example-item">Item 1</div>
+            <div className="example-item">Item 2</div>
+            <div className="example-item">Item 3</div>
             {/* tag::snippet[] */}
           </VerticalLayout>
           {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-margin.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-margin.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
-import { Button, HorizontalLayout, VerticalLayout } from '@vaadin/react-components';
+import { HorizontalLayout, VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -10,9 +10,9 @@ function Example() {
         <p>Vertical layout without margin:</p>
         <div className="container">
           <VerticalLayout theme="spacing padding" style={{ alignItems: 'stretch' }}>
-            <Button>Button 1</Button>
-            <Button>Button 2</Button>
-            <Button>Button 3</Button>
+            <div className="layout-item">Item 1</div>
+            <div className="layout-item">Item 2</div>
+            <div className="layout-item">Item 3</div>
           </VerticalLayout>
         </div>
       </div>
@@ -22,9 +22,9 @@ function Example() {
           {/* tag::snippet[] */}
           <VerticalLayout theme="margin spacing padding" style={{ alignItems: 'stretch' }}>
             {/* end::snippet[] */}
-            <Button>Button 1</Button>
-            <Button>Button 2</Button>
-            <Button>Button 3</Button>
+            <div className="layout-item">Item 1</div>
+            <div className="layout-item">Item 2</div>
+            <div className="layout-item">Item 3</div>
             {/* tag::snippet[] */}
           </VerticalLayout>
           {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-padding.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-padding.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
-import { Button, HorizontalLayout, VerticalLayout } from '@vaadin/react-components';
+import { HorizontalLayout, VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -9,9 +9,9 @@ function Example() {
       <div style={{ width: '100%' }}>
         <p>Vertical layout without padding:</p>
         <VerticalLayout theme="spacing" style={{ alignItems: 'stretch' }}>
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button>Button 3</Button>
+          <div className="layout-item">Item 1</div>
+          <div className="layout-item">Item 2</div>
+          <div className="layout-item">Item 3</div>
         </VerticalLayout>
       </div>
       <div style={{ width: '100%' }}>
@@ -19,9 +19,9 @@ function Example() {
         {/* tag::snippet[] */}
         <VerticalLayout theme="padding spacing" style={{ alignItems: 'stretch' }}>
           {/* end::snippet[] */}
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button>Button 3</Button>
+          <div className="layout-item">Item 1</div>
+          <div className="layout-item">Item 2</div>
+          <div className="layout-item">Item 3</div>
           {/* tag::snippet[] */}
         </VerticalLayout>
         {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-padding.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-padding.tsx
@@ -9,9 +9,9 @@ function Example() {
       <div style={{ width: '100%' }}>
         <p>Vertical layout without padding:</p>
         <VerticalLayout theme="spacing" style={{ alignItems: 'stretch' }}>
-          <div className="layout-item">Item 1</div>
-          <div className="layout-item">Item 2</div>
-          <div className="layout-item">Item 3</div>
+          <div className="example-item">Item 1</div>
+          <div className="example-item">Item 2</div>
+          <div className="example-item">Item 3</div>
         </VerticalLayout>
       </div>
       <div style={{ width: '100%' }}>
@@ -19,9 +19,9 @@ function Example() {
         {/* tag::snippet[] */}
         <VerticalLayout theme="padding spacing" style={{ alignItems: 'stretch' }}>
           {/* end::snippet[] */}
-          <div className="layout-item">Item 1</div>
-          <div className="layout-item">Item 2</div>
-          <div className="layout-item">Item 3</div>
+          <div className="example-item">Item 1</div>
+          <div className="example-item">Item 2</div>
+          <div className="example-item">Item 3</div>
           {/* tag::snippet[] */}
         </VerticalLayout>
         {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-spacing.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-spacing.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
-import { Button, HorizontalLayout, VerticalLayout } from '@vaadin/react-components';
+import { HorizontalLayout, VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle';
 
 function Example() {
@@ -9,9 +9,9 @@ function Example() {
       <div style={{ width: '100%' }}>
         <p>Vertical layout without spacing:</p>
         <VerticalLayout theme="padding" style={{ alignItems: 'stretch' }}>
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button>Button 3</Button>
+          <div className="layout-item">Item 1</div>
+          <div className="layout-item">Item 2</div>
+          <div className="layout-item">Item 3</div>
         </VerticalLayout>
       </div>
       <div style={{ width: '100%' }}>
@@ -19,9 +19,9 @@ function Example() {
         {/* tag::snippet[] */}
         <VerticalLayout theme="spacing padding" style={{ alignItems: 'stretch' }}>
           {/* end::snippet[] */}
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button>Button 3</Button>
+          <div className="layout-item">Item 1</div>
+          <div className="layout-item">Item 2</div>
+          <div className="layout-item">Item 3</div>
           {/* tag::snippet[] */}
         </VerticalLayout>
         {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-spacing.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-spacing.tsx
@@ -9,9 +9,9 @@ function Example() {
       <div style={{ width: '100%' }}>
         <p>Vertical layout without spacing:</p>
         <VerticalLayout theme="padding" style={{ alignItems: 'stretch' }}>
-          <div className="layout-item">Item 1</div>
-          <div className="layout-item">Item 2</div>
-          <div className="layout-item">Item 3</div>
+          <div className="example-item">Item 1</div>
+          <div className="example-item">Item 2</div>
+          <div className="example-item">Item 3</div>
         </VerticalLayout>
       </div>
       <div style={{ width: '100%' }}>
@@ -19,9 +19,9 @@ function Example() {
         {/* tag::snippet[] */}
         <VerticalLayout theme="spacing padding" style={{ alignItems: 'stretch' }}>
           {/* end::snippet[] */}
-          <div className="layout-item">Item 1</div>
-          <div className="layout-item">Item 2</div>
-          <div className="layout-item">Item 3</div>
+          <div className="example-item">Item 1</div>
+          <div className="example-item">Item 2</div>
+          <div className="example-item">Item 3</div>
           {/* tag::snippet[] */}
         </VerticalLayout>
         {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-horizontal-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-horizontal-alignment.tsx
@@ -1,15 +1,15 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { Button, VerticalLayout } from '@vaadin/react-components';
+import { VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
   return (
     // tag::snippet[]
     <VerticalLayout theme="spacing padding" style={{ alignItems: 'center' }}>
-      <Button>Button 1</Button>
-      <Button>Button 2</Button>
-      <Button>Button 3</Button>
+      <div className="layout-item">Item 1</div>
+      <div className="layout-item">Item 2</div>
+      <div className="layout-item">Item 3</div>
     </VerticalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-horizontal-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-horizontal-alignment.tsx
@@ -7,9 +7,9 @@ function Example() {
   return (
     // tag::snippet[]
     <VerticalLayout theme="spacing padding" style={{ alignItems: 'center' }}>
-      <div className="layout-item">Item 1</div>
-      <div className="layout-item">Item 2</div>
-      <div className="layout-item">Item 3</div>
+      <div className="example-item">Item 1</div>
+      <div className="example-item">Item 2</div>
+      <div className="example-item">Item 3</div>
     </VerticalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-individual-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-individual-alignment.tsx
@@ -1,17 +1,19 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { Button, VerticalLayout } from '@vaadin/react-components';
+import { VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
   return (
     // tag::snippet[]
     <VerticalLayout theme="spacing padding" style={{ alignItems: 'start' }}>
-      <Button style={{ alignSelf: 'end' }} theme="primary">
-        Button 1
-      </Button>
-      <Button style={{ alignSelf: 'center' }}>Button 2</Button>
-      <Button>Button 3</Button>
+      <div className="layout-item" style={{ alignSelf: 'end' }}>
+        Item 1
+      </div>
+      <div className="layout-item" style={{ alignSelf: 'center' }}>
+        Item 2
+      </div>
+      <div className="layout-item">Item 3</div>
     </VerticalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-individual-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-individual-alignment.tsx
@@ -7,13 +7,13 @@ function Example() {
   return (
     // tag::snippet[]
     <VerticalLayout theme="spacing padding" style={{ alignItems: 'start' }}>
-      <div className="layout-item" style={{ alignSelf: 'end' }}>
+      <div className="example-item" style={{ alignSelf: 'end' }}>
         Item 1
       </div>
-      <div className="layout-item" style={{ alignSelf: 'center' }}>
+      <div className="example-item" style={{ alignSelf: 'center' }}>
         Item 2
       </div>
-      <div className="layout-item">Item 3</div>
+      <div className="example-item">Item 3</div>
     </VerticalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-vertical-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-vertical-alignment.tsx
@@ -1,6 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { Button, VerticalLayout } from '@vaadin/react-components';
+import { VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -11,9 +11,9 @@ function Example() {
       className="height-4xl"
       style={{ justifyContent: 'center' }}
     >
-      <Button>Button 1</Button>
-      <Button>Button 2</Button>
-      <Button>Button 3</Button>
+      <div className="layout-item">Item 1</div>
+      <div className="layout-item">Item 2</div>
+      <div className="layout-item">Item 3</div>
     </VerticalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-vertical-alignment.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-vertical-alignment.tsx
@@ -11,9 +11,9 @@ function Example() {
       className="height-4xl"
       style={{ justifyContent: 'center' }}
     >
-      <div className="layout-item">Item 1</div>
-      <div className="layout-item">Item 2</div>
-      <div className="layout-item">Item 3</div>
+      <div className="example-item">Item 1</div>
+      <div className="example-item">Item 2</div>
+      <div className="example-item">Item 3</div>
     </VerticalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-wrapping.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-wrapping.tsx
@@ -8,10 +8,10 @@ function Example() {
       <div style={{ width: '100%' }}>
         <p>Vertical layout without wrapping:</p>
         <VerticalLayout theme="spacing padding" style={{ alignItems: 'stretch', height: '200px' }}>
-          <div className="layout-item">Item 1</div>
-          <div className="layout-item">Item 2</div>
-          <div className="layout-item">Item 3</div>
-          <div className="layout-item">Item 4</div>
+          <div className="example-item">Item 1</div>
+          <div className="example-item">Item 2</div>
+          <div className="example-item">Item 3</div>
+          <div className="example-item">Item 4</div>
         </VerticalLayout>
       </div>
       <div style={{ width: '100%' }}>
@@ -22,10 +22,10 @@ function Example() {
           style={{ alignItems: 'stretch', height: '200px' }}
         >
           {/* end::snippet[] */}
-          <div className="layout-item">Item 1</div>
-          <div className="layout-item">Item 2</div>
-          <div className="layout-item">Item 3</div>
-          <div className="layout-item">Item 4</div>
+          <div className="example-item">Item 1</div>
+          <div className="example-item">Item 2</div>
+          <div className="example-item">Item 3</div>
+          <div className="example-item">Item 4</div>
           {/* tag::snippet[] */}
         </VerticalLayout>
         {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-wrapping.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout-wrapping.tsx
@@ -1,5 +1,5 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import { Button, HorizontalLayout, VerticalLayout } from '@vaadin/react-components';
+import { HorizontalLayout, VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
@@ -8,10 +8,10 @@ function Example() {
       <div style={{ width: '100%' }}>
         <p>Vertical layout without wrapping:</p>
         <VerticalLayout theme="spacing padding" style={{ alignItems: 'stretch', height: '200px' }}>
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button>Button 3</Button>
-          <Button>Button 4</Button>
+          <div className="layout-item">Item 1</div>
+          <div className="layout-item">Item 2</div>
+          <div className="layout-item">Item 3</div>
+          <div className="layout-item">Item 4</div>
         </VerticalLayout>
       </div>
       <div style={{ width: '100%' }}>
@@ -22,10 +22,10 @@ function Example() {
           style={{ alignItems: 'stretch', height: '200px' }}
         >
           {/* end::snippet[] */}
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button>Button 3</Button>
-          <Button>Button 4</Button>
+          <div className="layout-item">Item 1</div>
+          <div className="layout-item">Item 2</div>
+          <div className="layout-item">Item 3</div>
+          <div className="layout-item">Item 4</div>
           {/* tag::snippet[] */}
         </VerticalLayout>
         {/* end::snippet[] */}

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout.tsx
@@ -1,15 +1,15 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { Button, VerticalLayout } from '@vaadin/react-components';
+import { VerticalLayout } from '@vaadin/react-components';
 import layoutExampleStyle from './layoutExampleStyle'; // hidden-source-line
 
 function Example() {
   return (
     // tag::snippet[]
     <VerticalLayout theme="spacing padding">
-      <Button>Button 1</Button>
-      <Button>Button 2</Button>
-      <Button>Button 3</Button>
+      <div className="layout-item">Item 1</div>
+      <div className="layout-item">Item 2</div>
+      <div className="layout-item">Item 3</div>
     </VerticalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout.tsx
+++ b/frontend/demo/component/basiclayouts/react/basic-layouts-vertical-layout.tsx
@@ -7,9 +7,9 @@ function Example() {
   return (
     // tag::snippet[]
     <VerticalLayout theme="spacing padding">
-      <div className="layout-item">Item 1</div>
-      <div className="layout-item">Item 2</div>
-      <div className="layout-item">Item 3</div>
+      <div className="example-item">Item 1</div>
+      <div className="example-item">Item 2</div>
+      <div className="example-item">Item 3</div>
     </VerticalLayout>
     // end::snippet[]
   );

--- a/frontend/demo/component/basiclayouts/react/layoutExampleStyle.ts
+++ b/frontend/demo/component/basiclayouts/react/layoutExampleStyle.ts
@@ -22,7 +22,7 @@ const layoutExampleStyles = css`
     border-radius: var(--lumo-border-radius-l);
   }
 
-  .layout-item {
+  .example-item {
     background: var(--lumo-primary-color);
     color: var(--lumo-primary-contrast-color);
     border-radius: var(--lumo-border-radius-m);

--- a/frontend/demo/component/basiclayouts/react/layoutExampleStyle.ts
+++ b/frontend/demo/component/basiclayouts/react/layoutExampleStyle.ts
@@ -21,6 +21,14 @@ const layoutExampleStyles = css`
     border: 1px solid var(--lumo-success-color);
     border-radius: var(--lumo-border-radius-l);
   }
+
+  .layout-item {
+    background: var(--lumo-primary-color);
+    color: var(--lumo-primary-contrast-color);
+    border-radius: var(--lumo-border-radius-m);
+    padding: var(--lumo-space-s) var(--lumo-space-l);
+    white-space: nowrap;
+  }
 `;
 
 export default layoutExampleStyles;

--- a/frontend/themes/docs/basic-layouts.css
+++ b/frontend/themes/docs/basic-layouts.css
@@ -25,3 +25,12 @@
     border: 1px solid var(--lumo-success-color);
     border-radius: var(--lumo-border-radius-l);
 }
+
+.basic-layouts-example .layout-item,
+:host(.basic-layouts-example) .layout-item {
+    background: var(--lumo-primary-color);
+    color: var(--lumo-primary-contrast-color);
+    border-radius: var(--lumo-border-radius-m);
+    padding: var(--lumo-space-s) var(--lumo-space-l);
+    white-space: nowrap;
+}

--- a/frontend/themes/docs/basic-layouts.css
+++ b/frontend/themes/docs/basic-layouts.css
@@ -26,8 +26,8 @@
     border-radius: var(--lumo-border-radius-l);
 }
 
-.basic-layouts-example .layout-item,
-:host(.basic-layouts-example) .layout-item {
+.basic-layouts-example .example-item,
+:host(.basic-layouts-example) .example-item {
     background: var(--lumo-primary-color);
     color: var(--lumo-primary-contrast-color);
     border-radius: var(--lumo-border-radius-m);

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsExpandingItems.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsExpandingItems.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 
@@ -11,16 +10,23 @@ public class BasicLayoutsExpandingItems extends Div {
 
     public BasicLayoutsExpandingItems() {
         // tag::snippet[]
-        Button button1 = new Button("Button 1");
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
         HorizontalLayout layout = new HorizontalLayout();
-        layout.setFlexGrow(1, button1);
+        layout.setFlexGrow(1, item1);
         // end::snippet[]
         layout.setPadding(true);
-        layout.add(button1);
-        layout.add(new Button("Button 2"));
-        layout.add(new Button("Button 3"));
+        layout.add(item1);
+        
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        layout.add(item2);
+        
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+        layout.add(item3);
+        
         this.add(layout);
-
         this.setClassName("basic-layouts-example");
     }
 

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsExpandingItems.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsExpandingItems.java
@@ -11,7 +11,7 @@ public class BasicLayoutsExpandingItems extends Div {
     public BasicLayoutsExpandingItems() {
         // tag::snippet[]
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         HorizontalLayout layout = new HorizontalLayout();
         layout.setFlexGrow(1, item1);
         // end::snippet[]
@@ -19,11 +19,11 @@ public class BasicLayoutsExpandingItems extends Div {
         layout.add(item1);
         
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         layout.add(item2);
         
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
         layout.add(item3);
         
         this.add(layout);

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayout.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayout.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 
@@ -12,13 +11,20 @@ public class BasicLayoutsHorizontalLayout extends Div {
         // tag::snippet[]
         HorizontalLayout layout = new HorizontalLayout();
         layout.setPadding(true);
-        layout.add(new Button("Button 1"));
-        layout.add(new Button("Button 2"));
-        layout.add(new Button("Button 3"));
+        
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+        
+        layout.add(item1, item2, item3);
         // end::snippet[]
-
+        
         this.setClassName("basic-layouts-example");
-
         this.add(layout);
     }
 

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayout.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayout.java
@@ -11,19 +11,19 @@ public class BasicLayoutsHorizontalLayout extends Div {
         // tag::snippet[]
         HorizontalLayout layout = new HorizontalLayout();
         layout.setPadding(true);
-        
+
         Div item1 = new Div("Item 1");
         item1.setClassName("example-item");
-        
+
         Div item2 = new Div("Item 2");
         item2.setClassName("example-item");
-        
+
         Div item3 = new Div("Item 3");
         item3.setClassName("example-item");
-        
+
         layout.add(item1, item2, item3);
         // end::snippet[]
-        
+
         this.setClassName("basic-layouts-example");
         this.add(layout);
     }

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayout.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayout.java
@@ -13,13 +13,13 @@ public class BasicLayoutsHorizontalLayout extends Div {
         layout.setPadding(true);
         
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
         
         layout.add(item1, item2, item3);
         // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutHorizontalAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutHorizontalAlignment.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -15,9 +14,17 @@ public class BasicLayoutsHorizontalLayoutHorizontalAlignment extends Div {
         HorizontalLayout layout = new HorizontalLayout();
         layout.setPadding(true);
         layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
-        layout.add(new Button("Button 1"));
-        layout.add(new Button("Button 2"));
-        layout.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layout.add(item1, item2, item3);
         // end::layout[]
 
         this.setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutHorizontalAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutHorizontalAlignment.java
@@ -16,13 +16,13 @@ public class BasicLayoutsHorizontalLayoutHorizontalAlignment extends Div {
         layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
 
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
 
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layout.add(item1, item2, item3);
         // end::layout[]

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutIndividualAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutIndividualAlignment.java
@@ -16,16 +16,16 @@ public class BasicLayoutsHorizontalLayoutIndividualAlignment extends Div {
         layout.setAlignItems(FlexComponent.Alignment.STRETCH);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         layout.add(item1);
         layout.setAlignSelf(FlexComponent.Alignment.START, item1);
 
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         layout.add(item2);
 
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
         layout.add(item3);
         layout.setAlignSelf(FlexComponent.Alignment.END, item3);
         // end::layout[]

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutIndividualAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutIndividualAlignment.java
@@ -4,7 +4,6 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.router.Route;
 
 @Route("basic-layouts/horizontal-layout-individual-alignment")
@@ -12,16 +11,23 @@ public class BasicLayoutsHorizontalLayoutIndividualAlignment extends Div {
 
     public BasicLayoutsHorizontalLayoutIndividualAlignment() {
         // tag::layout[]
-        TextArea textArea1 = new TextArea("Text area 1");
         HorizontalLayout layout = new HorizontalLayout();
         layout.setPadding(true);
         layout.setAlignItems(FlexComponent.Alignment.STRETCH);
-        layout.add(textArea1);
-        layout.setAlignSelf(FlexComponent.Alignment.START, textArea1);
-        layout.add(new TextArea("Text area 2"));
-        TextArea textArea3 = new TextArea("Text area 3");
-        layout.add(textArea3);
-        layout.setAlignSelf(FlexComponent.Alignment.END, textArea3);
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        layout.add(item1);
+        layout.setAlignSelf(FlexComponent.Alignment.START, item1);
+
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        layout.add(item2);
+
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+        layout.add(item3);
+        layout.setAlignSelf(FlexComponent.Alignment.END, item3);
         // end::layout[]
 
         this.setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutMargin.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutMargin.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -15,9 +14,15 @@ public class BasicLayoutsHorizontalLayoutMargin extends Div {
         HorizontalLayout layoutWithoutMargin = new HorizontalLayout();
         layoutWithoutMargin.setPadding(true);
         layoutWithoutMargin.setWidth("auto");
-        layoutWithoutMargin.add(new Button("Button 1"));
-        layoutWithoutMargin.add(new Button("Button 2"));
-        layoutWithoutMargin.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layoutWithoutMargin.add(item1, item2, item3);
 
         Div container2 = new Div();
         container2.setClassName("container");
@@ -31,9 +36,15 @@ public class BasicLayoutsHorizontalLayoutMargin extends Div {
         // end::snippet[]
         layoutWithMargin.setPadding(true);
         layoutWithMargin.setWidth("auto");
-        layoutWithMargin.add(new Button("Button 1"));
-        layoutWithMargin.add(new Button("Button 2"));
-        layoutWithMargin.add(new Button("Button 3"));
+
+        Div marginItem1 = new Div("Item 1");
+        marginItem1.setClassName("layout-item");
+        Div marginItem2 = new Div("Item 2");
+        marginItem2.setClassName("layout-item");
+        Div marginItem3 = new Div("Item 3");
+        marginItem3.setClassName("layout-item");
+
+        layoutWithMargin.add(marginItem1, marginItem2, marginItem3);
 
         Div container1 = new Div();
         container1.setClassName("container");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutMargin.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutMargin.java
@@ -16,11 +16,11 @@ public class BasicLayoutsHorizontalLayoutMargin extends Div {
         layoutWithoutMargin.setWidth("auto");
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layoutWithoutMargin.add(item1, item2, item3);
 
@@ -38,11 +38,11 @@ public class BasicLayoutsHorizontalLayoutMargin extends Div {
         layoutWithMargin.setWidth("auto");
 
         Div marginItem1 = new Div("Item 1");
-        marginItem1.setClassName("layout-item");
+        marginItem1.setClassName("example-item");
         Div marginItem2 = new Div("Item 2");
-        marginItem2.setClassName("layout-item");
+        marginItem2.setClassName("example-item");
         Div marginItem3 = new Div("Item 3");
-        marginItem3.setClassName("layout-item");
+        marginItem3.setClassName("example-item");
 
         layoutWithMargin.add(marginItem1, marginItem2, marginItem3);
 

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutPadding.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutPadding.java
@@ -14,11 +14,11 @@ public class BasicLayoutsHorizontalLayoutPadding extends Div {
         HorizontalLayout layoutWithoutPadding = new HorizontalLayout();
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layoutWithoutPadding.add(item1, item2, item3);
         this.add(layoutWithoutPadding);
@@ -30,11 +30,11 @@ public class BasicLayoutsHorizontalLayoutPadding extends Div {
         // end::snippet[]
 
         Div paddingItem1 = new Div("Item 1");
-        paddingItem1.setClassName("layout-item");
+        paddingItem1.setClassName("example-item");
         Div paddingItem2 = new Div("Item 2");
-        paddingItem2.setClassName("layout-item");
+        paddingItem2.setClassName("example-item");
         Div paddingItem3 = new Div("Item 3");
-        paddingItem3.setClassName("layout-item");
+        paddingItem3.setClassName("example-item");
 
         layoutWithPadding.add(paddingItem1, paddingItem2, paddingItem3);
         this.add(layoutWithPadding);

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutPadding.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutPadding.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -13,9 +12,15 @@ public class BasicLayoutsHorizontalLayoutPadding extends Div {
     public BasicLayoutsHorizontalLayoutPadding() {
         add(new Paragraph("Horizontal layout without padding:"));
         HorizontalLayout layoutWithoutPadding = new HorizontalLayout();
-        layoutWithoutPadding.add(new Button("Button 1"));
-        layoutWithoutPadding.add(new Button("Button 2"));
-        layoutWithoutPadding.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layoutWithoutPadding.add(item1, item2, item3);
         this.add(layoutWithoutPadding);
 
         add(new Paragraph("Horizontal layout with padding:"));
@@ -23,9 +28,15 @@ public class BasicLayoutsHorizontalLayoutPadding extends Div {
         HorizontalLayout layoutWithPadding = new HorizontalLayout();
         layoutWithPadding.setPadding(true);
         // end::snippet[]
-        layoutWithPadding.add(new Button("Button 1"));
-        layoutWithPadding.add(new Button("Button 2"));
-        layoutWithPadding.add(new Button("Button 3"));
+
+        Div paddingItem1 = new Div("Item 1");
+        paddingItem1.setClassName("layout-item");
+        Div paddingItem2 = new Div("Item 2");
+        paddingItem2.setClassName("layout-item");
+        Div paddingItem3 = new Div("Item 3");
+        paddingItem3.setClassName("layout-item");
+
+        layoutWithPadding.add(paddingItem1, paddingItem2, paddingItem3);
         this.add(layoutWithPadding);
 
         this.setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacing.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacing.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
@@ -18,17 +17,29 @@ public class BasicLayoutsHorizontalLayoutSpacing extends Div {
         layoutWithoutSpacing.setSpacing(false);
         // end::snippet[]
         layoutWithoutSpacing.setPadding(true);
-        layoutWithoutSpacing.add(new Button("Button 1"));
-        layoutWithoutSpacing.add(new Button("Button 2"));
-        layoutWithoutSpacing.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layoutWithoutSpacing.add(item1, item2, item3);
         add(layoutWithoutSpacing);
 
         add(new Paragraph("Horizontal layout with spacing:"));
         HorizontalLayout layoutWithSpacing = new HorizontalLayout();
         layoutWithSpacing.setPadding(true);
-        layoutWithSpacing.add(new Button("Button 1"));
-        layoutWithSpacing.add(new Button("Button 2"));
-        layoutWithSpacing.add(new Button("Button 3"));
+
+        Div spacingItem1 = new Div("Item 1");
+        spacingItem1.setClassName("layout-item");
+        Div spacingItem2 = new Div("Item 2");
+        spacingItem2.setClassName("layout-item");
+        Div spacingItem3 = new Div("Item 3");
+        spacingItem3.setClassName("layout-item");
+
+        layoutWithSpacing.add(spacingItem1, spacingItem2, spacingItem3);
         add(layoutWithSpacing);
 
         this.setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacing.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutSpacing.java
@@ -19,11 +19,11 @@ public class BasicLayoutsHorizontalLayoutSpacing extends Div {
         layoutWithoutSpacing.setPadding(true);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layoutWithoutSpacing.add(item1, item2, item3);
         add(layoutWithoutSpacing);
@@ -33,11 +33,11 @@ public class BasicLayoutsHorizontalLayoutSpacing extends Div {
         layoutWithSpacing.setPadding(true);
 
         Div spacingItem1 = new Div("Item 1");
-        spacingItem1.setClassName("layout-item");
+        spacingItem1.setClassName("example-item");
         Div spacingItem2 = new Div("Item 2");
-        spacingItem2.setClassName("layout-item");
+        spacingItem2.setClassName("example-item");
         Div spacingItem3 = new Div("Item 3");
-        spacingItem3.setClassName("layout-item");
+        spacingItem3.setClassName("example-item");
 
         layoutWithSpacing.add(spacingItem1, spacingItem2, spacingItem3);
         add(layoutWithSpacing);

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutVerticalAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutVerticalAlignment.java
@@ -16,13 +16,13 @@ public class BasicLayoutsHorizontalLayoutVerticalAlignment extends Div {
         layout.setAlignItems(FlexComponent.Alignment.CENTER);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
 
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
 
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layout.add(item1, item2, item3);
         // end::layout[]

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutVerticalAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutVerticalAlignment.java
@@ -4,7 +4,6 @@ import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.router.Route;
 
 @Route("basic-layouts/horizontal-layout-vertical-alignment")
@@ -15,9 +14,17 @@ public class BasicLayoutsHorizontalLayoutVerticalAlignment extends Div {
         HorizontalLayout layout = new HorizontalLayout();
         layout.setPadding(true);
         layout.setAlignItems(FlexComponent.Alignment.CENTER);
-        layout.add(new TextArea("Text area 1"));
-        layout.add(new TextArea("Text area 2"));
-        layout.add(new TextArea("Text area 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layout.add(item1, item2, item3);
         // end::layout[]
 
         this.setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutWrapping.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutWrapping.java
@@ -18,15 +18,15 @@ public class BasicLayoutsHorizontalLayoutWrapping extends Div {
         layoutWithoutWrap.setWidth("350px");
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
         Div item4 = new Div("Item 4");
-        item4.setClassName("layout-item");
+        item4.setClassName("example-item");
         Div item5 = new Div("Item 5");
-        item5.setClassName("layout-item");
+        item5.setClassName("example-item");
 
         layoutWithoutWrap.add(item1, item2, item3, item4, item5);
         this.add(layoutWithoutWrap);
@@ -42,15 +42,15 @@ public class BasicLayoutsHorizontalLayoutWrapping extends Div {
         layoutWithWrap.setWidth("350px");
 
         Div wrapItem1 = new Div("Item 1");
-        wrapItem1.setClassName("layout-item");
+        wrapItem1.setClassName("example-item");
         Div wrapItem2 = new Div("Item 2");
-        wrapItem2.setClassName("layout-item");
+        wrapItem2.setClassName("example-item");
         Div wrapItem3 = new Div("Item 3");
-        wrapItem3.setClassName("layout-item");
+        wrapItem3.setClassName("example-item");
         Div wrapItem4 = new Div("Item 4");
-        wrapItem4.setClassName("layout-item");
+        wrapItem4.setClassName("example-item");
         Div wrapItem5 = new Div("Item 5");
-        wrapItem5.setClassName("layout-item");
+        wrapItem5.setClassName("example-item");
 
         layoutWithWrap.add(wrapItem1, wrapItem2, wrapItem3, wrapItem4, wrapItem5);
 

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutWrapping.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsHorizontalLayoutWrapping.java
@@ -3,7 +3,6 @@ package com.vaadin.demo.component.basiclayouts;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Paragraph;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 
@@ -17,11 +16,19 @@ public class BasicLayoutsHorizontalLayoutWrapping extends Div {
         layoutWithoutWrap.setSpacing(true);
         layoutWithoutWrap.setMargin(true);
         layoutWithoutWrap.setWidth("350px");
-        layoutWithoutWrap.add(new Button("Button 1"));
-        layoutWithoutWrap.add(new Button("Button 2"));
-        layoutWithoutWrap.add(new Button("Button 3"));
-        layoutWithoutWrap.add(new Button("Button 4"));
-        layoutWithoutWrap.add(new Button("Button 5"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+        Div item4 = new Div("Item 4");
+        item4.setClassName("layout-item");
+        Div item5 = new Div("Item 5");
+        item5.setClassName("layout-item");
+
+        layoutWithoutWrap.add(item1, item2, item3, item4, item5);
         this.add(layoutWithoutWrap);
 
         add(new Paragraph("Horizontal layout with wrapping:"));
@@ -33,11 +40,19 @@ public class BasicLayoutsHorizontalLayoutWrapping extends Div {
         layoutWithWrap.setPadding(true);
         layoutWithWrap.setSpacing(true);
         layoutWithWrap.setWidth("350px");
-        layoutWithWrap.add(new Button("Button 1"));
-        layoutWithWrap.add(new Button("Button 2"));
-        layoutWithWrap.add(new Button("Button 3"));
-        layoutWithWrap.add(new Button("Button 4"));
-        layoutWithWrap.add(new Button("Button 5"));
+
+        Div wrapItem1 = new Div("Item 1");
+        wrapItem1.setClassName("layout-item");
+        Div wrapItem2 = new Div("Item 2");
+        wrapItem2.setClassName("layout-item");
+        Div wrapItem3 = new Div("Item 3");
+        wrapItem3.setClassName("layout-item");
+        Div wrapItem4 = new Div("Item 4");
+        wrapItem4.setClassName("layout-item");
+        Div wrapItem5 = new Div("Item 5");
+        wrapItem5.setClassName("layout-item");
+
+        layoutWithWrap.add(wrapItem1, wrapItem2, wrapItem3, wrapItem4, wrapItem5);
 
         this.setClassName("basic-layouts-example");
         this.add(layoutWithWrap);

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsMargin.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsMargin.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -29,9 +28,16 @@ public class BasicLayoutsMargin extends Div {
         VerticalLayout layoutWithoutMargin = new VerticalLayout();
         layoutWithoutMargin.setWidth("auto");
         layoutWithoutMargin.setAlignItems(FlexComponent.Alignment.STRETCH);
-        layoutWithoutMargin.add(new Button("Button 1"));
-        layoutWithoutMargin.add(new Button("Button 2"));
-        layoutWithoutMargin.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layoutWithoutMargin.add(item1, item2, item3);
+
         container.add(layoutWithoutMargin);
 
         wrapper = new Div();
@@ -49,9 +55,16 @@ public class BasicLayoutsMargin extends Div {
         // end::snippet[]
         layoutWithMargin.setWidth("auto");
         layoutWithMargin.setAlignItems(FlexComponent.Alignment.STRETCH);
-        layoutWithMargin.add(new Button("Button 1"));
-        layoutWithMargin.add(new Button("Button 2"));
-        layoutWithMargin.add(new Button("Button 3"));
+
+        Div marginItem1 = new Div("Item 1");
+        marginItem1.setClassName("layout-item");
+        Div marginItem2 = new Div("Item 2");
+        marginItem2.setClassName("layout-item");
+        Div marginItem3 = new Div("Item 3");
+        marginItem3.setClassName("layout-item");
+
+        layoutWithMargin.add(marginItem1, marginItem2, marginItem3);
+
         container.add(layoutWithMargin);
 
         setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsMargin.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsMargin.java
@@ -30,11 +30,11 @@ public class BasicLayoutsMargin extends Div {
         layoutWithoutMargin.setAlignItems(FlexComponent.Alignment.STRETCH);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layoutWithoutMargin.add(item1, item2, item3);
 
@@ -57,11 +57,11 @@ public class BasicLayoutsMargin extends Div {
         layoutWithMargin.setAlignItems(FlexComponent.Alignment.STRETCH);
 
         Div marginItem1 = new Div("Item 1");
-        marginItem1.setClassName("layout-item");
+        marginItem1.setClassName("example-item");
         Div marginItem2 = new Div("Item 2");
-        marginItem2.setClassName("layout-item");
+        marginItem2.setClassName("example-item");
         Div marginItem3 = new Div("Item 3");
-        marginItem3.setClassName("layout-item");
+        marginItem3.setClassName("example-item");
 
         layoutWithMargin.add(marginItem1, marginItem2, marginItem3);
 

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsPadding.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsPadding.java
@@ -29,11 +29,11 @@ public class BasicLayoutsPadding extends Div {
         layoutWithoutPadding.setAlignItems(FlexComponent.Alignment.STRETCH);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layoutWithoutPadding.add(item1, item2, item3);
         wrapper.add(layoutWithoutPadding);
@@ -47,11 +47,11 @@ public class BasicLayoutsPadding extends Div {
         layoutWithPadding.setAlignItems(FlexComponent.Alignment.STRETCH);
 
         Div paddingItem1 = new Div("Item 1");
-        paddingItem1.setClassName("layout-item");
+        paddingItem1.setClassName("example-item");
         Div paddingItem2 = new Div("Item 2");
-        paddingItem2.setClassName("layout-item");
+        paddingItem2.setClassName("example-item");
         Div paddingItem3 = new Div("Item 3");
-        paddingItem3.setClassName("layout-item");
+        paddingItem3.setClassName("example-item");
 
         layoutWithPadding.add(paddingItem1, paddingItem2, paddingItem3);
         wrapper.add(layoutWithPadding);

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsPadding.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsPadding.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -28,9 +27,15 @@ public class BasicLayoutsPadding extends Div {
         layoutWithoutPadding.setPadding(false);
         // end::snippet[]
         layoutWithoutPadding.setAlignItems(FlexComponent.Alignment.STRETCH);
-        layoutWithoutPadding.add(new Button("Button 1"));
-        layoutWithoutPadding.add(new Button("Button 2"));
-        layoutWithoutPadding.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layoutWithoutPadding.add(item1, item2, item3);
         wrapper.add(layoutWithoutPadding);
 
         wrapper = new Div();
@@ -40,9 +45,15 @@ public class BasicLayoutsPadding extends Div {
 
         VerticalLayout layoutWithPadding = new VerticalLayout();
         layoutWithPadding.setAlignItems(FlexComponent.Alignment.STRETCH);
-        layoutWithPadding.add(new Button("Button 1"));
-        layoutWithPadding.add(new Button("Button 2"));
-        layoutWithPadding.add(new Button("Button 3"));
+
+        Div paddingItem1 = new Div("Item 1");
+        paddingItem1.setClassName("layout-item");
+        Div paddingItem2 = new Div("Item 2");
+        paddingItem2.setClassName("layout-item");
+        Div paddingItem3 = new Div("Item 3");
+        paddingItem3.setClassName("layout-item");
+
+        layoutWithPadding.add(paddingItem1, paddingItem2, paddingItem3);
         wrapper.add(layoutWithPadding);
 
         setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsSpacing.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsSpacing.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -28,9 +27,15 @@ public class BasicLayoutsSpacing extends Div {
         layoutWithoutSpacing.setSpacing(false);
         // end::snippet[]
         layoutWithoutSpacing.setAlignItems(FlexComponent.Alignment.STRETCH);
-        layoutWithoutSpacing.add(new Button("Button 1"));
-        layoutWithoutSpacing.add(new Button("Button 2"));
-        layoutWithoutSpacing.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layoutWithoutSpacing.add(item1, item2, item3);
         wrapper.add(layoutWithoutSpacing);
 
         wrapper = new Div();
@@ -40,9 +45,15 @@ public class BasicLayoutsSpacing extends Div {
 
         VerticalLayout layoutWithSpacing = new VerticalLayout();
         layoutWithSpacing.setAlignItems(FlexComponent.Alignment.STRETCH);
-        layoutWithSpacing.add(new Button("Button 1"));
-        layoutWithSpacing.add(new Button("Button 2"));
-        layoutWithSpacing.add(new Button("Button 3"));
+
+        Div spacingItem1 = new Div("Item 1");
+        spacingItem1.setClassName("layout-item");
+        Div spacingItem2 = new Div("Item 2");
+        spacingItem2.setClassName("layout-item");
+        Div spacingItem3 = new Div("Item 3");
+        spacingItem3.setClassName("layout-item");
+
+        layoutWithSpacing.add(spacingItem1, spacingItem2, spacingItem3);
         wrapper.add(layoutWithSpacing);
 
         setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsSpacing.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsSpacing.java
@@ -29,11 +29,11 @@ public class BasicLayoutsSpacing extends Div {
         layoutWithoutSpacing.setAlignItems(FlexComponent.Alignment.STRETCH);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layoutWithoutSpacing.add(item1, item2, item3);
         wrapper.add(layoutWithoutSpacing);
@@ -47,11 +47,11 @@ public class BasicLayoutsSpacing extends Div {
         layoutWithSpacing.setAlignItems(FlexComponent.Alignment.STRETCH);
 
         Div spacingItem1 = new Div("Item 1");
-        spacingItem1.setClassName("layout-item");
+        spacingItem1.setClassName("example-item");
         Div spacingItem2 = new Div("Item 2");
-        spacingItem2.setClassName("layout-item");
+        spacingItem2.setClassName("example-item");
         Div spacingItem3 = new Div("Item 3");
-        spacingItem3.setClassName("layout-item");
+        spacingItem3.setClassName("example-item");
 
         layoutWithSpacing.add(spacingItem1, spacingItem2, spacingItem3);
         wrapper.add(layoutWithSpacing);

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayout.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayout.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
@@ -11,9 +10,17 @@ public class BasicLayoutsVerticalLayout extends Div {
     public BasicLayoutsVerticalLayout() {
         // tag::snippet[]
         VerticalLayout layout = new VerticalLayout();
-        layout.add(new Button("Button 1"));
-        layout.add(new Button("Button 2"));
-        layout.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layout.add(item1, item2, item3);
         // end::snippet[]
 
         this.setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayout.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayout.java
@@ -12,13 +12,13 @@ public class BasicLayoutsVerticalLayout extends Div {
         VerticalLayout layout = new VerticalLayout();
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
 
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
 
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layout.add(item1, item2, item3);
         // end::snippet[]

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutHorizontalAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutHorizontalAlignment.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
@@ -14,9 +13,17 @@ public class BasicLayoutsVerticalLayoutHorizontalAlignment extends Div {
         // tag::layout[]
         VerticalLayout layout = new VerticalLayout();
         layout.setAlignItems(FlexComponent.Alignment.CENTER);
-        layout.add(new Button("Button 1"));
-        layout.add(new Button("Button 2"));
-        layout.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layout.add(item1, item2, item3);
         // end::layout[]
 
         this.setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutHorizontalAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutHorizontalAlignment.java
@@ -15,13 +15,13 @@ public class BasicLayoutsVerticalLayoutHorizontalAlignment extends Div {
         layout.setAlignItems(FlexComponent.Alignment.CENTER);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
 
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
 
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layout.add(item1, item2, item3);
         // end::layout[]

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutIndividualAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutIndividualAlignment.java
@@ -16,17 +16,17 @@ public class BasicLayoutsVerticalLayoutIndividualAlignment extends Div {
         layout.setAlignItems(FlexComponent.Alignment.START);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         layout.add(item1);
         layout.setAlignSelf(Alignment.END, item1);
 
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         layout.add(item2);
         layout.setAlignSelf(Alignment.CENTER, item2);
 
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
         layout.add(item3);
         // end::layout[]
 

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutIndividualAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutIndividualAlignment.java
@@ -2,8 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
@@ -14,16 +12,22 @@ public class BasicLayoutsVerticalLayoutIndividualAlignment extends Div {
 
     public BasicLayoutsVerticalLayoutIndividualAlignment() {
         // tag::layout[]
-        Button button1 = new Button("Button 1");
-        Button button2 = new Button("Button 2");
-        button1.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         VerticalLayout layout = new VerticalLayout();
-        layout.add(button1);
-        layout.setAlignSelf(Alignment.END, button1);
-        layout.add(button2);
-        layout.setAlignSelf(Alignment.CENTER, button2);
         layout.setAlignItems(FlexComponent.Alignment.START);
-        layout.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        layout.add(item1);
+        layout.setAlignSelf(Alignment.END, item1);
+
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        layout.add(item2);
+        layout.setAlignSelf(Alignment.CENTER, item2);
+
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+        layout.add(item3);
         // end::layout[]
 
         this.setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutVerticalAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutVerticalAlignment.java
@@ -15,13 +15,13 @@ public class BasicLayoutsVerticalLayoutVerticalAlignment extends Div {
         layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
 
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
 
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
 
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
 
         layout.add(item1, item2, item3);
         // end::layout[]

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutVerticalAlignment.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutVerticalAlignment.java
@@ -2,7 +2,6 @@ package com.vaadin.demo.component.basiclayouts;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
@@ -14,9 +13,17 @@ public class BasicLayoutsVerticalLayoutVerticalAlignment extends Div {
         // tag::layout[]
         VerticalLayout layout = new VerticalLayout();
         layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
-        layout.add(new Button("Button 1"));
-        layout.add(new Button("Button 2"));
-        layout.add(new Button("Button 3"));
+
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+
+        layout.add(item1, item2, item3);
         // end::layout[]
 
         this.setClassName("basic-layouts-example");

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutWrapping.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutWrapping.java
@@ -28,13 +28,13 @@ public class BasicLayoutsVerticalLayoutWrapping extends Div {
         layoutWithoutWrap.setHeight("200px");
         
         Div item1 = new Div("Item 1");
-        item1.setClassName("layout-item");
+        item1.setClassName("example-item");
         Div item2 = new Div("Item 2");
-        item2.setClassName("layout-item");
+        item2.setClassName("example-item");
         Div item3 = new Div("Item 3");
-        item3.setClassName("layout-item");
+        item3.setClassName("example-item");
         Div item4 = new Div("Item 4");
-        item4.setClassName("layout-item");
+        item4.setClassName("example-item");
         
         layoutWithoutWrap.add(item1, item2, item3, item4);
         wrapper.add(layoutWithoutWrap);
@@ -54,13 +54,13 @@ public class BasicLayoutsVerticalLayoutWrapping extends Div {
         layoutWithWrap.setHeight("200px");
         
         Div wrapItem1 = new Div("Item 1");
-        wrapItem1.setClassName("layout-item");
+        wrapItem1.setClassName("example-item");
         Div wrapItem2 = new Div("Item 2");
-        wrapItem2.setClassName("layout-item");
+        wrapItem2.setClassName("example-item");
         Div wrapItem3 = new Div("Item 3");
-        wrapItem3.setClassName("layout-item");
+        wrapItem3.setClassName("example-item");
         Div wrapItem4 = new Div("Item 4");
-        wrapItem4.setClassName("layout-item");
+        wrapItem4.setClassName("example-item");
         
         layoutWithWrap.add(wrapItem1, wrapItem2, wrapItem3, wrapItem4);
         wrapper.add(layoutWithWrap);

--- a/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutWrapping.java
+++ b/src/main/java/com/vaadin/demo/component/basiclayouts/BasicLayoutsVerticalLayoutWrapping.java
@@ -3,7 +3,6 @@ package com.vaadin.demo.component.basiclayouts;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Paragraph;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
@@ -27,10 +26,17 @@ public class BasicLayoutsVerticalLayoutWrapping extends Div {
         layoutWithoutWrap.setSpacing(true);
         layoutWithoutWrap.setAlignItems(FlexComponent.Alignment.STRETCH);
         layoutWithoutWrap.setHeight("200px");
-        layoutWithoutWrap.add(new Button("Button 1"));
-        layoutWithoutWrap.add(new Button("Button 2"));
-        layoutWithoutWrap.add(new Button("Button 3"));
-        layoutWithoutWrap.add(new Button("Button 4"));
+        
+        Div item1 = new Div("Item 1");
+        item1.setClassName("layout-item");
+        Div item2 = new Div("Item 2");
+        item2.setClassName("layout-item");
+        Div item3 = new Div("Item 3");
+        item3.setClassName("layout-item");
+        Div item4 = new Div("Item 4");
+        item4.setClassName("layout-item");
+        
+        layoutWithoutWrap.add(item1, item2, item3, item4);
         wrapper.add(layoutWithoutWrap);
         parent.add(wrapper);
 
@@ -46,11 +52,17 @@ public class BasicLayoutsVerticalLayoutWrapping extends Div {
         layoutWithWrap.setSpacing(true);
         layoutWithWrap.setAlignItems(FlexComponent.Alignment.STRETCH);
         layoutWithWrap.setHeight("200px");
-        layoutWithWrap.add(new Button("Button 1"));
-        layoutWithWrap.add(new Button("Button 2"));
-        layoutWithWrap.add(new Button("Button 3"));
-        layoutWithWrap.add(new Button("Button 4"));
-
+        
+        Div wrapItem1 = new Div("Item 1");
+        wrapItem1.setClassName("layout-item");
+        Div wrapItem2 = new Div("Item 2");
+        wrapItem2.setClassName("layout-item");
+        Div wrapItem3 = new Div("Item 3");
+        wrapItem3.setClassName("layout-item");
+        Div wrapItem4 = new Div("Item 4");
+        wrapItem4.setClassName("layout-item");
+        
+        layoutWithWrap.add(wrapItem1, wrapItem2, wrapItem3, wrapItem4);
         wrapper.add(layoutWithWrap);
         parent.add(wrapper);
         this.setClassName("basic-layouts-example");


### PR DESCRIPTION
Before:
![Bildschirmfoto 2024-12-13 um 12 29 35](https://github.com/user-attachments/assets/970b8d3c-bbde-438d-a2c2-2b22773bcac5)

After:
![Bildschirmfoto 2024-12-13 um 12 29 48](https://github.com/user-attachments/assets/763e03ae-cc7b-4417-8bdc-55b99149c805)



Closes https://github.com/vaadin/docs/issues/3995