### PR TITLE
Update AppSec Kit configuration documentation

### DIFF
--- a/articles/tools/appsec/advanced-topics.adoc
+++ b/articles/tools/appsec/advanced-topics.adoc
@@ -27,6 +27,8 @@ AppSecService.getInstance().setConfiguration(appSecConfiguration);
 
 You can set or override the following configuration values in the `AppSecConfiguration`:
 
+`vaadinPlatformVersion`::
+The Vaadin platform version that the application is using.
 `appSecRoute`::
 The route of the AppSec Kit user interface.
 `dataFilePath`::
@@ -46,6 +48,10 @@ The boolean value to decide if the npm development dependencies should be includ
 `automaticallyActivatePush`::
 The boolean value to decide if the server push should be automatically activated in the application.
 
+
+=== Vaadin Platform Version
+
+The AppSec Kit requires the Vaadin platform version that is used in the application when getting the Vaadin platform BOM. First, it checks if the `vaadin-core` dependency is present in the application and uses the version of that dependency as the Vaadin platform version. If the `vaadin-core` dependency is not present then it gets the version defined in the AppSec Kit configuration through this configuration option. If this configuration option is not defined then an `AppSecException` is thrown. The version should be defined as a `String`. The default value is `null`.
 
 === AppSec Kit Route
 


### PR DESCRIPTION
Adds the `vaadinPlatformVersion` configuration option description to the AppSec Kit configuration documentation.