### PR TITLE
docs: new styling docs / advanced / embedded components

### DIFF
--- a/articles/styling/advanced/embedded-components.adoc
+++ b/articles/styling/advanced/embedded-components.adoc
@@ -47,4 +47,4 @@ The Lumo or Aura theme can be applied to the component by using an `@import` rul
 * *Aura*: `@vaadin/aura/aura.css`
 * *Lumo*: `@vaadin/vaadin-lumo-styles/lumo.css`
 
-If the embedded component is also used as a normal Flow component in a Flow application, it is recommended to load all styles for the application with [classname]`@CssImport` (from the `src/main/frontend folder`) instead of the usual way with [classname]`@StyleSheet`, in order to avoid conflicts and duplication between styles loaded by the component and the application.
+If the embedded component is also used as a normal Flow component in a Flow application, it is recommended to load all styles for the application with [annotationname]`@CssImport` (from the [filename]`src/main/frontend/` folder) instead of the usual way with [annotationname]`@StyleSheet`, in order to avoid conflicts and duplication between styles loaded by the component and the application.


### PR DESCRIPTION
Adds the "Advanced / Styling Embedded Components" article for the new styling docs.

> [!NOTE]
> The PR targets a base branch for the new styling docs. That branch has the old styling docs removed and new articles are added gradually until the new section is ready. Cross-references between new articles will be filled in later, respective sections have been marked with TODOs.