### PR TITLE
Fixed typo (wrong method name) in code example

### DIFF
--- a/articles/flow/advanced/downloads.adoc
+++ b/articles/flow/advanced/downloads.adoc
@@ -421,7 +421,7 @@ Anchor downloadLink = new Anchor(new DownloadHandler() {
     }
 
     @Override
-    public boolean allowInert() {
+    public boolean isAllowInert() {
         return true; // default is false
     }
 


### PR DESCRIPTION
Fixes #4433


