### PR TITLE
[Control Center] Add missing prefix to probe config values

### DIFF
--- a/articles/control-center/getting-started/configure-installation.adoc
+++ b/articles/control-center/getting-started/configure-installation.adoc
@@ -92,29 +92,29 @@ The following table lists the available values and their descriptions. Each of t
 
 | app.pass:[<wbr>]resources | No | | The resource to allocate for the Control Center application containers.
 
-| startupProbe.pass:[<wbr>]httpGet.pass:[<wbr>]path | No | /actuator/pass:[<wbr>]health | The path to use for the startup probe for the Control Center application.
+| app.pass:[<wbr>]startupProbe.pass:[<wbr>]httpGet.pass:[<wbr>]path | No | /actuator/pass:[<wbr>]health | The path to use for the startup probe for the Control Center application.
 
-| startupProbe.pass:[<wbr>]httpGet.pass:[<wbr>]port | No | `http` | The port to use for the startup probe.
+| app.pass:[<wbr>]startupProbe.pass:[<wbr>]httpGet.pass:[<wbr>]port | No | `http` | The port to use for the startup probe.
 
-| startupProbe.pass:[<wbr>]initialDelaySeconds | No | 0 | The initial delay in seconds for the startup probe.
+| app.pass:[<wbr>]startupProbe.pass:[<wbr>]initialDelaySeconds | No | 0 | The initial delay in seconds for the startup probe.
 
-| startupProbe.pass:[<wbr>]failureThreshold | No | 30 | The failure threshold for the startup probe. If the probe fails this many times, the container is restarted.
+| app.pass:[<wbr>]startupProbe.pass:[<wbr>]failureThreshold | No | 30 | The failure threshold for the startup probe. If the probe fails this many times, the container is restarted.
 
-| livenessProbe.pass:[<wbr>]httpGet.pass:[<wbr>]path | No | /actuator/pass:[<wbr>]health/pass:[<wbr>]liveness | The path to use for the liveness probe for the Control Center application.
+| app.pass:[<wbr>]livenessProbe.pass:[<wbr>]httpGet.pass:[<wbr>]path | No | /actuator/pass:[<wbr>]health/pass:[<wbr>]liveness | The path to use for the liveness probe for the Control Center application.
 
-| livenessProbe.pass:[<wbr>]httpGet.pass:[<wbr>]port | No | `http` | The port to use for the liveness probe.
+| app.pass:[<wbr>]livenessProbe.pass:[<wbr>]httpGet.pass:[<wbr>]port | No | `http` | The port to use for the liveness probe.
 
-| livenessProbe.pass:[<wbr>]initialDelaySeconds | No | 0 | The initial delay in seconds for the liveness probe.
+| app.pass:[<wbr>]livenessProbe.pass:[<wbr>]initialDelaySeconds | No | 0 | The initial delay in seconds for the liveness probe.
 
-| livenessProbe.pass:[<wbr>]failureThreshold | No | 3 | The failure threshold for the liveness probe. If the probe fails this many times, the container is restarted.
+| app.pass:[<wbr>]livenessProbe.pass:[<wbr>]failureThreshold | No | 3 | The failure threshold for the liveness probe. If the probe fails this many times, the container is restarted.
 
-| readinessProbe.pass:[<wbr>]httpGet.pass:[<wbr>]path | No | /actuator/pass:[<wbr>]health/pass:[<wbr>]readiness | The path to use for the readiness probe for the Control Center application.
+| app.pass:[<wbr>]readinessProbe.pass:[<wbr>]httpGet.pass:[<wbr>]path | No | /actuator/pass:[<wbr>]health/pass:[<wbr>]readiness | The path to use for the readiness probe for the Control Center application.
 
-| readinessProbe.pass:[<wbr>]httpGet.pass:[<wbr>]port | No | `http` | The port to use for the readiness probe.
+| app.pass:[<wbr>]readinessProbe.pass:[<wbr>]httpGet.pass:[<wbr>]port | No | `http` | The port to use for the readiness probe.
 
-| readinessProbe.pass:[<wbr>]initialDelaySeconds | No | 0 | The initial delay in seconds for the readiness probe.
+| app.pass:[<wbr>]readinessProbe.pass:[<wbr>]initialDelaySeconds | No | 0 | The initial delay in seconds for the readiness probe.
 
-| readinessProbe.pass:[<wbr>]failureThreshold | No | 3 | The failure threshold for the readiness probe.
+| app.pass:[<wbr>]readinessProbe.pass:[<wbr>]failureThreshold | No | 3 | The failure threshold for the readiness probe.
 
 | app.pass:[<wbr>]volumes | No | | The volume definitions for the Control Center application.
 


### PR DESCRIPTION
@manolo reported that some of the configuration values for Control Center were not correct. The values related to different probe settings now have a `app.` prefix on them.