### PR TITLE
Removed "Brief Step-by-Step" section

### DIFF
--- a/articles/tools/copilot/index.adoc
+++ b/articles/tools/copilot/index.adoc
@@ -23,13 +23,6 @@ See the <</getting-started/start#, Start a Project>> guide for more information.
 
 Once your application is running, click the image:images/activation-button.png[Activation button,26] button to activate or deactivate Copilot.
 
-*Brief Step-by-Step Instructions*
-
-- Go to https://start.vaadin.com/?preset=hilla[start.vaadin.com] and click _Download Project_.
-- After downloading, unzip the project.
-- Run `./mvnw` in the project folder.
-- Once the project opens in your browser, click the image:images/activation-button.png[Activation button,26] button.
-
 
 === Development Workflow
 


### PR DESCRIPTION
That part points to outdated Start preset (Hilla Lit) and should be updated to include Walking Skeleton. Since there is no point of duplicating Getting Started guide; it's not worth maintaining.

Same information is present one paragraph above.