### PR TITLE
docs: new styling docs / advanced / dynamic stylesheets

### DIFF
--- a/articles/styling/advanced/dynamic-stylesheets.adoc
+++ b/articles/styling/advanced/dynamic-stylesheets.adoc
@@ -22,7 +22,7 @@ UI.getCurrent().getPage().addStyleSheet("dynamic-styles.css");
 UI.getCurrent().getPage().addStyleSheet("https://example.com/styles.css");
 ----
 
-Note that files loaded this way are applied to the entire UI in the current session, and remain applied until the end of the session.
+Files loaded this way are applied to the entire UI in the current session, and remain applied until the end of the session.
 
 Dynamic stylesheets can be removed using the [classname]`Registration` instance returned by the `addStyleSheet` method.
 


### PR DESCRIPTION
Adds the "Advanced / Loading Stylesheets Dynamically" article for the new styling docs.

This is mostly adapted from the existing article, with additional content on how to remove dynamically added stylesheets.

> [!NOTE]
> The PR targets a base branch for the new styling docs. That branch has the old styling docs removed and new articles are added gradually until the new section is ready. Cross-references between new articles will be filled in later, respective sections have been marked with TODOs.