### PR TITLE
fix: Fix empty code example for downloads

### DIFF
--- a/articles/flow/advanced/downloads.adoc
+++ b/articles/flow/advanced/downloads.adoc
@@ -57,7 +57,7 @@ This is the most flexible helper method as it can be used with any data source t
 
 [source,java]
 ----
-include::{root}/src/main/java/com/vaadin/demo/flow/advanced/download/InputStreamDownloadView.java[render,tags=snippet,indent=0]
+include::{root}/src/main/java/com/vaadin/demo/flow/advanced/download/InputStreamDownloadView.java[tags=snippet]
 ----
 
 This method is particularly useful for:


### PR DESCRIPTION
This hopefully fixes (couldn't verify as dsp doesn't properly start for me) the empty code snippet:
![Screenshot 2025-06-18 at 19 14 01](https://github.com/user-attachments/assets/4a215869-f072-4460-b632-3e2c11bf8eb6)
