### PR TITLE
docs: update custom item presentation link

### DIFF
--- a/articles/components/multi-select-combo-box/index.adoc
+++ b/articles/components/multi-select-combo-box/index.adoc
@@ -64,7 +64,7 @@ The overlay opens when the user clicks the field using a pointing device. Using 
 Multi-Select Combo Box supports the following features from the regular Combo Box. All the linked examples and code snippets can be applied by replacing the Combo Box with a Multi-Select Combo Box.
 
 - <<../combo-box#custom-value-entry, Custom Value Entry>>
-- <<../combo-box#custom-item-representation, Custom Item Presentation>>
+- <<../combo-box#custom-item-presentation, Custom Item Presentation>>
 - <<../combo-box#auto-open, Auto Open>>
 - <<../combo-box#placeholder, Placeholder>>
 - <<../combo-box#custom-filtering, Custom Filtering>>


### PR DESCRIPTION
Fixes a cross-reference to combo box docs.