### PR TITLE
chore: update applyTheme imports

### DIFF
--- a/frontend/demo/component/accordion/accordion-basic.ts
+++ b/frontend/demo/component/accordion/accordion-basic.ts
@@ -4,13 +4,12 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('accordion-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/accordion/accordion-content.ts
+++ b/frontend/demo/component/accordion/accordion-content.ts
@@ -4,7 +4,7 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('accordion-content')
 export class Example extends LitElement {
@@ -17,7 +17,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/accordion/accordion-disabled-panels.ts
+++ b/frontend/demo/component/accordion/accordion-disabled-panels.ts
@@ -4,13 +4,12 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('accordion-disabled-panels')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/accordion/accordion-filled-panels.ts
+++ b/frontend/demo/component/accordion/accordion-filled-panels.ts
@@ -4,13 +4,12 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('accordion-filled-panels')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/accordion/accordion-reverse-panels.ts
+++ b/frontend/demo/component/accordion/accordion-reverse-panels.ts
@@ -4,13 +4,12 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('accordion-reverse-panels')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/accordion/accordion-small-panels.ts
+++ b/frontend/demo/component/accordion/accordion-small-panels.ts
@@ -4,13 +4,12 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('accordion-small-panels')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/accordion/accordion-summary.ts
+++ b/frontend/demo/component/accordion/accordion-summary.ts
@@ -16,7 +16,7 @@ import { getCountries } from 'Frontend/demo/domain/DataService';
 import CardModel from 'Frontend/generated/com/vaadin/demo/domain/CardModel';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import PersonModel from 'Frontend/generated/com/vaadin/demo/domain/PersonModel';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 const responsiveSteps: FormLayoutResponsiveStep[] = [
   { minWidth: 0, columns: 1 },
@@ -41,7 +41,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/app-layout/app-layout-basic.ts
+++ b/frontend/demo/component/app-layout/app-layout-basic.ts
@@ -8,7 +8,7 @@ import '@vaadin/side-nav';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('app-layout-basic')
 export class Example extends LitElement {
@@ -21,7 +21,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
@@ -6,7 +6,7 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { patchAppLayoutNavigation } from './app-layout-helper'; // hidden-source-line
 
 @customElement('app-layout-bottom-navbar')
@@ -29,7 +29,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/app-layout/app-layout-drawer.ts
+++ b/frontend/demo/component/app-layout/app-layout-drawer.ts
@@ -8,7 +8,7 @@ import '@vaadin/side-nav';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('app-layout-drawer')
 export class Example extends LitElement {
@@ -21,7 +21,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/app-layout/app-layout-height-auto.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-auto.ts
@@ -5,7 +5,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('app-layout-height-auto')
 export class Example extends LitElement {
@@ -18,7 +18,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/app-layout/app-layout-height-full.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-full.ts
@@ -5,7 +5,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('app-layout-height-full')
 export class Example extends LitElement {
@@ -22,7 +22,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
@@ -8,7 +8,7 @@ import '@vaadin/side-nav';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('app-layout-navbar-placement-side')
 export class Example extends LitElement {
@@ -21,7 +21,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
@@ -8,7 +8,7 @@ import '@vaadin/side-nav';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('app-layout-navbar-placement')
 export class Example extends LitElement {
@@ -21,7 +21,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/app-layout/app-layout-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar.ts
@@ -6,7 +6,7 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { patchAppLayoutNavigation } from './app-layout-helper'; // hidden-source-line
 
 @customElement('app-layout-navbar')
@@ -26,7 +26,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
+++ b/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
@@ -10,7 +10,7 @@ import '@vaadin/vertical-layout';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { patchAppLayoutNavigation } from './app-layout-helper'; // hidden-source-line
 
 @customElement('app-layout-secondary-navigation')
@@ -30,7 +30,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-abbreviation.ts
+++ b/frontend/demo/component/avatar/avatar-abbreviation.ts
@@ -3,13 +3,12 @@ import '@vaadin/avatar';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('avatar-abbreviation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-basic.ts
+++ b/frontend/demo/component/avatar/avatar-basic.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('avatar-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-group-basic.ts
+++ b/frontend/demo/component/avatar/avatar-group-basic.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('avatar-group-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-group-bg-color.ts
+++ b/frontend/demo/component/avatar/avatar-group-bg-color.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('avatar-group-bg-color')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-group-internationalisation.ts
+++ b/frontend/demo/component/avatar/avatar-group-internationalisation.ts
@@ -5,13 +5,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { AvatarGroupI18n } from '@vaadin/avatar-group';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('avatar-group-internationalistion')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-group-max-items.ts
+++ b/frontend/demo/component/avatar/avatar-group-max-items.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('avatar-group-max-items')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-image.ts
+++ b/frontend/demo/component/avatar/avatar-image.ts
@@ -5,14 +5,13 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import companyLogo from '../../../../src/main/resources/images/company-logo.png?url';
 
 @customElement('avatar-image')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-menu-bar.ts
+++ b/frontend/demo/component/avatar/avatar-menu-bar.ts
@@ -6,13 +6,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { MenuBarItem } from '@vaadin/menu-bar';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('avatar-menu-bar')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-name.ts
+++ b/frontend/demo/component/avatar/avatar-name.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('avatar-name')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/avatar/avatar-sizes.ts
+++ b/frontend/demo/component/avatar/avatar-sizes.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('avatar-sizes')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-basic.ts
+++ b/frontend/demo/component/badge/badge-basic.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('badge-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-color.ts
+++ b/frontend/demo/component/badge/badge-color.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('badge-color')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-counter.ts
+++ b/frontend/demo/component/badge/badge-counter.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/tabs';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('badge-counter')
 export class Example extends LitElement {
@@ -14,7 +14,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-highlight.ts
+++ b/frontend/demo/component/badge/badge-highlight.ts
@@ -7,7 +7,7 @@ import { customElement, state } from 'lit/decorators.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getReports, ReportStatus } from 'Frontend/demo/domain/DataService';
 import type Report from 'Frontend/generated/com/vaadin/demo/domain/Report';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
@@ -22,7 +22,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -8,7 +8,7 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getUserPermissions } from 'Frontend/demo/domain/DataService'; // hidden-source-line
 import type UserPermissions from 'Frontend/generated/com/vaadin/demo/domain/UserPermissions'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('badge-icons-only-table')
 export class Example extends LitElement {
@@ -17,7 +17,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-icons-only.ts
+++ b/frontend/demo/component/badge/badge-icons-only.ts
@@ -4,13 +4,12 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('badge-icons-only')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-icons.ts
+++ b/frontend/demo/component/badge/badge-icons.ts
@@ -5,13 +5,12 @@ import '@vaadin/icons';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('badge-icons')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-interactive.ts
+++ b/frontend/demo/component/badge/badge-interactive.ts
@@ -12,7 +12,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import type { Button } from '@vaadin/button';
 import type { ComboBoxChangeEvent } from '@vaadin/combo-box';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 type Profession = string;
 
@@ -26,7 +26,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-shape.ts
+++ b/frontend/demo/component/badge/badge-shape.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('badge-shape')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/badge/badge-size.ts
+++ b/frontend/demo/component/badge/badge-size.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('badge-size')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/board/board-basic.ts
+++ b/frontend/demo/component/board/board-basic.ts
@@ -4,7 +4,7 @@ import './example-indicator';
 import './example-chart';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('board-basic')
 export class Example extends LitElement {
@@ -15,7 +15,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/board/board-breakpoints.ts
+++ b/frontend/demo/component/board/board-breakpoints.ts
@@ -3,7 +3,7 @@ import '@vaadin/board';
 import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('board-breakpoints')
 export class Example extends LitElement {
@@ -14,7 +14,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/board/board-column-span.ts
+++ b/frontend/demo/component/board/board-column-span.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/board';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('board-column-span')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/board/board-column-wrapping.ts
+++ b/frontend/demo/component/board/board-column-wrapping.ts
@@ -3,7 +3,7 @@ import '@vaadin/board';
 import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('board-column-wrapping')
 export class Example extends LitElement {
@@ -14,7 +14,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/board/board-nested.ts
+++ b/frontend/demo/component/board/board-nested.ts
@@ -4,7 +4,7 @@ import './example-indicator';
 import './example-statistics';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('board-nested')
 export class Example extends LitElement {
@@ -15,7 +15,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/board/example-indicator.ts
+++ b/frontend/demo/component/board/example-indicator.ts
@@ -3,7 +3,7 @@ import '@vaadin/icons';
 import '@vaadin/vertical-layout';
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('example-indicator')
 export class ExampleIndicator extends LitElement {
@@ -60,7 +60,6 @@ export class ExampleIndicator extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-basic.ts
+++ b/frontend/demo/component/button/button-basic.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-contrast.ts
+++ b/frontend/demo/component/button/button-contrast.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-contrast')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-dialog.ts
+++ b/frontend/demo/component/button/button-dialog.ts
@@ -7,13 +7,12 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-dialog')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-disable-long-action.ts
+++ b/frontend/demo/component/button/button-disable-long-action.ts
@@ -5,14 +5,13 @@ import '@vaadin/progress-bar';
 import './fake-progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import type { FakeProgressBar } from './fake-progress-bar';
 
 @customElement('button-disable-long-action')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-disabled.ts
+++ b/frontend/demo/component/button/button-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-error.ts
+++ b/frontend/demo/component/button/button-error.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-error')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-focus.ts
+++ b/frontend/demo/component/button/button-focus.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-focus')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-form.ts
+++ b/frontend/demo/component/button/button-form.ts
@@ -7,13 +7,12 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-form')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-grid.ts
+++ b/frontend/demo/component/button/button-grid.ts
@@ -10,13 +10,12 @@ import type { GridSelectedItemsChangedEvent } from '@vaadin/grid';
 import type { GridSelectionColumnSelectAllChangedEvent } from '@vaadin/grid/vaadin-grid-selection-column';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-grid')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-icons.ts
+++ b/frontend/demo/component/button/button-icons.ts
@@ -6,13 +6,12 @@ import '@vaadin/icons';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-icons')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-images.ts
+++ b/frontend/demo/component/button/button-images.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import img from '../../../../src/main/resources/images/vaadin-logo-dark.png?url';
 
 @customElement('button-images')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-labels.ts
+++ b/frontend/demo/component/button/button-labels.ts
@@ -6,7 +6,7 @@ import '@vaadin/vertical-layout';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { EmailFieldValueChangedEvent } from '@vaadin/email-field';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-labels')
 export class Example extends LitElement {
@@ -18,7 +18,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-sizes.ts
+++ b/frontend/demo/component/button/button-sizes.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-sizes')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-styles.ts
+++ b/frontend/demo/component/button/button-styles.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-success.ts
+++ b/frontend/demo/component/button/button-success.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-success')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-tertiary-inline.ts
+++ b/frontend/demo/component/button/button-tertiary-inline.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-tertiary-inline')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/button/button-warning.ts
+++ b/frontend/demo/component/button/button-warning.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('button-warning')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-combine-variants.ts
+++ b/frontend/demo/component/card/card-combine-variants.ts
@@ -3,14 +3,13 @@ import '@vaadin/avatar';
 import '@vaadin/card';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import img from '../../../../src/main/resources/images/lapland.avif?url';
 
 @customElement('card-combine-variants')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-content.ts
+++ b/frontend/demo/component/card/card-content.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/card';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-content')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-cover-media.ts
+++ b/frontend/demo/component/card/card-cover-media.ts
@@ -5,14 +5,13 @@ import '@vaadin/icon';
 import '@vaadin/vaadin-lumo-styles/icons.js';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import img from '../../../../src/main/resources/images/lapland.avif?url';
 
 @customElement('card-cover-media')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-features.ts
+++ b/frontend/demo/component/card/card-features.ts
@@ -13,13 +13,12 @@ import { customElement, query } from 'lit/decorators.js';
 import type { Card } from '@vaadin/card';
 import type { CheckboxGroup } from '@vaadin/checkbox-group';
 import type { Select } from '@vaadin/select';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-footer.ts
+++ b/frontend/demo/component/card/card-footer.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/card';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-footer')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-header-prefix.ts
+++ b/frontend/demo/component/card/card-header-prefix.ts
@@ -3,13 +3,12 @@ import '@vaadin/avatar';
 import '@vaadin/card';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-header-prefix')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-header-suffix.ts
+++ b/frontend/demo/component/card/card-header-suffix.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/card';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-header-suffix')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-header.ts
+++ b/frontend/demo/component/card/card-header.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/card';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-header')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-horizontal.ts
+++ b/frontend/demo/component/card/card-horizontal.ts
@@ -3,13 +3,12 @@ import '@vaadin/avatar';
 import '@vaadin/card';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-horizontal')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-media.ts
+++ b/frontend/demo/component/card/card-media.ts
@@ -5,14 +5,13 @@ import '@vaadin/icon';
 import '@vaadin/vaadin-lumo-styles/icons.js';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import img from '../../../../src/main/resources/images/lapland.avif?url';
 
 @customElement('card-media')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-stretch-media.ts
+++ b/frontend/demo/component/card/card-stretch-media.ts
@@ -4,14 +4,13 @@ import '@vaadin/icon';
 import '@vaadin/vaadin-lumo-styles/icons.js';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import img from '../../../../src/main/resources/images/lapland.avif?url';
 
 @customElement('card-stretch-media')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-subtitle.ts
+++ b/frontend/demo/component/card/card-subtitle.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/card';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-subtitle')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-title.ts
+++ b/frontend/demo/component/card/card-title.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/card';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-title')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/card/card-variants.ts
+++ b/frontend/demo/component/card/card-variants.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/card';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('card-variants')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/charts/charts-area.ts
+++ b/frontend/demo/component/charts/charts-area.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/charts';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('charts-area')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/charts/charts-column.ts
+++ b/frontend/demo/component/charts/charts-column.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/charts';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('charts-column')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/charts/charts-gantt.ts
+++ b/frontend/demo/component/charts/charts-gantt.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/charts';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('charts-gantt')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/charts/charts-overview.ts
+++ b/frontend/demo/component/charts/charts-overview.ts
@@ -3,13 +3,12 @@ import '@vaadin/charts';
 import type { Options, PointOptionsObject } from 'highcharts';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('charts-overview')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/charts/charts-pie.ts
+++ b/frontend/demo/component/charts/charts-pie.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/charts';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('charts-pie')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/charts/charts-polar.ts
+++ b/frontend/demo/component/charts/charts-polar.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/charts';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('charts-polar')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts
+++ b/frontend/demo/component/checkbox/checkbox-adjacent-groups.ts
@@ -4,13 +4,12 @@ import '@vaadin/checkbox-group';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-adjacent-groups')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-basic.ts
+++ b/frontend/demo/component/checkbox/checkbox-basic.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/checkbox';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-disabled.ts
+++ b/frontend/demo/component/checkbox/checkbox-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-group-basic-features.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-basic-features.ts
@@ -4,13 +4,12 @@ import '@vaadin/tooltip';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-group-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-group-basic.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-basic.ts
@@ -4,13 +4,12 @@ import '@vaadin/checkbox-group';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { CheckboxGroupValueChangedEvent } from '@vaadin/checkbox-group';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-group-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-group-styles.ts
+++ b/frontend/demo/component/checkbox/checkbox-group-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/checkbox-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-group-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-horizontal.ts
+++ b/frontend/demo/component/checkbox/checkbox-horizontal.ts
@@ -3,13 +3,12 @@ import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-horizontal')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-indeterminate.ts
+++ b/frontend/demo/component/checkbox/checkbox-indeterminate.ts
@@ -7,13 +7,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { CheckboxGroupValueChangedEvent } from '@vaadin/checkbox-group';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-indeterminate')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-labeling.ts
+++ b/frontend/demo/component/checkbox/checkbox-labeling.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/checkbox';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('checkbox-labeling')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-readonly.ts
+++ b/frontend/demo/component/checkbox/checkbox-readonly.ts
@@ -3,13 +3,12 @@ import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-group-readonly')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-required.ts
+++ b/frontend/demo/component/checkbox/checkbox-required.ts
@@ -6,13 +6,12 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Binder, field, Required } from '@vaadin/hilla-lit-form';
 import UserPermissionsModel from 'Frontend/generated/com/vaadin/demo/domain/UserPermissionsModel';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-required')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/checkbox/checkbox-vertical.ts
+++ b/frontend/demo/component/checkbox/checkbox-vertical.ts
@@ -3,13 +3,12 @@ import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('checkbox-vertical')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-auto-open.ts
+++ b/frontend/demo/component/combobox/combo-box-auto-open.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-auto-open')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-basic-features.ts
+++ b/frontend/demo/component/combobox/combo-box-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/icons';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-basic.ts
+++ b/frontend/demo/component/combobox/combo-box-basic.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-1.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-custom-entry-1')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
+++ b/frontend/demo/component/combobox/combo-box-custom-entry-2.ts
@@ -3,13 +3,12 @@ import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { ComboBoxCustomValueSetEvent } from '@vaadin/combo-box';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-custom-entry-2')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-filtering-1.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-1.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-filtering-1')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-filtering-2.ts
+++ b/frontend/demo/component/combobox/combo-box-filtering-2.ts
@@ -5,14 +5,13 @@ import { customElement, state } from 'lit/decorators.js';
 import type { ComboBoxFilterChangedEvent } from '@vaadin/combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('combo-box-filtering-2')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-item-class-name.ts
+++ b/frontend/demo/component/combobox/combo-box-item-class-name.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-item-class-name')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-lazy-loading.ts
+++ b/frontend/demo/component/combobox/combo-box-lazy-loading.ts
@@ -8,13 +8,12 @@ import type {
 } from '@vaadin/react-components';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
 import { ComboBoxCountryService } from 'Frontend/generated/endpoints';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-lazy-loading')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-popup-width.ts
+++ b/frontend/demo/component/combobox/combo-box-popup-width.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-popup-width')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -7,13 +7,12 @@ import type { ComboBoxLitRenderer } from '@vaadin/combo-box/lit.js';
 import { comboBoxRenderer } from '@vaadin/combo-box/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-presentation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-readonly-and-disabled.ts
+++ b/frontend/demo/component/combobox/combo-box-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/combo-box';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-styles.ts
+++ b/frontend/demo/component/combobox/combo-box-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/combobox/combo-box-validation.ts
+++ b/frontend/demo/component/combobox/combo-box-validation.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/combo-box';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('combo-box-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-basic.ts
@@ -4,7 +4,7 @@ import '@vaadin/confirm-dialog';
 import '@vaadin/horizontal-layout';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('confirm-dialog-basic')
 export class Example extends LitElement {
@@ -24,7 +24,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-cancel-button.ts
@@ -4,13 +4,12 @@ import '@vaadin/confirm-dialog';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('confirm-dialog-cancel-button')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-confirm-button.ts
@@ -4,13 +4,12 @@ import '@vaadin/confirm-dialog';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('confirm-dialog-confirm-button')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
+++ b/frontend/demo/component/confirmdialog/confirm-dialog-reject-button.ts
@@ -4,13 +4,12 @@ import '@vaadin/confirm-dialog';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('confirm-dialog-reject-button')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-basic.ts
+++ b/frontend/demo/component/contextmenu/context-menu-basic.ts
@@ -6,13 +6,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('context-menu-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-best-practices.ts
+++ b/frontend/demo/component/contextmenu/context-menu-best-practices.ts
@@ -6,7 +6,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { Grid } from '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 interface FileItem {
   name: string;
@@ -17,7 +17,6 @@ interface FileItem {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-checkable.ts
+++ b/frontend/demo/component/contextmenu/context-menu-checkable.ts
@@ -3,13 +3,12 @@ import '@vaadin/context-menu';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { ContextMenuItem, ContextMenuItemSelectedEvent } from '@vaadin/context-menu';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('context-menu-checkable')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-classname.ts
+++ b/frontend/demo/component/contextmenu/context-menu-classname.ts
@@ -4,13 +4,12 @@ import '@vaadin/context-menu';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { ContextMenuItem } from '@vaadin/context-menu';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('context-menu-classname')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-custom-item-data.ts
+++ b/frontend/demo/component/contextmenu/context-menu-custom-item-data.ts
@@ -3,13 +3,12 @@ import '@vaadin/context-menu';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { ContextMenuItem, ContextMenuItemSelectedEvent } from '@vaadin/context-menu';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('context-menu-custom-item-data')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-disabled.ts
+++ b/frontend/demo/component/contextmenu/context-menu-disabled.ts
@@ -4,7 +4,7 @@ import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { Grid } from '@vaadin/grid';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 interface FileItem {
   name: string;
@@ -15,7 +15,6 @@ interface FileItem {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-dividers.ts
+++ b/frontend/demo/component/contextmenu/context-menu-dividers.ts
@@ -6,13 +6,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('context-menu-dividers')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
+++ b/frontend/demo/component/contextmenu/context-menu-hierarchical.ts
@@ -4,7 +4,7 @@ import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { Grid } from '@vaadin/grid';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 interface FileItem {
   name: string;
@@ -15,7 +15,6 @@ interface FileItem {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-left-click.ts
+++ b/frontend/demo/component/contextmenu/context-menu-left-click.ts
@@ -7,13 +7,12 @@ import type { ContextMenuOpenedChangedEvent } from '@vaadin/context-menu';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('context-menu-left-click')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/contextmenu/context-menu-presentation.ts
+++ b/frontend/demo/component/contextmenu/context-menu-presentation.ts
@@ -13,13 +13,12 @@ import type { Grid } from '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('context-menu-presentation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-basic.ts
+++ b/frontend/demo/component/crud/crud-basic.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-columns.ts
+++ b/frontend/demo/component/crud/crud-columns.ts
@@ -6,13 +6,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-columns')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-editor-aside.ts
+++ b/frontend/demo/component/crud/crud-editor-aside.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-editor-aside')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-editor-bottom.ts
+++ b/frontend/demo/component/crud/crud-editor-bottom.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-editor-bottom')
 export class Example extends LitElement {
@@ -16,7 +16,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-editor-content.ts
+++ b/frontend/demo/component/crud/crud-editor-content.ts
@@ -9,13 +9,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-editor-content')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-grid-replacement.ts
+++ b/frontend/demo/component/crud/crud-grid-replacement.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-grid-replacement')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-hidden-toolbar.ts
+++ b/frontend/demo/component/crud/crud-hidden-toolbar.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-hidden-toolbar')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-item-initialization.ts
+++ b/frontend/demo/component/crud/crud-item-initialization.ts
@@ -6,13 +6,12 @@ import { customElement, query, state } from 'lit/decorators.js';
 import type { Crud, CrudNewEvent } from '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-item-initialization')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-localization.ts
+++ b/frontend/demo/component/crud/crud-localization.ts
@@ -5,13 +5,12 @@ import { customElement, query, state } from 'lit/decorators.js';
 import type { Crud } from '@vaadin/crud';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-localization')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-open-editor.ts
+++ b/frontend/demo/component/crud/crud-open-editor.ts
@@ -6,13 +6,12 @@ import type { CrudEditedItemChangedEvent } from '@vaadin/crud';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-open-editor')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-sorting-filtering.ts
+++ b/frontend/demo/component/crud/crud-sorting-filtering.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-sorting-filtering')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/crud/crud-toolbar.ts
+++ b/frontend/demo/component/crud/crud-toolbar.ts
@@ -8,13 +8,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('crud-toolbar')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/custom-field/custom-field-basic.ts
+++ b/frontend/demo/component/custom-field/custom-field-basic.ts
@@ -6,13 +6,12 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Binder, field } from '@vaadin/hilla-lit-form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('custom-field-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/custom-field/custom-field-native-input.ts
+++ b/frontend/demo/component/custom-field/custom-field-native-input.ts
@@ -4,13 +4,12 @@ import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { CustomFieldChangeEvent } from '@vaadin/custom-field';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('custom-field-native-input')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/custom-field/custom-field-size-variants.ts
+++ b/frontend/demo/component/custom-field/custom-field-size-variants.ts
@@ -5,13 +5,12 @@ import '@vaadin/select';
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('custom-field-size-variants')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dashboard/dashboard-announcements.ts
+++ b/frontend/demo/component/dashboard/dashboard-announcements.ts
@@ -15,7 +15,7 @@ import type {
 } from '@vaadin/dashboard';
 import type WidgetConfig from 'Frontend/generated/com/vaadin/demo/component/dashboard/WidgetConfig';
 import WidgetType from 'Frontend/generated/com/vaadin/demo/component/dashboard/WidgetConfig/WidgetType';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // Define a mapping from widget types to human-readable titles
 const widgetTitles: Record<WidgetType, string> = {
@@ -49,7 +49,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dashboard/dashboard-basic.ts
+++ b/frontend/demo/component/dashboard/dashboard-basic.ts
@@ -4,13 +4,12 @@ import '@vaadin/dashboard/vaadin-dashboard-layout.js';
 import '@vaadin/dashboard/vaadin-dashboard-widget.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dashboard-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dashboard/dashboard-dense-layout.ts
+++ b/frontend/demo/component/dashboard/dashboard-dense-layout.ts
@@ -5,13 +5,12 @@ import '@vaadin/dashboard/vaadin-dashboard-layout.js';
 import '@vaadin/dashboard/vaadin-dashboard-widget.js';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dashboard-dense-layout')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dashboard/dashboard-editable.ts
+++ b/frontend/demo/component/dashboard/dashboard-editable.ts
@@ -14,7 +14,7 @@ import type { MenuBarItem, MenuBarItemSelectedEvent } from '@vaadin/menu-bar';
 import type WidgetConfig from 'Frontend/generated/com/vaadin/demo/component/dashboard/WidgetConfig';
 import WidgetType from 'Frontend/generated/com/vaadin/demo/component/dashboard/WidgetConfig/WidgetType';
 import { DashboardService } from 'Frontend/generated/endpoints';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 // NOTE: This example uses the additional classes WidgetConfig and DashboardService,
@@ -59,7 +59,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dashboard/dashboard-sections.ts
+++ b/frontend/demo/component/dashboard/dashboard-sections.ts
@@ -5,13 +5,12 @@ import '@vaadin/dashboard/vaadin-dashboard-section.js';
 import '@vaadin/dashboard/vaadin-dashboard-widget.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dashboard-sections')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dashboard/dashboard-variants.ts
+++ b/frontend/demo/component/dashboard/dashboard-variants.ts
@@ -6,7 +6,7 @@ import '@vaadin/select';
 import '@vaadin/checkbox';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { SelectChangeEvent } from '@vaadin/select';
 import { CheckboxChangeEvent } from '@vaadin/checkbox';
 
@@ -14,7 +14,6 @@ import { CheckboxChangeEvent } from '@vaadin/checkbox';
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dashboard/dashboard-widget-contents.ts
+++ b/frontend/demo/component/dashboard/dashboard-widget-contents.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/dashboard/vaadin-dashboard-widget.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dashboard-widget-contents')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-auto-open.ts
+++ b/frontend/demo/component/datepicker/date-picker-auto-open.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-auto-open')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-basic-features.ts
+++ b/frontend/demo/component/datepicker/date-picker-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/icons';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-basic.ts
+++ b/frontend/demo/component/datepicker/date-picker-basic.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-custom-functions.ts
+++ b/frontend/demo/component/datepicker/date-picker-custom-functions.ts
@@ -5,13 +5,12 @@ import { parse as dateFnsParse } from 'date-fns/parse';
 import { html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import type { DatePicker, DatePickerChangeEvent, DatePickerDate } from '@vaadin/date-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-custom-functions')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-custom-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-custom-validation.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Binder, field } from '@vaadin/hilla-lit-form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-custom-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-format-indicator.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-date-format-indicator')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-date-range.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-range.ts
@@ -4,13 +4,12 @@ import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { DatePickerValueChangedEvent } from '@vaadin/date-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-date-range')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
+++ b/frontend/demo/component/datepicker/date-picker-individual-input-fields.ts
@@ -5,13 +5,12 @@ import { getDaysInMonth } from 'date-fns/getDaysInMonth';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { ComboBoxSelectedItemChangedEvent } from '@vaadin/combo-box';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-individual-input-fields')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-initial-position.ts
+++ b/frontend/demo/component/datepicker/date-picker-initial-position.ts
@@ -3,13 +3,12 @@ import '@vaadin/date-picker';
 import { formatISO, lastDayOfYear } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-initial-position')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-internationalization.ts
+++ b/frontend/demo/component/datepicker/date-picker-internationalization.ts
@@ -3,13 +3,12 @@ import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import type { DatePicker } from '@vaadin/date-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-internationalization')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-readonly-and-disabled.ts
+++ b/frontend/demo/component/datepicker/date-picker-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/date-picker';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-styles.ts
+++ b/frontend/demo/component/datepicker/date-picker-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-validation.ts
@@ -4,13 +4,12 @@ import { addDays, formatISO } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { DatePicker, DatePickerValidatedEvent } from '@vaadin/date-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datepicker/date-picker-week-numbers.ts
+++ b/frontend/demo/component/datepicker/date-picker-week-numbers.ts
@@ -3,13 +3,12 @@ import '@vaadin/date-picker';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import type { DatePicker } from '@vaadin/date-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-picker-week-numbers')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-auto-open.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-auto-open')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-basic-features.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/icons';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-basic.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-basic.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-custom-validation.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Binder, field } from '@vaadin/hilla-lit-form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-custom-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-initial-position.ts
@@ -5,7 +5,7 @@ import { formatISO } from 'date-fns/formatISO';
 import { startOfMonth } from 'date-fns/startOfMonth';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 const startOfNextMonth = startOfMonth(addMonths(new Date(), 1));
 const startOfNextMonthISOString = formatISO(startOfNextMonth, { representation: 'date' });
@@ -14,7 +14,6 @@ const startOfNextMonthISOString = formatISO(startOfNextMonth, { representation: 
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-input-format.ts
@@ -6,13 +6,12 @@ import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import type { DatePickerDate } from '@vaadin/date-picker';
 import type { DateTimePicker } from '@vaadin/date-time-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-input-format')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-internationalization.ts
@@ -3,13 +3,12 @@ import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import type { DateTimePicker } from '@vaadin/date-time-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-internationalization')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-minutes-step.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-minutes-step')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-range.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-range.ts
@@ -3,7 +3,7 @@ import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { DateTimePickerValueChangedEvent } from '@vaadin/date-time-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 const initialStartValue = '2020-08-25T20:00';
 const initialEndValue = '2020-09-01T20:00';
@@ -12,7 +12,6 @@ const initialEndValue = '2020-09-01T20:00';
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-readonly-and-disabled.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/vertical-layout';
 import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-seconds-step.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-seconds-step')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-styles.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-validation.ts
@@ -6,7 +6,7 @@ import { customElement, state } from 'lit/decorators.js';
 import type { DatePicker } from '@vaadin/date-picker';
 import type { DateTimePicker, DateTimePickerValidatedEvent } from '@vaadin/date-time-picker';
 import type { TimePicker } from '@vaadin/time-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-validation')
 export class Example extends LitElement {
@@ -21,7 +21,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-week-numbers.ts
@@ -3,13 +3,12 @@ import '@vaadin/date-time-picker';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import type { DateTimePicker } from '@vaadin/date-time-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('date-time-picker-week-numbers')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/details/details-basic.ts
+++ b/frontend/demo/component/details/details-basic.ts
@@ -3,13 +3,12 @@ import '@vaadin/details';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('details-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/details/details-content.ts
+++ b/frontend/demo/component/details/details-content.ts
@@ -3,7 +3,7 @@ import '@vaadin/details';
 import '@vaadin/vertical-layout';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('details-content')
 export class Example extends LitElement {
@@ -16,7 +16,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/details/details-disabled.ts
+++ b/frontend/demo/component/details/details-disabled.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/details';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('details-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/details/details-filled.ts
+++ b/frontend/demo/component/details/details-filled.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/details';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('details-filled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/details/details-reverse.ts
+++ b/frontend/demo/component/details/details-reverse.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/details';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('details-reverse')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/details/details-small.ts
+++ b/frontend/demo/component/details/details-small.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/details';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('details-small')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -11,13 +11,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('details-summary')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dialog/dialog-basic.ts
+++ b/frontend/demo/component/dialog/dialog-basic.ts
@@ -6,7 +6,7 @@ import '@vaadin/vertical-layout';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dialog-basic')
 export class Example extends LitElement {
@@ -26,7 +26,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dialog/dialog-closing.ts
+++ b/frontend/demo/component/dialog/dialog-closing.ts
@@ -5,13 +5,12 @@ import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { dialogRenderer } from '@vaadin/dialog/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dialog-closing')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dialog/dialog-draggable.ts
+++ b/frontend/demo/component/dialog/dialog-draggable.ts
@@ -7,13 +7,12 @@ import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { dialogFooterRenderer, dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dialog-draggable')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dialog/dialog-footer.ts
+++ b/frontend/demo/component/dialog/dialog-footer.ts
@@ -6,13 +6,12 @@ import { customElement, state } from 'lit/decorators.js';
 import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dialog-footer')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dialog/dialog-header.ts
+++ b/frontend/demo/component/dialog/dialog-header.ts
@@ -12,13 +12,12 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dialog-header')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dialog/dialog-no-padding.ts
+++ b/frontend/demo/component/dialog/dialog-no-padding.ts
@@ -9,13 +9,12 @@ import { dialogFooterRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dialog-no-padding')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/dialog/dialog-resizable.ts
+++ b/frontend/demo/component/dialog/dialog-resizable.ts
@@ -8,13 +8,12 @@ import { customElement, state } from 'lit/decorators.js';
 import { dialogRenderer } from '@vaadin/dialog/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('dialog-resizable')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/emailfield/email-field-basic-features.ts
+++ b/frontend/demo/component/emailfield/email-field-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/icons';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('email-field-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/emailfield/email-field-basic.ts
+++ b/frontend/demo/component/emailfield/email-field-basic.ts
@@ -3,13 +3,12 @@ import '@vaadin/email-field';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('email-field-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/emailfield/email-field-readonly-and-disabled.ts
+++ b/frontend/demo/component/emailfield/email-field-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/email-field';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('email-field-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/emailfield/email-field-styles.ts
+++ b/frontend/demo/component/emailfield/email-field-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/email-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('email-field-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/emailfield/email-field-validation.ts
+++ b/frontend/demo/component/emailfield/email-field-validation.ts
@@ -3,13 +3,12 @@ import '@vaadin/email-field';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { EmailField, EmailFieldValidatedEvent } from '@vaadin/email-field';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('email-field-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/formlayout/form-layout-basic.ts
+++ b/frontend/demo/component/formlayout/form-layout-basic.ts
@@ -7,13 +7,12 @@ import '@vaadin/email-field';
 import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('form-layout-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/formlayout/form-layout-colspan.ts
+++ b/frontend/demo/component/formlayout/form-layout-colspan.ts
@@ -4,13 +4,12 @@ import '@vaadin/form-layout/vaadin-form-row.js';
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('form-layout-colspan')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/formlayout/form-layout-expand-columns.ts
+++ b/frontend/demo/component/formlayout/form-layout-expand-columns.ts
@@ -7,13 +7,12 @@ import '@vaadin/email-field';
 import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('form-layout-expand-columns')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/formlayout/form-layout-expand-fields.ts
+++ b/frontend/demo/component/formlayout/form-layout-expand-fields.ts
@@ -7,13 +7,12 @@ import '@vaadin/email-field';
 import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('form-layout-expand-fields')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/formlayout/form-layout-labels-aside.ts
+++ b/frontend/demo/component/formlayout/form-layout-labels-aside.ts
@@ -6,13 +6,12 @@ import '@vaadin/email-field';
 import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('form-layout-labels-aside')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/formlayout/form-layout-steps-basic.ts
+++ b/frontend/demo/component/formlayout/form-layout-steps-basic.ts
@@ -6,13 +6,12 @@ import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('form-layout-steps-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/formlayout/form-layout-steps-labels-aside.ts
+++ b/frontend/demo/component/formlayout/form-layout-steps-labels-aside.ts
@@ -6,13 +6,12 @@ import '@vaadin/split-layout';
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('form-layout-steps-labels-aside')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-basic.ts
+++ b/frontend/demo/component/grid/grid-basic.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-cell-focus.ts
+++ b/frontend/demo/component/grid/grid-cell-focus.ts
@@ -6,7 +6,7 @@ import { customElement, query, state } from 'lit/decorators.js';
 import type { Grid, GridCellFocusEvent } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-cell-focus')
 export class Example extends LitElement {
@@ -18,7 +18,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-column-alignment.ts
+++ b/frontend/demo/component/grid/grid-column-alignment.ts
@@ -6,13 +6,12 @@ import { customElement, state } from 'lit/decorators.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-column-alignment')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-column-borders.ts
+++ b/frontend/demo/component/grid/grid-column-borders.ts
@@ -7,13 +7,12 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-column-borders')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-column-filtering.ts
+++ b/frontend/demo/component/grid/grid-column-filtering.ts
@@ -9,7 +9,7 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 type PersonEnhanced = Person & { displayName: string };
 
@@ -17,7 +17,6 @@ type PersonEnhanced = Person & { displayName: string };
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-column-freezing.ts
+++ b/frontend/demo/component/grid/grid-column-freezing.ts
@@ -6,13 +6,12 @@ import { customElement, state } from 'lit/decorators.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-column-freezing')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-column-grouping.ts
+++ b/frontend/demo/component/grid/grid-column-grouping.ts
@@ -5,14 +5,13 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-column-grouping')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-column-header-footer.ts
+++ b/frontend/demo/component/grid/grid-column-header-footer.ts
@@ -13,13 +13,12 @@ import {
 } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-column-header-footer')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-column-reordering-resizing.ts
+++ b/frontend/demo/component/grid/grid-column-reordering-resizing.ts
@@ -5,14 +5,13 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-column-reordering-resizing')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-column-width.ts
+++ b/frontend/demo/component/grid/grid-column-width.ts
@@ -8,14 +8,13 @@ import { customElement, state } from 'lit/decorators.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-column-width')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-compact.ts
+++ b/frontend/demo/component/grid/grid-compact.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-compact')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-content.ts
+++ b/frontend/demo/component/grid/grid-content.ts
@@ -11,13 +11,12 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-content')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-context-menu.ts
+++ b/frontend/demo/component/grid/grid-context-menu.ts
@@ -10,13 +10,12 @@ import { contextMenuRenderer } from '@vaadin/context-menu/lit.js';
 import type { Grid } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-context-menu')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-data-provider.ts
+++ b/frontend/demo/component/grid/grid-data-provider.ts
@@ -16,7 +16,7 @@ import type {
 import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 function matchesTerm(value: string, searchTerm: string) {
   return value.toLowerCase().includes(searchTerm.toLowerCase());
@@ -69,7 +69,6 @@ async function fetchPeople(params: {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-drag-drop-filters.ts
+++ b/frontend/demo/component/grid/grid-drag-drop-filters.ts
@@ -14,14 +14,13 @@ import type {
 } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-drag-drop-filters')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
+++ b/frontend/demo/component/grid/grid-drag-rows-between-grids.ts
@@ -6,7 +6,7 @@ import type { GridDragStartEvent } from '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-drag-rows-between-grids')
 export class Example extends LitElement {
@@ -28,7 +28,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-dynamic-height.ts
+++ b/frontend/demo/component/grid/grid-dynamic-height.ts
@@ -12,13 +12,12 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-dynamic-height')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-empty-state.ts
+++ b/frontend/demo/component/grid/grid-empty-state.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/grid';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-empty-state')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-external-filtering.ts
+++ b/frontend/demo/component/grid/grid-external-filtering.ts
@@ -13,7 +13,7 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 type PersonEnhanced = Person & { displayName: string };
 
@@ -21,7 +21,6 @@ type PersonEnhanced = Person & { displayName: string };
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-header-footer-styling.ts
+++ b/frontend/demo/component/grid/grid-header-footer-styling.ts
@@ -6,7 +6,7 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer, columnFooterRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 interface PersonWithRating extends Person {
@@ -17,7 +17,6 @@ interface PersonWithRating extends Person {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-item-details-toggle.ts
+++ b/frontend/demo/component/grid/grid-item-details-toggle.ts
@@ -10,14 +10,13 @@ import { customElement, state } from 'lit/decorators.js';
 import { columnBodyRenderer, gridRowDetailsRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-item-details-toggle')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-item-details.ts
+++ b/frontend/demo/component/grid/grid-item-details.ts
@@ -8,14 +8,13 @@ import type { GridActiveItemChangedEvent } from '@vaadin/grid';
 import { gridRowDetailsRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-item-details')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-lazy-column-rendering.ts
+++ b/frontend/demo/component/grid/grid-lazy-column-rendering.ts
@@ -5,13 +5,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { GridBodyRenderer } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-lazy-column-rendering')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-manual-pagination.ts
+++ b/frontend/demo/component/grid/grid-manual-pagination.ts
@@ -15,7 +15,7 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 type PersonEnhanced = Person & { displayName: string };
 
@@ -23,7 +23,6 @@ type PersonEnhanced = Person & { displayName: string };
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }
@@ -133,7 +132,6 @@ export class GridPaginationControls extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-multi-select-mode.ts
+++ b/frontend/demo/component/grid/grid-multi-select-mode.ts
@@ -5,14 +5,13 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-multi-select-mode')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-multisort.ts
+++ b/frontend/demo/component/grid/grid-multisort.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-multisort')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-no-border.ts
+++ b/frontend/demo/component/grid/grid-no-border.ts
@@ -7,13 +7,12 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-no-border')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-no-row-border.ts
+++ b/frontend/demo/component/grid/grid-no-row-border.ts
@@ -7,13 +7,12 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-no-row-border')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-range-selection.ts
+++ b/frontend/demo/component/grid/grid-range-selection.ts
@@ -6,14 +6,13 @@ import { customElement, state } from 'lit/decorators.js';
 import type { GridItemToggleEvent, GridSelectedItemsChangedEvent } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-range-selection')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-rich-content-sorting.ts
+++ b/frontend/demo/component/grid/grid-rich-content-sorting.ts
@@ -11,13 +11,12 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer, columnHeaderRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-rich-content-sorting')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-row-reordering.ts
+++ b/frontend/demo/component/grid/grid-row-reordering.ts
@@ -8,14 +8,13 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-row-reordering')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-row-stripes.ts
+++ b/frontend/demo/component/grid/grid-row-stripes.ts
@@ -7,13 +7,12 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-row-stripes')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-single-selection-mode.ts
+++ b/frontend/demo/component/grid/grid-single-selection-mode.ts
@@ -5,13 +5,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { GridActiveItemChangedEvent } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-single-select-mode')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-sorting.ts
+++ b/frontend/demo/component/grid/grid-sorting.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-sorting')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-styling.ts
+++ b/frontend/demo/component/grid/grid-styling.ts
@@ -8,7 +8,7 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridColumn } from '@vaadin/grid/vaadin-grid-column.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 interface PersonWithRating extends Person {
@@ -19,7 +19,6 @@ interface PersonWithRating extends Person {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-tooltip-generator.ts
+++ b/frontend/demo/component/grid/grid-tooltip-generator.ts
@@ -11,13 +11,12 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-tooltip-generator')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/grid/grid-wrap-cell-content.ts
+++ b/frontend/demo/component/grid/grid-wrap-cell-content.ts
@@ -7,14 +7,13 @@ import type { GridColumnBodyLitRenderer } from '@vaadin/grid/lit.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 // tag::snippet[]
 @customElement('grid-wrap-cell-content')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-basic.ts
+++ b/frontend/demo/component/gridpro/grid-pro-basic.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-cell-editability.ts
+++ b/frontend/demo/component/gridpro/grid-pro-cell-editability.ts
@@ -6,13 +6,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { GridItemModel } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-cell-editability')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-edit-column.ts
+++ b/frontend/demo/component/gridpro/grid-pro-edit-column.ts
@@ -7,13 +7,12 @@ import { customElement, state } from 'lit/decorators.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-edit-column')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-editors.ts
+++ b/frontend/demo/component/gridpro/grid-pro-editors.ts
@@ -9,13 +9,12 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { columnEditModeRenderer } from '@vaadin/grid-pro/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-editors')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
+++ b/frontend/demo/component/gridpro/grid-pro-enter-next-row.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-enter-next-row')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-editable-cells.ts
@@ -6,13 +6,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-highlight-editable-cells')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
+++ b/frontend/demo/component/gridpro/grid-pro-highlight-read-only-cells.ts
@@ -6,13 +6,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-highlight-read-only-cells')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
+++ b/frontend/demo/component/gridpro/grid-pro-prevent-save.ts
@@ -6,13 +6,12 @@ import { customElement, state } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-prevent-save')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-cell-edit.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-single-cell-edit')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/gridpro/grid-pro-single-click.ts
+++ b/frontend/demo/component/gridpro/grid-pro-single-click.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('grid-pro-single-click')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-basic.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-basic.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-basic')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-expanding-items.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-expanding-items.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-expanding-items')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-horizontal-alignment.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-horizontal-alignment')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-individual-alignment.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-individual-alignment.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-individual-alignment')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-margin.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-margin.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-margin')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-padding.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-padding.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-padding')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-slots-wrapping.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-slots-wrapping.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-slots-wrapping')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-slots.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-slots.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-slots')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-spacing-variants.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-spacing-variants.ts
@@ -4,7 +4,7 @@ import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-spacing-variants')
 export class Example extends LitElement {
@@ -15,7 +15,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-spacing.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-spacing.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-spacing')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-vertical-alignment.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-vertical-alignment.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-vertical-alignment')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/horizontal-layout/horizontal-layout-wrapping.ts
+++ b/frontend/demo/component/horizontal-layout/horizontal-layout-wrapping.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('horizontal-layout-wrapping')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/icon-basic.ts
+++ b/frontend/demo/component/icons/icon-basic.ts
@@ -5,13 +5,12 @@ import '@vaadin/icons';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('icon-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/icon-fonts.ts
+++ b/frontend/demo/component/icons/icon-fonts.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('icon-fonts')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/icons-accessibility.ts
+++ b/frontend/demo/component/icons/icons-accessibility.ts
@@ -4,13 +4,12 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('icons-accessibility')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/icons-color.ts
+++ b/frontend/demo/component/icons/icons-color.ts
@@ -3,14 +3,13 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import codeBranch from '../../../../src/main/resources/icons/code-branch.svg?url';
 
 @customElement('icons-color')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/icons-padding.ts
+++ b/frontend/demo/component/icons/icons-padding.ts
@@ -3,14 +3,13 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import codeBranch from '../../../../src/main/resources/icons/code-branch.svg?url';
 
 @customElement('icons-padding')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/icons-sizing.ts
+++ b/frontend/demo/component/icons/icons-sizing.ts
@@ -3,14 +3,13 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import codeBranch from '../../../../src/main/resources/icons/code-branch.svg?url';
 
 @customElement('icons-sizing')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/lumo-icons.ts
+++ b/frontend/demo/component/icons/lumo-icons.ts
@@ -4,13 +4,12 @@ import '@vaadin/icon';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('lumo-icons')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/svg-sprites.ts
+++ b/frontend/demo/component/icons/svg-sprites.ts
@@ -3,14 +3,13 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import solidSprite from '../../../../src/main/resources/icons/solid.svg?url';
 
 @customElement('svg-sprites')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/svg-standalone.ts
+++ b/frontend/demo/component/icons/svg-standalone.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/icon';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import codeBranchIcon from '../../../../src/main/resources/icons/code-branch.svg?url';
 
 @customElement('svg-standalone')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/icons/vaadin-icons.ts
+++ b/frontend/demo/component/icons/vaadin-icons.ts
@@ -5,13 +5,12 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vaadin-icons')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/listbox/list-box-basic.ts
+++ b/frontend/demo/component/listbox/list-box-basic.ts
@@ -3,13 +3,12 @@ import '@vaadin/item';
 import '@vaadin/list-box';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('list-box-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
+++ b/frontend/demo/component/listbox/list-box-custom-item-presentation.ts
@@ -8,13 +8,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('list-box-custom-item-presentation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/listbox/list-box-disabled-items.ts
+++ b/frontend/demo/component/listbox/list-box-disabled-items.ts
@@ -3,13 +3,12 @@ import '@vaadin/item';
 import '@vaadin/list-box';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('list-box-disabled-items')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/listbox/list-box-multi-selection.ts
+++ b/frontend/demo/component/listbox/list-box-multi-selection.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('list-box-multi-selection')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/listbox/list-box-separators.ts
+++ b/frontend/demo/component/listbox/list-box-separators.ts
@@ -3,13 +3,12 @@ import '@vaadin/item';
 import '@vaadin/list-box';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('list-box-separators')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/listbox/list-box-single-selection.ts
+++ b/frontend/demo/component/listbox/list-box-single-selection.ts
@@ -3,13 +3,12 @@ import '@vaadin/item';
 import '@vaadin/list-box';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('list-box-single-selection')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-additional-information.ts
+++ b/frontend/demo/component/login/login-additional-information.ts
@@ -3,13 +3,12 @@ import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import type { LoginOverlay } from '@vaadin/login';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-additional-information')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-basic.ts
+++ b/frontend/demo/component/login/login-basic.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/login/vaadin-login-form.js';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-basic')
 export class Example extends LitElement {
@@ -17,7 +17,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-internationalization.ts
+++ b/frontend/demo/component/login/login-internationalization.ts
@@ -3,7 +3,7 @@ import '@vaadin/login/vaadin-login-form.js';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { LoginI18n } from '@vaadin/login';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-internationalization')
 export class Example extends LitElement {
@@ -18,7 +18,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-overlay-basic.ts
+++ b/frontend/demo/component/login/login-overlay-basic.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-overlay-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-overlay-custom-form-area.ts
+++ b/frontend/demo/component/login/login-overlay-custom-form-area.ts
@@ -3,13 +3,12 @@ import '@vaadin/integer-field';
 import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-overlay-custom-form-area')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-overlay-footer.ts
+++ b/frontend/demo/component/login/login-overlay-footer.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-overlay-footer')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-overlay-header.ts
+++ b/frontend/demo/component/login/login-overlay-header.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-overlay-header')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-overlay-internationalization.ts
+++ b/frontend/demo/component/login/login-overlay-internationalization.ts
@@ -3,13 +3,12 @@ import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { LoginI18n } from '@vaadin/login';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-overlay-internationalization')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -2,7 +2,7 @@ import '@vaadin/login/vaadin-login-form.js';
 import { css, html, LitElement, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { LoginI18n } from '@vaadin/login';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import img from '../../../../src/main/resources/images/starry-sky.png?url';
 
 @customElement('login-overlay-mockup')
@@ -70,7 +70,6 @@ export class LoginOverlayMockupElement extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-rich-content.ts
+++ b/frontend/demo/component/login/login-rich-content.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/login/vaadin-login-form.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-rich-content')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/login-validation.ts
+++ b/frontend/demo/component/login/login-validation.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/login';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/login/react/login-overlay-custom-form-area.tsx
+++ b/frontend/demo/component/login/react/login-overlay-custom-form-area.tsx
@@ -2,7 +2,6 @@ import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-lin
 import React from 'react';
 import { IntegerField } from '@vaadin/react-components/IntegerField.js';
 import { LoginOverlay } from '@vaadin/react-components/LoginOverlay.js';
-import { applyTheme } from 'Frontend/generated/theme';
 
 function Example() {
   return (
@@ -14,4 +13,4 @@ function Example() {
   );
 }
 
-export default reactExample(Example, applyTheme); // hidden-source-line
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/login/react/login-overlay-footer.tsx
+++ b/frontend/demo/component/login/react/login-overlay-footer.tsx
@@ -1,7 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { LoginOverlay } from '@vaadin/react-components/LoginOverlay.js';
-import { applyTheme } from 'Frontend/generated/theme';
 
 function Example() {
   return (
@@ -15,4 +14,4 @@ function Example() {
   );
 }
 
-export default reactExample(Example, applyTheme); // hidden-source-line
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/login/react/login-overlay-header.tsx
+++ b/frontend/demo/component/login/react/login-overlay-header.tsx
@@ -1,7 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
 import { LoginOverlay } from '@vaadin/react-components/LoginOverlay.js';
-import { applyTheme } from 'Frontend/generated/theme';
 
 function Example() {
   return (
@@ -11,4 +10,4 @@ function Example() {
   );
 }
 
-export default reactExample(Example, applyTheme); // hidden-source-line
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/login/react/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/react/login-overlay-mockup.ts
@@ -2,7 +2,7 @@ import '@vaadin/login/vaadin-login-form.js';
 import { css, html, LitElement, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { LoginI18n } from '@vaadin/login';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import img from '../../../../../src/main/resources/images/starry-sky.png?url';
 
 @customElement('login-overlay-mockup')
@@ -70,7 +70,6 @@ export class LoginOverlayMockupElement extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/markdown/markdown-basic.ts
+++ b/frontend/demo/component/markdown/markdown-basic.ts
@@ -1,13 +1,12 @@
 import '@vaadin/markdown';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('markdown-basic')
 export class MarkdownBasic extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/master-detail-layout/react/wrapper.ts
+++ b/frontend/demo/component/master-detail-layout/react/wrapper.ts
@@ -1,7 +1,7 @@
 import 'Frontend/demo/init';
 import React, { type ComponentClass, type FunctionComponent } from 'react';
 import { createRoot } from 'react-dom/client';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 /**
  * Custom wrapper for rendering Master Detail Layout examples into an iframe. Compared to the usual

--- a/frontend/demo/component/menubar/menu-bar-basic.ts
+++ b/frontend/demo/component/menubar/menu-bar-basic.ts
@@ -3,13 +3,12 @@ import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { MenuBarItem, MenuBarItemSelectedEvent } from '@vaadin/menu-bar';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-checkable.ts
+++ b/frontend/demo/component/menubar/menu-bar-checkable.ts
@@ -3,13 +3,12 @@ import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { MenuBarItemSelectedEvent, SubMenuItem } from '@vaadin/menu-bar';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-checkable')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
+++ b/frontend/demo/component/menubar/menu-bar-combo-buttons.ts
@@ -4,13 +4,12 @@ import '@vaadin/icons';
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-combo-buttons')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-custom-item-data.ts
+++ b/frontend/demo/component/menubar/menu-bar-custom-item-data.ts
@@ -3,13 +3,12 @@ import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { MenuBarItem, MenuBarItemSelectedEvent } from '@vaadin/menu-bar';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-custom-item-data')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-custom-styling.ts
+++ b/frontend/demo/component/menubar/menu-bar-custom-styling.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-custom-styling')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-disabled.ts
+++ b/frontend/demo/component/menubar/menu-bar-disabled.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-dividers.ts
+++ b/frontend/demo/component/menubar/menu-bar-dividers.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-dividers')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-drop-down-indicators.ts
+++ b/frontend/demo/component/menubar/menu-bar-drop-down-indicators.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-drop-down-indicators')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-drop-down.ts
+++ b/frontend/demo/component/menubar/menu-bar-drop-down.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-drop-down')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-icon-only.ts
+++ b/frontend/demo/component/menubar/menu-bar-icon-only.ts
@@ -4,13 +4,12 @@ import '@vaadin/icons';
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-icon-only')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-icons.ts
+++ b/frontend/demo/component/menubar/menu-bar-icons.ts
@@ -4,13 +4,12 @@ import '@vaadin/icons';
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-icons')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-internationalization.ts
+++ b/frontend/demo/component/menubar/menu-bar-internationalization.ts
@@ -4,13 +4,12 @@ import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { MenuBarI18n } from '@vaadin/menu-bar';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-internationalization')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
+++ b/frontend/demo/component/menubar/menu-bar-open-on-hover.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-open-on-hover')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-overflow.ts
+++ b/frontend/demo/component/menubar/menu-bar-overflow.ts
@@ -3,13 +3,12 @@ import '@vaadin/menu-bar';
 import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-overflow')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-right-aligned.ts
+++ b/frontend/demo/component/menubar/menu-bar-right-aligned.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/menu-bar';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-right-aligned')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-styles.ts
+++ b/frontend/demo/component/menubar/menu-bar-styles.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/menu-bar';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-styles')
 export class Example extends LitElement {
@@ -14,7 +14,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/menubar/menu-bar-tooltip.ts
+++ b/frontend/demo/component/menubar/menu-bar-tooltip.ts
@@ -5,13 +5,12 @@ import '@vaadin/menu-bar';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('menu-bar-tooltip')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/messages/message-basic.ts
+++ b/frontend/demo/component/messages/message-basic.ts
@@ -6,13 +6,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { MessageInputSubmitEvent } from '@vaadin/message-input';
 import type { MessageListItem } from '@vaadin/message-list';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('message-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/messages/message-input-component.ts
+++ b/frontend/demo/component/messages/message-input-component.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { MessageInputSubmitEvent } from '@vaadin/message-input';
 import { Notification } from '@vaadin/notification';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('message-input-component')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/messages/message-list-ai-chat.ts
+++ b/frontend/demo/component/messages/message-list-ai-chat.ts
@@ -6,7 +6,7 @@ import { customElement, state } from 'lit/decorators.js';
 import type { MessageInputSubmitEvent } from '@vaadin/message-input';
 import type { MessageListItem } from '@vaadin/message-list';
 import LLMChatService from 'Frontend/demo/services/LLMChatService.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 function createItem(text: string, assistant = false): MessageListItem {
   return {
@@ -20,7 +20,6 @@ function createItem(text: string, assistant = false): MessageListItem {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/messages/message-list-component.ts
+++ b/frontend/demo/component/messages/message-list-component.ts
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('message-list-component')
 export class Example extends LitElement {
@@ -16,7 +16,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/messages/message-list-markdown.ts
+++ b/frontend/demo/component/messages/message-list-markdown.ts
@@ -3,13 +3,12 @@ import '@vaadin/message-list';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { MessageListItem } from '@vaadin/message-list';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('message-list-markdown')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/messages/message-list-with-theme-component.ts
+++ b/frontend/demo/component/messages/message-list-with-theme-component.ts
@@ -5,7 +5,7 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('message-list-component-with-theme')
 export class Example extends LitElement {
@@ -16,7 +16,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-auto-expand.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('multi-select-combo-box-auto-expand')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-basic.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('multi-select-combo-box-basic')
 export class Example extends LitElement {
@@ -16,7 +16,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-i18n.ts
@@ -5,7 +5,7 @@ import { customElement, state } from 'lit/decorators.js';
 import type { MultiSelectComboBoxI18n } from '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('multi-select-combo-box-basic')
 export class Example extends LitElement {
@@ -17,7 +17,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-item-class-name.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-item-class-name.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/multi-select-combo-box';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('multi-select-combo-box-item-class-name')
 export class Example extends LitElement {
@@ -14,7 +14,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-read-only.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('multi-select-combo-box-read-only')
 export class Example extends LitElement {
@@ -16,7 +16,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selected-items-on-top.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('multi-select-combo-box-selected-items-on-top')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection-change.ts
@@ -7,13 +7,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { MultiSelectComboBoxSelectedItemsChangedEvent } from '@vaadin/multi-select-combo-box';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('multi-select-combo-box-selection-change')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
+++ b/frontend/demo/component/multi-select-combo-box/multi-select-combo-box-selection.ts
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getCountries } from 'Frontend/demo/domain/DataService';
 import type Country from 'Frontend/generated/com/vaadin/demo/domain/Country';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('multi-select-combo-box-selection')
 export class Example extends LitElement {
@@ -16,7 +16,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-content-length-do.ts
+++ b/frontend/demo/component/notification/notification-content-length-do.ts
@@ -4,12 +4,11 @@ import '@vaadin/icon';
 import '@vaadin/notification';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { html, LitElement } from 'lit';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-content-length-dont.ts
+++ b/frontend/demo/component/notification/notification-content-length-dont.ts
@@ -4,12 +4,11 @@ import '@vaadin/icon';
 import '@vaadin/notification';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { html, LitElement } from 'lit';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-error.ts
+++ b/frontend/demo/component/notification/notification-error.ts
@@ -8,7 +8,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import { notificationRenderer } from '@vaadin/notification/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-error')
 export class Example extends LitElement {
@@ -17,7 +17,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-keyboard-a11y.ts
+++ b/frontend/demo/component/notification/notification-keyboard-a11y.ts
@@ -6,7 +6,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import { notificationRenderer } from '@vaadin/notification/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-keyboard-a11y')
 export class Example extends LitElement {
@@ -18,7 +18,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-link.ts
+++ b/frontend/demo/component/notification/notification-link.ts
@@ -8,7 +8,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import { notificationRenderer } from '@vaadin/notification/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-link')
 export class Example extends LitElement {
@@ -17,7 +17,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-popup.ts
+++ b/frontend/demo/component/notification/notification-popup.ts
@@ -6,7 +6,7 @@ import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { contextMenuRenderer } from '@vaadin/context-menu/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-popup')
 export class Example2 extends LitElement {
@@ -26,7 +26,6 @@ export class Example2 extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-position.ts
+++ b/frontend/demo/component/notification/notification-position.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { NotificationPosition } from '@vaadin/notification';
 import { Notification } from '@vaadin/notification';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-position')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-retry.ts
+++ b/frontend/demo/component/notification/notification-retry.ts
@@ -8,7 +8,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import { notificationRenderer } from '@vaadin/notification/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-retry')
 export class Example extends LitElement {
@@ -17,7 +17,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-rich-preview.ts
+++ b/frontend/demo/component/notification/notification-rich-preview.ts
@@ -7,13 +7,12 @@ import '@vaadin/notification';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-rich-preview')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-rich.ts
+++ b/frontend/demo/component/notification/notification-rich.ts
@@ -10,13 +10,12 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { Notification } from '@vaadin/notification';
 import { notificationRenderer } from '@vaadin/notification/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-rich')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-static-helper.ts
+++ b/frontend/demo/component/notification/notification-static-helper.ts
@@ -3,13 +3,12 @@ import '@vaadin/button';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-static-helper')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-undo.ts
+++ b/frontend/demo/component/notification/notification-undo.ts
@@ -8,7 +8,7 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import { notificationRenderer } from '@vaadin/notification/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-undo')
 export class Example extends LitElement {
@@ -17,7 +17,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/notification/notification-warning.ts
+++ b/frontend/demo/component/notification/notification-warning.ts
@@ -8,7 +8,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { NotificationLitRenderer } from '@vaadin/notification/lit.js';
 import { notificationRenderer } from '@vaadin/notification/lit.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('notification-warning')
 export class Example extends LitElement {
@@ -17,7 +17,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/numberfield/number-field-basic-features.ts
+++ b/frontend/demo/component/numberfield/number-field-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/number-field';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('number-field-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/numberfield/number-field-basic.ts
+++ b/frontend/demo/component/numberfield/number-field-basic.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/number-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('number-field-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/numberfield/number-field-integer.ts
+++ b/frontend/demo/component/numberfield/number-field-integer.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/integer-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('number-field-integer')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/numberfield/number-field-readonly-and-disabled.ts
+++ b/frontend/demo/component/numberfield/number-field-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/number-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('number-field-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/numberfield/number-field-step-buttons.ts
+++ b/frontend/demo/component/numberfield/number-field-step-buttons.ts
@@ -5,7 +5,7 @@ import '@vaadin/integer-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 const layoutSteps: FormLayoutResponsiveStep[] = [
   {
@@ -19,7 +19,6 @@ const layoutSteps: FormLayoutResponsiveStep[] = [
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/numberfield/number-field-step.ts
+++ b/frontend/demo/component/numberfield/number-field-step.ts
@@ -3,13 +3,12 @@ import '@vaadin/number-field';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { NumberField, NumberFieldValidatedEvent } from '@vaadin/number-field';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('number-field-step')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/numberfield/number-field-styles.ts
+++ b/frontend/demo/component/numberfield/number-field-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/number-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('number-field-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/numberfield/number-field-validation.ts
+++ b/frontend/demo/component/numberfield/number-field-validation.ts
@@ -3,13 +3,12 @@ import '@vaadin/integer-field';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { IntegerField, IntegerFieldValidatedEvent } from '@vaadin/integer-field';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('number-field-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
+++ b/frontend/demo/component/passwordfield/password-field-advanced-helper.ts
@@ -5,7 +5,7 @@ import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { PasswordFieldValueChangedEvent } from '@vaadin/password-field';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 type PasswordStrength = 'moderate' | 'strong' | 'weak';
 
@@ -19,7 +19,6 @@ const StrengthColor: Record<PasswordStrength, string> = {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/passwordfield/password-field-basic-features.ts
+++ b/frontend/demo/component/passwordfield/password-field-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/password-field';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('password-field-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/passwordfield/password-field-basic.ts
+++ b/frontend/demo/component/passwordfield/password-field-basic.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('password-field-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/passwordfield/password-field-helper.ts
+++ b/frontend/demo/component/passwordfield/password-field-helper.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('input-field-helper')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/passwordfield/password-field-readonly-and-disabled.ts
+++ b/frontend/demo/component/passwordfield/password-field-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('password-field-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts
+++ b/frontend/demo/component/passwordfield/password-field-reveal-button-hidden.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('password-field-reveal-button-hidden')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/passwordfield/password-field-styles.ts
+++ b/frontend/demo/component/passwordfield/password-field-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('password-field-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/passwordfield/password-field-validation.ts
+++ b/frontend/demo/component/passwordfield/password-field-validation.ts
@@ -3,13 +3,12 @@ import '@vaadin/password-field';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { PasswordField, PasswordFieldValidatedEvent } from '@vaadin/password-field';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('password-field-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/popover/popover-anchored-dialog.ts
+++ b/frontend/demo/component/popover/popover-anchored-dialog.ts
@@ -11,7 +11,7 @@ import { customElement, state } from 'lit/decorators.js';
 import type { CheckboxChangeEvent } from '@vaadin/checkbox';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 type ColumnConfig = { label: string; key: string; visible: boolean };
 
@@ -28,7 +28,6 @@ const DEFAULT_COLUMNS = [
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/popover/popover-arrow.ts
+++ b/frontend/demo/component/popover/popover-arrow.ts
@@ -5,13 +5,12 @@ import '@vaadin/popover';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('popover-arrow')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/popover/popover-dropdown-field.ts
+++ b/frontend/demo/component/popover/popover-dropdown-field.ts
@@ -11,13 +11,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { DatePickerChangeEvent } from '@vaadin/date-picker';
 import type { SelectChangeEvent } from '@vaadin/select';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('popover-dropdown-field')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/popover/popover-interactive-tooltip.ts
+++ b/frontend/demo/component/popover/popover-interactive-tooltip.ts
@@ -5,13 +5,12 @@ import '@vaadin/popover';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { PopoverTrigger } from '@vaadin/popover';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('popover-interactive-tooltip')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/popover/popover-modal.ts
+++ b/frontend/demo/component/popover/popover-modal.ts
@@ -4,13 +4,12 @@ import '@vaadin/popover';
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('popover-modal')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/popover/popover-notification-panel.ts
+++ b/frontend/demo/component/popover/popover-notification-panel.ts
@@ -11,13 +11,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { MessageListItem } from '@vaadin/message-list';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('popover-notifications-panel')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/popover/popover-positioning.ts
+++ b/frontend/demo/component/popover/popover-positioning.ts
@@ -7,13 +7,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { PopoverPosition } from '@vaadin/popover';
 import type { SelectChangeEvent } from '@vaadin/select';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('popover-positioning')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/popover/popover-user-menu.ts
+++ b/frontend/demo/component/popover/popover-user-menu.ts
@@ -8,13 +8,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('popover-user-menu')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/progressbar/progress-bar-basic.ts
+++ b/frontend/demo/component/progressbar/progress-bar-basic.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('progress-bar-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/progressbar/progress-bar-completion-time.ts
+++ b/frontend/demo/component/progressbar/progress-bar-completion-time.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('progress-bar-completion-time')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/progressbar/progress-bar-custom-range.ts
+++ b/frontend/demo/component/progressbar/progress-bar-custom-range.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('progress-bar-custom-range')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/progressbar/progress-bar-determinate.ts
+++ b/frontend/demo/component/progressbar/progress-bar-determinate.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('progress-bar-determinate')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/progressbar/progress-bar-indeterminate.ts
+++ b/frontend/demo/component/progressbar/progress-bar-indeterminate.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('progress-bar-indeterminate')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/progressbar/progress-bar-label.ts
+++ b/frontend/demo/component/progressbar/progress-bar-label.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/progress-bar';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('progress-bar-label')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/progressbar/progress-bar-theme-variants.ts
+++ b/frontend/demo/component/progressbar/progress-bar-theme-variants.ts
@@ -3,13 +3,12 @@ import '@vaadin/progress-bar';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('progress-bar-theme-variants')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-basic.ts
+++ b/frontend/demo/component/radiobutton/radio-button-basic.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts
+++ b/frontend/demo/component/radiobutton/radio-button-checkbox-alternative.ts
@@ -4,13 +4,12 @@ import '@vaadin/radio-group';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-checkbox-alternative')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-custom-option.ts
+++ b/frontend/demo/component/radiobutton/radio-button-custom-option.ts
@@ -8,13 +8,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
 import { getCards } from 'Frontend/demo/domain/DataService';
 import type Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-custom-option')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-default-value.ts
+++ b/frontend/demo/component/radiobutton/radio-button-default-value.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-default-value')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-disabled.ts
+++ b/frontend/demo/component/radiobutton/radio-button-disabled.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-group-basic-features.ts
+++ b/frontend/demo/component/radiobutton/radio-button-group-basic-features.ts
@@ -3,13 +3,12 @@ import '@vaadin/radio-group';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-group-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-group-labels.ts
+++ b/frontend/demo/component/radiobutton/radio-button-group-labels.ts
@@ -3,13 +3,12 @@ import '@vaadin/radio-group';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-group-labels')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-group-styles.ts
+++ b/frontend/demo/component/radiobutton/radio-button-group-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-group-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-horizontal.ts
+++ b/frontend/demo/component/radiobutton/radio-button-horizontal.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-horizontal')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-presentation.ts
+++ b/frontend/demo/component/radiobutton/radio-button-presentation.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getCards } from 'Frontend/demo/domain/DataService';
 import type Card from 'Frontend/generated/com/vaadin/demo/domain/Card';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-presentation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-readonly.ts
+++ b/frontend/demo/component/radiobutton/radio-button-readonly.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-readonly')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/radiobutton/radio-button-vertical.ts
+++ b/frontend/demo/component/radiobutton/radio-button-vertical.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/radio-group';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('radio-button-vertical')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-basic.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-min-max-height.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-min-max-height')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-readonly.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-readonly')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-set-get-value.ts
@@ -9,13 +9,12 @@ import type {
   RichTextEditorValueChangedEvent,
 } from '@vaadin/rich-text-editor';
 import type { TextAreaChangeEvent } from '@vaadin/text-area';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('rich-text-editor-set-get-value')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-compact.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-theme-compact')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
+++ b/frontend/demo/component/richtexteditor/rich-text-editor-theme-no-border.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/rich-text-editor';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('rich-text-editor-no-border')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/scroller/scroller-basic.ts
+++ b/frontend/demo/component/scroller/scroller-basic.ts
@@ -9,7 +9,7 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('scroller-basic')
 export class Example extends LitElement {
@@ -22,7 +22,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/scroller/scroller-both.ts
+++ b/frontend/demo/component/scroller/scroller-both.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/scroller';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import img from '../../../../src/main/resources/images/reindeer.jpg?url';
 
 @customElement('scroller-both')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/scroller/scroller-mobile.ts
+++ b/frontend/demo/component/scroller/scroller-mobile.ts
@@ -6,7 +6,7 @@ import '@vaadin/icons';
 import '@vaadin/scroller';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('scroller-mobile')
 export class Example extends LitElement {
@@ -18,7 +18,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/scroller/scroller-overflow-indicators.ts
+++ b/frontend/demo/component/scroller/scroller-overflow-indicators.ts
@@ -7,7 +7,7 @@ import '@vaadin/text-field';
 import '@vaadin/vertical-layout';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('scroller-overflow-indicators')
 export class Example extends LitElement {
@@ -23,7 +23,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-basic-features.ts
+++ b/frontend/demo/component/select/select-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/select';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-basic.ts
+++ b/frontend/demo/component/select/select-basic.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-complex-value-label.ts
+++ b/frontend/demo/component/select/select-complex-value-label.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { SelectItem } from '@vaadin/select';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-complex-value-label')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -7,7 +7,7 @@ import { customElement, state } from 'lit/decorators.js';
 import { selectRenderer } from '@vaadin/select/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 const formatPersonFullName = (person: Person) => `${person.firstName} ${person.lastName}`;
 
@@ -15,7 +15,6 @@ const formatPersonFullName = (person: Person) => `${person.firstName} ${person.l
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-disabled.ts
+++ b/frontend/demo/component/select/select-disabled.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-dividers.ts
+++ b/frontend/demo/component/select/select-dividers.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-dividers')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-no-vertical-overlap.ts
+++ b/frontend/demo/component/select/select-no-vertical-overlap.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-no-vertical-overlap')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-overlay-width.ts
+++ b/frontend/demo/component/select/select-overlay-width.ts
@@ -7,7 +7,7 @@ import { customElement, state } from 'lit/decorators.js';
 import type { SelectItem } from '@vaadin/select';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 const formatPersonFullName = (person: Person) => `${person.firstName} ${person.lastName}`;
 
@@ -15,7 +15,6 @@ const formatPersonFullName = (person: Person) => `${person.firstName} ${person.l
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-placeholder.ts
+++ b/frontend/demo/component/select/select-placeholder.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-placeholder')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -7,13 +7,12 @@ import { customElement, state } from 'lit/decorators.js';
 import { selectRenderer } from '@vaadin/select/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-presentation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-readonly-and-disabled.ts
+++ b/frontend/demo/component/select/select-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/select/select-styles.ts
+++ b/frontend/demo/component/select/select-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('select-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/side-nav/side-nav-basic.ts
+++ b/frontend/demo/component/side-nav/side-nav-basic.ts
@@ -5,13 +5,12 @@ import '@vaadin/side-nav';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('side-nav-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/side-nav/side-nav-hierarchy.ts
+++ b/frontend/demo/component/side-nav/side-nav-hierarchy.ts
@@ -5,13 +5,12 @@ import '@vaadin/side-nav';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('side-nav-hierarchy')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/side-nav/side-nav-labelled.ts
+++ b/frontend/demo/component/side-nav/side-nav-labelled.ts
@@ -6,13 +6,12 @@ import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('side-nav-labelled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/side-nav/side-nav-styling.ts
+++ b/frontend/demo/component/side-nav/side-nav-styling.ts
@@ -5,13 +5,12 @@ import '@vaadin/side-nav';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('side-nav-styling')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/side-nav/side-nav-suffix.ts
+++ b/frontend/demo/component/side-nav/side-nav-suffix.ts
@@ -5,13 +5,12 @@ import '@vaadin/side-nav';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { patchSideNavNavigation } from 'Frontend/demo/component/side-nav/side-nav-helper'; // hidden-source-line
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('side-nav-suffix')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/splitlayout/split-layout-basic.ts
+++ b/frontend/demo/component/splitlayout/split-layout-basic.ts
@@ -4,13 +4,12 @@ import './master-content';
 import './detail-content';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('split-layout-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts
+++ b/frontend/demo/component/splitlayout/split-layout-initial-splitter-position.ts
@@ -4,13 +4,12 @@ import './master-content';
 import './detail-content';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('split-layout-initial-splitter-position')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/splitlayout/split-layout-min-max-size.ts
+++ b/frontend/demo/component/splitlayout/split-layout-min-max-size.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/split-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('split-layout-min-max-size')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/splitlayout/split-layout-orientation.ts
+++ b/frontend/demo/component/splitlayout/split-layout-orientation.ts
@@ -4,13 +4,12 @@ import './master-content';
 import './detail-content';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('split-layout-orientation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts
+++ b/frontend/demo/component/splitlayout/split-layout-theme-minimal.ts
@@ -4,13 +4,12 @@ import './master-content';
 import './detail-content';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('split-layout-theme-minimal')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/splitlayout/split-layout-theme-small.ts
+++ b/frontend/demo/component/splitlayout/split-layout-theme-small.ts
@@ -4,13 +4,12 @@ import './master-content';
 import './detail-content';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('split-layout-theme-small')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/splitlayout/split-layout-toggle.ts
+++ b/frontend/demo/component/splitlayout/split-layout-toggle.ts
@@ -7,13 +7,12 @@ import './master-content';
 import './detail-content';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('split-layout-toggle')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tabs/tabs-content.ts
+++ b/frontend/demo/component/tabs/tabs-content.ts
@@ -4,7 +4,7 @@ import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { TabsSelectedChangedEvent } from '@vaadin/tabs';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tabs-content')
 export class Example extends LitElement {
@@ -16,7 +16,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tabs/tabsheet-basic.ts
+++ b/frontend/demo/component/tabs/tabsheet-basic.ts
@@ -3,13 +3,12 @@ import '@vaadin/tabs';
 import '@vaadin/tabsheet';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tabsheet-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
+++ b/frontend/demo/component/tabs/tabsheet-lazy-initialization.ts
@@ -4,13 +4,12 @@ import '@vaadin/tabsheet';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { TabSheetSelectedChangedEvent } from '@vaadin/tabsheet';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tabsheet-lazy-initialization')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts
+++ b/frontend/demo/component/tabs/tabsheet-prefix-suffix.ts
@@ -6,13 +6,12 @@ import '@vaadin/tabs';
 import '@vaadin/tabsheet';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tabsheet-prefix-suffix')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textarea/text-area-auto-height.ts
+++ b/frontend/demo/component/textarea/text-area-auto-height.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/text-area';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('text-area-auto-height')
@@ -15,7 +15,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textarea/text-area-basic-features.ts
+++ b/frontend/demo/component/textarea/text-area-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/text-area';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-area-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textarea/text-area-basic.ts
+++ b/frontend/demo/component/textarea/text-area-basic.ts
@@ -3,13 +3,12 @@ import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { TextAreaValueChangedEvent } from '@vaadin/text-area';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-area-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textarea/text-area-height.ts
+++ b/frontend/demo/component/textarea/text-area-height.ts
@@ -2,14 +2,13 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('text-area-height')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textarea/text-area-helper.ts
+++ b/frontend/demo/component/textarea/text-area-helper.ts
@@ -3,7 +3,7 @@ import '@vaadin/text-area';
 import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { TextAreaValueChangedEvent } from '@vaadin/text-area';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import templates from '../../../../src/main/resources/data/templates.json';
 
 @customElement('text-area-helper-2')
@@ -16,7 +16,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textarea/text-area-readonly-and-disabled.ts
+++ b/frontend/demo/component/textarea/text-area-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-area-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textarea/text-area-styles.ts
+++ b/frontend/demo/component/textarea/text-area-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-area-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textarea/text-area-validation.ts
+++ b/frontend/demo/component/textarea/text-area-validation.ts
@@ -3,13 +3,12 @@ import '@vaadin/text-area';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { TextArea, TextAreaValidatedEvent } from '@vaadin/text-area';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-area-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textfield/text-field-basic-features.ts
+++ b/frontend/demo/component/textfield/text-field-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/text-field';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-field-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textfield/text-field-basic.ts
+++ b/frontend/demo/component/textfield/text-field-basic.ts
@@ -4,13 +4,12 @@ import '@vaadin/icons';
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-field-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textfield/text-field-readonly-and-disabled.ts
+++ b/frontend/demo/component/textfield/text-field-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-field-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textfield/text-field-styles.ts
+++ b/frontend/demo/component/textfield/text-field-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-field-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/textfield/text-field-validation.ts
+++ b/frontend/demo/component/textfield/text-field-validation.ts
@@ -3,13 +3,12 @@ import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { TextField, TextFieldValidatedEvent } from '@vaadin/text-field';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('text-field-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-auto-open.ts
+++ b/frontend/demo/component/timepicker/time-picker-auto-open.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-auto-open')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-basic-features.ts
+++ b/frontend/demo/component/timepicker/time-picker-basic-features.ts
@@ -5,13 +5,12 @@ import '@vaadin/time-picker';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-basic-features')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-basic.ts
+++ b/frontend/demo/component/timepicker/time-picker-basic.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-custom-parser.ts
+++ b/frontend/demo/component/timepicker/time-picker-custom-parser.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-custom-parser')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-custom-validation.ts
+++ b/frontend/demo/component/timepicker/time-picker-custom-validation.ts
@@ -4,13 +4,12 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Binder, field } from '@vaadin/hilla-lit-form';
 import AppointmentModel from 'Frontend/generated/com/vaadin/demo/domain/AppointmentModel';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-custom-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-minutes-step.ts
+++ b/frontend/demo/component/timepicker/time-picker-minutes-step.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-minutes-step')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-readonly-and-disabled.ts
+++ b/frontend/demo/component/timepicker/time-picker-readonly-and-disabled.ts
@@ -3,13 +3,12 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-readonly-and-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-seconds-step.ts
+++ b/frontend/demo/component/timepicker/time-picker-seconds-step.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-seconds-step')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-styles.ts
+++ b/frontend/demo/component/timepicker/time-picker-styles.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-styles')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/timepicker/time-picker-validation.ts
+++ b/frontend/demo/component/timepicker/time-picker-validation.ts
@@ -3,13 +3,12 @@ import '@vaadin/time-picker';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { TimePicker, TimePickerValidatedEvent } from '@vaadin/time-picker';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('time-picker-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tooltip/tooltip-basic.ts
+++ b/frontend/demo/component/tooltip/tooltip-basic.ts
@@ -5,13 +5,12 @@ import '@vaadin/tooltip';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tooltip-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tooltip/tooltip-html-element.ts
+++ b/frontend/demo/component/tooltip/tooltip-html-element.ts
@@ -2,13 +2,12 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tooltip-html-element')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tooltip/tooltip-manual.ts
+++ b/frontend/demo/component/tooltip/tooltip-manual.ts
@@ -6,13 +6,12 @@ import '@vaadin/tooltip';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tooltip-manual')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tooltip/tooltip-positioning.ts
+++ b/frontend/demo/component/tooltip/tooltip-positioning.ts
@@ -7,13 +7,12 @@ import '@vaadin/tabs';
 import '@vaadin/tooltip';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tooltip-positioning')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tree-grid/tree-grid-basic.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-basic.ts
@@ -6,13 +6,12 @@ import { customElement } from 'lit/decorators.js';
 import type { GridDataProviderCallback, GridDataProviderParams } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tree-grid-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tree-grid/tree-grid-column.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-column.ts
@@ -8,13 +8,12 @@ import { customElement, state } from 'lit/decorators.js';
 import type { GridDataProviderCallback, GridDataProviderParams } from '@vaadin/grid';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tree-grid-column')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -15,13 +15,12 @@ import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import type { GridTreeToggleExpandedChangedEvent } from '@vaadin/grid/vaadin-grid-tree-toggle.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tree-grid-rich-content')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/tree-grid/tree-grid-scroll-to-index.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-scroll-to-index.ts
@@ -16,13 +16,12 @@ import type {
 import type { IntegerFieldChangeEvent } from '@vaadin/integer-field';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('tree-grid-scroll-to-index')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-all-files.ts
+++ b/frontend/demo/component/upload/upload-all-files.ts
@@ -4,14 +4,13 @@ import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import type { Upload } from '@vaadin/upload';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { createFakeFilesUploadAllFiles } from './upload-demo-mock-files'; // hidden-source-line
 
 @customElement('upload-all-files')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-auto-upload-disabled.ts
+++ b/frontend/demo/component/upload/upload-auto-upload-disabled.ts
@@ -3,14 +3,13 @@ import './upload-demo-helpers'; // hidden-source-line
 import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { createFakeFilesUploadAutoUploadDisabled } from './upload-demo-mock-files'; // hidden-source-line
 
 @customElement('upload-auto-upload-disabled')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-basic.ts
+++ b/frontend/demo/component/upload/upload-basic.ts
@@ -3,14 +3,13 @@ import './upload-demo-helpers'; // hidden-source-line
 import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { createFakeFilesUploadBasic } from './upload-demo-mock-files'; // hidden-source-line
 
 @customElement('upload-basic')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-button-theme-variant.ts
+++ b/frontend/demo/component/upload/upload-button-theme-variant.ts
@@ -6,13 +6,12 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
 import type { UploadFileRejectEvent, UploadMaxFilesReachedChangedEvent } from '@vaadin/upload';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('upload-button-theme-variant')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-clear-button.ts
+++ b/frontend/demo/component/upload/upload-clear-button.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { createFakeUploadFiles } from './upload-demo-helpers'; // hidden-source-line
 
 function createFakeFiles() {
@@ -20,7 +20,6 @@ function createFakeFiles() {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-drag-and-drop.ts
+++ b/frontend/demo/component/upload/upload-drag-and-drop.ts
@@ -5,7 +5,7 @@ import '@vaadin/upload';
 import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 const layoutSteps: FormLayoutResponsiveStep[] = [
   { minWidth: 0, columns: 1, labelsPosition: 'top' },
@@ -22,7 +22,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-drop-label.ts
+++ b/frontend/demo/component/upload/upload-drop-label.ts
@@ -5,13 +5,12 @@ import '@vaadin/icons';
 import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('upload-drop-label')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-error-messages.ts
+++ b/frontend/demo/component/upload/upload-error-messages.ts
@@ -4,7 +4,7 @@ import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { FormLayoutResponsiveStep } from '@vaadin/form-layout';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 /* prettier-ignore */
 import { createFakeFilesUploadErrorMessagesA, createFakeFilesUploadErrorMessagesB } from './upload-demo-mock-files'; // hidden-source-line
 
@@ -17,7 +17,6 @@ const layoutSteps: FormLayoutResponsiveStep[] = [
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-file-count.ts
+++ b/frontend/demo/component/upload/upload-file-count.ts
@@ -5,7 +5,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
 import type { UploadFileRejectEvent } from '@vaadin/upload';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('upload-file-count')
 export class Example extends LitElement {
@@ -21,7 +21,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-file-format.ts
+++ b/frontend/demo/component/upload/upload-file-format.ts
@@ -5,7 +5,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
 import type { UploadFileRejectEvent } from '@vaadin/upload';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('upload-file-format')
 export class Example extends LitElement {
@@ -21,7 +21,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-file-size.ts
+++ b/frontend/demo/component/upload/upload-file-size.ts
@@ -5,7 +5,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
 import type { UploadFileRejectEvent } from '@vaadin/upload';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('upload-file-size')
 export class Example extends LitElement {
@@ -21,7 +21,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-helper.ts
+++ b/frontend/demo/component/upload/upload-helper.ts
@@ -5,7 +5,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
 import type { UploadFileRejectEvent } from '@vaadin/upload';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('upload-helper')
 export class Example extends LitElement {
@@ -21,7 +21,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-internationalization.ts
+++ b/frontend/demo/component/upload/upload-internationalization.ts
@@ -3,13 +3,12 @@ import './upload-demo-helpers'; // hidden-source-line
 import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('upload-internationalization')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-labelling.ts
+++ b/frontend/demo/component/upload/upload-labelling.ts
@@ -5,13 +5,12 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
 import type { UploadFileRejectEvent } from '@vaadin/upload';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('upload-labelling')
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-retry-button.ts
+++ b/frontend/demo/component/upload/upload-retry-button.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { createFakeUploadFiles } from './upload-demo-helpers'; // hidden-source-line
 
 function createFakeFiles() {
@@ -15,7 +15,6 @@ function createFakeFiles() {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/upload/upload-start-button.ts
+++ b/frontend/demo/component/upload/upload-start-button.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/upload';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import { createFakeUploadFiles } from './upload-demo-helpers'; // hidden-source-line
 
 function createFakeFiles() {
@@ -19,7 +19,6 @@ function createFakeFiles() {
 export class Example extends LitElement {
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/vertical-layout/vertical-layout-basic.ts
+++ b/frontend/demo/component/vertical-layout/vertical-layout-basic.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vertical-layout-basic')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/vertical-layout/vertical-layout-horizontal-alignment.ts
+++ b/frontend/demo/component/vertical-layout/vertical-layout-horizontal-alignment.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vertical-layout-horizontal-alignment')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/vertical-layout/vertical-layout-individual-alignment.ts
+++ b/frontend/demo/component/vertical-layout/vertical-layout-individual-alignment.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vertical-layout-individual-alignment')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/vertical-layout/vertical-layout-margin.ts
+++ b/frontend/demo/component/vertical-layout/vertical-layout-margin.ts
@@ -3,7 +3,7 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vertical-layout-margin')
 export class Example extends LitElement {
@@ -14,7 +14,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/vertical-layout/vertical-layout-padding.ts
+++ b/frontend/demo/component/vertical-layout/vertical-layout-padding.ts
@@ -3,7 +3,7 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vertical-layout-padding')
 export class Example extends LitElement {
@@ -14,7 +14,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/vertical-layout/vertical-layout-spacing-variants.ts
+++ b/frontend/demo/component/vertical-layout/vertical-layout-spacing-variants.ts
@@ -4,7 +4,7 @@ import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { RadioGroupValueChangedEvent } from '@vaadin/radio-group';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vertical-layout-spacing-variants')
 export class Example extends LitElement {
@@ -15,7 +15,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/vertical-layout/vertical-layout-spacing.ts
+++ b/frontend/demo/component/vertical-layout/vertical-layout-spacing.ts
@@ -3,7 +3,7 @@ import '@vaadin/horizontal-layout';
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vertical-layout-spacing')
 export class Example extends LitElement {
@@ -14,7 +14,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/vertical-layout/vertical-layout-vertical-alignment.ts
+++ b/frontend/demo/component/vertical-layout/vertical-layout-vertical-alignment.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/vertical-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vertical-layout-vertical-alignment')
 export class Example extends LitElement {
@@ -13,7 +13,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/vertical-layout/vertical-layout-wrapping.ts
+++ b/frontend/demo/component/vertical-layout/vertical-layout-wrapping.ts
@@ -3,7 +3,7 @@ import '@vaadin/vertical-layout';
 import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('vertical-layout-wrapping')
 export class Example extends LitElement {
@@ -14,7 +14,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/component/virtuallist/virtual-list-basic.ts
+++ b/frontend/demo/component/virtuallist/virtual-list-basic.ts
@@ -12,7 +12,7 @@ import type { VirtualListLitRenderer } from '@vaadin/virtual-list/lit.js';
 import { virtualListRenderer } from '@vaadin/virtual-list/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('virtual-list-basic')
 export class Example extends LitElement {
@@ -25,7 +25,6 @@ export class Example extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/demo/react-example.ts
+++ b/frontend/demo/react-example.ts
@@ -2,7 +2,7 @@ import 'Frontend/demo/init';
 import React, { type ComponentClass, type FunctionComponent } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { CSSResult } from 'lit';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 
 export function reactExample(
   Example: ComponentClass<any> | FunctionComponent<any>,

--- a/frontend/demo/theme.ts
+++ b/frontend/demo/theme.ts
@@ -13,8 +13,11 @@ function createStylesheet(css: CSSResultGroup | string): CSSStyleSheet {
 
 const docsStylesheet = createStylesheet(docsCss);
 
-export function applyTheme(root: DocumentOrShadowRoot) {
-  if (!root.adoptedStyleSheets.includes(docsStylesheet)) {
+export function applyTheme(root: DocumentFragment | DocumentOrShadowRoot | HTMLElement) {
+  // The root parameter type is very broad to handle the default return type of
+  // LitElement.createRenderRoot. In general, we expect this to either be a document or a shadow
+  // root. The adoptedStyleSheets check below makes Typescript accept the parameter type.
+  if ('adoptedStyleSheets' in root && !root.adoptedStyleSheets.includes(docsStylesheet)) {
     root.adoptedStyleSheets = [...root.adoptedStyleSheets, docsStylesheet];
   }
 }

--- a/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
+++ b/frontend/demo/tools/observability/newrelic/dashboard-generator.ts
@@ -8,7 +8,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { Notification } from '@vaadin/notification';
 import type { TextFieldValueChangedEvent } from '@vaadin/text-field';
-import { applyTheme } from 'Frontend/generated/theme';
+import { applyTheme } from 'Frontend/demo/theme';
 import template from './dashboard-template.json';
 
 @customElement('new-relic-dashboard-generator')
@@ -28,7 +28,6 @@ export class DashboardGenerator extends LitElement {
 
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
-    // Apply custom theme (only supported if your app uses one)
     applyTheme(root);
     return root;
   }

--- a/frontend/types.d.ts
+++ b/frontend/types.d.ts
@@ -18,5 +18,4 @@ declare module '*.avif?url' {
   export = value;
 }
 
-declare module 'Frontend/generated/theme';
 declare module 'Frontend/generated/jar-resources/dev-tools-database.js';

--- a/vite.dspublisher.ts
+++ b/vite.dspublisher.ts
@@ -30,7 +30,6 @@ const config: UserConfig = {
   resolve: {
     alias: {
       'Frontend/generated/endpoints': endpointMocks,
-      'Frontend/generated/theme': resolve(__dirname, 'frontend', 'demo', 'theme.js'),
       ...vaadin.resolve?.alias,
       'all-flow-imports-or-empty':
         process.env.DOCS_IMPORT_EXAMPLE_RESOURCES === 'true' ? allFlowImportsPath : 'lit',


### PR DESCRIPTION
- Import `applyTheme` from `theme.ts` instead of generated Flow theme path
- Remove comments indicating that `applyTheme` should be used to apply themes to custom Lit elements
- Remove alias for Flow theme path from DSP Vite config
- Update `applyTheme` to handle return type of `LitElement.createRenderRoot` as argument