### PR TITLE
refactor: remove unused nav link class names

### DIFF
--- a/articles/hilla/guides/routing.adoc
+++ b/articles/hilla/guides/routing.adoc
@@ -171,10 +171,6 @@ import { SideNav } from '@vaadin/react-components/SideNav.js';
 import { SideNavItem } from '@vaadin/react-components/SideNavItem.js';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 
-const navLinkClasses = ({ isActive }: any) => {
-  return `block rounded-m p-s ${isActive ? 'bg-primary-10 text-primary' : 'text-body'}`;
-};
-
 export default function MainMenu() {
   const navigate = useNavigate();
   const location = useLocation();


### PR DESCRIPTION
Remove unused class names from Hilla routing example.