### PR TITLE
docs: remove no longer relevant overlay class name

### DIFF
--- a/articles/components/select/index.adoc
+++ b/articles/components/select/index.adoc
@@ -173,29 +173,6 @@ include::{root}/frontend/demo/component/select/react/select-overlay-width.tsx[re
 endif::[]
 --
 
-=== Overlay Class Name
-
-Like other field components with overlays, Select provides dedicated API to set a CSS class name on the overlay for styling. See <<{articles}/styling/styling-components/styling-component-instances#,Styling Component Instances>> for more information.
-
-[.example]
---
-[source,java]
-----
-<source-info group="Flow"></source-info>
-Select<String> select = new Select<>();
-select.setOverlayClassName("locales");
-----
-[source,tsx]
-----
-<source-info group="React"></source-info>
-<Select overlayClass="locales" />
-----
-[source,html]
-----
-<source-info group="Lit"></source-info>
-<vaadin-select overlay-class="locales"></vaadin-select>
-----
---
 
 
 // Basic Features


### PR DESCRIPTION
We have removed `setOverlayClassName()` API in V25, so let's drop it from the docs.