### PR TITLE
[Control Center] Add cloud resources recommendation

### DIFF
--- a/articles/control-center/getting-started/index.adoc
+++ b/articles/control-center/getting-started/index.adoc
@@ -17,7 +17,15 @@ Control Center is designed to run in a production environment. For local develop
 
 == Prerequisites
 
-Before you begin, make sure you have a Kubernetes cluster running and available. It can be a service like https://cloud.google.com/kubernetes-engine[Google Kubernetes Engine (GKE)], https://aws.amazon.com/eks[Amazon EKS], or https://azure.microsoft.com/en-us/products/kubernetes-service[Azure AKS].
+Before you begin, make sure you have a Kubernetes cluster running and available. It can be a service like https://cloud.google.com/kubernetes-engine[Google Kubernetes Engine (GKE)], https://aws.amazon.com/eks[Amazon EKS], https://azure.microsoft.com/en-us/products/kubernetes-service[Azure AKS], https://www.digitalocean.com/[DigitalOcean].
+
+[IMPORTANT]
+.Cloud Resources
+====
+You will need to ensure that your cluster provides sufficient resources for Control Center. This includes CPU, memory, and storage. The exact requirements depend on the size and number of applications you plan to deploy and the traffic they'll receive.
+
+For example, a node with 4 vCPUs and 8 GB of memory should be sufficient for Control Center and an application created with https://start.vaadin.com[Vaadin Start].
+====
 
 You'll also need to install https://helm.sh/[Helm]. It's a Kubernetes package manager that simplifies application deployment and management. Make sure it's configured to interact with your cluster.
 


### PR DESCRIPTION
This adds an admonition block to the Getting Started page that explains the resources required to run Control Center.

Fixes https://github.com/vaadin/control-center/issues/851