### PR TITLE
docs: use correct HTML tag name for strike-through text

### DIFF
--- a/articles/components/rich-text-editor/index.adoc
+++ b/articles/components/rich-text-editor/index.adoc
@@ -74,7 +74,7 @@ Rich Text Editor supports values in the HTML format, with the following restrict
 | `<h1>`, `<h2>`, ..., `<h6>`
 
 | Bold, italic, underlined and strike-through text
-| `<strong>`, `<em>`, `<u>`, `<strikethrough>`
+| `<strong>`, `<em>`, `<u>`, `<s>`
 
 | Links
 | `<a href="...">...</a>`


### PR DESCRIPTION
Fixed a finding from the comments. The actual tag used by Quill is `<s>` and not `<strikethrough>`.