### PR TITLE
chore: improve custom servlet configuration example

### DIFF
--- a/articles/flow/integrations/spring/configuration.adoc
+++ b/articles/flow/integrations/spring/configuration.adoc
@@ -128,9 +128,12 @@ public class OverriddenServletConfiguration {
                 .isRootMapping(configurationProperties.getUrlMapping());
         // Calls default configuration for ServletRegistrationBean at
         // com.vaadin.flow.spring.SpringBootAutoConfiguration.configureServletRegistrationBean
-        return configureServletRegistrationBean(multipartConfig,
+        ServletRegistrationBean<SpringServlet> registrationBean = configureServletRegistrationBean(multipartConfig,
                 configurationProperties,
                 new OverriddenSpringServlet(context, rootMapping));
+        // Configure additional servlet settings if needed, e.g. init parameters
+        // registrationBean.addInitParameter("closeIdleSessions", "true");
+        return registrationBean;
     }
 
     public static class OverriddenSpringServlet extends SpringServlet {


### PR DESCRIPTION
Updates the custom servlet configuration example to show how to further configure the servlet, for example, by adding an init parameter.

Context: https://vaadin.com/forum/t/push-creates-new-threads-permanently-atmosphere-shared/167987/10


