### PR TITLE
chore: add missing hidden-source-line to DemoExporter imports

### DIFF
--- a/src/main/java/com/vaadin/demo/component/card/CardHorizontal.java
+++ b/src/main/java/com/vaadin/demo/component/card/CardHorizontal.java
@@ -1,8 +1,8 @@
 package com.vaadin.demo.component.card;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.avatar.Avatar;
-import com.vaadin.flow.component.card.Card; // hidden-source-line
+import com.vaadin.flow.component.card.Card;
 import com.vaadin.flow.component.card.CardVariant;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;

--- a/src/main/java/com/vaadin/demo/component/card/CardSubtitle.java
+++ b/src/main/java/com/vaadin/demo/component/card/CardSubtitle.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.card;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.card.Card;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeArea.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeArea.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaRange.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaRange.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.AxisType;
 import com.vaadin.flow.component.charts.model.ChartType;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSpline.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSpline.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.AxisTitle;
 import com.vaadin.flow.component.charts.model.ChartType;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSplineRange.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeAreaSplineRange.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBar.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBar.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.AxisTitle;
 import com.vaadin.flow.component.charts.model.ChartType;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBoxPlot.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBoxPlot.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.BoxPlotItem;
 import com.vaadin.flow.component.charts.model.ChartType;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBubble.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBubble.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBullet.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeBullet.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeCandlestick.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeCandlestick.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumn.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumn.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumnRange.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeColumnRange.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.AxisType;
 import com.vaadin.flow.component.charts.model.ChartType;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeErrorBar.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeErrorBar.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeFlags.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeFlags.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeFunnel.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeFunnel.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeGantt.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeGantt.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.charts.model.style.SolidColor;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeGauge.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeGauge.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeHeatMap.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeHeatMap.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeLine.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeLine.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeOhlc.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeOhlc.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeOrganization.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeOrganization.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePie.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePie.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePolar.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePolar.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePolygon.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePolygon.java
@@ -2,7 +2,7 @@ package com.vaadin.demo.component.charts.charttypes;
 
 import java.util.Random;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePyramid.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypePyramid.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeScatter.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeScatter.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeSolidGauge.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeSolidGauge.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.Background;
 import com.vaadin.flow.component.charts.model.BackgroundShape;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeSpline.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeSpline.java
@@ -2,7 +2,7 @@ package com.vaadin.demo.component.charts.charttypes;
 
 import java.util.Random;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.AxisTitle;
 import com.vaadin.flow.component.charts.model.AxisType;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeTimeline.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeTimeline.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeTreeMap.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeTreeMap.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeWaterfall.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeWaterfall.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.charts.charttypes;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.AxisType;
 import com.vaadin.flow.component.charts.model.ChartType;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeXrange.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/ChartTypeXrange.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.AxisType;
 import com.vaadin.flow.component.charts.model.ChartType;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttBasicDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttBasicDemo.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCurrentDateIndicationDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCurrentDateIndicationDemo.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCustomDataDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCustomDataDemo.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCustomLabelsDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCustomLabelsDemo.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttDragAndDropDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttDragAndDropDemo.java
@@ -8,7 +8,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttHorizontalAxisConfiguration.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttHorizontalAxisConfiguration.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.charts.model.style.Style;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttProcessManagementDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttProcessManagementDemo.java
@@ -8,7 +8,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.charts.model.style.SolidColor;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttProgressIndicatorDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttProgressIndicatorDemo.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.charts.model.style.SolidColor;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttSmallTaskDependenciesDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttSmallTaskDependenciesDemo.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttVerticalCategoriesGrouping.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttVerticalCategoriesGrouping.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttWithNavigationDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttWithNavigationDemo.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.charts.model.style.SolidColor;

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttYAxisAsGridDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttYAxisAsGridDemo.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.*;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/grid/GridHeaderFooterStyling.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridHeaderFooterStyling.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.grid;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/grid/GridManualPagination.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridManualPagination.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.grid;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.domain.DataService;
 import com.vaadin.demo.domain.Person;
 import com.vaadin.flow.component.Component;

--- a/src/main/java/com/vaadin/demo/component/icons/IconsColor.java
+++ b/src/main/java/com/vaadin/demo/component/icons/IconsColor.java
@@ -1,11 +1,11 @@
 package com.vaadin.demo.component.icons;
 
-import com.vaadin.demo.DemoExporter;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.FontIcon;
 import com.vaadin.flow.component.icon.SvgIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 
 @Route("icons-color")
 public class IconsColor extends Div {

--- a/src/main/java/com/vaadin/demo/component/icons/IconsPadding.java
+++ b/src/main/java/com/vaadin/demo/component/icons/IconsPadding.java
@@ -1,10 +1,10 @@
 package com.vaadin.demo.component.icons;
 
-import com.vaadin.demo.DemoExporter;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.SvgIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 
 @Route("icons-padding")
 public class IconsPadding extends Div {

--- a/src/main/java/com/vaadin/demo/component/icons/IconsSizing.java
+++ b/src/main/java/com/vaadin/demo/component/icons/IconsSizing.java
@@ -1,10 +1,10 @@
 package com.vaadin.demo.component.icons;
 
-import com.vaadin.demo.DemoExporter;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.SvgIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 
 @Route("icons-sizing")
 public class IconsSizing extends Div {

--- a/src/main/java/com/vaadin/demo/component/map/MapClusters.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapClusters.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.map;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Coordinate;

--- a/src/main/java/com/vaadin/demo/component/map/MapMarkerDragDrop.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapMarkerDragDrop.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.map;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Coordinate;

--- a/src/main/java/com/vaadin/demo/component/map/MapMarkerText.java
+++ b/src/main/java/com/vaadin/demo/component/map/MapMarkerText.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.map;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.map.Map;
 import com.vaadin.flow.component.map.configuration.Coordinate;

--- a/src/main/java/com/vaadin/demo/component/markdown/MarkdownBasic.java
+++ b/src/main/java/com/vaadin/demo/component/markdown/MarkdownBasic.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.markdown;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.markdown.Markdown;
 import com.vaadin.flow.router.Route;

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationPopup.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationPopup.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.notification;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.contextmenu.ContextMenu;
 import com.vaadin.flow.component.html.Div;

--- a/src/main/java/com/vaadin/demo/component/tabs/TabsAutoselect.java
+++ b/src/main/java/com/vaadin/demo/component/tabs/TabsAutoselect.java
@@ -1,6 +1,6 @@
 package com.vaadin.demo.component.tabs;
 
-import com.vaadin.demo.DemoExporter;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;


### PR DESCRIPTION
While working on replacing LumoUtility, I noticed some files were missing `// hidden-source-line`. This PR fixes those.