### PR TITLE
Top-level nav items are collapsed by default

### DIFF
--- a/articles/building-apps/index.adoc
+++ b/articles/building-apps/index.adoc
@@ -4,7 +4,7 @@ page-title: How to Build Apps with Vaadin
 description: How to build real-world business applications with Vaadin.
 meta-description: Get an overview of best practices and frameworks for building business applications with Vaadin.
 order: 10
-section-nav: flat expanded
+section-nav: flat
 ---
 
 

--- a/articles/components/index.adoc
+++ b/articles/components/index.adoc
@@ -8,7 +8,7 @@ layout: index
 page-links:
   - https://github.com/vaadin/web-components/releases/tag/v{moduleNpmVersion:vaadin-themable-mixin}[Web Components {moduleNpmVersion:vaadin-themable-mixin}]
   - https://github.com/vaadin/flow-components/releases/tag/{moduleMavenVersion:com.vaadin:vaadin-lumo-theme}[Flow Components {moduleMavenVersion:com.vaadin:vaadin-lumo-theme}]
-section-nav: flat reveal
+section-nav: flat
 ---
 
 

--- a/articles/control-center/index.adoc
+++ b/articles/control-center/index.adoc
@@ -4,7 +4,7 @@ page-title: How to use Vaadin Control Center
 description: Speed up development with Control Center, a specialized tool designed specifically for managing Vaadin applications on Kubernetes clusters.
 meta-description: Speed up development with Vaadin's Control Center, a specialized tool designed specifically for managing Vaadin applications on Kubernetes clusters.
 order: 70
-section-nav: flat expanded
+section-nav: flat
 ---
 
 

--- a/articles/designing-apps/index.adoc
+++ b/articles/designing-apps/index.adoc
@@ -2,7 +2,7 @@
 title: Designing Apps
 description: The basics of designing user interfaces for Vaadin applications.
 order: 790
-section-nav: flat expanded
+section-nav: flat
 ---
 
 

--- a/articles/flow/index.adoc
+++ b/articles/flow/index.adoc
@@ -4,5 +4,5 @@ page-title: Vaadin Flow documentation | Comprehensive guide for developers
 description: Build web applications with only Java.
 meta-description: Explore the Vaadin Flow framework for building full-stack Java web applications. Read the documentation for a comprehensive guide.
 order: 10
-section-nav: flat reveal
+section-nav: flat
 ---

--- a/articles/getting-started/index.adoc
+++ b/articles/getting-started/index.adoc
@@ -4,7 +4,7 @@ page-title: Guide for Getting Started with Vaadin
 description: Get started building applications with Vaadin.
 meta-description: Explore this beginner's guide to start building applications with Vaadin.
 order: 5
-section-nav: flat expanded
+section-nav: flat
 ---
 
 = Welcome to the Getting Started Guide!

--- a/articles/hilla/index.adoc
+++ b/articles/hilla/index.adoc
@@ -4,5 +4,5 @@ page-title: "Hilla: A full-stack framework for modern web apps"
 description: Learn how to use Hilla, a full-stack web framework that seamlessly integrates a Spring Boot backend and a React frontend.
 meta-description: Learn how to use the full-stack web framework Hilla, created by Vaadin, that seamlessly integrates a Spring Boot backend and a React frontend.
 order: 20
-section-nav: flat expanded
+section-nav: flat
 ---

--- a/articles/styling/index.adoc
+++ b/articles/styling/index.adoc
@@ -4,7 +4,7 @@ page-title: Styling guide for Vaadin applications
 description: A brief overview of styling Vaadin applications.
 meta-description: Explore Vaadin styling options to create visually appealing applications.
 order: 55
-section-nav: flat expanded
+section-nav: flat
 ---
 
 

--- a/articles/tools/index.adoc
+++ b/articles/tools/index.adoc
@@ -5,7 +5,7 @@ description: Speed up development with official Vaadin tools.
 meta-description: Explore Vaadin tools designed to enhance application development, styling, and deployment.
 order: 60
 layout: index
-section-nav: flat reveal
+section-nav: flat
 ---
 
 = Tools

--- a/dspublisher/theme/global.css
+++ b/dspublisher/theme/global.css
@@ -441,7 +441,7 @@ body[style*="pointer-events: none"] [class*="drawerScrollContainer"] > * {
 /* "flat": don't indent the child items under the that parent item */
 /* "reveal" (works only together with "flat"): show a handful of children even when the parent item is collapsed */
 
-nav[aria-label=sections] li:not(.reveal) > div > [class*=toggleButton]:where(:not(:focus-visible)),
+/* nav[aria-label=sections] li:not(.reveal) > div > [class*=toggleButton]:where(:not(:focus-visible)),
 nav[aria-label=sections] li.reveal > div > [class*=toggleButton]::before,
 nav[aria-label=sections] li.reveal > div > [class*=toggleButton]::after {
   opacity: 0;
@@ -456,7 +456,7 @@ nav[aria-label=sections] li.flat:not(.reveal) > div:hover > [class*=toggleButton
 nav[aria-label=sections] li.reveal > div > [class*=toggleButton]:focus-visible::before,
 nav[aria-label=sections] li.reveal:not([class*=-expanded]):hover > div > [class*=toggleButton]::after {
   opacity: 1;
-}
+} */
 
 nav[aria-label=sections] li > [class*=title] {
   padding-inline-end: var(--docs-space-2xs);


### PR DESCRIPTION
Also, always shows the expand toggles.

Before:
![Screenshot 2025-06-02 at 11 17 02](https://github.com/user-attachments/assets/2994b9e1-c48f-4fcb-aed0-84ff4bdc8b85)


After: 
![Screenshot 2025-06-02 at 11 15 52](https://github.com/user-attachments/assets/30122e58-2fc6-4035-90cb-a410615d7259)
