### PR TITLE
Fix code example of configuring SecurityContext requireExplicitSave

### DIFF
--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -224,7 +224,7 @@ If the application is using Spring Security 5, the default behavior is for the `
 
 In Spring Security 6, users now must explicitly save the `SecurityContext` to the `SecurityContextRepository`.
 
-You can return the old behavior by adding to [methodname]`configuration(HttpSecurity)` the line `http.securityContext((securityContext) -> securityContext.requireExplicitSave(false));`.
+You can return the old behavior by adding to [methodname]`configure(HttpSecurity http)` the line `http.securityContext ( (securityContext) -> securityContext.requireExplicitSave( false ) );`.
 
 For more information see https://docs.spring.io/spring-security/reference/5.8/migration/servlet/session-management.html#_require_explicit_saving_of_securitycontextrepository[Servlet Migrations - Session Management].
 


### PR DESCRIPTION
configuration method is really called 'configure' but I am not sure I could correct the broken braces rendering.


