### PR TITLE
docs: add version badge for Gantt chart

### DIFF
--- a/articles/components/charts/charttypes.adoc
+++ b/articles/components/charts/charttypes.adoc
@@ -940,7 +940,7 @@ The result is illustrated in <<figure.charts.charttypes.pie.donut>>.
 [.fill.white]
 image::img/charts-donut.png[width="60%"]
 
-
+[role="since:com.vaadin:vaadin@V24.7"]
 [[charts.charttypes.gantt]]
 == Gantt Charts
 

--- a/articles/components/charts/gantt.adoc
+++ b/articles/components/charts/gantt.adoc
@@ -7,9 +7,9 @@ order: 9
 version: since:com.vaadin:vaadin@V24.7
 ---
 
-
 [[charts.gantt]]
-= Gantt Chart
+
+= [since:com.vaadin:vaadin@V24.7]#Gantt Chart#
 
 A Gantt chart is a type of bar chart that can represent a project schedule. It's used for planning and scheduling projects, for displaying the start and finish dates of a project's various elements. It can help in visualizing a project's timeline, task dependencies, and progress.
 

--- a/articles/components/charts/usage-with-lit.adoc
+++ b/articles/components/charts/usage-with-lit.adoc
@@ -56,7 +56,7 @@ include::{root}/frontend/demo/component/charts/charts-polar.ts[render,tags=snipp
 ----
 --
 
-
+[role="since:com.vaadin:vaadin@V24.7"]
 == Gantt Chart
 
 [.example]

--- a/articles/components/charts/usage-with-react.adoc
+++ b/articles/components/charts/usage-with-react.adoc
@@ -53,6 +53,7 @@ include::{root}/frontend/demo/component/charts/react/charts-polar.tsx[render,tag
 ----
 --
 
+[role="since:com.vaadin:vaadin@V24.7"]
 == Gantt Chart
 
 [.example]


### PR DESCRIPTION
Add missing version badge in docs that refer to the new Gantt chart type.