### PR TITLE
Remove card and dashboard components from feature flag docs

### DIFF
--- a/articles/flow/configuration/feature-flags.adoc
+++ b/articles/flow/configuration/feature-flags.adoc
@@ -25,11 +25,8 @@ dl code {
 </style>
 ++++
 
-`cardComponent`::
-A versatile container for grouping related content and actions. <</components/card#,Learn More>>
-
-`dashboardComponent`::
-A component for building static dashboard layouts and dynamic, user-configurable dashboards. <</components/dashboard#,Learn More>>
+`masterDetailLayoutComponent`::
+A component for building UIs with a horizontally or vertically split pair consisting of a master area and a detail area that can responsively switch to an overlay. <</components/master-detail-layout#,Learn More>>
 
 
 == Managing Feature Flags
@@ -55,7 +52,7 @@ When you have that file open, add a line for each feature in the format of `com.
 .`vaadin-featureflags.properties`
 [source,properties]
 ----
-com.vaadin.experimental.cardComponent=true
+com.vaadin.experimental.masterDetailLayoutComponent=true
 ----
 
 To disable a feature, remove the corresponding line or set its value to `false`.
@@ -70,6 +67,6 @@ The last method for managing feature flags is to set the Java system properties.
 The property name should be in the format, `vaadin.<FEATURE_NAME>`, like so:
 
 [source,terminal]
--Dvaadin.cardComponent=true
+-Dvaadin.masterDetailLayoutComponent=true
 
 To temporarily disable a feature, set its property value to `false`.


### PR DESCRIPTION
Since 24.8, Card and Dashboard components are not under preview. So they do not require the feature flag. Hence removed these two components from the feature flag doc and instead added the Master-Detail Layout that is still a preview feature in 24.8