### PR TITLE
Fixing the Flow Query Parameters code snippet

### DIFF
--- a/articles/building-apps/views/pass-data/query-parameters/flow.adoc
+++ b/articles/building-apps/views/pass-data/query-parameters/flow.adoc
@@ -26,11 +26,11 @@ public class OrdersView extends Main implements BeforeEnterObserver {
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
-        event.getQueryParameters().getSingleParameter(QUERY_PARAM_SORT)
+        event.getLocation().getQueryParameters().getSingleParameter(QUERY_PARAM_SORT)
             .ifPresent(sort -> {
                 // Process the sort parameter
             });
-        event.getQueryParameters().getSingleParameter(QUERY_PARAM_FILTER)
+        event.getLocation().getQueryParameters().getSingleParameter(QUERY_PARAM_FILTER)
             .ifPresent(filter -> {
                 // Process the filter parameter
             });


### PR DESCRIPTION
Adding the missing getLocation() to the query parameter handling snippet in the Flow code examples for V24.


