### PR TITLE
Adds V25 prerelease to versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "Vaadin 25 (prerelease)",
+    "shortTitle": "V25 (pre)",
+    "url": "/docs/v25/",
+    "canonicalUrl": "/docs/v25"
+  },
+  {
     "title": "Vaadin 24",
     "shortTitle": "V24",
     "url": "/docs/latest/",


### PR DESCRIPTION
Vaadin 25 has reached alpha status and a prerelease of the documentation needs to be published.

The default version still is Vaadin 24 pointing to vaadin.com/docs/latest.

Also, this version is build with noindex by build configuration in Jenkins to prevent it getting indexed by search engines.