### PR TITLE
docs: ordered layouts custom spacing

### DIFF
--- a/articles/components/horizontal-layout/index.adoc
+++ b/articles/components/horizontal-layout/index.adoc
@@ -267,6 +267,38 @@ endif::[]
 
 --
 
+[since:com.vaadin:vaadin@V24.7]#Alternatively, the spacing can be set to a custom value:#
+
+[.example]
+--
+ifdef::lit[]
+[source,html]
+----
+<source-info group="Lit"></source-info>
+<vaadin-horizontal-layout style="gap: 12px">
+</vaadin-horizontal-layout>
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+<source-info group="Flow"></source-info>
+HorizontalLayout layout = new HorizontalLayout();
+layout.setSpacing(12, Unit.PIXELS);
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+<source-info group="React"></source-info>
+<HorizontalLayout style={{ gap: '12px' }}>
+</HorizontalLayout>
+----
+endif::[]
+
+--
 
 == Padding
 

--- a/articles/components/vertical-layout/index.adoc
+++ b/articles/components/vertical-layout/index.adoc
@@ -272,6 +272,38 @@ endif::[]
 
 --
 
+[since:com.vaadin:vaadin@V24.7]#Alternatively, the spacing can be set to a custom value:#
+
+[.example]
+--
+ifdef::lit[]
+[source,html]
+----
+<source-info group="Lit"></source-info>
+<vaadin-vertical-layout style="gap: 12px">
+</vaadin-vertical-layout>
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+<source-info group="Flow"></source-info>
+VerticalLayout layout = new VerticalLayout();
+layout.setSpacing(12, Unit.PIXELS);
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+<source-info group="React"></source-info>
+<VerticalLayout style={{ gap: '12px' }}>
+</VerticalLayout>
+----
+endif::[]
+
+--
 
 == Padding
 


### PR DESCRIPTION
Adds documentation for setting a custom spacing in horizontal and vertical layout.

Part of https://github.com/vaadin/flow-components/issues/6999