### PR TITLE
fix: add documentation for using chartoptions to set language translations

### DIFF
--- a/articles/components/charts/configuration.adoc
+++ b/articles/components/charts/configuration.adoc
@@ -451,7 +451,7 @@ fi.setWeekdays(new String[] { "Ma", "Ti", "Ke", "To", "Pe", "La", "Su" });
 fi.setNoData("Data puuttuu");
 ----
 
-[classname]`Lang` option is global and can be set with [methodname]`setLang()` in the [classname]`ChartOptions`:
+The [classname]`Lang` instance is set globally for all charts through [classname]`ChartOptions`:
 
 [source, java]
 ----


### PR DESCRIPTION
fix for #4690 