### PR TITLE
Replace old hilla.dev links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Official documentation and code examples for Vaadin.
 
-This repository does not generate the [vaadin.com/docs](https://vaadin.com/docs) or [hilla.dev/docs](https://hilla.dev/docs) websites. It only contains the content for them. The builds are done using [Vaadin Design System Publisher](https://vaadin.com/design-system-publisher).
+This repository does not generate the [vaadin.com/docs](https://vaadin.com/docs) website. It only contains the content for them. The builds are done using [Vaadin Design System Publisher](https://vaadin.com/design-system-publisher).
 
 ## Contents
 

--- a/articles/flow/advanced/modifying-the-bootstrap-page.adoc
+++ b/articles/flow/advanced/modifying-the-bootstrap-page.adoc
@@ -74,7 +74,7 @@ const {serverSideRoutes} = new Flow({
 });
 
 const routes = [
-  // for client-side, place routes below (more info https://hilla.dev/docs/routing)
+  // for client-side, place routes below (more info https://vaadin.com/docs/latest/hilla/guides/routing)
 
   // for server-side, the next magic line sends all unmatched routes:
   ...serverSideRoutes // IMPORTANT: this must be the last entry in the array

--- a/articles/flow/advanced/modifying-the-bootstrap-page.adoc
+++ b/articles/flow/advanced/modifying-the-bootstrap-page.adoc
@@ -74,7 +74,7 @@ const {serverSideRoutes} = new Flow({
 });
 
 const routes = [
-  // for client-side, place routes below (more info https://vaadin.com/docs/latest/hilla/guides/routing)
+  // for client-side, place routes below
 
   // for server-side, the next magic line sends all unmatched routes:
   ...serverSideRoutes // IMPORTANT: this must be the last entry in the array

--- a/articles/flow/configuration/pwa.adoc
+++ b/articles/flow/configuration/pwa.adoc
@@ -9,7 +9,7 @@ order: 90
 
 Some extra configuration enables a Vaadin application to run as a _Progressive Web Application_ (PWA). PWAs aim to give the same experience as native applications, with a user-friendly installation flow, and a capability to work offline. They look like a regular application in the home screen of a mobile device or in the application menus of a desktop operating system. A PWA needs some metadata, such as name, description, and icon, which are used by the operating system to display information about the application.
 
-To enable offline use, TypeScript needs to be used to provide the offline views. https://hilla.dev[Hilla] is the recommended framework to build client-side views.
+To enable offline use, TypeScript needs to be used to provide the offline views. https://vaadin.com/hilla[Hilla] is the recommended framework to build client-side views.
 
 For a generic introduction to PWA, see the article on https://vaadin.com/pwa[What are Progressive Web Applications and Why Build a PWA].
 

--- a/articles/flow/integrations/hilla.adoc
+++ b/articles/flow/integrations/hilla.adoc
@@ -94,7 +94,7 @@ public class HelloView extends VerticalLayout {
 }
 ----
 
-Use Vaadin's https://vaadin.com/docs/latest/components/side-nav[Side Navigation] or React's https://vaadin.com/docs/latest/hilla/guides/routing#adding-routes[NavLink] / https://reactrouter.com/en/main/components/link[Link] components to navigate from a Hilla view to a Flow view:
+Use Vaadin's <<{articles}/components/side-nav#,Side Navigation>> or React's <<{articles}/hilla/guides/routing#adding-routes,NavLink>> / https://reactrouter.com/en/main/components/link[Link] components to navigate from a Hilla view to a Flow view:
 
 [source,javascript]
 ----

--- a/articles/flow/integrations/hilla.adoc
+++ b/articles/flow/integrations/hilla.adoc
@@ -94,7 +94,7 @@ public class HelloView extends VerticalLayout {
 }
 ----
 
-Use Vaadin's https://hilla.dev/docs/react/components/side-nav[Side Navigation] or React's https://hilla.dev/docs/react/guides/routing#adding-routes[NavLink] / https://reactrouter.com/en/main/components/link[Link] components to navigate from a Hilla view to a Flow view:
+Use Vaadin's https://vaadin.com/docs/latest/components/side-nav[Side Navigation] or React's https://vaadin.com/docs/latest/hilla/guides/routing#adding-routes[NavLink] / https://reactrouter.com/en/main/components/link[Link] components to navigate from a Hilla view to a Flow view:
 
 [source,javascript]
 ----

--- a/articles/flow/security/enabling-security.adoc
+++ b/articles/flow/security/enabling-security.adoc
@@ -280,7 +280,7 @@ The implementation of the [methodname]`userDetailsService()` method is just an i
 
 The most important configuration in the previous example is the call to [methodname]`setLoginView(http, LoginView.class)` inside the first configure method. This is how the view-based access control mechanism knows where to redirect users when they try to navigate to a protected view.
 
-The log-in view should always be accessible by anonymous users, so it should have the [annotationname]`@AnonymousAllowed` annotation. This is especially important when using the variant of the [methodname]`setLoginView` method where you provide the route path -- although this signature is meant to be used with https://hilla.dev[Hilla] views, not with Flow views.
+The log-in view should always be accessible by anonymous users, so it should have the [annotationname]`@AnonymousAllowed` annotation. This is especially important when using the variant of the [methodname]`setLoginView` method where you provide the route path -- although this signature is meant to be used with https://vaadin.com/hilla[Hilla] views, not with Flow views.
 
 For additional information about navigation access control, consult the <<{articles}/flow/security/advanced-topics/navigation-access-control#, related documentation>>.
 

--- a/articles/hilla/lit/guides/reactive-endpoints.adoc
+++ b/articles/hilla/lit/guides/reactive-endpoints.adoc
@@ -17,7 +17,7 @@ Although traditional server calls work fine in most cases, sometimes you need di
 
 If you want to know more about Reactor, see their curated https://projectreactor.io/learn[learning page].
 
-Although getting comfortable with creating streaming, non-blocking applications requires some effort, Hilla allows you to take advantage of Reactor in minutes. To learn the basics of reactive endpoints, read the Hilla https://hilla.dev/blog/interactive-applications-with-server-push/[blog article] on the subject.
+Although getting comfortable with creating streaming, non-blocking applications requires some effort, Hilla allows you to take advantage of Reactor in minutes. To learn the basics of reactive endpoints, read the https://vaadin.com/blog/interactive-applications-with-server-push[blog article] on the subject.
 
 
 == Familiarizing

--- a/articles/hilla/lit/guides/upgrading/index.adoc
+++ b/articles/hilla/lit/guides/upgrading/index.adoc
@@ -723,7 +723,7 @@ The behavior of null type annotations, such as `@com.vaadin.hilla.Nonnull`, has 
 - `String @com.vaadin.hilla.Nonnull []` is a non-null array type whose items are nullable.
 - `@com.vaadin.hilla.Nonnull String @dev.hilla.Nonnull []` is a non-null array type whose items are non-null.
 
-This also affects nullability in generated TypeScript code. Consider using the link:https://hilla.dev/docs/lit/reference/type-nullability/#nonnullapi[@NonNullApi] annotation for declaring nullability on the package level.
+This also affects nullability in generated TypeScript code. Consider using the link:https://vaadin.com/docs/latest/hilla/lit/reference/type-nullability#nonnullapi[@NonNullApi] annotation for declaring nullability on the package level.
 
 
 === Breaking Changes in Vaadin Components

--- a/articles/hilla/lit/guides/upgrading/index.adoc
+++ b/articles/hilla/lit/guides/upgrading/index.adoc
@@ -725,11 +725,14 @@ The behavior of null type annotations, such as `@com.vaadin.hilla.Nonnull`, has 
 
 This also affects nullability in generated TypeScript code. Consider using the <<{articles}/hilla/lit/reference/type-nullability#nonnullapi,@NonNullApi>> annotation for declaring nullability on the package level.
 
+// Allow Vaadin Components in header
+pass:[<!-- vale Vaadin.ProductName = NO -->]
 
 === Breaking Changes in Vaadin Components
 
 Upgrading a Hilla application to Hilla 2 can involve several breaking changes. They're described in the following sub-sections.
 
+pass:[<!-- vale Vaadin.ProductName = YES -->]
 
 ==== Behavior & Styling
 

--- a/articles/hilla/lit/guides/upgrading/index.adoc
+++ b/articles/hilla/lit/guides/upgrading/index.adoc
@@ -723,7 +723,7 @@ The behavior of null type annotations, such as `@com.vaadin.hilla.Nonnull`, has 
 - `String @com.vaadin.hilla.Nonnull []` is a non-null array type whose items are nullable.
 - `@com.vaadin.hilla.Nonnull String @dev.hilla.Nonnull []` is a non-null array type whose items are non-null.
 
-This also affects nullability in generated TypeScript code. Consider using the link:https://vaadin.com/docs/latest/hilla/lit/reference/type-nullability#nonnullapi[@NonNullApi] annotation for declaring nullability on the package level.
+This also affects nullability in generated TypeScript code. Consider using the <<{articles}/hilla/lit/reference/type-nullability#nonnullapi,@NonNullApi>> annotation for declaring nullability on the package level.
 
 
 === Breaking Changes in Vaadin Components

--- a/articles/hilla/lit/start/faq.adoc
+++ b/articles/hilla/lit/start/faq.adoc
@@ -58,7 +58,7 @@ Hilla is supported by Vaadin. All the commercial support, components, warranty, 
 ifdef::hilla-lit[]
 == How is Hilla Different from React?
 
-Hilla has a component model that's similar to React, using the https://lit.dev/[Lit] library. However, you can also https://hilla.dev/docs/react[use React] instead of Lit together with Hilla. What makes Hilla different from React is that it includes both the frontend and Java backend in the same project. Hilla includes everything you need to build an application in one package: UI components, routing, forms, security, build tooling. You can get first-party support for using Hilla from Vaadin, the company that built it.
+Hilla has a component model that's similar to React, using the https://lit.dev/[Lit] library. However, you can also https://vaadin.com/docs/latest/hilla[use React] instead of Lit together with Hilla. What makes Hilla different from React is that it includes both the frontend and Java backend in the same project. Hilla includes everything you need to build an application in one package: UI components, routing, forms, security, build tooling. You can get first-party support for using Hilla from Vaadin, the company that built it.
 endif::hilla-lit[]
 
 
@@ -119,6 +119,6 @@ Hilla is developed using Java as the reference language for the backend. Hilla p
 
 == Does Hilla Support a Microservice Architecture?
 
-Yes. Hilla only requires a thin endpoint layer to communicate with the frontend. The rest of the backend can employ a microservice setup with which Hilla endpoints would communicate. See the https://hilla.dev/blog/using-microservices-from-hilla/["Using microservices from Hilla"] article for more details.
+Yes. Hilla only requires a thin endpoint layer to communicate with the frontend. The rest of the backend can employ a microservice setup with which Hilla endpoints would communicate. See the https://vaadin.com/blog/using-microservices-from-hilla/["Using microservices from Hilla"] article for more details.
 
 // end::content[]

--- a/articles/hilla/lit/start/faq.adoc
+++ b/articles/hilla/lit/start/faq.adoc
@@ -58,7 +58,7 @@ Hilla is supported by Vaadin. All the commercial support, components, warranty, 
 ifdef::hilla-lit[]
 == How is Hilla Different from React?
 
-Hilla has a component model that's similar to React, using the https://lit.dev/[Lit] library. However, you can also https://vaadin.com/docs/latest/hilla[use React] instead of Lit together with Hilla. What makes Hilla different from React is that it includes both the frontend and Java backend in the same project. Hilla includes everything you need to build an application in one package: UI components, routing, forms, security, build tooling. You can get first-party support for using Hilla from Vaadin, the company that built it.
+Hilla has a component model that's similar to React, using the https://lit.dev/[Lit] library. However, you can also <<{articles}/hilla#,use React>> instead of Lit together with Hilla. What makes Hilla different from React is that it includes both the frontend and Java backend in the same project. Hilla includes everything you need to build an application in one package: UI components, routing, forms, security, build tooling. You can get first-party support for using Hilla from Vaadin, the company that built it.
 endif::hilla-lit[]
 
 


### PR DESCRIPTION
Old hilla.dev links redirect to vaadin.com now. This fix replaces those links in the latest Docs content with the final addresses they currently redirect to, removing the old links pointing to hilla.dev and removing redirections.

Example:
- Old link: https://hilla.dev
- New link: https://vaadin.com/hilla


