### PR TITLE
v10 - fix header & HaaS stacking issue on mobile screens

### DIFF
--- a/dspublisher/theme/global.css
+++ b/dspublisher/theme/global.css
@@ -115,14 +115,6 @@ dspublisher-header {
   }
 }
 
-/* Keep Haas elements below docs search */
-@media (max-width: 1024px) {
-  body:not(.haas-open) dspublisher-header {
-    position: relative;
-    z-index: 1;
-  }
-}
-
 [class*='docsHeader-'] {
   box-shadow: inset 0 -1px 0 0 var(--docs-divider-color-1), 0 -1px 0 0 var(--docs-divider-color-1);
 }


### PR DESCRIPTION
Fixes stacking issue:
When the mobile HaaS menu is open the docs' header stacks on top it. Happens on screens smaller than 1024px.

The haas-open class is no longer given to the HTML body, when the HaaS mobile menu is opened.