### PR TITLE
Add warning theme examples for Badges

### DIFF
--- a/articles/components/badge/index.adoc
+++ b/articles/components/badge/index.adoc
@@ -249,20 +249,24 @@ Recommended for informational messages.
 This style may be confused with a Button or link.
 
 |Success
-|`Success`
+|`success`
 |Highlight positive outcomes, such as when a task or operation is completed.
 
+|Warning
+|`warning`
+|Communicates caution or potential issues that require user attention.
+
 |Error
-|`Error`
-|Use the error theme variant to communicate alerts, failures, or warnings.
+|`error`
+|Use the error theme variant to communicate alerts and failures.
 
 |Contrast
-|`Contrast`
+|`contrast`
 |A high-contrast version that improves legibility and distinguishes the badge from the rest of the UI.
 Recommended for neutral badges (that don't communicate success or errors).
 
 |Primary
-|`Primary`
+|`primary`
 |Used for important information and/or to draw more attention to your badge.
 Can be combined with all other theme variants.
 

--- a/frontend/demo/component/badge/badge-basic.ts
+++ b/frontend/demo/component/badge/badge-basic.ts
@@ -19,6 +19,7 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <span theme="badge">Pending</span>
         <span theme="badge success">Confirmed</span>
+        <span theme="badge warning">Warning</span>
         <span theme="badge error">Denied</span>
         <span theme="badge contrast">On hold</span>
         <!-- end::snippet[] -->

--- a/frontend/demo/component/badge/badge-color.ts
+++ b/frontend/demo/component/badge/badge-color.ts
@@ -21,12 +21,14 @@ export class Example extends LitElement {
         <vaadin-horizontal-layout theme="spacing">
           <span theme="badge">Pending</span>
           <span theme="badge success">Confirmed</span>
+          <span theme="badge warning">Warning</span>
           <span theme="badge error">Denied</span>
           <span theme="badge contrast">On hold</span>
         </vaadin-horizontal-layout>
         <vaadin-horizontal-layout theme="spacing">
           <span theme="badge primary">Pending</span>
           <span theme="badge success primary">Confirmed</span>
+          <span theme="badge warning primary">Warning</span>
           <span theme="badge error primary">Denied</span>
           <span theme="badge contrast primary">On hold</span>
         </vaadin-horizontal-layout>

--- a/frontend/demo/component/badge/badge-icons.ts
+++ b/frontend/demo/component/badge/badge-icons.ts
@@ -29,6 +29,10 @@ export class Example extends LitElement {
             <vaadin-icon icon="vaadin:check" style="padding: var(--lumo-space-xs)"></vaadin-icon>
             <span>Confirmed</span>
           </span>
+          <span theme="badge warning">
+            <vaadin-icon icon="vaadin:warning" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+            <span>Warning</span>
+          </span>
           <span theme="badge error">
             <vaadin-icon
               icon="vaadin:exclamation-circle-o"
@@ -49,6 +53,10 @@ export class Example extends LitElement {
           <span theme="badge success">
             <span>Confirmed</span>
             <vaadin-icon icon="vaadin:check" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+          </span>
+          <span theme="badge warning">
+            <span>Warning</span>
+            <vaadin-icon icon="vaadin:warning" style="padding: var(--lumo-space-xs)"></vaadin-icon>
           </span>
           <span theme="badge error">
             <span>Denied</span>

--- a/frontend/demo/component/badge/badge-shape.ts
+++ b/frontend/demo/component/badge/badge-shape.ts
@@ -19,6 +19,7 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <span theme="badge pill">Pending</span>
         <span theme="badge success pill">Confirmed</span>
+        <span theme="badge warning pill">Warning</span>
         <span theme="badge error pill">Denied</span>
         <span theme="badge contrast pill">On hold</span>
         <!-- end::snippet[] -->

--- a/frontend/demo/component/badge/badge-size.ts
+++ b/frontend/demo/component/badge/badge-size.ts
@@ -19,6 +19,7 @@ export class Example extends LitElement {
         <!-- tag::snippet[] -->
         <span theme="badge small">Pending</span>
         <span theme="badge success small">Confirmed</span>
+        <span theme="badge warning small">Warning</span>
         <span theme="badge error small">Denied</span>
         <span theme="badge contrast small">On hold</span>
         <!-- end::snippet[] -->

--- a/frontend/demo/component/badge/react/badge-basic.tsx
+++ b/frontend/demo/component/badge/react/badge-basic.tsx
@@ -10,6 +10,7 @@ function Example() {
         can use the spread operator to pass the theme attribute to the span element. */}
       <span {...{ theme: 'badge' }}>Pending</span>
       <span {...{ theme: 'badge success' }}>Confirmed</span>
+      <span {...{ theme: 'badge warning' }}>Warning</span>
       <span {...{ theme: 'badge error' }}>Denied</span>
       <span {...{ theme: 'badge contrast' }}>On hold</span>
       {/* end::snippet[] */}

--- a/frontend/demo/component/badge/react/badge-color.tsx
+++ b/frontend/demo/component/badge/react/badge-color.tsx
@@ -9,12 +9,14 @@ function Example() {
       <HorizontalLayout theme="spacing">
         <span {...{ theme: 'badge ' }}>Pending</span>
         <span {...{ theme: 'badge success ' }}>Confirmed</span>
+        <span {...{ theme: 'badge warning ' }}>Warning</span>
         <span {...{ theme: 'badge error ' }}>Denied</span>
         <span {...{ theme: 'badge contrast ' }}>On hold</span>
       </HorizontalLayout>
       <HorizontalLayout theme="spacing">
         <span {...{ theme: 'badge primary ' }}>Pending</span>
         <span {...{ theme: 'badge success primary ' }}>Confirmed</span>
+        <span {...{ theme: 'badge warning primary ' }}>Warning</span>
         <span {...{ theme: 'badge error primary ' }}>Denied</span>
         <span {...{ theme: 'badge contrast primary ' }}>On hold</span>
       </HorizontalLayout>

--- a/frontend/demo/component/badge/react/badge-icons.tsx
+++ b/frontend/demo/component/badge/react/badge-icons.tsx
@@ -16,6 +16,10 @@ function Example() {
           <Icon icon="vaadin:check" style={{ padding: 'var(--lumo-space-xs)' }} />
           <span>Confirmed</span>
         </span>
+        <span {...{ theme: 'badge warning' }}>
+          <Icon icon="vaadin:warning" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <span>Warning</span>
+        </span>
         <span {...{ theme: 'badge error' }}>
           <Icon icon="vaadin:exclamation-circle-o" style={{ padding: 'var(--lumo-space-xs)' }} />
           <span>Denied</span>
@@ -33,6 +37,10 @@ function Example() {
         <span {...{ theme: 'badge success' }}>
           <span>Confirmed</span>
           <Icon icon="vaadin:check" style={{ padding: 'var(--lumo-space-xs)' }} />
+        </span>
+        <span {...{ theme: 'badge warning' }}>
+          <span>Warning</span>
+          <Icon icon="vaadin:warning" style={{ padding: 'var(--lumo-space-xs)' }} />
         </span>
         <span {...{ theme: 'badge error' }}>
           <span>Denied</span>

--- a/frontend/demo/component/badge/react/badge-shape.tsx
+++ b/frontend/demo/component/badge/react/badge-shape.tsx
@@ -8,6 +8,7 @@ function Example() {
       {/* tag::snippet[] */}
       <span {...{ theme: 'badge pill' }}>Pending</span>
       <span {...{ theme: 'badge success pill' }}>Confirmed</span>
+      <span {...{ theme: 'badge warning pill' }}>Warning</span>
       <span {...{ theme: 'badge error pill' }}>Denied</span>
       <span {...{ theme: 'badge contrast pill' }}>On hold</span>
       {/* end::snippet[] */}

--- a/frontend/demo/component/badge/react/badge-size.tsx
+++ b/frontend/demo/component/badge/react/badge-size.tsx
@@ -8,6 +8,7 @@ function Example() {
       {/* tag::snippet[] */}
       <span {...{ theme: 'badge small' }}>Pending</span>
       <span {...{ theme: 'badge success small' }}>Confirmed</span>
+      <span {...{ theme: 'badge warning small' }}>Warning</span>
       <span {...{ theme: 'badge error small' }}>Denied</span>
       <span {...{ theme: 'badge contrast small' }}>On hold</span>
       {/* end::snippet[] */}

--- a/src/main/java/com/vaadin/demo/component/badge/BadgeBasic.java
+++ b/src/main/java/com/vaadin/demo/component/badge/BadgeBasic.java
@@ -16,6 +16,9 @@ public class BadgeBasic extends HorizontalLayout {
         Span confirmed = new Span("Confirmed");
         confirmed.getElement().getThemeList().add("badge success");
 
+        Span warning = new Span("Warning");
+        warning.getElement().getThemeList().add("badge warning");
+
         Span denied = new Span("Denied");
         denied.getElement().getThemeList().add("badge error");
 
@@ -23,7 +26,7 @@ public class BadgeBasic extends HorizontalLayout {
         onHold.getElement().getThemeList().add("badge contrast");
         // end::snippet[]
 
-        add(pending, confirmed, denied, onHold);
+        add(pending, confirmed, warning, denied, onHold);
     }
 
     public static class Exporter extends DemoExporter<BadgeBasic> { // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/badge/BadgeColor.java
+++ b/src/main/java/com/vaadin/demo/component/badge/BadgeColor.java
@@ -19,6 +19,9 @@ public class BadgeColor extends VerticalLayout {
         Span confirmed = new Span("Confirmed");
         confirmed.getElement().getThemeList().add("badge success");
 
+        Span warning = new Span("Warning");
+        warning.getElement().getThemeList().add("badge warning");
+
         Span denied = new Span("Denied");
         denied.getElement().getThemeList().add("badge error");
 
@@ -35,14 +38,17 @@ public class BadgeColor extends VerticalLayout {
         confirmedPrimary.getElement().getThemeList()
                 .add("badge success primary");
 
+        Span warningPrimary = new Span("Warning");
+        warningPrimary.getElement().getThemeList().add("badge warning primary");
+
         Span deniedPrimary = new Span("Denied");
         deniedPrimary.getElement().getThemeList().add("badge error primary");
 
         Span onHoldPrimary = new Span("On hold");
         onHoldPrimary.getElement().getThemeList().add("badge contrast primary");
 
-        add(new HorizontalLayout(pending, confirmed, denied, onHold),
-                new HorizontalLayout(pendingPrimary, confirmedPrimary,
+        add(new HorizontalLayout(pending, confirmed, warning, denied, onHold),
+                new HorizontalLayout(pendingPrimary, confirmedPrimary, warningPrimary,
                         deniedPrimary, onHoldPrimary));
         setPadding(false);
         setSizeUndefined();

--- a/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java
+++ b/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java
@@ -23,6 +23,10 @@ public class BadgeIcons extends VerticalLayout {
                 new Span("Confirmed"));
         confirmed1.getElement().getThemeList().add("badge success");
 
+        Span warning1 = new Span(createIcon(VaadinIcon.WARNING),
+                new Span("Warning"));
+        warning1.getElement().getThemeList().add("badge warning");
+
         Span denied1 = new Span(createIcon(VaadinIcon.EXCLAMATION_CIRCLE_O),
                 new Span("Denied"));
         denied1.getElement().getThemeList().add("badge error");
@@ -42,6 +46,10 @@ public class BadgeIcons extends VerticalLayout {
                 createIcon(VaadinIcon.CHECK));
         confirmed2.getElement().getThemeList().add("badge success");
 
+        Span warning2 = new Span( new Span("Warning"),
+                createIcon(VaadinIcon.WARNING));
+        warning2.getElement().getThemeList().add("badge warning");
+
         Span denied2 = new Span(new Span("Denied"),
                 createIcon(VaadinIcon.EXCLAMATION_CIRCLE_O));
         denied2.getElement().getThemeList().add("badge error");
@@ -50,8 +58,8 @@ public class BadgeIcons extends VerticalLayout {
                 createIcon(VaadinIcon.HAND));
         onHold2.getElement().getThemeList().add("badge contrast");
 
-        add(new HorizontalLayout(pending1, confirmed1, denied1, onHold1),
-                new HorizontalLayout(pending2, confirmed2, denied2, onHold2));
+        add(new HorizontalLayout(pending1, confirmed1, warning1, denied1, onHold1),
+                new HorizontalLayout(pending2, confirmed2, warning2, denied2, onHold2));
         setPadding(false);
         setSizeUndefined();
     }

--- a/src/main/java/com/vaadin/demo/component/badge/BadgeShape.java
+++ b/src/main/java/com/vaadin/demo/component/badge/BadgeShape.java
@@ -16,6 +16,9 @@ public class BadgeShape extends HorizontalLayout {
         Span confirmed = new Span("Confirmed");
         confirmed.getElement().getThemeList().add("badge success pill");
 
+        Span warning = new Span("Warning");
+        warning.getElement().getThemeList().add("badge warning pill");
+
         Span denied = new Span("Denied");
         denied.getElement().getThemeList().add("badge error pill");
 
@@ -23,7 +26,7 @@ public class BadgeShape extends HorizontalLayout {
         onHold.getElement().getThemeList().add("badge contrast pill");
         // end::snippet[]
 
-        add(pending, confirmed, denied, onHold);
+        add(pending, confirmed, warning, denied, onHold);
     }
 
     public static class Exporter extends DemoExporter<BadgeShape> { // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/badge/BadgeSize.java
+++ b/src/main/java/com/vaadin/demo/component/badge/BadgeSize.java
@@ -16,6 +16,9 @@ public class BadgeSize extends HorizontalLayout {
         Span confirmed = new Span("Confirmed");
         confirmed.getElement().getThemeList().add("badge success small");
 
+        Span warning = new Span("Warning");
+        warning.getElement().getThemeList().add("badge warning small");
+
         Span denied = new Span("Denied");
         denied.getElement().getThemeList().add("badge error small");
 
@@ -23,7 +26,7 @@ public class BadgeSize extends HorizontalLayout {
         onHold.getElement().getThemeList().add("badge contrast small");
         // end::snippet[]
 
-        add(pending, confirmed, denied, onHold);
+        add(pending, confirmed, warning, denied, onHold);
     }
 
     public static class Exporter extends DemoExporter<BadgeSize> { // hidden-source-line


### PR DESCRIPTION

<img width="708" height="362" alt="image" src="https://github.com/user-attachments/assets/056dce16-390f-4d7c-8c61-ef41b05de725" />


Solves:
#3898

* Added "warning" theme examples where all other theme examples were shown,
* Added description for warning theme in the table under the Color section.
* Adjusted theme names in "Color" table to start with lowercase.