### PR TITLE
docs: input field focus ring properties

### DIFF
--- a/articles/components/_styling-section-theming-props.adoc
+++ b/articles/components/_styling-section-theming-props.adoc
@@ -87,6 +87,14 @@ Style properties whose names start with `--vaadin-input-field` are shared among 
 |`--vaadin-input-field-readonly-border`
 |`1px dashed --lumo-contrast-30pct`
 
+|Focus ring width
+|`--vaadin-focus-ring-width`
+|`2px`
+
+|Focus ring color
+|`--vaadin-focus-ring-color`
+|`--lumo-primary-color-50pct`
+
 |===
 // end::input-surface[]
 


### PR DESCRIPTION
Adds documentation for focus ring CSS properties for input fields.