### PR TITLE
docs: new styling docs / advanced / npm assets

### DIFF
--- a/articles/styling/advanced/npm-assets.adoc
+++ b/articles/styling/advanced/npm-assets.adoc
@@ -26,7 +26,7 @@ Once you have added an npm package dependency, you can import resources from tha
 [#styles-from-npm]
 == Importing Stylesheets from npm Packages
 
-Use the [annotation]`@CssImport` annotation to import stylesheets from an npm package. For example, to load `all.min.css` from `@fortawesome/fontawesome-free`:
+Use the [annotationname]`@CssImport` annotation to import stylesheets from an npm package. For example, to load `all.min.css` from `@fortawesome/fontawesome-free`:
 
 .Importing a stylesheet from an npm package
 [source,java]


### PR DESCRIPTION
Adds the "Importing Resources from npm Packages" article for the new styling docs.

This is an exact copy of the existing article. It still recommends using `@CssImport` for loading stylesheets due to https://github.com/vaadin/flow/issues/22713.

> [!NOTE]
> The PR targets a base branch for the new styling docs. That branch has the old styling docs removed and new articles are added gradually until the new section is ready. Cross-references between new articles will be filled in later, respective sections have been marked with TODOs.