### PR TITLE
Remove redirection chains from v8 content

### DIFF
--- a/articles/bakeryfw8/adding-a-view.asciidoc
+++ b/articles/bakeryfw8/adding-a-view.asciidoc
@@ -57,7 +57,7 @@ image::img/about-view-not-in-menu.png[About view available, but not in menu.]
 
 == Adding the view to the menu
 
-To modify the menu, we want to first open the main layout design, `MainViewDesign` in the view package. We want to add a new Button into the 'menu' layout. The easiest way to do this is select the last view and pressing copy paste on it (ctrl+c -> ctrl+v). This will add a copy of the menu button with same icon and caption. Let's change those. In the properties panel, you want to change Name, Icon, Caption and DomId to match your new view. Next to icon is a handy button where you see the icons and select a new one visually. The list contains all the built-in font-icons from link:https://vaadin.com/icons[Vaadin Icons].
+To modify the menu, we want to first open the main layout design, `MainViewDesign` in the view package. We want to add a new Button into the 'menu' layout. The easiest way to do this is select the last view and pressing copy paste on it (ctrl+c -> ctrl+v). This will add a copy of the menu button with same icon and caption. Let's change those. In the properties panel, you want to change Name, Icon, Caption and DomId to match your new view. Next to icon is a handy button where you see the icons and select a new one visually. The list contains all the built-in font-icons from link:https://vaadin.com/docs/latest/components/icons[Vaadin Icons].
 
 TIP: Refer to link:https://vaadin.com/docs/-/part/designer/designer-overview.html[Vaadin Designer documentation] to learn more about visually designing your UI.
 

--- a/articles/bakeryfw8/adding-a-view.asciidoc
+++ b/articles/bakeryfw8/adding-a-view.asciidoc
@@ -57,7 +57,7 @@ image::img/about-view-not-in-menu.png[About view available, but not in menu.]
 
 == Adding the view to the menu
 
-To modify the menu, we want to first open the main layout design, `MainViewDesign` in the view package. We want to add a new Button into the 'menu' layout. The easiest way to do this is select the last view and pressing copy paste on it (ctrl+c -> ctrl+v). This will add a copy of the menu button with same icon and caption. Let's change those. In the properties panel, you want to change Name, Icon, Caption and DomId to match your new view. Next to icon is a handy button where you see the icons and select a new one visually. The list contains all the built-in font-icons from link:https://vaadin.com/docs/latest/components/icons[Vaadin Icons].
+To modify the menu, we want to first open the main layout design, `MainViewDesign` in the view package. We want to add a new Button into the 'menu' layout. The easiest way to do this is select the last view and pressing copy paste on it (ctrl+c -> ctrl+v). This will add a copy of the menu button with same icon and caption. Let's change those. In the properties panel, you want to change Name, Icon, Caption and DomId to match your new view. Next to icon is a handy button where you see the icons and select a new one visually. The list contains all the built-in font-icons from link:https://vaadin.com/docs/latest/components/icons/default-icons[Vaadin Icons].
 
 TIP: Refer to link:https://vaadin.com/docs/-/part/designer/designer-overview.html[Vaadin Designer documentation] to learn more about visually designing your UI.
 

--- a/articles/charts/productpage-external.asciidoc
+++ b/articles/charts/productpage-external.asciidoc
@@ -1,5 +1,5 @@
 ---
 title: Product page
 order: 1000
-url: https://vaadin.com/docs/latest/components/charts
+url: https://vaadin.com/docs/v8/charts/charts-overview
 ---

--- a/articles/charts/productpage-external.asciidoc
+++ b/articles/charts/productpage-external.asciidoc
@@ -1,5 +1,5 @@
 ---
 title: Product page
 order: 1000
-url: https://vaadin.com/charts
+url: https://vaadin.com/docs/latest/components/charts
 ---

--- a/articles/framework/articles/VaadinTutorialForSwingDevelopers.asciidoc
+++ b/articles/framework/articles/VaadinTutorialForSwingDevelopers.asciidoc
@@ -301,7 +301,7 @@ But, like with non trivial Swing apps, you might want to delegate some
 of this low level stuff to a framework that takes care of servlet, setup
 and UI mapping. It is highly suggested to use e.g.
 https://vaadin.com/javaee[Java EE environment] with Vaadin CDI add-on
-or https://vaadin.com/spring/[Spring] as a basis for your application.
+or https://vaadin.com/docs/latest/flow/integrations/spring[Spring] as a basis for your application.
 In these cases you typically end up having different application views
 as class files and container specific annotations to hint how those
 should be served for the end users. In the example we are using

--- a/articles/framework/articles/VaadinTutorialForSwingDevelopers.asciidoc
+++ b/articles/framework/articles/VaadinTutorialForSwingDevelopers.asciidoc
@@ -301,7 +301,7 @@ But, like with non trivial Swing apps, you might want to delegate some
 of this low level stuff to a framework that takes care of servlet, setup
 and UI mapping. It is highly suggested to use e.g.
 https://vaadin.com/javaee[Java EE environment] with Vaadin CDI add-on
-or https://vaadin.com/docs/latest/flow/integrations/spring[Spring] as a basis for your application.
+or https://vaadin.com/docs/v8/framework/advanced/advanced-spring[Spring] as a basis for your application.
 In these cases you typically end up having different application views
 as class files and container specific annotations to hint how those
 should be served for the end users. In the example we are using

--- a/articles/framework/introduction-external.asciidoc
+++ b/articles/framework/introduction-external.asciidoc
@@ -1,5 +1,5 @@
 ---
 title: Introduction
 order: 1000
-url: https://vaadin.com/framework
+url: https://vaadin.com/
 ---

--- a/articles/spreadsheet/spreadsheet-overview.asciidoc
+++ b/articles/spreadsheet/spreadsheet-overview.asciidoc
@@ -142,7 +142,7 @@ Vaadin Spreadsheet 2.0 has the following limitations:
 == Licensing
 
 Vaadin Spreadsheet is a commercial product licensed under the CVAL license (
-link:https://vaadin.com/license/cval-3.0[Commercial Vaadin Add-On License]).
+link:https://vaadin.com/commercial-license-and-service-terms[Commercial Vaadin Add-On License]).
 Development licenses need to be purchased for each developer working with Vaadin
 Spreadsheet, regardless of whether the resulting applications using it are
 deployed publicly or privately in an intranet.

--- a/articles/spreadsheet/spreadsheet-overview.asciidoc
+++ b/articles/spreadsheet/spreadsheet-overview.asciidoc
@@ -142,7 +142,7 @@ Vaadin Spreadsheet 2.0 has the following limitations:
 == Licensing
 
 Vaadin Spreadsheet is a commercial product licensed under the CVAL license (
-link:https://vaadin.com/license/cval-3[Commercial Vaadin Add-On License]).
+link:https://vaadin.com/license/cval-3.0[Commercial Vaadin Add-On License]).
 Development licenses need to be purchased for each developer working with Vaadin
 Spreadsheet, regardless of whether the resulting applications using it are
 deployed publicly or privately in an intranet.


### PR DESCRIPTION
Removes redirections from version 8 docs content by changing a link's URL to the final address that URL redirects to.