### PR TITLE
fix(hilla): make `useNavigate` example programmatic

### DIFF
--- a/articles/hilla/guides/from-java-to-react.adoc
+++ b/articles/hilla/guides/from-java-to-react.adoc
@@ -333,21 +333,28 @@ The `useNavigate` hook is used to navigate programmatically. It returns a functi
 .TSX
 [source,jsx]
 ----
-const navigate = useNavigate();
-const id = useSignal('');
+import { useSignal } from "@vaadin/hilla-react-signals";
+import { Button, NumberField } from "@vaadin/react-components";
+import { useNavigate } from "react-router";
 
-function checkNumber() {
-    if (Number(id.value) === 42) {
-        navigate('/win');
-    } else {
-        navigate('/lose');
+export default function GameView() {
+    const secretNumber = 42;
+    const navigate = useNavigate();
+    const id = useSignal('');
+
+    function checkNumber() {
+        if (Number(id.value) === secretNumber) {
+            navigate('/win');
+        } else {
+            navigate('/lose');
+        }
     }
-}
 
-return <>
-    <NumberField label="Guess the number" value={id.value} onValueChanged={(e) => id.value = e.detail.value} />
-    <Button onClick={checkNumber}>Check</Button>
-</>;
+    return <>
+        <NumberField label="Guess the number" value={id.value} onValueChanged={(e) => id.value = e.detail.value} />
+        <Button onClick={checkNumber}>Check</Button>
+    </>;
+}
 ----
 
 

--- a/articles/hilla/guides/from-java-to-react.adoc
+++ b/articles/hilla/guides/from-java-to-react.adoc
@@ -333,13 +333,21 @@ The `useNavigate` hook is used to navigate programmatically. It returns a functi
 .TSX
 [source,jsx]
 ----
-import { useNavigate } from 'react-router-dom';
+const navigate = useNavigate();
+const id = useSignal('');
 
-export default function HomeView() {
-    const navigate = useNavigate();
-
-    return <Button onClick={() => navigate('/user/123')}>Go to user 123</Button>;
+function checkNumber() {
+    if (Number(id.value) === 42) {
+        navigate('/win');
+    } else {
+        navigate('/lose');
+    }
 }
+
+return <>
+    <NumberField label="Guess the number" value={id.value} onValueChanged={(e) => id.value = e.detail.value} />
+    <Button onClick={checkNumber}>Check</Button>
+</>;
 ----
 
 


### PR DESCRIPTION
Current example uses a button for something that looks like regular navigation.