### PR TITLE
fix: ensure popover does not close in React example

### DIFF
--- a/frontend/demo/component/popover/react/popover-dropdown-field.tsx
+++ b/frontend/demo/component/popover/react/popover-dropdown-field.tsx
@@ -85,6 +85,11 @@ function Example() {
         position="bottom-start"
         accessibleName="Select a date range"
         opened={opened.value}
+        onOpenedChanged={(e) => {
+          if (e.detail.value) {
+            opened.value = true;
+          }
+        }}
         onClosed={() => {
           opened.value = false;
         }}


### PR DESCRIPTION
Same as https://github.com/vaadin/docs/pull/4614 but for `v24` branch.