### PR TITLE
fix: store updated widgets in dashboard announcements example

### DIFF
--- a/frontend/demo/component/dashboard/dashboard-announcements.ts
+++ b/frontend/demo/component/dashboard/dashboard-announcements.ts
@@ -89,6 +89,9 @@ export class Example extends LitElement {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const title = widgetTitles[(e.detail.item as WidgetConfig).type];
     this.announcement = `Moved widget ${title} to position ${position} of ${total}`;
+
+    // Store updated widgets after user has modified them
+    this.widgets = e.detail.items as WidgetConfig[];
   }
 
   handleResize(e: DashboardItemResizedEvent<WidgetConfig>) {
@@ -98,6 +101,9 @@ export class Example extends LitElement {
     const title = widgetTitles[e.detail.item.type];
 
     this.announcement = `Resized widget ${title} to ${colspan} columns, ${rowspan} rows`;
+
+    // Store updated widgets after user has modified them
+    this.widgets = e.detail.items as WidgetConfig[];
   }
 
   handleRemove(e: DashboardItemRemovedEvent<WidgetConfig>) {
@@ -105,6 +111,9 @@ export class Example extends LitElement {
     const title = widgetTitles[(e.detail.item as WidgetConfig).type];
 
     this.announcement = `Removed widget ${title}`;
+
+    // Store updated widgets after user has modified them
+    this.widgets = e.detail.items as WidgetConfig[];
   }
 
   render() {

--- a/frontend/demo/component/dashboard/react/dashboard-announcements.tsx
+++ b/frontend/demo/component/dashboard/react/dashboard-announcements.tsx
@@ -84,6 +84,9 @@ function Example() {
     const title = widgetTitles[(e.detail.item as WidgetConfig).type];
 
     announcement.value = `Moved widget ${title} to position ${position} of ${total}`;
+
+    // Store updated widgets after user has modified them
+    widgets.value = e.detail.items as WidgetConfig[];
   }
 
   function handleResize(e: DashboardItemResizedEvent<WidgetConfig>) {
@@ -93,6 +96,9 @@ function Example() {
     const title = widgetTitles[e.detail.item.type];
 
     announcement.value = `Resized widget ${title} to ${colspan} columns, ${rowspan} rows`;
+
+    // Store updated widgets after user has modified them
+    widgets.value = e.detail.items as WidgetConfig[];
   }
 
   function handleRemove(e: DashboardItemRemovedEvent<WidgetConfig>) {
@@ -100,6 +106,9 @@ function Example() {
     const title = widgetTitles[(e.detail.item as WidgetConfig).type];
 
     announcement.value = `Removed widget ${title}`;
+
+    // Store updated widgets after user has modified them
+    widgets.value = e.detail.items as WidgetConfig[];
   }
 
   return (


### PR DESCRIPTION
Also update the state widgets in Dashboard announcements example. Otherwise, the widgets can get reverted on state change:

https://github.com/user-attachments/assets/e5daaa7d-56dc-48ac-9e33-e97cf5a4855a

