### PR TITLE
docs: remove no longer needed item label attribute workaround

### DIFF
--- a/frontend/demo/component/select/react/select-custom-renderer-label.tsx
+++ b/frontend/demo/component/select/react/select-custom-renderer-label.tsx
@@ -26,11 +26,7 @@ function Example() {
       <ListBox>
         {people.value.map((person) => (
           // Use the label attribute to display full name of the person as selected value label
-          <Item
-            value={String(person.id)}
-            key={person.id}
-            {...{ label: formatPersonFullName(person) }}
-          >
+          <Item value={String(person.id)} key={person.id} label={formatPersonFullName(person)}>
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <img
                 src={person.pictureUrl}


### PR DESCRIPTION
This workaround is no longer needed after adding `label` property to `vaadin-item` in https://github.com/vaadin/web-components/pull/6919.
See https://github.com/vaadin/react-components/issues/147 for the original issue where this specific case was mentioned.