### PR TITLE
chore: fix eslint warnings for MenuBarItem import and usage

### DIFF
--- a/frontend/demo/component/menubar/react/menu-bar-basic.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-basic.tsx
@@ -9,7 +9,7 @@ function Example() {
   // tag::snippet[]
   const selectedItem = useSignal<MenuBarItem | undefined>(undefined);
 
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/react/menu-bar-checkable.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-checkable.tsx
@@ -12,7 +12,7 @@ import {
 function Example() {
   useSignals(); // hidden-source-line
   // tag::snippet[]
-  const items = useSignal<Array<MenuBarItem>>([
+  const items = useSignal<MenuBarItem[]>([
     {
       text: 'Options',
       children: [{ text: 'Save automatically', checked: true }, { text: 'Notify watchers' }],

--- a/frontend/demo/component/menubar/react/menu-bar-combo-buttons.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-combo-buttons.tsx
@@ -2,11 +2,11 @@ import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { text: 'Save' },
     {
       component: <Icon icon="vaadin:chevron-down" aria-label="Other save options" />,

--- a/frontend/demo/component/menubar/react/menu-bar-custom-styling.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-custom-styling.tsx
@@ -1,10 +1,10 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { text: 'View', className: 'bg-primary text-primary-contrast' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/react/menu-bar-disabled.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-disabled.tsx
@@ -1,10 +1,10 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { text: 'View' },
     { text: 'Edit', disabled: true },
     {

--- a/frontend/demo/component/menubar/react/menu-bar-dividers.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-dividers.tsx
@@ -1,10 +1,10 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     {
       text: 'Share',
       children: [

--- a/frontend/demo/component/menubar/react/menu-bar-drop-down-indicators.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-drop-down-indicators.tsx
@@ -1,9 +1,9 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {
-  const items : Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/react/menu-bar-drop-down.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-drop-down.tsx
@@ -1,10 +1,10 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     {
       text: 'John Smith',
       children: [

--- a/frontend/demo/component/menubar/react/menu-bar-icon-only.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-icon-only.tsx
@@ -2,7 +2,7 @@ import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function createItem(iconName: string, ariaLabel: string) {
   return <Icon icon={`vaadin:${iconName}`} aria-label={ariaLabel} />;
@@ -10,7 +10,7 @@ function createItem(iconName: string, ariaLabel: string) {
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { component: createItem('eye', 'View') },
     { component: createItem('pencil', 'Edit') },
     {

--- a/frontend/demo/component/menubar/react/menu-bar-icons.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-icons.tsx
@@ -2,7 +2,7 @@ import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function createItem(iconName: string, text: string, isChild = false) {
   const iconStyle: React.CSSProperties = {
@@ -26,7 +26,7 @@ function createItem(iconName: string, text: string, isChild = false) {
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     {
       component: createItem('share', 'Share'),
       children: [

--- a/frontend/demo/component/menubar/react/menu-bar-internationalization.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-internationalization.tsx
@@ -1,9 +1,9 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { MenuBar, type MenuBarI18n, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarI18n, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/react/menu-bar-open-on-hover.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-open-on-hover.tsx
@@ -1,10 +1,10 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/react/menu-bar-overflow.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-overflow.tsx
@@ -1,11 +1,11 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 import { SplitLayout } from '@vaadin/react-components/SplitLayout.js';
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/react/menu-bar-right-aligned.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-right-aligned.tsx
@@ -1,9 +1,9 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 
 function Example() {
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { text: 'View' },
     { text: 'Edit' },
     {

--- a/frontend/demo/component/menubar/react/menu-bar-tooltip.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-tooltip.tsx
@@ -2,7 +2,7 @@ import '@vaadin/icons';
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { Icon } from '@vaadin/react-components/Icon.js';
-import { MenuBar, MenuBarItem } from '@vaadin/react-components/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '@vaadin/react-components/MenuBar.js';
 import { Tooltip } from '@vaadin/react-components/Tooltip.js';
 
 function createItem(iconName: string) {
@@ -11,7 +11,7 @@ function createItem(iconName: string) {
 
 function Example() {
   // tag::snippet[]
-  const items: Array<MenuBarItem> = [
+  const items: MenuBarItem[] = [
     { component: createItem('eye'), tooltip: 'View' },
     { component: createItem('pencil'), tooltip: 'Edit' },
     { component: createItem('folder'), tooltip: 'Move' },


### PR DESCRIPTION
Follow-up to #4273

This fixes the following ESLint warnings:

```
  3:1   error  Imports "MenuBarItem" are only used as type                                                       @typescript-eslint/consistent-type-imports
  7:16  error  Array type using 'Array<MenuBarItem>' is forbidden for simple types. Use 'MenuBarItem[]' instead  @typescript-eslint/array-type

```