### PR TITLE
Update WebDriverManager dependency

### DIFF
--- a/articles/flow/testing/selenium.adoc
+++ b/articles/flow/testing/selenium.adoc
@@ -44,12 +44,30 @@ Add the WebDriverManager dependency to your project's [filename]`pom.xml` file.
 [source,xml]
 ----
 <!-- WebDriver Management Software -->
-<dependency>
-   <groupId>io.github.bonigarcia</groupId>
-   <artifactId>webdrivermanager</artifactId>
-   <version>5.3.1</version>
-   <scope>test</scope>
-</dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>6.1.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.docker-java</groupId>
+                    <artifactId>docker-java-transport-httpclient5</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna-platform</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 ----
 
 The latest version of WebDriverManager can be found https://search.maven.org/artifact/io.github.bonigarcia/webdrivermanager[here].


### PR DESCRIPTION
The exclusions are good to document, as they are needed due our license checker conflicting with them.