### PR TITLE
Fix password to match the configured in memory security config

### DIFF
--- a/articles/building-apps/security/add-login/flow.adoc
+++ b/articles/building-apps/security/add-login/flow.adoc
@@ -308,7 +308,7 @@ Restart your application to make sure all your changes have been applied. Naviga
 
 You should now see the login screen. Login with one of the following credentials:
 
-* *User:* user / *Password:* password
+* *User:* user / *Password:* user
 * *Admin:* admin / *Password:* admin
 
 After logging in, you should be able to access the task list view.

--- a/articles/building-apps/security/add-login/hilla.adoc
+++ b/articles/building-apps/security/add-login/hilla.adoc
@@ -443,7 +443,7 @@ Restart your application to make sure all your changes have been applied. Naviga
 
 You should now see the login screen. Login with one of the following credentials:
 
-* *User:* user / *Password:* password
+* *User:* user / *Password:* user
 * *Admin:* admin / *Password:* admin
 
 After logging in, you should be able to access the task list view.


### PR DESCRIPTION
The password in the "Test the Application" collapsible doesn't match the in memory one configured in the `SecurityConfig.java`, and can lead to confusions. 