### PR TITLE
docs: replace Lumo utility classes in add login article

### DIFF
--- a/articles/building-apps/security/add-login/flow.adoc
+++ b/articles/building-apps/security/add-login/flow.adoc
@@ -31,12 +31,17 @@ public class LoginView extends Main implements BeforeEnterObserver {
     private final LoginForm login;
 
     public LoginView() {
-        addClassNames(LumoUtility.Display.FLEX, LumoUtility.JustifyContent.CENTER,
-            LumoUtility.AlignItems.CENTER);
-        setSizeFull();
         login = new LoginForm();
         login.setAction("login"); // <3>
-        add(login);
+
+        VerticalLayout layout = new VerticalLayout();
+        layout.setAlignItems(FlexComponent.Alignment.CENTER);
+        layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+        layout.add(login);
+        layout.setSizeFull();
+
+        add(layout);
+        setSizeFull();
     }
 
     @Override
@@ -195,12 +200,13 @@ Inside this package, create a [classname]`LoginView` class:
 ----
 import com.vaadin.flow.component.html.Main;
 import com.vaadin.flow.component.login.LoginForm;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
-import com.vaadin.flow.theme.lumo.LumoUtility;
 
 @Route(value = "login", autoLayout = false)
 @PageTitle("Login")
@@ -210,13 +216,17 @@ public class LoginView extends Main implements BeforeEnterObserver {
     private final LoginForm login;
 
     public LoginView() {
-        addClassNames(LumoUtility.Display.FLEX,
-            LumoUtility.JustifyContent.CENTER,
-            LumoUtility.AlignItems.CENTER);
-        setSizeFull();
         login = new LoginForm();
         login.setAction("login");
-        add(login);
+
+        VerticalLayout layout = new VerticalLayout();
+        layout.setAlignItems(FlexComponent.Alignment.CENTER);
+        layout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+        layout.add(login);
+        layout.setSizeFull();
+
+        add(layout);
+        setSizeFull();
     }
 
     @Override


### PR DESCRIPTION
I went through adding security with the updated v25 starter, which resulted in the login form not being positioned correctly as Lumo utilities are not loaded.

This changes the add login guide to use a vertical layout instead. I noticed that there are several other articles in the guide that need similar updates, but maybe this helps getting started.