### PR TITLE
v23: add team trial banner card to docs home

### DIFF
--- a/articles/index.asciidoc
+++ b/articles/index.asciidoc
@@ -33,6 +33,16 @@ banner-style: important
 image:_images/code-editor-illustration.svg["", opts=inline]
 --
 
+[.cards.quiet.large.callout.hide-title]
+== Request a Team Trial
+
+[.card.large]
+=== Evaluate Vaadin the right way—with your team
+
+Apply for the Team Trial and get expert-led guidance before you start building together.
+
+link:https://pages.vaadin.com/request-a-team-trial[Apply For a Free Consultation, role="button-link"]
+
 [.cards.quiet.large.components]
 == image:_images/components.svg["", opts=inline, role=icon, width=48] Components
 
@@ -269,6 +279,26 @@ nav[aria-label=breadcrumb] {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.callout .card {
+  background-color: var(--blue-50);
+}
+
+html[theme~=dark] .callout .card {
+  color: #FFF;
+  background-color: var(--blue-500);
+  border: none;
+}
+
+html[theme~=dark] .callout .card a:hover::before {
+  border: 1px solid white;
+  box-shadow: none;
+}
+    
+html[theme~=dark] .callout .card .button-link {
+  color: white;
+  text-decoration: underline;
 }
 </style>
 ++++


### PR DESCRIPTION
Adds a banner to the v23 docs homepage leading users to a landing page, where they can request a team trial.

<img width="720" height="625" alt="image" src="https://github.com/user-attachments/assets/b518eb10-9b36-41a3-96b8-8c2a046be076" />
<img width="720" height="647" alt="image" src="https://github.com/user-attachments/assets/4387c4ed-7196-4a9a-af10-6458b2e382c5" />
