### PR TITLE
Fix missing dot in Vaadin URL Mapping example

### DIFF
--- a/articles/flow/integrations/spring/configuration.adoc
+++ b/articles/flow/integrations/spring/configuration.adoc
@@ -206,8 +206,7 @@ FilterRegistrationBean<?> publicImagesAliasFilter(@Value("${vaadin.url-mapping}"
                         throws ServletException, IOException {
         // Remove Vaadin URL mapping from the path and forward the request
         String path = request.getRequestURI().substring(baseMapping.length());
-        request.getRequestDispatcher(path)
-          forward(request, response);
+        request.getRequestDispatcher(path).forward(request, response);
       }
     });
   registrationBean.addUrlPatterns(baseMapping + "/images/*");


### PR DESCRIPTION
The example code had missing dot, so some code wasn't resolved.