### PR TITLE
docs: new styling docs / utility classes

### DIFF
--- a/articles/styling/utility-classes.adoc
+++ b/articles/styling/utility-classes.adoc
@@ -9,7 +9,7 @@ order: 50
 
 = Utility Classes
 
-CSS utility classes are pre-built CSS classes that can be used to style native HTML elements and layouts by applying CSS classnames to them.
+CSS utility classes are pre-built CSS classes that can be used to style native HTML elements and layouts by applying CSS class names to them.
 
 // TODO: Link Lumo "utility classes" to reference article
 Vaadin supports link:https://tailwindcss.com/[Tailwind CSS], and the Lumo theme has its own set of utility classes. These two collections are mutually exclusive and cannot be used simultaneously.
@@ -30,24 +30,25 @@ warningBox.addClassNames("bg-orange-400 p-20");
 <source-info group="React"></source-info>
 <div className="bg-orange-400 p-20">Warning!</div>
 ----
+
 --
 
-Using a large number of utility classes can lead to code that is hard to comprehend, as such they are best used sparingly. If you find yourself applying the same set of utility classes to many elements, consider creating your own CSS class in a stylesheet instead, or creating a reusable component that encapsulates the application of those classnames.
+Using a large number of utility classes can lead to code that is hard to comprehend, as such they are best used sparingly. If you find yourself applying the same set of utility classes to many elements, consider creating your own CSS class in a stylesheet instead, or creating a reusable component that encapsulates the application of those class names.
 
 
 [role="since:com.vaadin:vaadin@V25.0"]
 == Tailwind CSS (experimental)
 
-Tailwind CSS is a popular CSS utility class framework that Vaadin 25.0 has experimental built-in support for.
+Tailwind CSS is a popular CSS utility class framework that Vaadin has experimental built-in support for.
 
-To enable Tailwind, enable the `com.vaadin.experimental.tailwindCss` feature flag by adding the following line to `src/main/resources/vaadin-featureflags.properties`:
+To enable Tailwind, enable the `com.vaadin.experimental.tailwindCss` <<{articles}/flow/configuration/feature-flags#,feature flag>> by adding the following line to `src/main/resources/vaadin-featureflags.properties`:
 
 [source,properties]
 ----
 com.vaadin.experimental.tailwindCss=true
 ----
 
-Tailwind classes are applied to UI elements like any other CSS classname:
+Tailwind classes are applied to UI elements like any other CSS class name:
 
 [.example]
 --
@@ -63,11 +64,12 @@ warningBox.addClassNames("bg-orange-400 p-20");
 <source-info group="React"></source-info>
 <div className="bg-orange-400 p-20">Warning!</div>
 ----
+
 --
 
 A complete list of Tailwind utility classes is available in the link:https://tailwindcss.com/[Tailwind CSS documentation].
 
-When enabled, the Vaadin build process feeds all source files through the Tailwind compiler that collects all Tailwind classnames used in them and compiles a static stylesheet that contains CSS only for the identified classnames.
+When enabled, the Vaadin build process feeds all source files through the Tailwind compiler that collects all Tailwind class names used in them and compiles a static stylesheet that contains CSS only for the identified class names.
 
 == Lumo Utility Classes
 
@@ -98,7 +100,7 @@ public class Application implements AppShellConfigurator {
 [NOTE]
 In Vaadin 25, it is no longer possible to load the Lumo Utility Classes through the `theme.json` configuration file in your theme folder. Use the approach documented above instead.
 
-The [classname]`LumoUtility` class provides all included classnames as constants for easy usage in Flow.
+The [classname]`LumoUtility` class provides all included class names as constants for easy usage in Flow.
 
 [source,java]
 ----


### PR DESCRIPTION
Adds the "Utility Classes" article for the new styling docs.

> [!NOTE]
> The PR targets a base branch for the new styling docs. That branch has the old styling docs removed and new articles are added gradually until the new section is ready. Cross-references between new articles will be filled in later, respective sections have been marked with TODOs.