### PR TITLE
docs: reorder descriptions of annotations in integration example

### DIFF
--- a/articles/flow/integrations/react.adoc
+++ b/articles/flow/integrations/react.adoc
@@ -25,8 +25,8 @@ include::../../../src/main/java/com/vaadin/demo/flow/integration/react/RgbaColor
 ----
 
 <1> Since this will integrate a third-party React component, the [annotationname]`@NpmPackage` annotation is added to be installed from npm.
-<2> The [annotationname]`@Tag` annotation defines the DOM element name of the adapter Web Component (see below).
-<3> The client-side part of the integration (i.e., the adapter Web Component) is yet to be defined and implemented in TypeScript. Therefore, you'll need a separate file for it. Although this file will be created later, the [annotationname]`@JsModule` annotation is added here to import it.
+<2> The client-side part of the integration (i.e., the adapter Web Component) is yet to be defined and implemented in TypeScript. Therefore, you'll need a separate file for it. Although this file will be created later, the [annotationname]`@JsModule` annotation is added here to import it.
+<3> The [annotationname]`@Tag` annotation defines the DOM element name of the adapter Web Component (see below).
 
 
 === Java & React States Synchronized


### PR DESCRIPTION
The numbered callouts (2 and 3) are not aligned with the explanations below.
![image](https://github.com/user-attachments/assets/194091f0-27ba-4747-a806-a05163bcdbe9)

