### PR TITLE
docs: update popover docs for V25, do not use deprecated API

### DIFF
--- a/articles/components/popover/index.adoc
+++ b/articles/components/popover/index.adoc
@@ -43,7 +43,7 @@ include::{root}/frontend/themes/docs/popover-notification-panel.css[]
 
 Popovers support focusable, interactive content, and can be used to build virtually any type of anchored overlays from custom drop-down fields and drop-down buttons to interactive tooltips.
 
-The popover’s position is anchored to an element in the UI, called the *target element*, by calling `setTarget()`. The actual content of the popover's overlay is added to it as with any other component container.
+The popover’s position is anchored to an element in the UI, called the *target element*, by calling `setTarget()`. The actual content of the popover is added to it as with any other component container.
 
 Popovers differ from <<../dialog#,Dialogs>> in that they are visually anchored to a target element, and they differ from <<../tooltip#,Tooltips>> in that they can be focused and support rich, interactive content.
 
@@ -119,7 +119,7 @@ popover.setFocusDelay(500);
 The following triggers close the popover by default:
 
 - *Target click*: Clicking the target element (non-modal popovers only)
-- *Outside click*: clicking anywhere outside the overlay (can be disabled)
+- *Outside click*: clicking anywhere outside the popover (can be disabled)
 - *Esc*: pressing kbd:[Esc] (can be disabled)
 
 [.example.show-code]
@@ -149,8 +149,8 @@ popover.setCloseOnOutsideClick(false);
 
 Additionally:
 
-- When opened on hover, the popover closes on mouseout, i.e. when the pointer leaves the target element and the overlay.
-- When opened on focus, the popover closes on blur, i.e. when focus is no longer on the target element or in the overlay.
+- When opened on hover, the popover closes on mouseout, i.e. when the pointer leaves the target element and the popover.
+- When opened on focus, the popover closes on blur, i.e. when focus is no longer on the target element or in the popover.
 
 The mouseout closing trigger has a configurable delay.
 
@@ -359,7 +359,7 @@ include::{root}/frontend/demo/component/popover/react/popover-modal.tsx[render,t
 
 == Accessibility
 
-By default, the Popover overlay has the ARIA role `dialog`. This can be changed to another role to provide appropriate semantics for the type of content and interaction in the popover (see <<typical-use-cases, Typical Use Cases>> for examples).
+By default, the Popover has the ARIA role `dialog`. This can be changed to another role to provide appropriate semantics for the type of content and interaction in the popover (see <<typical-use-cases, Typical Use Cases>> for examples).
 
 - `menu`: when the content is a list of actions or links
 - `listbox`: when the content is a list form which you can select one or more items
@@ -368,9 +368,9 @@ By default, the Popover overlay has the ARIA role `dialog`. This can be changed 
 
 Remember that, unlike <<../tooltip#,Tooltip>>, the contents of a Popover are _not_ automatically announced by screen readers when it opens. Consider using a live region to announce non-interactive popovers, and ensure keyboard access to interactive popovers.
 
-The target element is automatically applied `aria-controls` (with a reference to the Popover overlay), `aria-haspopup` (with the overlay’s role as the value), and `aria-expanded` (set to `true` when open, and to `false` otherwise).
+The target element is automatically applied `aria-controls` (with a reference to the Popover), `aria-haspopup` (with the overlay’s role as the value), and `aria-expanded` (set to `true` when open, and to `false` otherwise).
 
-An accessible name can be provided for the overlay using the ARIA label API:
+An accessible name can be provided for the popover using the ARIA label API:
 
 [.example.show-code]
 --
@@ -497,7 +497,7 @@ include::{root}/frontend/themes/docs/popover-notification-panel.css[]
 - Closes on kbd:[Esc], outside click, target click
 - Modal, no modality curtain (small popovers like this usually don’t need them)
 - ARIA role `dialog` (although mainly a list, there interactive non-list elements as well)
-- ARIA labelled-by pointing to heading in overlay
+- ARIA labelled-by pointing to heading in the popover
 - Arrow variant
 
 === Rich, Interactive Tooltip
@@ -526,7 +526,7 @@ include::{root}/frontend/demo/component/popover/react/popover-interactive-toolti
 - Non-modal
 - Not auto-focused
 - ARIA role `dialog` (`tooltip` would be invalid due to interactive contents)
-- ARIA labelled-by pointing to heading in overlay
+- ARIA labelled-by pointing to heading in the popover
 - Positioned above target
 - Arrow variant
 
@@ -557,7 +557,7 @@ include::{root}/frontend/demo/component/popover/react/popover-anchored-dialog.ts
 - Modal, with curtain
 - Auto-focused
 - ARIA role `dialog`
-- ARIA labelled-by pointing to heading in the overlay
+- ARIA labelled-by pointing to heading in the popover
 
 Note: if the dialog doesn’t benefit from being anchored-positioned to another element, consider using a <<../dialog#,Dialog>> instead.
 

--- a/articles/components/popover/index.adoc
+++ b/articles/components/popover/index.adoc
@@ -41,7 +41,7 @@ include::{root}/frontend/themes/docs/popover-notification-panel.css[]
 ----
 --
 
-Popovers support focusable, interactive content, and can be used to build virtually any type of anchored overlays from custom drop-down fields and drop-down buttons to and interactive tooltips.
+Popovers support focusable, interactive content, and can be used to build virtually any type of anchored overlays from custom drop-down fields and drop-down buttons to interactive tooltips.
 
 The popover’s position is anchored to an element in the UI, called the *target element*, by calling `setTarget()`. The actual content of the popover's overlay is added to it as with any other component container.
 
@@ -387,16 +387,16 @@ popover.setAriaLabelledby("label-element-id");
 [source,html]
 ----
 <source-info group="Lit"></source-info>
-<vaadin-popover accessible-name="Label"></vaadin-popover>
-<vaadin-popover accessible-name-ref="label-element-id"></vaadin-popover>
+<vaadin-popover aria-label="Label"></vaadin-popover>
+<vaadin-popover aria-labelledby="label-element-id"></vaadin-popover>
 
 ----
 
 [source,tsx]
 ----
 <source-info group="React"></source-info>
-<Popover accessibleName="Label" />
-<Popover accessibleNameRef="label-element-id" />
+<Popover aria-label="Label" />
+<Popover aria-labelledby="label-element-id" />
 ----
 
 --

--- a/frontend/demo/component/popover/popover-anchored-dialog.ts
+++ b/frontend/demo/component/popover/popover-anchored-dialog.ts
@@ -9,10 +9,11 @@ import '@vaadin/popover';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { CheckboxChangeEvent } from '@vaadin/checkbox';
-import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
+
+type ColumnConfig = { label: string; key: string; visible: boolean };
 
 const DEFAULT_COLUMNS = [
   { label: 'First name', key: 'firstName', visible: true },
@@ -36,7 +37,7 @@ export class Example extends LitElement {
   private items: Person[] = [];
 
   @state()
-  private gridColumns = [...DEFAULT_COLUMNS];
+  private gridColumns: ColumnConfig[] = [...DEFAULT_COLUMNS];
 
   protected override async firstUpdated() {
     const { people } = await getPeople();
@@ -53,13 +54,9 @@ export class Example extends LitElement {
         </vaadin-button>
       </vaadin-horizontal-layout>
 
-      <vaadin-popover
-        for="toggle-columns"
-        modal
-        with-backdrop
-        position="bottom-end"
-        ${popoverRenderer(this.popoverRenderer, [this.gridColumns])}
-      ></vaadin-popover>
+      <vaadin-popover for="toggle-columns" modal with-backdrop position="bottom-end">
+        ${this.renderPopover(this.gridColumns)}
+      </vaadin-popover>
       <!-- end::snippet[] -->
 
       <!-- tag::gridsnippet[] -->
@@ -78,15 +75,13 @@ export class Example extends LitElement {
   }
 
   // tag::snippet[]
-  popoverRenderer() {
-    const visibleColumns = this.gridColumns
-      .filter((column) => column.visible)
-      .map((column) => column.key);
+  renderPopover(columns: ColumnConfig[]) {
+    const visibleColumns = columns.filter((column) => column.visible).map((column) => column.key);
 
     return html`
       <div style="font-weight: 600; padding: var(--lumo-space-xs);">Configure columns</div>
       <vaadin-checkbox-group theme="vertical" .value="${visibleColumns}">
-        ${this.gridColumns.map(
+        ${columns.map(
           (column) => html`
             <vaadin-checkbox
               .label="${column.label}"

--- a/frontend/demo/component/popover/popover-arrow.ts
+++ b/frontend/demo/component/popover/popover-arrow.ts
@@ -5,7 +5,6 @@ import '@vaadin/popover';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('popover-arrow')
@@ -23,16 +22,10 @@ export class Example extends LitElement {
         <vaadin-icon icon="lumo:bell"></vaadin-icon>
       </vaadin-button>
       <!-- tag::snippet[] -->
-      <vaadin-popover
-        for="target"
-        theme="arrow"
-        ${popoverRenderer(this.popoverRenderer)}
-      ></vaadin-popover>
+      <vaadin-popover for="target" theme="arrow">
+        <div>No new notifications</div>
+      </vaadin-popover>
       <!-- end::snippet[] -->
     `;
-  }
-
-  popoverRenderer() {
-    return html`<div>No new notifications</div>`;
   }
 }

--- a/frontend/demo/component/popover/popover-dropdown-field.ts
+++ b/frontend/demo/component/popover/popover-dropdown-field.ts
@@ -10,7 +10,6 @@ import { formatISO, subMonths, subWeeks, subYears } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { DatePickerChangeEvent } from '@vaadin/date-picker';
-import { popoverRenderer } from '@vaadin/popover/lit.js';
 import type { SelectChangeEvent } from '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
 
@@ -62,44 +61,37 @@ export class Example extends LitElement {
         modal
         width="340px"
         position="bottom-start"
-        accessible-name="Select a date range"
+        aria-label="Select a date range"
         .opened="${this.opened}"
         @closed="${this.onClosed}"
-        ${popoverRenderer(this.popoverRenderer, [this.from, this.to])}
-      ></vaadin-popover>
+      >
+        <vaadin-select
+          label="Common ranges"
+          .items="${this.presets}"
+          placeholder="Select preset"
+          style="width: 100%"
+          .value="${this.range}"
+          @change="${this.onRangeChange}"
+        ></vaadin-select>
+        <vaadin-horizontal-layout theme="spacing-s" style="align-items: baseline">
+          <vaadin-date-picker
+            label="From"
+            style="width: 150px"
+            .value="${this.from}"
+            @change="${this.onFromChange}"
+          ></vaadin-date-picker>
+          <div>−</div>
+          <vaadin-date-picker
+            label="To"
+            style="width: 150px"
+            .value="${this.to}"
+            @change="${this.onToChange}"
+          ></vaadin-date-picker>
+        </vaadin-horizontal-layout>
+      </vaadin-popover>
       <!-- end::snippet[] -->
     `;
   }
-
-  // tag::snippet[]
-  popoverRenderer() {
-    return html`
-      <vaadin-select
-        label="Common ranges"
-        .items="${this.presets}"
-        placeholder="Select preset"
-        style="width: 100%"
-        .value="${this.range}"
-        @change="${this.onRangeChange}"
-      ></vaadin-select>
-      <vaadin-horizontal-layout theme="spacing-s" style="align-items: baseline">
-        <vaadin-date-picker
-          label="From"
-          style="width: 150px"
-          .value="${this.from}"
-          @change="${this.onFromChange}"
-        ></vaadin-date-picker>
-        <div>−</div>
-        <vaadin-date-picker
-          label="To"
-          style="width: 150px"
-          .value="${this.to}"
-          @change="${this.onToChange}"
-        ></vaadin-date-picker>
-      </vaadin-horizontal-layout>
-    `;
-  }
-  // end::snippet[]
 
   onKeyDown(event: KeyboardEvent) {
     if (event.key === 'ArrowDown') {

--- a/frontend/demo/component/popover/popover-interactive-tooltip.ts
+++ b/frontend/demo/component/popover/popover-interactive-tooltip.ts
@@ -5,7 +5,6 @@ import '@vaadin/popover';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { PopoverTrigger } from '@vaadin/popover';
-import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('popover-interactive-tooltip')
@@ -29,23 +28,18 @@ export class Example extends LitElement {
         .trigger="${this.trigger}"
         position="top"
         theme="arrow"
-        accessible-name-ref="cvv-heading"
-        ${popoverRenderer(this.cvvRenderer)}
-      ></vaadin-popover>
+        aria-labelledby="cvv-heading"
+      >
+        <h3 id="cvv-heading" style="margin: 0; font-size: 1rem">Card Verification Value</h3>
+        <div style="max-width: 300px">
+          A three or four digit code, usually printed on the back of the card, next to, or at the
+          end of, the signature strip.
+        </div>
+        <a href="https://www.cvvnumber.com/cvv.html" target="_blank">
+          See where to find CVV on different cards
+        </a>
+      </vaadin-popover>
       <!-- end::snippet[] -->
-    `;
-  }
-
-  cvvRenderer() {
-    return html`
-      <h3 id="cvv-heading" style="margin: 0; font-size: 1rem">Card Verification Value</h3>
-      <div style="max-width: 300px">
-        A three or four digit code, usually printed on the back of the card, next to, or at the end
-        of, the signature strip.
-      </div>
-      <a href="https://www.cvvnumber.com/cvv.html" target="_blank">
-        See where to find CVV on different cards
-      </a>
     `;
   }
 }

--- a/frontend/demo/component/popover/popover-modal.ts
+++ b/frontend/demo/component/popover/popover-modal.ts
@@ -4,7 +4,6 @@ import '@vaadin/popover';
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { applyTheme } from 'Frontend/generated/theme';
 
 @customElement('popover-modal')
@@ -20,20 +19,11 @@ export class Example extends LitElement {
     return html`
       <vaadin-button id="target">Discount</vaadin-button>
       <!-- tag::snippet[] -->
-      <vaadin-popover
-        for="target"
-        modal
-        with-backdrop
-        ${popoverRenderer(this.popoverRenderer)}
-      ></vaadin-popover>
+      <vaadin-popover for="target" modal with-backdrop>
+        <vaadin-text-field label="Discount code"></vaadin-text-field>
+        <vaadin-button>Apply</vaadin-button>
+      </vaadin-popover>
       <!-- end::snippet[] -->
-    `;
-  }
-
-  popoverRenderer() {
-    return html`
-      <vaadin-text-field label="Discount code"></vaadin-text-field>
-      <vaadin-button>Apply</vaadin-button>
     `;
   }
 }

--- a/frontend/demo/component/popover/popover-notification-panel.ts
+++ b/frontend/demo/component/popover/popover-notification-panel.ts
@@ -10,7 +10,6 @@ import { format, subMinutes } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { MessageListItem } from '@vaadin/message-list';
-import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import { applyTheme } from 'Frontend/generated/theme';
 
@@ -73,19 +72,17 @@ export class Example extends LitElement {
         for="show-notifications"
         theme="arrow no-padding"
         modal
-        accessible-name-ref="notifications-heading"
+        aria-labelledby="notifications-heading"
         width="300px"
         position="bottom"
-        ${popoverRenderer(this.notificationsRenderer, [
-          this.unreadNotifications,
-          this.allNotifications,
-        ])}
-      ></vaadin-popover>
+      >
+        ${this.renderNotifications(this.unreadNotifications, this.allNotifications)}
+      </vaadin-popover>
       <!-- end::snippet[] -->
     `;
   }
 
-  notificationsRenderer() {
+  renderNotifications(unread: MessageListItem[], all: MessageListItem[]) {
     return html`
       <vaadin-horizontal-layout
         style="align-items: center; padding: var(--lumo-space-m) var(--lumo-space-m) var(--lumo-space-xs)"
@@ -101,14 +98,12 @@ export class Example extends LitElement {
           <vaadin-tab id="all-tab">All</vaadin-tab>
         </vaadin-tabs>
         <div tab="unread-tab">
-          ${this.unreadNotifications.length
-            ? html`
-                <vaadin-message-list .items="${this.unreadNotifications}"></vaadin-message-list>
-              `
+          ${unread.length
+            ? html`<vaadin-message-list .items="${unread}"></vaadin-message-list>`
             : html`<div class="no-notifications-msg">No unread notifications</div>`}
         </div>
         <div tab="all-tab">
-          <vaadin-message-list .items="${this.allNotifications}"></vaadin-message-list>
+          <vaadin-message-list .items="${all}"></vaadin-message-list>
         </div>
       </vaadin-tabsheet>
     `;

--- a/frontend/demo/component/popover/popover-positioning.ts
+++ b/frontend/demo/component/popover/popover-positioning.ts
@@ -6,7 +6,6 @@ import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { PopoverPosition } from '@vaadin/popover';
-import { popoverRenderer } from '@vaadin/popover/lit.js';
 import type { SelectChangeEvent } from '@vaadin/select';
 import { applyTheme } from 'Frontend/generated/theme';
 
@@ -52,17 +51,9 @@ export class Example extends LitElement {
         ></vaadin-select>
       </vaadin-vertical-layout>
       <!-- tag::snippet[] -->
-      <vaadin-popover
-        for="target"
-        .position="${this.position}"
-        ${popoverRenderer(this.popoverRenderer)}
-      ></vaadin-popover>
+      <vaadin-popover for="target" .position="${this.position}"> Popover content </vaadin-popover>
       <!-- end::snippet[] -->
     `;
-  }
-
-  popoverRenderer() {
-    return html`Popover content`;
   }
 
   onPositionChange(event: SelectChangeEvent) {

--- a/frontend/demo/component/popover/popover-positioning.ts
+++ b/frontend/demo/component/popover/popover-positioning.ts
@@ -51,7 +51,7 @@ export class Example extends LitElement {
         ></vaadin-select>
       </vaadin-vertical-layout>
       <!-- tag::snippet[] -->
-      <vaadin-popover for="target" .position="${this.position}"> Popover content </vaadin-popover>
+      <vaadin-popover for="target" .position="${this.position}">Popover content</vaadin-popover>
       <!-- end::snippet[] -->
     `;
   }

--- a/frontend/demo/component/popover/popover-user-menu.ts
+++ b/frontend/demo/component/popover/popover-user-menu.ts
@@ -6,7 +6,6 @@ import '@vaadin/popover';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { popoverRenderer } from '@vaadin/popover/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/generated/theme';
@@ -49,11 +48,12 @@ export class Example extends LitElement {
         for="avatar"
         position="bottom-end"
         modal
-        overlay-role="menu"
-        accessible-name="User menu"
+        role="menu"
+        aria-label="User menu"
         theme="no-padding"
-        ${popoverRenderer(this.userMenuRenderer, [this.person])}
-      ></vaadin-popover>
+      >
+        ${this.renderUserMenu(this.person)}
+      </vaadin-popover>
       <!-- end::snippet[] -->
     `;
   }
@@ -62,8 +62,8 @@ export class Example extends LitElement {
   // We are using inline styles here to keep the example simple.
   // We recommend placing CSS in a separate style sheet and
   // encapsulating the styling in a new component.
-  userMenuRenderer() {
-    const { firstName, lastName, pictureUrl } = this.person ?? {};
+  renderUserMenu(person?: Person) {
+    const { firstName, lastName, pictureUrl } = person ?? {};
     const nickName = `@${firstName}${lastName}`.toLowerCase();
 
     return html`

--- a/frontend/demo/component/popover/react/popover-dropdown-field.tsx
+++ b/frontend/demo/component/popover/react/popover-dropdown-field.tsx
@@ -83,7 +83,7 @@ function Example() {
         modal
         width="340px"
         position="bottom-start"
-        accessibleName="Select a date range"
+        aria-label="Select a date range"
         opened={opened.value}
         onClosed={() => {
           opened.value = false;

--- a/frontend/demo/component/popover/react/popover-interactive-tooltip.tsx
+++ b/frontend/demo/component/popover/react/popover-interactive-tooltip.tsx
@@ -11,7 +11,7 @@ function Example() {
         for="cvv-field"
         position="top"
         trigger={['hover', 'focus']}
-        accessibleNameRef="cvv-heading"
+        aria-labelledby="cvv-heading"
         theme="arrow"
       >
         <h3 id="cvv-heading" style={{ margin: 0, fontSize: '1rem' }}>

--- a/frontend/demo/component/popover/react/popover-notification-panel.tsx
+++ b/frontend/demo/component/popover/react/popover-notification-panel.tsx
@@ -68,7 +68,7 @@ function Example() {
         modal
         position="bottom"
         width="300px"
-        accessibleNameRef="notifications-heading"
+        aria-labelledby="notifications-heading"
       >
         <HorizontalLayout
           style={{

--- a/frontend/demo/component/popover/react/popover-user-menu.tsx
+++ b/frontend/demo/component/popover/react/popover-user-menu.tsx
@@ -45,9 +45,9 @@ function Example() {
       <Popover
         for="avatar"
         position="bottom-end"
-        overlayRole="menu"
+        role="menu"
         modal
-        accessibleName="User menu"
+        aria-label="User menu"
         theme="no-padding"
       >
         <HorizontalLayout className="userMenuHeader">

--- a/frontend/themes/docs/document.css
+++ b/frontend/themes/docs/document.css
@@ -1,2 +1,0 @@
-@import './popover-notification-panel.css';
-@import './popover-user-menu.css';

--- a/frontend/themes/docs/styles.css
+++ b/frontend/themes/docs/styles.css
@@ -14,6 +14,8 @@
 @import './multi-select-combo-box-item-class-name.css';
 @import './nav-item-styling.css';
 @import './icon-fonts.css';
+@import './popover-notification-panel.css';
+@import './popover-user-menu.css';
 
 html,
 :host {

--- a/src/main/java/com/vaadin/demo/component/popover/PopoverUserMenu.java
+++ b/src/main/java/com/vaadin/demo/component/popover/PopoverUserMenu.java
@@ -45,7 +45,7 @@ public class PopoverUserMenu extends HorizontalLayout {
 
         Popover popover = new Popover();
         popover.setModal(true);
-        popover.setOverlayRole("menu");
+        popover.setRole("menu");
         popover.setAriaLabel("User menu");
         popover.setTarget(button);
         popover.setPosition(PopoverPosition.BOTTOM_END);


### PR DESCRIPTION
Updated `vaadin-popover` examples:

- Replaced `overlayRole` with `role`
- Replaced `accessibleName` with `aria-label`
- Replaced `popoverRenderer` directive with light DOM content
  - Preserved separate methods for some large templates
- Moved `.css` files from `document.css` to `styles.css`

Also changed wording to not use `overlay`.