### PR TITLE
docs: fix grid part names

### DIFF
--- a/articles/components/grid/styling.adoc
+++ b/articles/components/grid/styling.adoc
@@ -286,8 +286,8 @@ Sort order indicator:: `vaadin-grid-sorter+++<wbr>+++**::part(order)**`
 === Item Details
 
 Item details cell (spans entire row):: `vaadin-grid+++<wbr>+++**::part(details-cell)**`
-Cell in row with open details:: `vaadin-grid+++<wbr>+++**::part(details-open-row-cell)**`
-Row with open details:: `vaadin-grid+++<wbr>+++**::part(details-open-row)**`
+Cell in row with open details:: `vaadin-grid+++<wbr>+++**::part(details-opened-row-cell)**`
+Row with open details:: `vaadin-grid+++<wbr>+++**::part(details-opened-row)**`
 
 
 === Drag & Drop


### PR DESCRIPTION
Use correct part names for rows/cells with opened details.