### PR TITLE
fix: update popover dropdown field to open on arrow down

### DIFF
--- a/frontend/demo/component/popover/popover-dropdown-field.ts
+++ b/frontend/demo/component/popover/popover-dropdown-field.ts
@@ -10,7 +10,7 @@ import { formatISO, subMonths, subWeeks, subYears } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { DatePickerChangeEvent } from '@vaadin/date-picker';
-import type { PopoverOpenedChangedEvent, PopoverTrigger } from '@vaadin/popover';
+import type { PopoverOpenedChangedEvent } from '@vaadin/popover';
 import { popoverRenderer } from '@vaadin/popover/lit.js';
 import type { SelectChangeEvent } from '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -37,9 +37,6 @@ export class Example extends LitElement {
   opened = false;
 
   @state()
-  trigger: PopoverTrigger[] = ['click', 'focus'];
-
-  @state()
   presets = [
     { label: 'Today', value: 'today' },
     { label: 'Last week', value: 'last-week' },
@@ -56,16 +53,15 @@ export class Example extends LitElement {
         label="Search date range"
         style="width: 340px"
         .value="${this.from && this.to ? `${this.from} − ${this.to}` : ''}"
+        @keydown="${this.onKeyDown}"
       >
         <vaadin-icon icon="lumo:dropdown" slot="suffix"></vaadin-icon>
       </vaadin-text-field>
       <!-- tag::snippet[] -->
       <vaadin-popover
         for="range-field"
-        .trigger="${this.trigger}"
-        focus-delay="0"
         modal
-        content-width="325px"
+        content-width="340px"
         position="bottom-start"
         accessible-name="Select a date range"
         .opened="${this.opened}"
@@ -105,6 +101,12 @@ export class Example extends LitElement {
     `;
   }
   // end::snippet[]
+
+  onKeyDown(event: KeyboardEvent) {
+    if (event.key === 'ArrowDown') {
+      this.opened = true;
+    }
+  }
 
   onFromChange(event: DatePickerChangeEvent) {
     this.range = '';

--- a/frontend/demo/component/popover/react/popover-dropdown-field.tsx
+++ b/frontend/demo/component/popover/react/popover-dropdown-field.tsx
@@ -69,16 +69,19 @@ function Example() {
         label="Search date range"
         value={from.value && to.value ? `${from.value} − ${to.value}` : ''}
         style={{ width: '340px' }}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowDown') {
+            opened.value = true;
+          }
+        }}
       >
         <Icon slot="suffix" icon="lumo:dropdown" />
       </TextField>
       {/* tag::snippet[] */}
       <Popover
         for="range-field"
-        trigger={['click', 'focus']}
-        focusDelay={0}
         modal
-        contentWidth="325px"
+        contentWidth="340px"
         position="bottom-start"
         accessibleName="Select a date range"
         opened={opened.value}

--- a/src/main/java/com/vaadin/demo/component/popover/PopoverDropdownField.java
+++ b/src/main/java/com/vaadin/demo/component/popover/PopoverDropdownField.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.TemporalAdjusters;
 
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.Shortcuts;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.Icon;
@@ -36,11 +38,12 @@ public class PopoverDropdownField extends Div {
 
         popover = new Popover();
         popover.setModal(true);
-        popover.setWidth("325px");
+        popover.setWidth("340px");
         popover.setAriaLabel("Select a date range");
-        popover.setOpenOnFocus(true);
-        popover.setFocusDelay(0);
         popover.setTarget(field);
+
+        Shortcuts.addShortcutListener(field, popover::open, Key.ARROW_DOWN)
+                .listenOn(field);
         // end::snippet[]
 
         rangeSelector = new Select<>();


### PR DESCRIPTION
Fixes #4147

Added logic to open on <kbd>Arrow Down</kbd> instead of focus as suggested, in addition to click.
This removes the need to set the custom `trigger` in TS examples since `click` is used by default.

Also fixed the width to match the field width (currently examples look broken due to overlay being more narrow).