### PR TITLE
chore: Upgrade supported Node.js to 20

### DIFF
--- a/articles/compatibility.adoc
+++ b/articles/compatibility.adoc
@@ -17,7 +17,7 @@ This page shows the minimum required versions of supported technologies for Vaad
 
 | Java| 17 or later
 | Spring Boot| 3.0 or later
-| Node.js| 18 or later
+| Node.js| 20 or later
 | Maven| 3.5 or later (except for 3.8.2 and 3.8.3)
 | Gradle| 8.5 or later
 | Servlet| 6 or later


### PR DESCRIPTION
Node.js goes out of support and React 19 needs Node.js 20+


