### PR TITLE
docs: replace Lumo utility in app-layout examples

### DIFF
--- a/frontend/demo/component/app-layout/app-layout-basic.ts
+++ b/frontend/demo/component/app-layout/app-layout-basic.ts
@@ -35,7 +35,7 @@ export class Example extends LitElement {
       <vaadin-app-layout>
         <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
         <h1 slot="navbar">MyApp</h1>
-        <vaadin-scroller slot="drawer" class="p-s">
+        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
           <vaadin-side-nav>
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>

--- a/frontend/demo/component/app-layout/app-layout-drawer.ts
+++ b/frontend/demo/component/app-layout/app-layout-drawer.ts
@@ -35,7 +35,7 @@ export class Example extends LitElement {
       <vaadin-app-layout primary-section="drawer">
         <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
         <h1 slot="navbar">Dashboard</h1>
-        <vaadin-scroller slot="drawer" class="p-s">
+        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
           <vaadin-side-nav>
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
@@ -35,7 +35,7 @@ export class Example extends LitElement {
       <vaadin-app-layout primary-section="drawer">
         <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
         <h1 slot="navbar">Dashboard</h1>
-        <vaadin-scroller slot="drawer" class="p-s">
+        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
           <vaadin-side-nav>
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
@@ -35,7 +35,7 @@ export class Example extends LitElement {
       <vaadin-app-layout>
         <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
         <h1 slot="navbar">MyApp</h1>
-        <vaadin-scroller slot="drawer" class="p-s">
+        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
           <vaadin-side-nav>
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>

--- a/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
+++ b/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
@@ -44,7 +44,7 @@ export class Example extends LitElement {
       <!-- tag::snippet[] -->
       <vaadin-app-layout primary-section="drawer">
         <h1 slot="drawer">MyApp</h1>
-        <vaadin-scroller slot="drawer" class="p-s">
+        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
           <vaadin-side-nav>
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>

--- a/frontend/demo/component/app-layout/react/app-layout-basic.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-basic.tsx
@@ -34,7 +34,7 @@ function Example() {
       <h1 slot="navbar" style={h1Style}>
         MyApp
       </h1>
-      <Scroller slot="drawer" className="p-s">
+      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
         <SideNav ref={sideNavRef}>
           <SideNavItem path="/dashboard">
             <Icon icon="vaadin:dashboard" slot="prefix" />

--- a/frontend/demo/component/app-layout/react/app-layout-drawer.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-drawer.tsx
@@ -35,7 +35,7 @@ function Example() {
         Dashboard
       </h1>
 
-      <Scroller slot="drawer" className="p-s">
+      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
         <SideNav ref={sideNavRef}>
           <SideNavItem path="/dashboard">
             <Icon icon="vaadin:dashboard" slot="prefix" />

--- a/frontend/demo/component/app-layout/react/app-layout-navbar-placement-side.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-navbar-placement-side.tsx
@@ -36,7 +36,7 @@ function Example() {
         Dashboard
       </h1>
 
-      <Scroller slot="drawer" className="p-s">
+      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
         <SideNav ref={sideNavRef}>
           <SideNavItem path="/dashboard">
             <Icon icon="vaadin:dashboard" slot="prefix" />

--- a/frontend/demo/component/app-layout/react/app-layout-navbar-placement.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-navbar-placement.tsx
@@ -35,7 +35,7 @@ function Example() {
         MyApp
       </h1>
 
-      <Scroller slot="drawer" className="p-s">
+      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
         <SideNav ref={sideNavRef}>
           <SideNavItem path="/dashboard">
             <Icon icon="vaadin:dashboard" slot="prefix" />

--- a/frontend/demo/component/app-layout/react/app-layout-secondary-navigation.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-secondary-navigation.tsx
@@ -50,7 +50,7 @@ function Example() {
       <h1 style={h1Style} slot="drawer">
         MyApp
       </h1>
-      <Scroller slot="drawer" className="p-s">
+      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
         <SideNav ref={sideNavRef}>
           <SideNavItem>
             <Icon icon="vaadin:dashboard" slot="prefix" />

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java
@@ -8,7 +8,6 @@ import com.vaadin.flow.component.orderedlayout.Scroller;
 import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.lumo.LumoUtility;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
 @Route("app-layout-basic")
@@ -25,7 +24,7 @@ public class AppLayoutBasic extends AppLayout {
         nav.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
 
         Scroller scroller = new Scroller(nav);
-        scroller.setClassName(LumoUtility.Padding.SMALL);
+        scroller.getStyle().set("padding", "0.5rem");
 
         addToDrawer(scroller);
         addToNavbar(toggle, title);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java
@@ -9,7 +9,6 @@ import com.vaadin.flow.component.orderedlayout.Scroller;
 import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.lumo.LumoUtility;
 
 @Route("app-layout-drawer")
 // tag::snippet[]
@@ -25,7 +24,7 @@ public class AppLayoutDrawer extends AppLayout {
         nav.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
 
         Scroller scroller = new Scroller(nav);
-        scroller.setClassName(LumoUtility.Padding.SMALL);
+        scroller.getStyle().set("padding", "0.5rem");
 
         addToDrawer(scroller);
         addToNavbar(toggle, title);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
@@ -9,7 +9,6 @@ import com.vaadin.flow.component.orderedlayout.Scroller;
 import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.lumo.LumoUtility;
 
 @Route("app-layout-navbar-placement")
 // tag::snippet[]
@@ -25,7 +24,7 @@ public class AppLayoutNavbarPlacement extends AppLayout {
         nav.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
 
         Scroller scroller = new Scroller(nav);
-        scroller.setClassName(LumoUtility.Padding.SMALL);
+        scroller.getStyle().set("padding", "0.5rem");
 
         addToDrawer(scroller);
         addToNavbar(toggle, title);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java
@@ -9,7 +9,6 @@ import com.vaadin.flow.component.orderedlayout.Scroller;
 import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.lumo.LumoUtility;
 
 @Route("app-layout-navbar-placement-side")
 // tag::snippet[]
@@ -25,7 +24,7 @@ public class AppLayoutNavbarPlacementSide extends AppLayout {
         nav.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
 
         Scroller scroller = new Scroller(nav);
-        scroller.setClassName(LumoUtility.Padding.SMALL);
+        scroller.getStyle().set("padding", "0.5rem");
 
         addToDrawer(scroller);
         addToNavbar(toggle, title);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
@@ -14,7 +14,6 @@ import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavItem;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
-import com.vaadin.flow.theme.lumo.LumoUtility;
 
 @Route("app-layout-secondary-navigation")
 // tag::snippet[]
@@ -30,7 +29,7 @@ public class AppLayoutSecondaryNavigation extends AppLayout {
         views.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
 
         Scroller scroller = new Scroller(views);
-        scroller.setClassName(LumoUtility.Padding.SMALL);
+        scroller.getStyle().set("padding", "0.5rem");
 
         DrawerToggle toggle = new DrawerToggle();
 


### PR DESCRIPTION
Part of https://github.com/vaadin/docs/issues/4801

Replaced usage of `p-s` class name in app-layout examples with inline styles.