### PR TITLE
chore: swap source control and gradle pages

### DIFF
--- a/articles/flow/configuration/gradle.adoc
+++ b/articles/flow/configuration/gradle.adoc
@@ -3,7 +3,7 @@ title: Gradle
 page-title: How to configure Gradle for Vaadin projects
 description: Configuring the Vaadin Gradle plugin.
 meta-description: Learn how to set up and use Gradle for building and managing Vaadin applications.
-order: 131
+order: 130
 ---
 
 include::{articles}/_vaadin-version.adoc[]

--- a/articles/flow/configuration/source-control.adoc
+++ b/articles/flow/configuration/source-control.adoc
@@ -3,7 +3,7 @@ title: Source Control
 page-title: Using source control with Vaadin Flow
 description: Track and manage changes to the source code in a Vaadin project.
 meta-description: Explore source control configurations and best practices for managing Vaadin Flow projects.
-order: 130
+order: 131
 ---
 
 


### PR DESCRIPTION
Swaps pages so that Gradle docs are immediately after Maven on the navigation menu.


