### PR TITLE
docs: add cellreference constructor change to upgrade guide

### DIFF
--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -481,6 +481,12 @@ vaadin-split-layout > * {
 
 The `SplitterDragendEvent` and `addSplitterDragendListener` have been renamed to `SplitterDragEndEvent` and `addSplitterDragEndListener`, respectively.
 
+=== Spreadsheet
+The events [classname]`CellValueChangeEvent`, [classname]`FormulaValueChangeEvent`, and [classname]`SelectionChangeEvent` in Spreadsheet provide a set of cells. Calling [methodname]`contains` on these sets now requires the [classname]`CellReference` argument to have a non-null sheet name, otherwise an [classname]`IllegalArgumentException` will be thrown. In order to achieve this, use one of the following constructors:
+
+* `CellReference(Cell)`
+* `CellReference(String, int, int, boolean, boolean)`
+
 === Tabs / Tab Sheet
 The [classname]`TabsVariant.LUMO_ICON_ON_TOP` and [classname]`TabSheetVariant.LUMO_ICON_ON_TOP` theme variants have been removed. Apply the [classname]`TabVariant.LUMO_ICON_ON_TOP` to individual tabs instead.
 


### PR DESCRIPTION
This PR updates the upgrade guide so that it mentions the [Spreadsheet CellReference breaking change](https://github.com/vaadin/flow-components/pull/4634). 