### PR TITLE
fix: enable top-level await for dependencies

### DIFF
--- a/vite.dspublisher.ts
+++ b/vite.dspublisher.ts
@@ -23,6 +23,9 @@ const themePlugin = vaadin.plugins?.find((plugin: any) => plugin.name === 'vaadi
 
 const endpointMocks = resolve(__dirname, 'frontend', 'demo', 'services', 'mocks.js');
 
+// Use newer target to support top-level await in Hilla dependencies
+const target = ['safari15', 'es2022'];
+
 const config: UserConfig = {
   resolve: {
     alias: {
@@ -40,6 +43,14 @@ const config: UserConfig = {
       '/vaadin': {
         target: 'http://localhost:8080',
       },
+    },
+  },
+  build: {
+    target,
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      target,
     },
   },
   plugins: [


### PR DESCRIPTION
Currently running the docs app in development mode is broken: When opening the app in the browser, the browser either just keeps loading indefinitely or loads an initial page, but with none of the links working. Firefox sometimes shows this error:
```
UnhandledRejection: Astro detected an unhandled rejection. Here's the stack trace:
Error: Build failed with 1 error:
../../../../../../dev/vaadin/docs/node_modules/@vaadin/hilla-frontend/FluxConnection.js:44:16: ERROR: Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
    at failureErrorWithLog (/Users/sascha/.npm/_npx/370bd51a675d5282/node_modules/@vaadin/dspublisher/node_modules/esbuild/lib/main.js:1472:15)
```

This is caused by a recent change in Hilla dependencies, where a top-level await was introduced: https://github.com/vaadin/hilla/pull/2901.

Similar to a related fix in Flow (https://github.com/vaadin/flow/pull/21276), this bumps the Vite target to add support for top-level await in esbuild.