### PR TITLE
(hilla) improve routing documentation clarity for routes.tsx usage

### DIFF
--- a/articles/hilla/guides/routing.adoc
+++ b/articles/hilla/guides/routing.adoc
@@ -432,7 +432,7 @@ Now, your application is equipped with an error page that is shown when no other
 
 The contents of the `routes.tsx` source file determine whether file-based routing, manually added routes for React Router, or the Flow server fallback are enabled.
 
-When the `routes.tsx` source file is missing, it's automatically generated under `src/main/frontend/generated/routes.tsx`. You can copy it to `src/main/frontend/` and customize it as needed. By default, the generated file combines the file routes with the Flow fallback.
+When the `routes.tsx` source file is not present under `src/main/frontend/`, it's automatically generated under `src/main/frontend/generated/routes.tsx`. You can copy it to `src/main/frontend/` and customize it as needed. By default, the generated file combines the file routes with the Flow fallback.
 
 [NOTE]
 .Using a Custom `routes.tsx` File


### PR DESCRIPTION
Enhance the documentation to clarify the usage of the `routes.tsx` file, including its impact on routing behavior and the implications of using a custom file.