### PR TITLE
Fix several formatting issues

### DIFF
--- a/articles/components/charts/configuration.adoc
+++ b/articles/components/charts/configuration.adoc
@@ -297,7 +297,7 @@ xlabels.setRotation(-45); // Tilt 45 degrees CCW
 `staggerLines`:: Defines number of lines for placing the labels to avoid overlapping. By default undefined, and the number of lines is automatically determined up to `maxStaggerLines`.
 pass:[<!-- vale Vale.Spelling = NO -->]
 +
-`step``:: Defines tick interval for showing labels, so that labels are shown at every __n__th tick.
+`step`:: Defines tick interval for showing labels, so that labels are shown at every __n__th tick.
 The default step is automatically determined, along with staggering, to avoid overlap.
 +
 pass:[<!-- vale Vale.Spelling = YES -->]

--- a/articles/flow/create-ui/web-components/introduction-to-webcomponents.adoc
+++ b/articles/flow/create-ui/web-components/introduction-to-webcomponents.adoc
@@ -45,9 +45,11 @@ To learn more about how Vaadin utilizes Web Components, see:
 
 // Allow Vaadin Components in link
 pass:[<!-- vale Vaadin.ProductName = NO -->]
+
 * <<{articles}/components#,Vaadin Components>>: A modern set of Web Components for business applications.
 * <<index#,Integrating a Web Component>> into Vaadin.
 * https://vaadin.com/directory[Vaadin Directory]: A list of curated and rated third-party Web Components.
+
 pass:[<!-- vale Vaadin.ProductName = YES -->]
 
 == External Links and References

--- a/articles/flow/security/advanced-topics/strict-csp.adoc
+++ b/articles/flow/security/advanced-topics/strict-csp.adoc
@@ -38,7 +38,9 @@ response.getDocument().getElementsByTag("script").attr("nonce", nonce);
 ----
 
 pass:[<!-- vale Vale.Spelling = NO -->]
+
 == Function Execution & Eval Calls
+
 pass:[<!-- vale Vale.Spelling = YES -->]
 
 The example in the above section only adds the nonce to the application. It doesn't help with handling all of the dynamic functions, `eval` calls, and chunk loading. An application that needs to use strict CSP must provide a JavaScript file for handling these issues in a CSP-compliant way.

--- a/articles/tools/mpr/configuration/limitations.adoc
+++ b/articles/tools/mpr/configuration/limitations.adoc
@@ -46,6 +46,7 @@ See <<{articles}/flow/advanced/dynamic-content#using-custom-servlet-and-request-
 The latest Vaadin 7 or Vaadin 8 extended maintenance version Is required. Multiplatform Runtime is only supported when using the latest version of Vaadin 7 or Vaadin 8, which are only available to customers who have purchased Extended Maintenance. See https://vaadin.com/releases[releases] and https://vaadin.com/pricing[pricing] for details.
 
 pass:[<!-- vale Vaadin.Abbr = NO -->]
+
 == CDN & FETCH
 
 CDN and FETCH aren't supported for the widget set mode.


### PR DESCRIPTION
@mcollovati found that a title in https://github.com/vaadin/docs/blob/latest/articles/flow/security/advanced-topics/strict-csp.adoc was not formatted correctly because of a `pass` command not having a blank line following.

I have fixed this and several other similar formatting issues.