### PR TITLE
Add link to Java language as it is with React and TS

### DIFF
--- a/articles/getting-started/prerequisites.adoc
+++ b/articles/getting-started/prerequisites.adoc
@@ -9,7 +9,9 @@ order: 10
 
 = Prerequisites
 
-Vaadin enables the creation of full-stack web applications in Java. The *Vaadin Flow* framework allows you to build even the user interface using Java only.
+Vaadin enables the creation of full-stack web applications in Java. 
+
+The *Vaadin Flow* framework allows you to build even the user interface using link:https://www.java.com/en/download/help/whatis_java.html[Java] only.
 
 You can also build your user interface in link:https://react.dev/[React] and link:https://www.typescriptlang.org/[TypeScript]. In this case, Vaadin takes care of the integration to the Java backend through the *Vaadin Hilla* framework. This makes it easy to call Java services from the browser using a type safe API. You can even combine Flow and Hilla views in the same application.
 


### PR DESCRIPTION
If we link to React and TS, we should also have a link to Java


