### PR TITLE
fix: ensure feature flags are set when rendering Lit/React examples

### DIFF
--- a/frontend/demo/init.ts
+++ b/frontend/demo/init.ts
@@ -7,6 +7,16 @@ import '../generated/theme-docs.global.generated.js';
 import client from 'Frontend/generated/connect-client.default';
 import { applyTheme } from 'Frontend/generated/theme';
 
+// Fix feature flags
+// Since https://github.com/vaadin/flow/pull/21066 Flow sets feature flags at runtime. However, that
+// doesn't work when rendering only Lit / React examples, as the Flow bootstrap logic is never
+// loaded. So for now, feature flags are set here in addition to vaadin-featureflags.properties.
+window.Vaadin.featureFlags = {
+  ...window.Vaadin.featureFlags,
+  cardComponent: true,
+  dashboardComponent: true,
+};
+
 // Apply the theme, so that overlay elements styles and custom property overrides work as expected
 applyTheme(document);
 


### PR DESCRIPTION
Add a workaround to make sure feature flags are set in Lit / React examples, even if Flow is not bootstrapped.