### PR TITLE
chore: configure preferred example render groups

### DIFF
--- a/dspublisher/config/production.json
+++ b/dspublisher/config/production.json
@@ -8,5 +8,6 @@
     "Flow",
     "React",
     "Lit"
-  ]
+  ],
+  "preferredExampleRenderGroups": ["React", "Lit"]
 }


### PR DESCRIPTION
Configure the preferred example render groups feature added in https://github.com/vaadin/docs-app/pull/505. This would make live examples preferrably render the React or Lit live example. If none of those are present if falls back to the live example for the currently selected group.