### PR TITLE
docs: remove experimental state from card component

### DIFF
--- a/articles/components/card/index.adoc
+++ b/articles/components/card/index.adoc
@@ -3,18 +3,14 @@ title: Card
 page-title: Card component | Vaadin components
 description: The Card component is a versatile container for grouping related content and actions, with several customization options for layout and appearance.
 meta-description: The Card component is a versatile container for grouping related content and actions, with several customization options for layout and appearance.
-section-nav: badge-preview
-version: since:com.vaadin:vaadin@V24.7
+version: since:com.vaadin:vaadin@V24.8
 layout: tabbed-page
 ---
 
 = Card
 :toclevels: 2
 
-:preview-feature: Card
-:feature-flag: com.vaadin.experimental.cardComponent
 :feedback-url: https://vaadin.com/forum/t/card-component/167926
-include::{articles}/_preview-banner.adoc[opts=optional]
 
 // tag::description[]
 The Card component is a versatile container for grouping related content and actions, with several customization options for layout and appearance.

--- a/src/main/resources/vaadin-featureflags.properties
+++ b/src/main/resources/vaadin-featureflags.properties
@@ -1,3 +1,2 @@
-com.vaadin.experimental.cardComponent=true
 com.vaadin.experimental.dashboardComponent=true
 com.vaadin.experimental.masterDetailLayoutComponent=true


### PR DESCRIPTION
Remove experimental / preview state from card component. Update since tag to reflect that it became stable in v24.8.

Depends on these to be merged / released first:
- https://github.com/vaadin/flow-components/pull/7503
- https://github.com/vaadin/web-components/pull/9272

Part of https://github.com/vaadin/components-team-tasks/issues/634