### PR TITLE
docs: fix broken Styling links and backticks

### DIFF
--- a/articles/hilla/lit/components/create.adoc
+++ b/articles/hilla/lit/components/create.adoc
@@ -236,7 +236,7 @@ include::{root}/frontend/demo/fusion/lit-basics/styling.ts[]
 == Shadow & Light DOM
 
 You can use two main approaches for web components.
-You can find more information in the https://vaadin.com/docs/styling/custom-theme/style-scopes[Style Scopes] article in the Vaadin documentation.
+You can find more information in the <<{articles}/styling#,Styling documentation>>.
 
 === Shadow DOM
 A web component can create a shadow tree within.

--- a/articles/hilla/lit/guides/upgrading/_styling.adoc
+++ b/articles/hilla/lit/guides/upgrading/_styling.adoc
@@ -2,7 +2,7 @@ The internal structure of many Vaadin components has been modified to improve ac
 
 When upgrading from Vaadin components 23 (Hilla 1) or earlier, you can refactor all CSS to the new styling approach. Another option is to stay on the old (Shadow DOM based) styling approach, and rewrite only those selectors that affect your application. Both methods can also be used in parallel, if desired.
 
-The instructions below are based on the old approach, which is a fast way of upgrading. The new styling approach is described in the link:https://vaadin.com/docs/next/styling[Styling section] of the Vaadin documentation.
+The instructions below are based on the old approach, which is a fast way of upgrading. The new styling approach is described in the <<{articles}/styling#,Styling documentation>>.
 
 // It is not feasible to extract these CSS examples into files
 pass:[<!-- vale Vaadin.SourceCode = NO -->]

--- a/articles/hilla/lit/guides/upgrading/_styling.adoc
+++ b/articles/hilla/lit/guides/upgrading/_styling.adoc
@@ -376,7 +376,7 @@ The upload button has been moved from shadow DOM to a slot:
 .`vaadin-upload.css`
 ----
 [part="upload-button"] {...}
-/* or*/
+/* or */
 #uploadButton {...}
 /* or */
 vaadin-button {...}

--- a/articles/styling/application-theme.adoc
+++ b/articles/styling/application-theme.adoc
@@ -29,7 +29,7 @@ Themes built this way can be <<advanced/multi-app-themes#, packaged as JAR files
 
 .Flow @CssImport Annotation
 [NOTE]
-In older versions of Vaadin, stylesheets were loaded using `@CssImport` and `@Stylesheet` annotations. In much older versions, they were loaded using the `@HtmlImport` annotation. Although `@CssImport `and `@Stylesheet` still work, they're recommended only for loading stylesheets into custom standalone components -- not as the primary way to load application styles.
+In older versions of Vaadin, stylesheets were loaded using `@CssImport` and `@Stylesheet` annotations. In much older versions, they were loaded using the `@HtmlImport` annotation. Although `@CssImport` and `@Stylesheet` still work, they're recommended only for loading stylesheets into custom standalone components -- not as the primary way to load application styles.
 
 
 == Applying a Theme

--- a/articles/upgrading/_styling.adoc
+++ b/articles/upgrading/_styling.adoc
@@ -399,7 +399,7 @@ The upload button has been moved from shadow DOM to a slot:
 .`vaadin-upload.css`
 ----
 [part="upload-button"] {...}
-/* or*/
+/* or */
 #uploadButton {...}
 /* or */
 vaadin-button {...}


### PR DESCRIPTION
Fixed two broken links: "style scopes" now returns 404 and the link to `next` branch navigates to main page.
Also fixed some wrong backtick for `@CssImport` annotation.