### PR TITLE
docs: mention removal of classNameGenerator API in Grid

### DIFF
--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -417,6 +417,10 @@ Use the following CSS properties on `vaadin-form-layout` instead:
 * `--vaadin-form-layout-label-spacing`
 * `--vaadin-form-layout-row-spacing`
 
+=== Grid
+
+The deprecated methods [methodname]`setClassNameGenerator` and [methodname]`getClassNameGenerator` have been removed from both the `Grid` and `Grid.Column` classes. Similarly, the `cellClassNameGenerator` property has been removed from the `vaadin-grid` and `vaadin-grid-column` elements. Instead, use the [methodname]`setPartNameGenerator` method and the [propertyname]`cellPartNameGenerator` property, respectively.
+
 === Map
 The Map component’s `borderless` / `BORDERLESS` style variant has been renamed `no-border` / `NO_BORDER` for consistency with other components.
 


### PR DESCRIPTION
Follow-up to 

- https://github.com/vaadin/flow-components/pull/8259
- https://github.com/vaadin/web-components/pull/10502