### PR TITLE
Clarify that Dashboard widget contents are inert in edit mode

### DIFF
--- a/articles/components/dashboard/index.adoc
+++ b/articles/components/dashboard/index.adoc
@@ -360,7 +360,7 @@ You can make dynamic dashboards editable by turning on editing mode, as seen in 
 
 .Editing mode should be temporary.
 [NOTE]
-The end user turns on editing mode when they want to edit the dashboard's contents and turns it off when they finish editing. When turned off, you typically want to persist the dashboard configuration to a storage. While in editing mode, the widget contents are inert, meaning they are visible but not interactable.
+The end user turns on editing mode when they want to edit the dashboard's contents and turns it off when they finish editing. When turned off, you typically want to persist the dashboard configuration to a storage. While in editing mode, the widget contents are visible but not interactable.
 
 The following operations are available in editing mode.
 


### PR DESCRIPTION
Fixes #4575 

<img width="849" height="310" alt="image" src="https://github.com/user-attachments/assets/9521efa9-b58a-42b3-b1e1-a393274905d0" />
