### PR TITLE
fix: update error in LoginView to make subsequent submit work

### DIFF
--- a/frontend/demo/auth/LoginView.tsx
+++ b/frontend/demo/auth/LoginView.tsx
@@ -20,6 +20,9 @@ export default function LoginView() {
       opened
       error={hasError.value}
       noForgotPassword
+      onErrorChanged={(event) => {
+        hasError.value = event.detail.value;
+      }}
       onLogin={async ({ detail: { username, password } }) => {
         const { error } = await login(username, password);
         hasError.value = Boolean(error);


### PR DESCRIPTION
Related to https://github.com/vaadin/start/pull/3303

Currently, there is a following problem:

- On first failed login attempt, the `hasError.value` is set to `true` as expected,
- When editing some fields and clicking "Submit" again, the `vaadin-login-form` [resets](https://github.com/vaadin/web-components/blob/dc87442bb489e6d447c42fdcb95b4e2921abf86e/packages/login/src/vaadin-login-form-mixin.js#L62) its `error` state to `false`,
- On subsequent failed login attempt, the `hasError.value` is set to `true` again but from the React point of view, nothing changes since the above change to `false` was not propagated and therefore the component is not re-rendered.

Added `onErrorChanged` listener to make sure that we update `hasError.value` on the event from the component.