### PR TITLE
Fix/missing or wrong length meta info

### DIFF
--- a/articles/building-apps/deep-dives/application-layer/background-jobs/index.adoc
+++ b/articles/building-apps/deep-dives/application-layer/background-jobs/index.adoc
@@ -1,6 +1,8 @@
 ---
 title: Background Jobs
+page-title: How handle background jobs in your Vaadin applications
 description: How to handle background jobs.
+meta-description: There are different ways of implementing background jobs. To reduce the risk, you should learn one way, and then apply it consistently in your Vaadin apps.
 order: 11
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/background-jobs/interaction/callbacks.adoc
+++ b/articles/building-apps/deep-dives/application-layer/background-jobs/interaction/callbacks.adoc
@@ -1,6 +1,8 @@
 ---
 title: Callbacks
-description: How to use callbacks to iteract with the user interface.
+page-title: How to use callbacks to interact with your UI | Vaadin 
+description: How to use callbacks to interact with the user interface.
+meta-description: When using a Flow user interface, the simplest way of allowing background jobs to interact with it is through callbacks. Learn more here.
 order: 10
 section-nav: badge-flow
 ---

--- a/articles/building-apps/deep-dives/application-layer/background-jobs/interaction/futures.adoc
+++ b/articles/building-apps/deep-dives/application-layer/background-jobs/interaction/futures.adoc
@@ -1,6 +1,8 @@
 ---
 title: Futures
-description: How to use CompletableFuture to iteract with the user interface.
+page-title: How to use CompletableFuture to interact with your app's UI
+description: How to use CompletableFuture to interact with the user interface.
+meta-description: Learn to use standard Java `CompletableFuture` with your user interface in your application.
 order: 20
 section-nav: badge-flow
 ---

--- a/articles/building-apps/deep-dives/application-layer/background-jobs/interaction/index.adoc
+++ b/articles/building-apps/deep-dives/application-layer/background-jobs/interaction/index.adoc
@@ -1,6 +1,8 @@
 ---
 title: UI Interaction
+page-title: How to interact with jobs from the UI | Vaadin
 description: How to interact with jobs from the user interface.
+meta-description: See explanations of different options for allowing a user to interact with a background job, and vice versa.
 order: 25
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/background-jobs/interaction/reactive.adoc
+++ b/articles/building-apps/deep-dives/application-layer/background-jobs/interaction/reactive.adoc
@@ -1,6 +1,8 @@
 ---
 title: Producing Reactive Streams
+page-title: How to use reactive streams to interact with the UI | Vaadin
 description: How to use reactive streams to interact with the user interface.
+meta-description: Learn to use reactive streams in your applications to interact with the user interface.
 order: 30
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/background-jobs/jobs.adoc
+++ b/articles/building-apps/deep-dives/application-layer/background-jobs/jobs.adoc
@@ -1,6 +1,8 @@
 ---
 title: Implementing Jobs
+page-title: How to implement background jobs in your applications
 description: How to implement background jobs.
+meta-description: Learn how to implement background jobs in your applications - transactions, security, batch jobs and more.
 order: 10
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/background-jobs/triggers.adoc
+++ b/articles/building-apps/deep-dives/application-layer/background-jobs/triggers.adoc
@@ -1,6 +1,8 @@
 ---
 title: Triggering Jobs
+page-title: How to trigger background jobs in your applications
 description: How to trigger background jobs.
+meta-description: See visual examples of different job triggers and learn more about how to use triggers for your application's background jobs.
 order: 20
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/consistency/eventual.adoc
+++ b/articles/building-apps/deep-dives/application-layer/consistency/eventual.adoc
@@ -1,6 +1,8 @@
 ---
 title: Eventual Consistency
+page-title: What is Eventual Consistency and how to achieve it | Vaadin
 description: Learn about eventual consistency and how to achieve it.
+meta-description: Learn what eventual consistency is and how you can achieve it.
 order: 50
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/consistency/index.adoc
+++ b/articles/building-apps/deep-dives/application-layer/consistency/index.adoc
@@ -1,6 +1,8 @@
 ---
 title: Data Consistency
+page-title: How to ensure data consistency in your Vaadin apps
 description: How to ensure data consistency in your applications.
+meta-description: Learn about data consistency and how to ensure it in your Vaadin applications.
 order: 25
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/consistency/optimistic-locking.adoc
+++ b/articles/building-apps/deep-dives/application-layer/consistency/optimistic-locking.adoc
@@ -1,6 +1,8 @@
 ---
 title: Optimistic Locking
+page-title: How to use optimistic locking in your application
 description: Learn about optimistic locking and when to use it.
+meta-description: Learn about optimistic locking and when you should use it in your application.
 order: 20
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/consistency/pessimistic-locking.adoc
+++ b/articles/building-apps/deep-dives/application-layer/consistency/pessimistic-locking.adoc
@@ -1,6 +1,8 @@
 ---
 title: Pessimistic Locking
+page-title: How to use pessimistic locking in your apps | Vaadin
 description: Learn about pessimistic locking and when to use it.
+meta-description: Learn more about pessimistic locking and when you could or should use it in your applications.
 order: 30
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/consistency/strong.adoc
+++ b/articles/building-apps/deep-dives/application-layer/consistency/strong.adoc
@@ -1,6 +1,8 @@
 ---
 title: Strong Consistency
+page-title: How to achieve strong consistency in your app | Vaadin
 description: Learn about strong consistency and how to achieve it.
+meta-description: Learn about strong consistency and how to achieve it in your applications.
 order: 5
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/consistency/transactions/declarative.adoc
+++ b/articles/building-apps/deep-dives/application-layer/consistency/transactions/declarative.adoc
@@ -1,6 +1,8 @@
 ---
 title: Declarative Transactions
+page-title: How to manage transactions declaratively in Vaadin apps
 description: How to manage transactions declaratively in Vaadin applications.
+meta-description: Learn about declarative transactions and how you can manage transactions that way in your Vaadin applications.
 order: 10
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/consistency/transactions/index.adoc
+++ b/articles/building-apps/deep-dives/application-layer/consistency/transactions/index.adoc
@@ -1,6 +1,8 @@
 ---
 title: Transactions
+page-title: How to use ACID transactions in your Vaadin applications
 description: Learn about ACID transactions and how to use them in Vaadin applications.
+meta-description: Learn about ACID transactions from things like deadlocks to overall management. 
 order: 10
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/consistency/transactions/programmatic.adoc
+++ b/articles/building-apps/deep-dives/application-layer/consistency/transactions/programmatic.adoc
@@ -1,6 +1,8 @@
 ---
 title: Programmatic Transactions
-description: How to manage programmatically transactions in Vaadin applications.
+page-title: How to manage transactions programmatically in Vaadin apps
+description: How to manage transactions programmatically in Vaadin applications.
+meta-description: Learn about programmatic transactions and how you can use them in your Vaadin applications.
 order: 20
 ---
 

--- a/articles/building-apps/deep-dives/application-layer/consistency/validation.adoc
+++ b/articles/building-apps/deep-dives/application-layer/consistency/validation.adoc
@@ -1,6 +1,8 @@
 ---
 title: Validation
+page-title: How to validate your data in your Vaadin apps
 description: Learn how to validate your data.
+meta-description: Learn about data validation - principles, semantics, sanitization and more.
 order: 15
 ---
 

--- a/articles/building-apps/security/add-login/flow.adoc
+++ b/articles/building-apps/security/add-login/flow.adoc
@@ -1,7 +1,7 @@
 ---
 title: Flow
 page-title: How to add a Flow login view to a Vaadin application
-meta-description: Learn how to create a secure login view in Vaadin Flow using Spring Security. This guide covers authentication setup, in-memory authentication, and best practices.
+meta-description: Learn to create a secure login view in Vaadin Flow using Spring Security. This guide covers authentication setup, in-memory authentication, and best practices.
 order: 5
 ---
 

--- a/articles/building-apps/security/add-logout/flow.adoc
+++ b/articles/building-apps/security/add-logout/flow.adoc
@@ -1,7 +1,7 @@
 ---
 title: Flow
 page-title: How to logout from a Vaadin Flow application
-meta-description: Learn how to implement logout functionality in a Vaadin Flow application using AuthenticationContext. This guide covers logout handling, custom redirects, and best practices.
+meta-description: Learn to implement logout functionality in a Flow application using AuthenticationContext. This guide covers logout, custom redirects and best practices.
 order: 5
 ---
 

--- a/articles/building-apps/security/add-logout/hilla.adoc
+++ b/articles/building-apps/security/add-logout/hilla.adoc
@@ -1,7 +1,7 @@
 ---
 title: Hilla
 page-title: How to logout from a Vaadin Hilla application
-meta-description: Learn how to implement logout functionality in a Vaadin application with Hilla views using the useAuth hook. This guide covers logout handling, redirects, and best practices.
+meta-description: Learn to implement logout functionality with Hilla views using the useAuth hook. This guide covers logout handling, redirect, and best practices.
 order: 10
 ---
 

--- a/articles/building-apps/security/add-logout/index.adoc
+++ b/articles/building-apps/security/add-logout/index.adoc
@@ -1,8 +1,8 @@
 ---
 title: Add Logout
-page-title: How to logout a user from a Vaadin application
+page-title: How to implement secure logout in your Vaadin application
 description: Learn how to securely logout users from a Vaadin application using Spring Security.
-meta-description: Discover how to implement secure logout in a Vaadin application using Spring Security. Learn about session invalidation and Vaadin's dedicated logout API for Flow and Hilla.
+meta-description: Learn to implement secure logout in a your application using Spring Security. Learn about session invalidation and Vaadin's logout API for Flow and Hilla.
 layout: tabbed-page
 tab-title: Overview
 order: 2

--- a/articles/building-apps/security/index.adoc
+++ b/articles/building-apps/security/index.adoc
@@ -2,7 +2,7 @@
 title: Security
 page-title: How to secure a Vaadin application
 description: Learn how to secure Vaadin applications using both Flow and Hilla.
-meta-description: Learn how to secure your Vaadin application with authentication, role-based access control, and best practices. This guide covers protecting views, services, login, logout, and method security for both Flow and Hilla applications.
+meta-description: This Vaadin guide covers protecting views, services, login, logout, and method security for both Flow and Hilla applications.
 order: 40
 ---
 

--- a/articles/building-apps/security/protect-services/flow.adoc
+++ b/articles/building-apps/security/protect-services/flow.adoc
@@ -1,7 +1,7 @@
 ---
 title: Flow
 page-title: How to protect Flow services in a Vaadin application
-meta-description: Learn how to protect Vaadin Flow services using Spring method security. This guide covers enabling method security, securing service methods, and best practices for access control.
+meta-description: Protect Flow services using Spring method security. This guide covers enabling method security, securing service methods, and best practices for access control.
 order: 5
 ---
 

--- a/articles/building-apps/security/protect-services/hilla.adoc
+++ b/articles/building-apps/security/protect-services/hilla.adoc
@@ -1,7 +1,7 @@
 ---
 title: Hilla
 page-title: How to protect browser callable services in a Vaadin application
-meta-description: Learn how to secure browser-callable services in Vaadin Hilla using role-based access control. This guide covers authentication, authorization, and best practices for protecting services.
+meta-description: Secure browser-callable services in Hilla with this guide: authentication, authorization, and best practices for protecting services.
 order: 10
 ---
 

--- a/articles/building-apps/views/add-router-layout/flow.adoc
+++ b/articles/building-apps/views/add-router-layout/flow.adoc
@@ -1,7 +1,7 @@
 ---
 title: Flow
 page-title: How to add a Flow view to a Vaadin application
-meta-description: Learn how to create and apply router layouts in Vaadin Flow, including automatic and explicit layouts, nested layouts, and route prefixes for structured navigation.
+meta-description: Learn to create and apply router layouts in Vaadin Flow, including automatic and explicit layouts, nested layouts, and route prefixes for structured navigation.
 order: 5
 ---
 

--- a/articles/building-apps/views/add-view/flow.adoc
+++ b/articles/building-apps/views/add-view/flow.adoc
@@ -1,7 +1,7 @@
 ---
 title: Flow
 page-title: How to add a Flow view to a Vaadin application
-meta-description: Learn how to create and organize Flow views in a Vaadin application. This guide covers defining routes, naming conventions, using route aliases, and structuring views into Java packages. Includes a hands-on tutorial to apply key concepts.
+meta-description: Learn about defining routes, naming conventions, using route aliases, and structuring views into Java packages. Includes a hands-on tutorial to apply key concepts.
 order: 5
 ---
 

--- a/articles/building-apps/views/add-view/hilla.adoc
+++ b/articles/building-apps/views/add-view/hilla.adoc
@@ -1,7 +1,7 @@
 ---
 title: Hilla
 page-title: How to add a Hilla view to a Vaadin application
-meta-description: Learn how to create, name, and organize views in Hilla. This guide covers routing conventions, directory structures, route aliases, and best practices for defining explicit routes.
+meta-description: Learn to create, name, and organize views in Hilla: routing conventions, directory structures, route aliases, and best practices for defining explicit routes.
 order: 10
 ---
 

--- a/articles/building-apps/views/index.adoc
+++ b/articles/building-apps/views/index.adoc
@@ -1,7 +1,7 @@
 ---
 title: Views & Navigation
-page-title: How to build views and navigate between them in Vaadin applications
+page-title: Building views and navigating between them in Vaadin apps
 description: Learn how to build views and navigate between them in Vaadin applications.
-meta-description: TODO Write a meta-description
+meta-description: Learn how to build views and navigate between them in Vaadin applications.
 order: 10
 ---

--- a/articles/building-apps/views/pass-data/index.adoc
+++ b/articles/building-apps/views/pass-data/index.adoc
@@ -2,7 +2,7 @@
 title: Pass Data to a View
 page-title: How to pass data to a view in a Vaadin application 
 description: Learn how to pass data between the views of a Vaadin application.
-meta-description: Learn how to pass data between views in Vaadin using URL parameters, enabling deep linking, bookmarking, and seamless navigation with route and query parameters.
+meta-description: Learn to pass data between views in Vaadin using URL parameters, enabling deep linking, bookmarking, and seamless navigation with route and query parameters.
 order: 16
 ---
 

--- a/articles/building-apps/views/pass-data/route-parameters/hilla.adoc
+++ b/articles/building-apps/views/pass-data/route-parameters/hilla.adoc
@@ -1,7 +1,7 @@
 ---
 title: Hilla
 page-title: How to use route parameters in Hilla | Vaadin
-meta-description: Learn how to use route parameters in Hilla to pass data between views, including required, optional, and wildcard parameters, for dynamic and flexible navigation.
+meta-description: Learn to use route parameters in Hilla to pass data between views, including required, optional, and wildcard parameters, for dynamic and flexible navigation.
 tab-title: Hilla
 order: 10
 ---

--- a/articles/building-apps/views/pass-data/route-templates.adoc
+++ b/articles/building-apps/views/pass-data/route-templates.adoc
@@ -2,7 +2,7 @@
 title: Route Templates
 page-title: How to use route templates in Flow | Vaadin
 description: Learn how to use route templates in Flow.
-meta-description: Learn how to use route templates in Vaadin Flow to handle multiple route parameters, optional and wildcard parameters, and constrain values with regular expressions.
+meta-description: Learn to use route templates in Flow to handle multiple route parameters, optional and wildcard parameters, and constrain values with regular expressions.
 section-nav: badge-flow
 order: 20
 ---

--- a/articles/components/auto-crud/index.adoc
+++ b/articles/components/auto-crud/index.adoc
@@ -3,7 +3,7 @@ title: Auto CRUD
 page-title: Auto CRUD component | Vaadin components
 order: 10
 description: Used to populate automatically CRUD views and actions based on a Java backend service.
-meta-description: Learn how to use Vaadin Auto CRUD component to streamline CRUD operations in your applications. Explore features, configuration options, and implementation examples.
+meta-description: How to use Vaadin Auto CRUD component to streamline CRUD operations in your applications. Explore features, configuration options, and implementation examples.
 section-nav: badge-hilla
 ---
 

--- a/articles/components/confirm-dialog/styling.adoc
+++ b/articles/components/confirm-dialog/styling.adoc
@@ -2,7 +2,7 @@
 title: Styling
 page-title: How to style Confirm Dialog component | Vaadin components
 description: Styling API reference for the Confirm Dialog component.
-meta-description: Learn how to style the Vaadin Confirm Dialog component with custom themes and CSS. Discover tips and examples for creating visually consistent and unique dialogs.
+meta-description: Learn to style the Vaadin Confirm Dialog component with custom themes and CSS. Discover tips and examples for creating visually consistent and unique dialogs.
 order: 50
 ---
 = Styling

--- a/articles/components/list-box/index.adoc
+++ b/articles/components/list-box/index.adoc
@@ -4,7 +4,7 @@ layout: tabbed-page
 title: List Box
 page-title: List Box component | Vaadin components
 description: List Box allows the user to select one or more values from a scrollable list of items.
-meta-description: Discover how to use the Vaadin List Box component to create interactive lists with customizable items. Learn about styling, features, and implementation examples.
+meta-description: Learn to use the Vaadin List Box component to create interactive lists with customizable items. Learn about styling, features, and implementation examples.
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/list-box}/#/elements/vaadin-list-box[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/listbox/ListBox.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/list-box}/packages/list-box[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-list-box-flow-parent[Java]'

--- a/articles/contributing/docs/types.adoc
+++ b/articles/contributing/docs/types.adoc
@@ -1,8 +1,8 @@
 ---
 title: Types of Documentation
-page-title: Types of Documentation | How to contribute to Vaadin Documentation
+page-title: Types of Vaadin Documentation
 description: Learn about the different types of Vaadin documentation - how-to guides, reference manuals, and deep dives - and understand best practices for writing each type effectively.
-meta-description: Learn about the different types of Vaadin documentation - how-to guides, reference manuals, and deep dives - and understand best practices for writing each type effectively.
+meta-description: Learn about the different types of Vaadin documentation and understand best practices for writing each type effectively.
 order: 5
 ---
 

--- a/articles/contributing/tests.adoc
+++ b/articles/contributing/tests.adoc
@@ -1,6 +1,6 @@
 ---
 title: Creating Tests
-page-title: Creating
+page-title: How to create tests for code contributions | Vaadin
 description: How to create tests for code contributions to ensure changes and additions work properly.
 meta-description: Learn how to create tests for your Vaadin code contributions to ensure changes and additions work properly.
 order: 30

--- a/articles/control-center/getting-started/configure-installation.adoc
+++ b/articles/control-center/getting-started/configure-installation.adoc
@@ -1,6 +1,8 @@
 ---
 title: Configure Installation
+page-title: Configuring the installation of Control Center using Helm
 description: How to configure the installation of Control Center using Helm.
+meta-description: This page explains how to configure the installation of Control Center using Helm. You can set many values, including your domain and user information.
 order: 30
 ---
 

--- a/articles/control-center/getting-started/docker-desktop.adoc
+++ b/articles/control-center/getting-started/docker-desktop.adoc
@@ -2,7 +2,7 @@
 title: Kubernetes on Docker Desktop
 page-title: Learn how to set up a Kubernetes cluster on Docker Desktop
 description: Learn how to set up a Kubernetes cluster on Docker Desktop.
-meta-description: Vaadin Control Center simplifies the management of Vaadin applications on Kubernetes clusters. Learn how to first set up a Kubernetes cluster on Docker Desktop.
+meta-description: Vaadin Control Center simplifies the management of Vaadin applications on Kubernetes clusters. Learn to first set up a Kubernetes cluster on Docker Desktop.
 order: 50
 ---
 

--- a/articles/flow/advanced/server-client-communication.adoc
+++ b/articles/flow/advanced/server-client-communication.adoc
@@ -1,6 +1,8 @@
 ---
 title: Server to Client Communication
+page-title: How server to client communications work | Vaadin docs 
 description: Technical details of how server to client communications work.
+meta-description: Learn technical details of how server to client communications work.
 order: 800
 ---
 

--- a/articles/flow/binding-data/index.adoc
+++ b/articles/flow/binding-data/index.adoc
@@ -1,6 +1,6 @@
 ---
 title: Forms pass:[&] Data Binding
-page-title: How to bind data effectively to forms and selection components in Vaadin.
+page-title: How to bind data to forms and selection components | Vaadin
 description: Learn how to bind data to forms and selection components in Vaadin Flow.
 meta-description: Learn how to bind data to forms and selection components in Vaadin Flow.
 order: 60

--- a/articles/flow/create-ui/dnd/index.adoc
+++ b/articles/flow/create-ui/dnd/index.adoc
@@ -2,7 +2,7 @@
 title: Drag pass:[&] Drop
 page-title: How to implement drag and drop in Vaadin
 description: Drag and drop between components as well as between the UI and the operating system.
-meta-description: Learn how to implement drag-and-drop functionality in Vaadin applications to drag and drop between components as well as between the UI and the operating system.
+meta-description: Learn to implement drag-and-drop functionality in Vaadin applications to drag and drop between components as well as between the UI and the operating system.
 order: 140
 ---
 

--- a/articles/flow/create-ui/templates/components.adoc
+++ b/articles/flow/create-ui/templates/components.adoc
@@ -2,7 +2,7 @@
 title: Binding to Components
 page-title: How to integrate and use components in Vaadin Flow templates
 description: How to use the @Id annotation to reference a JavaScript LitElement template.
-meta-description: Learn how to integrate and use components in Vaadin Flow templates. Explore best practices for creating interactive UIs with reusable and customizable components.
+meta-description: Learn to integrate and use components in Vaadin Flow templates. Explore best practices for creating interactive UIs with reusable and customizable components.
 order: 3
 ---
 

--- a/articles/flow/integrations/spring/oauth2.adoc
+++ b/articles/flow/integrations/spring/oauth2.adoc
@@ -1,8 +1,8 @@
 ---
 title: OAuth2 Authentication
-page-title: How to configure Vaadin and Spring Security for OAuth2 Authentication.
+page-title: How to configure Vaadin and Spring Security for OAuth2
 description: Vaadin and Spring Security configuration for OAuth2 Authentication.
-meta-description: Discover how to configure Vaadin to have users log into an application using their existing account with an OAuth 2.0 Provider or an OpenID Connect 1.0 Provider.
+meta-description: Learn to configure Vaadin to have users log into an application using their existing account with an OAuth 2.0 Provider or an OpenID Connect 1.0 Provider.
 order: 80
 ---
 

--- a/articles/getting-started/build.adoc
+++ b/articles/getting-started/build.adoc
@@ -2,7 +2,7 @@
 title: Build a Project
 page-title: How to make a production build of a Vaadin application
 description: Make a production build of your Vaadin application.
-meta-description: Learn how to make a production build of your Vaadin application. Use the Vaadin Maven plugin to optimize frontend resources, minimize dependencies, and package your app for deployment. Run your application in production mode with a single command.
+meta-description: Learn to make a production build of your Vaadin application. Use the Vaadin Maven plugin to optimize frontend resources, minimize dependencies, and package your app for deployment.
 order: 40
 ---
 

--- a/articles/getting-started/import/index.adoc
+++ b/articles/getting-started/import/index.adoc
@@ -2,7 +2,7 @@
 title: Import a Project
 page-title: Import a Vaadin project to your IDE
 description: Import your Vaadin project into your favorite IDE.
-meta-description: Learn how to import a Vaadin project into your favorite Java IDE. Follow quick guides for IntelliJ IDEA, Visual Studio Code, Eclipse, and NetBeans to set up your Vaadin walking skeleton efficiently.
+meta-description: Learn to import a Vaadin project into your favorite Java IDE. Follow quick guides for IntelliJ IDEA, Visual Studio Code, Eclipse, and NetBeans.
 layout: tabbed-page
 tab-title: Overview
 order: 30

--- a/articles/getting-started/next-steps.adoc
+++ b/articles/getting-started/next-steps.adoc
@@ -2,7 +2,7 @@
 title: Next Steps
 page-title: Add muscles to your Vaadin walking skeleton
 description: Add muscles to your Vaadin walking skeleton to turn it into a full-featured application.
-meta-description: Turn your Vaadin walking skeleton into a fully functional application by adding views, navigation, data handling, security, and a production-ready database. Follow step-by-step guides to build and enhance your app.
+meta-description: Turn your Vaadin walking skeleton into a fully functional application by adding views, navigation, data handling, security, and a production-ready database.
 order: 100
 ---
 

--- a/articles/getting-started/prerequisites.adoc
+++ b/articles/getting-started/prerequisites.adoc
@@ -2,7 +2,7 @@
 title: Prerequisites
 page-title: Prerequisites for getting started with Vaadin
 description: Set up your environment to get started with Vaadin.
-meta-description: Get started with Vaadin by ensuring you have the right prerequisites. Learn about required Java versions, IDEs, and tools for building full-stack web applications with Vaadin Flow and Hilla.
+meta-description: Learn about required Java versions, IDEs, and tools for building full-stack web applications with Vaadin Flow and Hilla.
 order: 10
 ---
 

--- a/articles/getting-started/run/index.adoc
+++ b/articles/getting-started/run/index.adoc
@@ -2,7 +2,7 @@
 title: Run a Project
 page-title: Run a Vaadin application in your IDE
 description: Run your Vaadin application with hot deploy and live reload from within your favorite IDE.
-meta-description: Run your Vaadin application directly from your IDE with hot deploy and live reload for a faster development workflow. Learn how to enable live reload for Java and frontend changes in IntelliJ IDEA, Visual Studio Code, Eclipse, and NetBeans.
+meta-description: Run your app directly from your IDE - IntelliJ IDEA, VSC, Eclipse, and NetBeans - with hot deploy and live reload for a faster development workflow.
 layout: tabbed-page
 tab-title: Overview
 order: 35

--- a/articles/getting-started/start/alternatives/gradle.adoc
+++ b/articles/getting-started/start/alternatives/gradle.adoc
@@ -1,6 +1,8 @@
 ---
 title: Gradle
+page-title: How to create a Vaadin project with Gradle.
 description: How to create a Vaadin project with Gradle.
+meta-description: This page describes how to create, compile, and run a Vaadin application using the Vaadin Gradle plugin. 
 order: 300
 ---
 

--- a/articles/getting-started/start/index.adoc
+++ b/articles/getting-started/start/index.adoc
@@ -2,7 +2,7 @@
 title: Start a Project
 page-title: Start a new Vaadin Project
 description: Create and run your first Vaadin application.
-meta-description: Start a new Vaadin project effortlessly with a walking skeleton. Learn how to generate, download, and run a fully functional minimal Vaadin application using Flow or Hilla. Get your development environment set up quickly and begin building your application.
+meta-description: Learn to generate, download, and run a fully functional minimal Vaadin application using Flow or Hilla. Get your development environment set up quickly.
 order: 20
 ---
 

--- a/articles/getting-started/walk-through.adoc
+++ b/articles/getting-started/walk-through.adoc
@@ -2,7 +2,7 @@
 title: Project Structure
 page-title: Walk-through of the Vaadin Walking Skeleton
 description: Learn about the building blocks of a Vaadin walking skeleton.
-meta-description: Explore the structure of a Vaadin walking skeleton project. Learn about its key components, including Java files, frontend files, and the Maven POM file. Understand how to organize your project for efficient development with Flow or Hilla.
+meta-description: Explore the structure of a Vaadin walking skeleton project. Learn about its key components, including Java files, frontend files, and the Maven POM file.
 order: 50
 ---
 

--- a/articles/hilla/guides/production/native.adoc
+++ b/articles/hilla/guides/production/native.adoc
@@ -1,6 +1,6 @@
 ---
 title: Native Image Compilation
-page-title: How to compile Hilla applications to Native Images with GraalVM | Vaadin
+page-title: How to compile Hilla to Native Images with GraalVM | Vaadin
 description: Learn how to compile a Hilla application into a native image using GraalVM.
 meta-description: Learn how to compile a Hilla application into a native image using GraalVM in Vaadin.
 order: 40

--- a/articles/hilla/guides/security/best-practices.adoc
+++ b/articles/hilla/guides/security/best-practices.adoc
@@ -1,6 +1,6 @@
 ---
 title: Best Practices
-page-title: How to implement security best practices in Hilla applications | Vaadin
+page-title: How to implement security best practices in Hilla apps
 description: Best practices in authentication and authorization, data validation, and SSL and HTTPS.
 meta-description: Follow best practices to secure Hilla applications and protect sensitive data.
 order: 151

--- a/articles/hilla/guides/styling.adoc
+++ b/articles/hilla/guides/styling.adoc
@@ -5,5 +5,8 @@ description: How to add CSS styles to views and React components in Hilla applic
 meta-description: Learn styling techniques for forms and elements in Hilla applications.
 order: 80
 ---
+
+= How to style forms and elements in Hilla
+
 :hilla-react:
 include::{root}/articles/hilla/lit/guides/styling.adoc[tag=content]

--- a/articles/hilla/guides/uploads-downloads.adoc
+++ b/articles/hilla/guides/uploads-downloads.adoc
@@ -1,6 +1,6 @@
 ---
 title: Uploading pass:[&] Downloading
-page-title: How to implement file uploading and downloading in Hilla React applications | Vaadin
+page-title: How to implement file uploading and downloading in Hilla
 description: How to implement file uploading and downloading in Hilla React applications.
 meta-description: Learn how to implement file uploading and downloading in Vaadin Hilla.
 order: 73

--- a/articles/hilla/reference/typescript-client.adoc
+++ b/articles/hilla/reference/typescript-client.adoc
@@ -2,7 +2,7 @@
 title: TypeScript Client
 page-title: How to use the TypeScript client in Hilla applications | Vaadin
 description: Understanding the Hilla TypeScript client library, the default TypeScript client, and generated client modules.
-meta-description: Learn how to use the TypeScript client in Hilla applications to understand the Hilla TypeScript client library, the default TypeScript client, and generated client modules.
+meta-description: Learn to understand the Hilla TypeScript client library, the default TypeScript client, and generated client modules.
 ---
 :hilla-react:
 include::{root}/articles/hilla/lit/reference/typescript-client.adoc[tag=content]

--- a/articles/tools/collaboration/components/index.adoc
+++ b/articles/tools/collaboration/components/index.adoc
@@ -1,6 +1,6 @@
 ---
 title: Binder pass:[&] Components
-page-title: "Vaadin Collaboration components: Real-time collaboration made easy"
+page-title: Learn about Vaadin Collaboration components
 meta-description: Enable real-time collaboration in your apps with Vaadin Collaboration Components. Learn how to integrate and customize these tools for seamless teamwork.
 order: 5
 ---

--- a/articles/tools/collaboration/going-to-production.adoc
+++ b/articles/tools/collaboration/going-to-production.adoc
@@ -2,7 +2,7 @@
 title: Production 
 page-title: How to deploy Vaadin Collaboration Kit to production
 description: Preparing a Vaadin application for production that uses Collaboration Kit.
-meta-description: Learn how to deploy Vaadin Collaboration Kit to production. Explore best practices for secure setup, licensing, and optimizing real-time collaboration features.
+meta-description: Learn to deploy Vaadin Collaboration Kit to production. Explore best practices for secure setup, licensing, and optimizing real-time collaboration features.
 order: 999
 ---
 

--- a/articles/tools/designer/index.adoc
+++ b/articles/tools/designer/index.adoc
@@ -1,6 +1,6 @@
 ---
 title: Designer
-page-title: Vaadin Designer
+page-title: Web components on a canvas | Vaadin Designer
 section-nav: commercial
 meta-description: Use the visual tool Vaadin Designer where you can drag and drop - and configure - web components on a canvas. 
 order: 130
@@ -24,7 +24,7 @@ xref:getting-started/setting-up-your-environment#[Get started using Designer, ro
 == Features
 
 WYSIWYG Design Canvas::
-Drag and drop web components. Updates when the design properties or styles are changed.
+Drag and drop web components. Updates when the design properties or styles are changed. 
 +
 <<using-designer/designing#,Designing>>
 


### PR DESCRIPTION
After a SEO audit, here are some improvements to missing meta info or titles/descriptions that are either too short or too long.
https://vaadin.com/docs/latest/contributing/docs#page-meta-data
- Add or improve meta titles and descriptions for building apps -section
- Add or improve meta titles and descriptions for getting started -section
- Add or improve meta titles and descriptions for hilla and flow -sections
- Add or improve meta titles and descriptions for components and tools -sections
- Add or improve meta titles and descriptions for contributing and control center -sections