### PR TITLE
chore: move dspublisher-header stylesheets to head

### DIFF
--- a/dspublisher/theme/init-browser.ts
+++ b/dspublisher/theme/init-browser.ts
@@ -9,6 +9,39 @@ if (!localStorage.getItem('vaadin.docsApp.preferredExample')) {
   localStorage.setItem('vaadin.docsApp.preferredExample', 'Java');
 }
 
+// Add stylesheet links to document head once
+if (process.env.NODE_ENV !== 'development') {
+  const stylesheets = [
+    {
+      rel: 'stylesheet',
+      href: 'https://cdn.vaadin.com/website/antlers/v2/assets/fonts/nbinternationalpro/stylesheet.css',
+    },
+    {
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.vaadin.com/website/antlers/v2/assets/icons/css/line-awesome.min.css',
+    },
+    {
+      rel: 'preload',
+      as: 'style',
+      href: 'https://cdn.vaadin.com/website/hubspot-theme/v2/haas/css/haas.css',
+    },
+  ];
+
+  stylesheets.forEach(({ rel, href, as }) => {
+    // Check if link already exists to prevent duplicates
+    if (!document.head.querySelector(`link[href="${href}"]`)) {
+      const link = document.createElement('link');
+      link.rel = rel;
+      link.href = href;
+      if (as) {
+        link.setAttribute('as', as);
+      }
+      document.head.appendChild(link);
+    }
+  });
+}
+
 class Header extends LitElement {
   createRenderRoot() {
     return this;
@@ -32,21 +65,6 @@ class Header extends LitElement {
     }
 
     return html`
-      <link
-        rel="stylesheet"
-        href="https://cdn.vaadin.com/website/antlers/v2/assets/fonts/nbinternationalpro/stylesheet.css"
-      />
-      <link
-        rel="preload"
-        as="style"
-        href="https://cdn.vaadin.com/website/antlers/v2/assets/icons/css/line-awesome.min.css"
-      />
-      <link
-        rel="preload"
-        as="style"
-        href="https://cdn.vaadin.com/website/hubspot-theme/v2/haas/css/haas.css"
-      />
-
       <div id="haas-container"></div>
       ${this.haasImportScript()}
     `;


### PR DESCRIPTION
Move the stylesheet links from inside Vaadin docs `<dspublisher-header>` to `<head>`.
This will make the elements persist across page navigations and will possibly also address a recent [page jamming issue](https://vaadin.slack.com/archives/CQUQWJ4KU/p1759315513921009).