### PR TITLE
Clarify developer responsibility when dealing with uploads in case `setAcceptedFileType` is used

### DIFF
--- a/articles/ds/components/upload/index.asciidoc
+++ b/articles/ds/components/upload/index.asciidoc
@@ -162,11 +162,19 @@ include::{root}/src/main/java/com/vaadin/demo/component/upload/UploadExamplesI18
 ----
 --
 
-.Prefer MIME-type
+.Prefer MIME Type
+[NOTE]
+Although https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types[MIME types] are widely supported, file extensions are only implemented https://caniuse.com/input-file-accept[in certain browsers] and should be avoided.
+
+ifdef::flow[]
+.File Format Restrictions are Client-Side
 [NOTE]
 ====
-While https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types[MIME types] are widely supported, file extensions are only implemented https://caniuse.com/input-file-accept[in certain browsers] and should be avoided.
+File format restrictions set with [methodname]`setAcceptedFileType` method are checked only on the client side. They indicate the hints for users as to what file types to upload.
+
+Using this method won't restrict the uploaded file's format on the server side. The Upload component doesn't have an API to restrict uploaded files by file format or content on the server side. If required, it's the responsibility of the application developer to implement application-specific restrictions on the server side in one or more of the Upload component's event listeners (e.g., in `Upload::addSucceededListener`).
 ====
+endif::[]
 
 === File Count
 


### PR DESCRIPTION
Backport from v24 docs