### PR TITLE
v8: Revert font weight back to semibold for docs headings

### DIFF
--- a/dspublisher/theme/global.css
+++ b/dspublisher/theme/global.css
@@ -39,7 +39,7 @@ html {
   --docs-font-size-h5: var(--text-size-md);
   --docs-font-size-h6: var(--text-size-sm);
 
-  --docs-font-weight-heading: normal;
+  --docs-font-weight-heading: var(--text-weight-semibold);
 
   --docs-line-height-s: var(--text-leading-sm);
   --docs-line-height-m: var(--text-leading-md);


### PR DESCRIPTION
Revert font weight back to semibold for docs headings.

Reason: Updated font face declarations will map the BOLD version of NB International Pro to headings with font weight of 600 or 700.