### PR TITLE
chore: clarify execution order for vaadin-maven-plugin

### DIFF
--- a/articles/flow/production/production-build.adoc
+++ b/articles/flow/production/production-build.adoc
@@ -114,7 +114,7 @@ Having the production build as a separate Maven profile is recommended to avoid 
 
 .Caution when defining `vaadin-maven-plugin`
 [WARNING]
-To ensure that the production build packages all resources correctly, make sure the `vaadin-maven-plugin` is executed after the `maven-compiler-plugin`. This can be achieved either configuring the execution goal of `vaadin-maven-plugin` to run after the goal targeted by `maven-compiler-plugin`, or if both target the same goal, placing the `vaadin-maven-plugin` definition after the `maven-compiler-plugin` in your `pom.xml`. The same applies for `kotlin-maven-plugin` or any other plugin that produces Vaadin related Java classes.
+To ensure that the production build packages all resources correctly, make sure the `vaadin-maven-plugin` is executed after the `maven-compiler-plugin`. This can be achieved either configuring the execution of `vaadin-maven-plugin` goal to run after the phase targeted by `maven-compiler-plugin`, or if both target the same phase, placing the `vaadin-maven-plugin` definition after the `maven-compiler-plugin` in your `pom.xml`. The same applies for `kotlin-maven-plugin` or any other plugin that produces Vaadin related Java classes.
 
 
 .Building for 64-bit


### PR DESCRIPTION
Plugins are composed by `goals`  bound to `phases`. Using `phase` term to indicate the goal execution order should be clearer.


