### PR TITLE
Fix upload progress tracking link in File Handling page

### DIFF
--- a/articles/components/upload/file-handling.adoc
+++ b/articles/components/upload/file-handling.adoc
@@ -25,7 +25,7 @@ The following built-in implementations of [classname]`UploadHandler` are availab
 - [classname]`TemporaryFileUploadHandler`, stores uploaded files to temporary files, typically using the system's temporary directory. This handler is useful when dealing with large files or when memory usage needs to be minimized.
 
 These are described in the sub-sections that follow.
-All of the build-in implementations extend [classname]`TransferProgressAwareHandler` and support <<add-progress-listener, adding progress listeners>>.
+All of the build-in implementations extend [classname]`TransferProgressAwareHandler` and support <<#upload-progress-tracking, upload progress tracking>>.
 
 [NOTE]
 The [classname]`Receiver` had implementations for single and multiple file upload.


### PR DESCRIPTION
Previously it linked to a section that no longer exists.