### PR TITLE
 Highlight that vaadin-maven-plugin must always be defined after maven-compiler-plugin

### DIFF
--- a/articles/flow/production/production-build.adoc
+++ b/articles/flow/production/production-build.adoc
@@ -114,7 +114,7 @@ Having the production build as a separate Maven profile is recommended to avoid 
 
 .Caution when defining `vaadin-maven-plugin`
 [WARNING]
-To ensure that the production build packages all resources correctly, make sure the `vaadin-maven-plugin` is executed after the `maven-compiler-plugin`. This can be achieved either configuring the execution goal of `vaadin-maven-plugin` to run after the goal targeted by `maven-compiler-plugin`, or if both target the same goal, placing the `vaadin-maven-plugin` definition after the `maven-compiler-plugin` in your `pom.xml`.
+To ensure that the production build packages all resources correctly, make sure the `vaadin-maven-plugin` is executed after the `maven-compiler-plugin`. This can be achieved either configuring the execution goal of `vaadin-maven-plugin` to run after the goal targeted by `maven-compiler-plugin`, or if both target the same goal, placing the `vaadin-maven-plugin` definition after the `maven-compiler-plugin` in your `pom.xml`. The same applies for `kotlin-maven-plugin` or any other plugin that produces Vaadin related Java classes.
 
 
 .Building for 64-bit

--- a/articles/flow/production/troubleshooting.adoc
+++ b/articles/flow/production/troubleshooting.adoc
@@ -105,7 +105,7 @@ One potential cause of this problem is that the `build-frontend` of the `flow-ma
 Frontend resources are missing or not loaded in the running application.::
 A production build can result in a running application without properly loaded frontend resources due to a misconfigured `vaadin-maven-plugin`.
 +
-To ensure that the production build packages all resources correctly, make sure the `vaadin-maven-plugin` is executed after the `maven-compiler-plugin`. This can be achieved either configuring the execution goal of `vaadin-maven-plugin` to run after the goal targeted by `maven-compiler-plugin`, or if both target the same goal, placing the `vaadin-maven-plugin` definition after the `maven-compiler-plugin` in your `pom.xml`.
+To ensure that the production build packages all resources correctly, make sure the `vaadin-maven-plugin` is executed after the `maven-compiler-plugin`. This can be achieved either configuring the execution goal of `vaadin-maven-plugin` to run after the goal targeted by `maven-compiler-plugin`, or if both target the same goal, placing the `vaadin-maven-plugin` definition after the `maven-compiler-plugin` in your `pom.xml`. The same applies for `kotlin-maven-plugin` or any other plugin that produces Vaadin related Java classes.
 
 When running multiple Vaadin applications on different ports on the same host, the browser tabs keeps reloading the page.::
 The cause of page reloading is possibly due to server session expiration caused by all Vaadin application having the same HTTP session cookie name (e.g., `JSESSIONID`). Cookies for a given host are shared across all of the ports on that host, even though "same-origin policy", typically used by web browsers, isolates content retrieved via different ports.


### PR DESCRIPTION
Solves: #4432

Production Build:
<img width="882" height="602" alt="image" src="https://github.com/user-attachments/assets/37b97a43-ed9d-4c44-9cdc-7c6b1f8a67a2" />

Troubleshooting Production Mode:
<img width="878" height="791" alt="image" src="https://github.com/user-attachments/assets/f4d7e295-b34a-4118-944e-4271354c2a33" />



