### PR TITLE
docs: update snippet tags for details Lit examples

### DIFF
--- a/frontend/demo/component/details/details-content.ts
+++ b/frontend/demo/component/details/details-content.ts
@@ -5,7 +5,6 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
-// tag::snippet[]
 @customElement('details-content')
 export class Example extends LitElement {
   static override styles = css`
@@ -23,6 +22,7 @@ export class Example extends LitElement {
   }
 
   protected override render() {
+    // tag::snippet[]
     return html`
       <vaadin-details summary="Analytics" opened>
         <vaadin-vertical-layout>
@@ -47,6 +47,6 @@ export class Example extends LitElement {
         </vaadin-vertical-layout>
       </vaadin-details>
     `;
+    // end::snippet[]
   }
 }
-// end::snippet[]

--- a/frontend/demo/component/details/details-disabled.ts
+++ b/frontend/demo/component/details/details-disabled.ts
@@ -4,7 +4,6 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
-// tag::snippet[]
 @customElement('details-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
@@ -15,6 +14,7 @@ export class Example extends LitElement {
   }
 
   protected override render() {
+    // tag::snippet[]
     return html`
       <vaadin-details summary="Members (8)" disabled>
         <ul>
@@ -29,6 +29,6 @@ export class Example extends LitElement {
         </ul>
       </vaadin-details>
     `;
+    // end::snippet[]
   }
 }
-// end::snippet[]

--- a/frontend/demo/component/details/details-filled.ts
+++ b/frontend/demo/component/details/details-filled.ts
@@ -4,7 +4,6 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
-// tag::snippet[]
 @customElement('details-filled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
@@ -15,6 +14,7 @@ export class Example extends LitElement {
   }
 
   protected override render() {
+    // tag::snippet[]
     return html`
       <vaadin-details summary="Members (8)" opened theme="filled">
         <ul>
@@ -29,6 +29,6 @@ export class Example extends LitElement {
         </ul>
       </vaadin-details>
     `;
+    // end::snippet[]
   }
 }
-// end::snippet[]

--- a/frontend/demo/component/details/details-reverse.ts
+++ b/frontend/demo/component/details/details-reverse.ts
@@ -4,7 +4,6 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
-// tag::snippet[]
 @customElement('details-reverse')
 export class Example extends LitElement {
   protected override createRenderRoot() {
@@ -15,6 +14,7 @@ export class Example extends LitElement {
   }
 
   protected override render() {
+    // tag::snippet[]
     return html`
       <vaadin-details summary="Members (8)" opened theme="reverse">
         <ul>
@@ -29,6 +29,6 @@ export class Example extends LitElement {
         </ul>
       </vaadin-details>
     `;
+    // end::snippet[]
   }
 }
-// end::snippet[]

--- a/frontend/demo/component/details/details-small.ts
+++ b/frontend/demo/component/details/details-small.ts
@@ -4,7 +4,6 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
-// tag::snippet[]
 @customElement('details-small')
 export class Example extends LitElement {
   protected override createRenderRoot() {
@@ -15,6 +14,7 @@ export class Example extends LitElement {
   }
 
   protected override render() {
+    // tag::snippet[]
     return html`
       <vaadin-details summary="Members (8)" opened theme="small">
         <ul>
@@ -29,6 +29,6 @@ export class Example extends LitElement {
         </ul>
       </vaadin-details>
     `;
+    // end::snippet[]
   }
 }
-// end::snippet[]

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -15,7 +15,6 @@ import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { applyTheme } from 'Frontend/generated/theme';
 
-// tag::snippet[]
 @customElement('details-summary')
 export class Example extends LitElement {
   protected override createRenderRoot() {
@@ -39,6 +38,7 @@ export class Example extends LitElement {
   }
 
   protected override render() {
+    // tag::snippet[]
     return html`
       <vaadin-details opened>
         <vaadin-details-summary slot="summary">
@@ -77,6 +77,6 @@ export class Example extends LitElement {
         </vaadin-form-layout>
       </vaadin-details>
     `;
+    // end::snippet[]
   }
 }
-// end::snippet[]


### PR DESCRIPTION
Current snippets for `vaadin-details` Lit examples are unnecessarily large (since these were added in https://github.com/vaadin/docs/pull/71).
While basic example was changed to only include relevant HTML in https://github.com/vaadin/docs/commit/20a20fc46f54f9f9ccfbf4e527eb9743ee9d47da, others were not. This PR fixes that.