### PR TITLE
chore: fix typo in docs

### DIFF
--- a/articles/components/upload/index.adoc
+++ b/articles/components/upload/index.adoc
@@ -275,7 +275,7 @@ endif::[]
 ====
 This constraint is set on the client and is checked before contacting the server.
 
-When using Java Flow with Spring Boot, file size limits are also affected by Spring’s multipart configuration.
+When using Vaadin Flow with Spring Boot, file size limits are also affected by Spring’s multipart configuration.
 
 By default, Spring Boot applies restrictive limits that may cause uploads to fail — typically for files larger than 1MB.
 You can increase these limits in your `application.properties` or `application.yml` file:


### PR DESCRIPTION
This PR fixes a typo where "Java Flow" was used instead of "Vaadin Flow".