### PR TITLE
docs: tooltip markdown support

### DIFF
--- a/articles/components/tooltip/index.adoc
+++ b/articles/components/tooltip/index.adoc
@@ -257,6 +257,7 @@ endif::[]
 [NOTE]
 ====
 Using Markdown is discouraged if accessibility of the tooltip content is essential, as semantics of the rendered HTML content (headers, lists, ...) will not be conveyed to assistive technologies.
+Likewise, any interactive content such as links may not be accessible. For more complex or interactive content, consider using a <<../popover#,Popover>> instead.
 ====
 
 


### PR DESCRIPTION
Adds a section about Markdown support in Tooltip.

Closes https://github.com/vaadin/web-components/issues/9771