### PR TITLE
Update JDK requirement in Vaadin 8 TestBench Overview

### DIFF
--- a/articles/testbench/testbench-overview.asciidoc
+++ b/articles/testbench/testbench-overview.asciidoc
@@ -172,7 +172,7 @@ Vaadin TestBench Library provides the central control logic for:
 
 Requirements for developing and running tests are:
 
-* Java JDK 1.6 or newer
+* Java JDK 8 or newer
 
 * Browsers installed on test nodes as supported by Selenium WebDriver
 


### PR DESCRIPTION
JDK 1.6 was a Vaadin 7 requirement, Vaadin 8 has required JDK 8 from the beginning.


