### PR TITLE
chore: remove theme plugin from DSP vite config

### DIFF
--- a/vite.dspublisher.ts
+++ b/vite.dspublisher.ts
@@ -18,9 +18,6 @@ const vaadin = vaadinConfig({
   command: 'build',
 }) as UserConfig;
 
-// Get the theme plugin from vaadinConfig
-const themePlugin = vaadin.plugins?.find((plugin: any) => plugin.name === 'vaadin:theme');
-
 const endpointMocks = resolve(__dirname, 'frontend', 'demo', 'services', 'mocks.js');
 
 // Use newer target to support top-level await in Hilla dependencies
@@ -54,7 +51,6 @@ const config: UserConfig = {
     },
   },
   plugins: [
-    themePlugin,
     {
       name: 'vite-plugin-rewrite-polymer-global',
       transform(code, id) {


### PR DESCRIPTION
Remove the Vaadin theme plugin from the DSP Vite config. The docs do not use the theme mechanism anymore and example styles are now imported through an `?inline` import from the DSP bundle which is enough to get the DSP Vite process to refresh the page when styles change.