### PR TITLE
v25: add team trial banner card to docs home

### DIFF
--- a/articles/index.adoc
+++ b/articles/index.adoc
@@ -49,6 +49,17 @@ Prefer to learn by watching? The free Vaadin training videos cover the basics of
 link:/learn/training[Start video course]
 
 
+[.cards.quiet.large.callout.hide-title]
+== Request a Team Trial
+
+[.card.large]
+=== Evaluate Vaadin the right way—with your team
+
+Apply for the Team Trial and get expert-led guidance before you start building together.
+
+link:https://pages.vaadin.com/request-a-team-trial[Apply For a Free Consultation, role="button-link"]
+
+
 [.cards.quiet.large.components]
 == Components
 
@@ -202,6 +213,26 @@ nav[aria-label=breadcrumb] {
 
 .components.cards .card .imageblock.icon {
   aspect-ratio: 111 / 80;
+}
+
+.callout .card {
+  background-color: var(--blue-50);
+}
+
+html[theme~=dark] .callout .card {
+  color: #FFF;
+  background-color: var(--blue-500);
+  border: none;
+}
+
+html[theme~=dark] .callout .card a:hover::before {
+  border: 1px solid white;
+  box-shadow: none;
+}
+    
+html[theme~=dark] .callout .card .button-link {
+  color: white;
+  text-decoration: underline;
 }
 </style>
 ++++


### PR DESCRIPTION
Adds a banner to the docs homepage leading users to a landing page, where they can request a team trial.

<img width="720" height="625" alt="image" src="https://github.com/user-attachments/assets/9437ab50-f663-4198-b06a-7b0982119b34" />


<img width="720" height="647" alt="image" src="https://github.com/user-attachments/assets/a984da9e-877a-4509-8f5d-e869c4699e5a" />
