### PR TITLE
chore: remove fixed commons-io version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,11 +88,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.16.1</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
The `commons-io` version was fixed to 2.16.1 in https://github.com/vaadin/docs/pull/3500 to unbreak the Spreadsheet examples. Using the fixed version is no longer necessary as a newer library version gets installed by default.