### PR TITLE
[Kubernetes Kit] Add a workaround for deprecated snippets

### DIFF
--- a/articles/tools/kubernetes/update-version.adoc
+++ b/articles/tools/kubernetes/update-version.adoc
@@ -142,6 +142,27 @@ kubectl apply -f ingress-v2-canary.yaml
 
 == Notify Existing Users
 
+[IMPORTANT]
+.Configuration Snippets
+====
+As of version 1.9.0 of Ingress NGINX (helm chart version 4.8.0), the `nginx.ingress.kubernetes.io/configuration-snippet` annotation is no longer supported by default. It is considered a security risk, as it allows arbitrary code execution in the NGINX configuration. To use this annotation, you must enable it explicitly in the NGINX Ingress Controller configuration.
+
+Create a patch file:
+
+.ingress-controller-patch.yaml
+[source,yaml]
+----
+data:
+  annotations-risk-level: "Critical"
+  allow-snippet-annotations: "true"
+----
+
+Next, apply the patch to your cluster:
+
+[source,terminal]
+kubectl -n ingress-nginx patch configmap ingress-nginx-controller --type merge --patch-file ingress-controller-patch.yaml
+====
+
 Next, you may want to notify existing users. To do this, create the ingress rule manifest:
 
 .ingress-v1-notify.yaml


### PR DESCRIPTION
This adds an admonition to the Kubernetes Kit update version page, detailing how to enable snippets, which are now disabled by default since Ingress NGINX 1.9.0.

Fixes: https://github.com/vaadin/kubernetes-kit/issues/188