### PR TITLE
docs: new styling docs / styling elements

### DIFF
--- a/articles/styling/styling-elements.adoc
+++ b/articles/styling/styling-elements.adoc
@@ -10,7 +10,7 @@ order: 40
 = Styling HTML Elements
 
 // TODO: Link "utility classes" to article
-Native HTML elements, like `<div>` and `<span>`, can be styled the way you would normally style HTML: with CSS and utility classes. CSS classnames are typically used to target specific instances of HTML elements.
+Native HTML elements, like `<div>` and `<span>`, can be styled the way you would normally style HTML: with CSS and utility classes. CSS class names are typically used to target specific instances of HTML elements.
 
 [.example]
 --
@@ -26,6 +26,7 @@ warningBox.addClassNames("warning-message");
 <source-info group="React"></source-info>
 <div className="warning-message">Warning!</div>
 ----
+
 --
 
 [source,css]
@@ -52,6 +53,7 @@ warningBox.addClassNames("bg-orange-400 p-20");
 <source-info group="React"></source-info>
 <div className="bg-orange-400 p-20">Warning!</div>
 ----
+
 --
 
 <<{articles}/styling#inline-styles,Inline styles>> can also be applied to individual elements and components.
@@ -70,6 +72,7 @@ warningBox.getStyles().setBackground("#ff8904");
 <source-info group="React"></source-info>
 <div style={{ backgroundColor: '#ff8904' }}>Warning!</div>
 ----
+
 --
 
 <<{articles}/styling/styling-components#theme-style-properties,Theme style properties>> can be used to apply theme styles to any HTML element:


### PR DESCRIPTION
Adds the "Styling HTML Elements" article for the new styling docs.

> [!NOTE]
> The PR targets a base branch for the new styling docs. That branch has the old styling docs removed and new articles are added gradually until the new section is ready. Cross-references between new articles will be filled in later, respective sections have been marked with TODOs.