### PR TITLE
Update Bakery Vaadin 8 page

### DIFF
--- a/articles/bakeryfw8/overview.asciidoc
+++ b/articles/bakeryfw8/overview.asciidoc
@@ -10,8 +10,6 @@ Bakery is an App Starter to give you a head start building your business applica
 
 It includes an end-to-end technology stack covering each layer that is needed to build a production grade application. The App Starter is opinionated and reflects Vaadin's view on what is the best way to build business applications.
 
-link:https://bakery.demo.vaadin.com[See a live demo of the application.^]
-
 image::img/overview.png[Bakery on different devices,250,align=center]
 
 == Features
@@ -88,7 +86,7 @@ Dependency management and building is handled by Maven and the standardized Mave
 
 == Getting started
 
-A personalized project can be link:https://vaadin.com/start/v8/full-stack-spring[downloaded from the product page^] by giving group id, artifact id and developer name.
+A personalized project can be link:https://vaadin.com/docs/v8/framework/getting-started/getting-started-archetypes[created from Maven Archetypes] by giving group id, artifact id and developer name.
 
 NOTE: A paid _Pro or Prime subscription is required_ for creating a new software project from a Starter template. After its creation, results can be used, developed and distributed freely, but licenses for the used commercial components are required during development. The Starter or its parts cannot be redistributed as a code example or template. For full terms, see the link:https://vaadin.com/license/cvtl-1[Commercial Vaadin Template License.]
 


### PR DESCRIPTION
- Remove link to live demo, as it is no longer active
- Replace link to start.vaadin.com with Maven Archetype doc page as start.vaadin.com cannot be used with Vaadin 8


