### PR TITLE
docs: deprecate Cookie Consent

### DIFF
--- a/articles/components/cookie-consent/index.adoc
+++ b/articles/components/cookie-consent/index.adoc
@@ -11,10 +11,18 @@ section-nav: commercial
 ---
 
 
-= Cookie Consent
+= [deprecated:com.vaadin:vaadin@V24.9]#Cookie Consent#
 
 :commercial-feature: Cookie Consent
 include::{articles}/_commercial-banner.adoc[opts=optional]
+
+.Cookie Consent will be removed in Vaadin 25.
+[WARNING]
+====
+Don't start a new project using Cookie Consent.
+====
+pass:[<!-- vale Vaadin.Will = YES -->]
+pass:[<!-- vale Vaadin.Versions = YES -->]
 
 // tag::description[]
 Cookie Consent aims to help you comply with privacy laws such as General Data Protection Regulation (GDPR) and California Consumer Privacy Act (CCPA).


### PR DESCRIPTION
Deprecate the Cookie Consent component with the intention to remove it in Vaadin 25.