### PR TITLE
docs: new styling docs / stylesheets

### DIFF
--- a/articles/styling/stylesheets.adoc
+++ b/articles/styling/stylesheets.adoc
@@ -68,8 +68,8 @@ public class CalendarView extends VerticalLayout {
 }
 ----
 
-// TODO: Link "CSS classnames" to where?
-Note that the stylesheet will remain loaded even after the user navigates away from the view, or when the component is no longer displayed, so you still need to ensure that the styles in it are scoped appropriately. You can use CSS classnames to scope styles to a particular view or other part of the UI.
+// TODO: Link "CSS class names" to where?
+Note that the stylesheet will remain loaded even after the user navigates away from the view, or when the component is no longer displayed, so you still need to ensure that the styles in it are scoped appropriately. You can use CSS class names to scope styles to a particular view or other part of the UI.
 
 [source,java]
 ----


### PR DESCRIPTION
Adds the Stylesheets article for the new styling docs.

> [!NOTE]
> The PR targets a base branch for the new styling docs. That branch has the old styling docs removed and new articles are added gradually until the new section is ready. Cross-references between new articles will be filled in later, respective sections have been marked with TODOs.