### PR TITLE
chore: fix some typos and remove trailing whitespaces

### DIFF
--- a/articles/getting-started/walk-through.adoc
+++ b/articles/getting-started/walk-through.adoc
@@ -20,14 +20,14 @@ my-application/
 ├── src/
 │   ├── main/
 │   │   ├── frontend/      <1>
-│   │   │   └── ...     
+│   │   │   └── ...
 │   │   ├── java/          <2>
-│   │   │   └── ...     
+│   │   │   └── ...
 │   │   └── resources/     <3>
-│   │   │   └── ...     
+│   │   │   └── ...
 │   └── test/
 │       └── java/          <4>
-│           └── ...     
+│           └── ...
 └── pom.xml                <5>
 ----
 <1> Frontend files, such as CSS and TypeScript files.
@@ -40,7 +40,7 @@ To make building easier, the skeleton includes the link:https://maven.apache.org
 
 The skeleton includes a `.gitignore` file optimized for Vaadin projects, and configuration files for the link:https://github.com/diffplug/spotless[Spotless] code formatter. The code formatter is needed when you generate code with <<{articles}/tools/copilot#,Vaadin Copilot>>, since it does not format the code itself.
 
-The `LICENCE.md` file is a placeholder for your application's licence. Replace with your own license, or delete if you don't need it.
+The `LICENSE.md` file is a placeholder for your application's license. Replace with your own license, or delete if you don't need it.
 
 Next, you'll have a closer look at the Java files, the frontend files, and the POM-file.
 
@@ -91,21 +91,21 @@ This feature-driven approach keeps related code together, making it easier to ma
 
 You'll find `package-info.java` files in every package. These files add the `@NullMarked` annotation from link:https://jspecify.dev[JSpecify] to each package. This instructs static analysis tools that every return value and method parameter can never be `null` unless explicitly stated with a `@Nullable` annotation. This is a good practice that reduces bugs caused by `NullPointerException`.
 
-`ArchitectureTest.java` is an link:https://www.archunit.org[ArchUnit] test that guards against unintentional dependencies between classes. As your application grows, it helps keep your code base in shape. 
+`ArchitectureTest.java` is an link:https://www.archunit.org[ArchUnit] test that guards against unintentional dependencies between classes. As your application grows, it helps keep your code base in shape.
 
 
 === The Todo Feature
 
 The `todo` feature consists of a JPA entity, a Spring Data JPA repository interface, and an application service.
 
-The repository stores and fetches entities from a relational database. The skeleton uses an in-memory H2 database. This is useful for prototyping, but soon you'll want to replace it with something else. 
+The repository stores and fetches entities from a relational database. The skeleton uses an in-memory H2 database. This is useful for prototyping, but soon you'll want to replace it with something else.
 
-The application service acts as the API of the feature and is the boundary between the _presentation layer_ and the _application layer_. Its main purpose in the skeleton is to show how an application service interacts with the domain model in a Vaadin application. 
+The application service acts as the API of the feature and is the boundary between the _presentation layer_ and the _application layer_. Its main purpose in the skeleton is to show how an application service interacts with the domain model in a Vaadin application.
 
 The todo service has a sample integration test. It starts up the application and its embedded H2 database, and checks that the service works as expected. Its main purpose in the skeleton is to show how to write integration tests for application services.
 
 
-=== Java Views [badge-flow]#Flow# 
+=== Java Views [badge-flow]#Flow#
 
 If you generated a Flow view, you'll find some extra Java files in the skeleton:
 
@@ -124,7 +124,7 @@ src
         └── todo
             └── ui
                 └── view
-                    └── TodoView.java 
+                    └── TodoView.java
 ----
 
 The `base` feature package contains one user interface package with two sub-packages: `component` and `view`.
@@ -133,9 +133,9 @@ The `component` package contains custom UI components that can be reused through
 
 The `view` package contains view-related classes that cut across multiple views in multiple features. The skeleton contains an error handler, and a main layout.
 
-The error handler receives all exceptions that reach the user interface, logs them, and shows an error notification to the user. You'll want to customize this as the application grows. 
+The error handler receives all exceptions that reach the user interface, logs them, and shows an error notification to the user. You'll want to customize this as the application grows.
 
-Your application shows all the views inside the main layout by default. It contains the application's name, a navigation menu, and a mock user menu that doesn't do anything. You'll want to at least change the application name, and either remove or  implement the user menu. 
+Your application shows all the views inside the main layout by default. It contains the application's name, a navigation menu, and a mock user menu that doesn't do anything. You'll want to at least change the application name, and either remove or  implement the user menu.
 
 The `todo` feature package contains one UI-related package. It contains the view that allows users to create and list tasks to do.
 
@@ -154,12 +154,12 @@ src
             └── theme.json
 ----
 
-This is an empty theme called `default`, based on the Lumo theme. It is activated in the `Application` class, using the `@Theme` annotation. 
+This is an empty theme called `default`, based on the Lumo theme. It is activated in the `Application` class, using the `@Theme` annotation.
 
 If you've started up your application, you'll see some auto-generated files in the `frontend` directory as well. You'll find an `index.html` file, and a `generated` directory. You don't have to touch these for now.
 
 
-=== React Views [badge-hilla]#Hilla# 
+=== React Views [badge-hilla]#Hilla#
 
 If you generated a Hilla view, you'll find more frontend files in the skeleton:
 
@@ -179,7 +179,7 @@ The `components` directory contains custom UI components that can be reused thro
 
 The `views` directory contains an example view, a main layout, and an error handler. The file names in this directory all have special meaning. You'll learn about it later.
 
-The example view - `@index.tsx` - allows users to add and list tasks to do. 
+The example view - `@index.tsx` - allows users to add and list tasks to do.
 
 Your application shows all the views inside the main layout - `@layout.tsx` - by default. It contains the application's name, a navigation menu, and a mock user menu that doesn't do anything. You'll want to at least change the application name, and either remove or implement the user menu.
 
@@ -196,8 +196,8 @@ The `spotless-maven-plugin` is used to format the Java and TypeScript source fil
 
 The `vaadin-maven-plugin` is used to prepare and build the frontend files. Under the hood it is using link:https://www.npmjs.com/[npm] and link:https://vite.dev/[Vite].
 
-The POM file defines two build profiles: `production`, and `integration-test`. 
+The POM file defines two build profiles: `production`, and `integration-test`.
 
 The `production` profile triggers a production build, and is deactivated by default. You'll learn more about making a production build on the <<build#,Build a Project>> page.
 
-The `integration-test` profile runs integration tests during the `verify` phase, and is deactivated by default. 
+The `integration-test` profile runs integration tests during the `verify` phase, and is deactivated by default.

--- a/articles/hilla/guides/full-stack-signals.adoc
+++ b/articles/hilla/guides/full-stack-signals.adoc
@@ -26,7 +26,7 @@ Also, the implementation of full-stack signals is currently only available for V
 [[server-side-signal-instance]]
 == Server-Side Full-Stack Signal Instance
 
-The purpose of a full-stack signal is to share and synchronize the state between the server and clients in real time. In Vaadin Hilla applications, you can do that by creating an instance of one of the available full-stack signal types and returning it from your [classname]`@BrowserCallable` annotated services. 
+The purpose of a full-stack signal is to share and synchronize the state between the server and clients in real time. In Vaadin Hilla applications, you can do that by creating an instance of one of the available full-stack signal types and returning it from your [classname]`@BrowserCallable` annotated services.
 
 In the following example, an instance of a [classname]`ValueSignal` is created and returned from a server-side, browser-callable service:
 
@@ -66,7 +66,7 @@ For a complete list of available full-stack signal types, see <<available-full-s
 [[client-subscription]]
 == Subscription to a Full-Stack Signal
 
-For a client to receive real-time updates when the state of a full-stack signal changes, it needs to subscribe to the signal. This can be done by calling any normal Vaadin browser-callable service. 
+For a client to receive real-time updates when the state of a full-stack signal changes, it needs to subscribe to the signal. This can be done by calling any normal Vaadin browser-callable service.
 
 The following example demonstrates how to subscribe to the `started` signal created in the previous section:
 
@@ -101,7 +101,7 @@ export default function VoteView() {
 [[available-full-stack-signal-types]]
 == Available Full-Stack Signal Types
 
-The full-stack signals are designed to be used in various scenarios. Based on the requirements, different types of full-stack signals are used. The server-side signal types are available in the `com.vaadin.hilla.signals` package. Their client-side counterparts are available in `@vaadin/hilla-react-signals`. 
+The full-stack signals are designed to be used in various scenarios. Based on the requirements, different types of full-stack signals are used. The server-side signal types are available in the `com.vaadin.hilla.signals` package. Their client-side counterparts are available in `@vaadin/hilla-react-signals`.
 
 As this is currently under active development, more signal types are added with each new release. The currently available ones are [classname]`ValueSignal`, [classname]`NumberSignal`, and [classname]`ListSignal`. These are described in the following sub-sections.
 
@@ -417,7 +417,7 @@ Since the `todoItems` signal holds the shared list of tasks, any subscribed clie
 
 The client-side API of the [classname]`ListSignal` provides methods to insert and remove items. The [classname]`ListSignal` is a sequence of [classname]`ValueSignal` entries. Therefore, its API is about how the entries are added to the list or removed, and how the concurrent operations regarding the structure of the entries is handled.
 
-As this is currently under active development, more methods and functionalities are added with each new release. The currently available ones are [methodname]`inserLast` and [methodname]`remove`. These are described below:
+As this is currently under active development, more methods and functionalities are added with each new release. The currently available ones are [methodname]`insertLast` and [methodname]`remove`. These are described below:
 
 `insertLast(value: T): Operation`:: Inserts a new value at the end of the list. The returned `Operation` object can be used to chain further operations via the `result` property, which is a `Promise`. The chained operations are resolved after the current operation is completed and confirmed by the server.
 `remove(item: ValueSignal<T>): Operation`:: Removes the given item from the list. The returned `Operation` object can be used to chain further operations via the `result` property, which is a `Promise`. The chained operations are resolved after the current operation is completed and confirmed by the server.
@@ -592,7 +592,7 @@ Security with full-Stack signals can be enabled in two separate levels. They're 
 
 === Controlling Browser-Callable Service Access
 
-Full-stack signals are exposed by the services that are annotated with [classname]`@BrowserCallable` -- or the synonym, [classname]`@Endpoint`. This means the services that expose the signals are secured by the same security rules as any other service using the [classname]`@AnonymousAllowed`, [classname]`@PermitAll`, [classname]`@RolesAllowed`, or [classname]`@DenyAll` on the class or the individual methods. 
+Full-stack signals are exposed by the services that are annotated with [classname]`@BrowserCallable` -- or the synonym, [classname]`@Endpoint`. This means the services that expose the signals are secured by the same security rules as any other service using the [classname]`@AnonymousAllowed`, [classname]`@PermitAll`, [classname]`@RolesAllowed`, or [classname]`@DenyAll` on the class or the individual methods.
 
 For more information on how to secure the services, see the <<./security/intro#, security documentation>>.
 
@@ -661,7 +661,7 @@ NumberSignal voteSignal = new NumberSignal() // <1>
 In the above example, the `operation` parameter is an instance of [classname]`SignalOperation`. At runtime, the operation can be one of the following types:
 
 `ValueOperation<T>`:: Represents an operation that contains a value of type `T`.
-`IncrementOpertaion`:: Specific to `NumberSignal`. Represents an operation that increments the value of the signal by a given value. Value is of Type `Double`. This operation is a special case of [classname]`ValueOperation<Double>`.
+`IncrementOperation`:: Specific to `NumberSignal`. Represents an operation that increments the value of the signal by a given value. Value is of Type `Double`. This operation is a special case of [classname]`ValueOperation<Double>`.
 `SetValueOperation<T>`:: Specific to `ValueSignal` and `NumberSignal`. Also, applies to changes happening to the items in a `ListSignal`. Represents an operation that sets the value of the signal to a new value of type `T`. This operation is a special case of [classname]`ValueOperation<T>`.
 `ReplaceValueOperation<T>`:: Specific to `ValueSignal` and `NumberSignal`. Also, applies to the changes happening to the items in a `ListSignal`. Represents an operation that replaces the value of the signal with a new value of type `T`. This operation is a special case of [classname]`ValueOperation<T>`.
 `ListInsertOperation<T>`:: Specific to `ListSignal`. Represents an operation that inserts a new value to the list signal at a given position. The value is of type `T`. This operation is a special case of [classname]`ValueOperation<T>`.


### PR DESCRIPTION
Fixed a few typos:

- `licence` -> `license`
- `inserLast` -> `insertLast`
- `Opertaion` -> `Operation`

This also removed some trailing whitespaces (auto-formatting on save in VSCode).