### PR TITLE
docs: replace Lumo utility in form-layout examples

### DIFF
--- a/frontend/demo/component/formlayout/form-layout-basic.ts
+++ b/frontend/demo/component/formlayout/form-layout-basic.ts
@@ -29,7 +29,7 @@ export class Example extends LitElement {
   private renderFormLayout() {
     // tag::snippet[]
     return html`
-      <vaadin-form-layout class="w-full" auto-responsive>
+      <vaadin-form-layout style="width: 100%" auto-responsive>
         <vaadin-form-row>
           <vaadin-text-field label="First name"></vaadin-text-field>
           <vaadin-text-field label="Last name"></vaadin-text-field>

--- a/frontend/demo/component/formlayout/form-layout-colspan.ts
+++ b/frontend/demo/component/formlayout/form-layout-colspan.ts
@@ -26,7 +26,7 @@ export class Example extends LitElement {
   private renderFormLayout() {
     // tag::snippet[]
     return html`
-      <vaadin-form-layout class="w-full" auto-responsive column-width="8em" expand-fields>
+      <vaadin-form-layout style="width: 100%" auto-responsive column-width="8em" expand-fields>
         <vaadin-form-row>
           <vaadin-text-field label="Street address" data-colspan="3"></vaadin-text-field>
         </vaadin-form-row>

--- a/frontend/demo/component/formlayout/form-layout-expand-columns.ts
+++ b/frontend/demo/component/formlayout/form-layout-expand-columns.ts
@@ -29,7 +29,7 @@ export class Example extends LitElement {
   private renderFormLayout() {
     // tag::snippet[]
     return html`
-      <vaadin-form-layout class="w-full" auto-responsive column-width="8em" expand-columns>
+      <vaadin-form-layout style="width: 100%" auto-responsive column-width="8em" expand-columns>
         <vaadin-form-row>
           <vaadin-text-field label="First name"></vaadin-text-field>
           <vaadin-text-field label="Last name"></vaadin-text-field>

--- a/frontend/demo/component/formlayout/form-layout-expand-fields.ts
+++ b/frontend/demo/component/formlayout/form-layout-expand-fields.ts
@@ -30,7 +30,7 @@ export class Example extends LitElement {
     // tag::snippet[]
     return html`
       <vaadin-form-layout
-        class="w-full"
+        style="width: 100%"
         auto-responsive
         column-width="8em"
         expand-columns

--- a/frontend/demo/component/formlayout/form-layout-labels-aside.ts
+++ b/frontend/demo/component/formlayout/form-layout-labels-aside.ts
@@ -28,7 +28,7 @@ export class Example extends LitElement {
   private renderFormLayout() {
     // tag::snippet[]
     return html`
-      <vaadin-form-layout class="w-full" auto-responsive labels-aside>
+      <vaadin-form-layout style="width: 100%" auto-responsive labels-aside>
         <vaadin-form-item>
           <label slot="label">First name</label>
           <vaadin-text-field></vaadin-text-field>

--- a/frontend/demo/component/formlayout/react/form-layout-basic.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-basic.tsx
@@ -13,7 +13,7 @@ function Example() {
   function renderFormLayout() {
     // tag::snippet[]
     return (
-      <FormLayout className="w-full" autoResponsive>
+      <FormLayout style={{ width: '100%' }} autoResponsive>
         <FormRow>
           <TextField label="First name" />
           <TextField label="Last name" />

--- a/frontend/demo/component/formlayout/react/form-layout-colspan.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-colspan.tsx
@@ -6,7 +6,7 @@ function Example() {
   function renderFormLayout() {
     // tag::snippet[]
     return (
-      <FormLayout className="w-full" autoResponsive columnWidth="8em" expandFields>
+      <FormLayout style={{ width: '100%' }} autoResponsive columnWidth="8em" expandFields>
         <FormRow>
           <TextField label="Street address" data-colspan="3" />
         </FormRow>

--- a/frontend/demo/component/formlayout/react/form-layout-expand-columns.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-expand-columns.tsx
@@ -13,7 +13,7 @@ function Example() {
   function renderFormLayout() {
     // tag::snippet[]
     return (
-      <FormLayout className="w-full" autoResponsive columnWidth="8em" expandColumns>
+      <FormLayout style={{ width: '100%' }} autoResponsive columnWidth="8em" expandColumns>
         <FormRow>
           <TextField label="First name" />
           <TextField label="Last name" />

--- a/frontend/demo/component/formlayout/react/form-layout-expand-fields.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-expand-fields.tsx
@@ -13,7 +13,7 @@ function Example() {
   function renderFormLayout() {
     // tag::snippet[]
     return (
-      <FormLayout className="w-full" autoResponsive columnWidth="8em" expandColumns expandFields>
+      <FormLayout style={{ width: '100%' }} autoResponsive columnWidth="8em" expandColumns expandFields>
         <FormRow>
           <TextField label="First name" />
           <TextField label="Last name" />

--- a/frontend/demo/component/formlayout/react/form-layout-labels-aside.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-labels-aside.tsx
@@ -6,7 +6,7 @@ function Example() {
   function renderFormLayout() {
     // tag::snippet[]
     return (
-      <FormLayout className="w-full" autoResponsive labelsAside>
+      <FormLayout style={{ width: '100%' }} autoResponsive labelsAside>
         <FormItem>
           <label slot="label">First name</label>
           <TextField />


### PR DESCRIPTION
Part of https://github.com/vaadin/docs/issues/4801

Replaced `w-full` class name with `width: 100%` inline style.