### PR TITLE
chore: exclude observability kit from runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>observability-kit-starter</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -175,6 +176,12 @@
                 <configuration>
                     <wait>500</wait>
                     <maxAttempts>240</maxAttempts>
+                    <excludes>
+                        <exclude>
+                            <groupId>com.vaadin</groupId>
+                            <artifactId>observability-kit-starter</artifactId>
+                        </exclude>
+                    </excludes>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Exclude observability kit from runtime to avoid getting errors like these in the logs:
```
ERROR 60835 --- [nio-8080-exec-5] c.v.observability.ObservabilityHandler   : Observability agent is not running
```

From what I can see observability kit is only in the dependencies so that the example code snippets compile, but these examples never actually run at runtime so the dependency should not be needed there. To exclude it:
- Change the scope to provided which should remove it from production builds
- Also exclude it from the Spring boot maven plugin, which otherwise still puts Maven dependencies with provided scope on the classpath when starting the app in dev mode