### PR TITLE
Fix cyclonedx configuration section

### DIFF
--- a/articles/tools/appsec/getting-started.adoc
+++ b/articles/tools/appsec/getting-started.adoc
@@ -51,24 +51,24 @@ To generate the SBOM file from Maven dependencies, you'll need to add the link:h
             <goals>
                 <goal>makeAggregateBom</goal>
             </goals>
+            <configuration>
+                <projectType>library</projectType>
+                <schemaVersion>1.4</schemaVersion>
+                <includeBomSerialNumber>true</includeBomSerialNumber>
+                <includeCompileScope>true</includeCompileScope>
+                <includeProvidedScope>true</includeProvidedScope>
+                <includeRuntimeScope>true</includeRuntimeScope>
+                <includeSystemScope>true</includeSystemScope>
+                <includeTestScope>false</includeTestScope>
+                <includeLicenseText>false</includeLicenseText>
+                <outputReactorProjects>true</outputReactorProjects>
+                <outputFormat>json</outputFormat>
+                <outputName>bom</outputName>
+                <outputDirectory>${project.build.outputDirectory}/resources</outputDirectory>
+                <verbose>false</verbose>
+            </configuration>
         </execution>
     </executions>
-    <configuration>
-        <projectType>library</projectType>
-        <schemaVersion>1.4</schemaVersion>
-        <includeBomSerialNumber>true</includeBomSerialNumber>
-        <includeCompileScope>true</includeCompileScope>
-        <includeProvidedScope>true</includeProvidedScope>
-        <includeRuntimeScope>true</includeRuntimeScope>
-        <includeSystemScope>true</includeSystemScope>
-        <includeTestScope>false</includeTestScope>
-        <includeLicenseText>false</includeLicenseText>
-        <outputReactorProjects>true</outputReactorProjects>
-        <outputFormat>json</outputFormat>
-        <outputName>bom</outputName>
-        <outputDirectory>${project.build.outputDirectory}/resources</outputDirectory>
-        <verbose>false</verbose>
-    </configuration>
 </plugin>
 ----
 


### PR DESCRIPTION
Fix cyclonedx plugin configuration section so it's included inside the execution block instead of at the plugin's root level. See relevant issue and comment: https://github.com/vaadin/appsec-kit/issues/195#issuecomment-2922702201


