### PR TITLE
docs: remove incorrect loading state from time-picker styling

### DIFF
--- a/articles/components/time-picker/styling.adoc
+++ b/articles/components/time-picker/styling.adoc
@@ -71,8 +71,6 @@ Error message text:: `vaadin-time-picker+++<wbr>+++** > [slot="error-message"]**
 Overlay element:: `vaadin-time-picker-overlay`
 Overlay background:: `vaadin-time-picker-overlay+++<wbr>+++**::part(overlay)**`
 Overlay content wrapper:: `vaadin-time-picker-overlay+++<wbr>+++**::part(content)**`
-Overlay in loading state:: `vaadin-time-picker-overlay+++<wbr>+++**[loading]**`
-Overlay loading indicator:: `vaadin-time-picker-overlay+++<wbr>+++**::part(loader)**`
 
 
 === Items


### PR DESCRIPTION
The `vaadin-time-picker-overlay` doesn't have loader part and `loading` state. Let's remove those from Styling docs.