### PR TITLE
fix: typo in .npmrc proxy example

### DIFF
--- a/articles/flow/configuration/development-mode/node-js.adoc
+++ b/articles/flow/configuration/development-mode/node-js.adoc
@@ -58,8 +58,8 @@ The [filename]`.npmrc` file structure is `ini` -- like Java properties files. It
 Here's an example of the content of such a file with proxy settings:
 
 ----
-proxy=http://myusername:s3cr3tpassw0rd@proxyserver1:8085"
-https-proxy=http://myusername:s3cr3tpassw0rd@proxyserver1:8086"
+proxy=http://myusername:s3cr3tpassw0rd@proxyserver1:8085
+https-proxy=http://myusername:s3cr3tpassw0rd@proxyserver1:8086
 noproxy=192.168.1.1,vaadin.com,mycompany.com
 ----
 


### PR DESCRIPTION
Fixes #4060