### PR TITLE
docs: replace usage of Lumo space custom CSS properties

### DIFF
--- a/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-bottom-navbar.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
   static override styles = css`
     h1 {
       font-size: 1.125rem;
-      margin: var(--lumo-space-m) var(--lumo-space-l);
+      margin: 1rem 1.5rem;
     }
 
     /* hidden-source-line: the bottom navbar is forced on in the example */

--- a/frontend/demo/component/app-layout/app-layout-height-auto.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-auto.ts
@@ -12,7 +12,7 @@ export class Example extends LitElement {
   static override styles = css`
     h1 {
       font-size: 1.125rem;
-      margin: var(--lumo-space-m);
+      margin: 1rem;
     }
   `;
 

--- a/frontend/demo/component/app-layout/app-layout-height-full.ts
+++ b/frontend/demo/component/app-layout/app-layout-height-full.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
 
     h1 {
       font-size: 1.125rem;
-      margin: var(--lumo-space-m);
+      margin: 1rem;
     }
   `;
 

--- a/frontend/demo/component/app-layout/app-layout-navbar.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar.ts
@@ -14,7 +14,7 @@ export class Example extends LitElement {
   static override styles = css`
     h1 {
       font-size: 1.125rem;
-      left: var(--lumo-space-l);
+      left: 1.5rem;
       margin: 0;
       position: absolute;
     }

--- a/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
+++ b/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
@@ -19,7 +19,7 @@ export class Example extends LitElement {
     h1 {
       font-size: 1.125rem;
       line-height: 2.75rem;
-      margin: 0 var(--lumo-space-m);
+      margin: 0 1rem;
     }
 
     h2 {

--- a/frontend/demo/component/app-layout/react/app-layout-bottom-navbar.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-bottom-navbar.tsx
@@ -12,7 +12,7 @@ import { patchAppLayoutNavigation } from '../app-layout-helper';
 
 const h1Style = {
   fontSize: '1.125rem',
-  margin: 'var(--lumo-space-m) var(--lumo-space-l)',
+  margin: '1rem 1.5rem',
 };
 
 const linkStyle = {

--- a/frontend/demo/component/app-layout/react/app-layout-height-auto.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-height-auto.tsx
@@ -8,7 +8,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 const h1Style = {
   fontSize: '1.125rem',
-  margin: 'var(--lumo-space-m)',
+  margin: '1rem',
 };
 
 function Example() {

--- a/frontend/demo/component/app-layout/react/app-layout-height-full.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-height-full.tsx
@@ -9,7 +9,7 @@ import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 const h1Style = {
   fontSize: '1.125rem',
-  margin: 'var(--lumo-space-m)',
+  margin: '1rem',
 };
 
 function Example() {

--- a/frontend/demo/component/app-layout/react/app-layout-navbar.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-navbar.tsx
@@ -9,7 +9,7 @@ import { patchAppLayoutNavigation } from '../app-layout-helper';
 
 const h1Style: React.CSSProperties = {
   fontSize: '1.125rem',
-  left: 'var(--lumo-space-l)',
+  left: '1.5rem',
   margin: 0,
   position: 'absolute',
 };

--- a/frontend/demo/component/app-layout/react/app-layout-secondary-navigation.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-secondary-navigation.tsx
@@ -18,7 +18,7 @@ import { patchAppLayoutNavigation } from '../app-layout-helper';
 const h1Style = {
   fontSize: '1.125rem',
   lineHeight: '2.75rem',
-  margin: '0 var(--lumo-space-m)',
+  margin: '0 1rem',
 };
 
 const h2Style = {

--- a/frontend/demo/component/badge/badge-counter.ts
+++ b/frontend/demo/component/badge/badge-counter.ts
@@ -8,7 +8,7 @@ import { applyTheme } from 'Frontend/demo/theme';
 export class Example extends LitElement {
   static override styles = css`
     span[theme~='badge'] {
-      margin-inline-start: var(--lumo-space-s);
+      margin-inline-start: 0.5rem;
     }
   `;
 

--- a/frontend/demo/component/badge/badge-icons-only-table.ts
+++ b/frontend/demo/component/badge/badge-icons-only-table.ts
@@ -46,7 +46,7 @@ export class Example extends LitElement {
         <vaadin-icon
           aria-label="${title}"
           icon="${icon}"
-          style="padding: var(--lumo-space-xs)"
+          style="padding: 0.25rem"
           theme="badge ${theme}"
           title="${title}"
         ></vaadin-icon>

--- a/frontend/demo/component/badge/badge-icons-only.ts
+++ b/frontend/demo/component/badge/badge-icons-only.ts
@@ -21,14 +21,14 @@ export class Example extends LitElement {
         <vaadin-icon
           aria-label="Confirmed"
           icon="vaadin:check"
-          style="padding: var(--lumo-space-xs)"
+          style="padding: 0.25rem"
           theme="badge success"
           title="Confirmed"
         ></vaadin-icon>
         <vaadin-icon
           aria-label="Cancelled"
           icon="vaadin:close-small"
-          style="padding: var(--lumo-space-xs)"
+          style="padding: 0.25rem"
           theme="badge error"
           title="Cancelled"
         ></vaadin-icon>

--- a/frontend/demo/component/badge/badge-icons.ts
+++ b/frontend/demo/component/badge/badge-icons.ts
@@ -21,52 +21,46 @@ export class Example extends LitElement {
       <vaadin-vertical-layout theme="spacing">
         <vaadin-horizontal-layout theme="spacing">
           <span theme="badge">
-            <vaadin-icon icon="vaadin:clock" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+            <vaadin-icon icon="vaadin:clock" style="padding: 0.25rem"></vaadin-icon>
             <span>Pending</span>
           </span>
           <span theme="badge success">
-            <vaadin-icon icon="vaadin:check" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+            <vaadin-icon icon="vaadin:check" style="padding: 0.25rem"></vaadin-icon>
             <span>Confirmed</span>
           </span>
           <span theme="badge warning">
-            <vaadin-icon icon="vaadin:warning" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+            <vaadin-icon icon="vaadin:warning" style="padding: 0.25rem"></vaadin-icon>
             <span>Warning</span>
           </span>
           <span theme="badge error">
-            <vaadin-icon
-              icon="vaadin:exclamation-circle-o"
-              style="padding: var(--lumo-space-xs)"
-            ></vaadin-icon>
+            <vaadin-icon icon="vaadin:exclamation-circle-o" style="padding: 0.25rem"></vaadin-icon>
             <span>Denied</span>
           </span>
           <span theme="badge contrast">
-            <vaadin-icon icon="vaadin:hand" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+            <vaadin-icon icon="vaadin:hand" style="padding: 0.25rem"></vaadin-icon>
             <span>On hold</span>
           </span>
         </vaadin-horizontal-layout>
         <vaadin-horizontal-layout theme="spacing">
           <span theme="badge">
             <span>Pending</span>
-            <vaadin-icon icon="vaadin:clock" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+            <vaadin-icon icon="vaadin:clock" style="padding: 0.25rem"></vaadin-icon>
           </span>
           <span theme="badge success">
             <span>Confirmed</span>
-            <vaadin-icon icon="vaadin:check" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+            <vaadin-icon icon="vaadin:check" style="padding: 0.25rem"></vaadin-icon>
           </span>
           <span theme="badge warning">
             <span>Warning</span>
-            <vaadin-icon icon="vaadin:warning" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+            <vaadin-icon icon="vaadin:warning" style="padding: 0.25rem"></vaadin-icon>
           </span>
           <span theme="badge error">
             <span>Denied</span>
-            <vaadin-icon
-              icon="vaadin:exclamation-circle-o"
-              style="padding: var(--lumo-space-xs)"
-            ></vaadin-icon>
+            <vaadin-icon icon="vaadin:exclamation-circle-o" style="padding: 0.25rem"></vaadin-icon>
           </span>
           <span theme="badge contrast">
             <span>On hold</span>
-            <vaadin-icon icon="vaadin:hand" style="padding: var(--lumo-space-xs)"></vaadin-icon>
+            <vaadin-icon icon="vaadin:hand" style="padding: 0.25rem"></vaadin-icon>
           </span>
         </vaadin-horizontal-layout>
       </vaadin-vertical-layout>

--- a/frontend/demo/component/badge/badge-interactive.ts
+++ b/frontend/demo/component/badge/badge-interactive.ts
@@ -56,7 +56,7 @@ export class Example extends LitElement {
                   data-profession="${profession}"
                   theme="contrast tertiary-inline"
                   title="Clear filter: ${profession}"
-                  style="margin-inline-start: var(--lumo-space-xs)"
+                  style="margin-inline-start: 0.25rem"
                   @click="${this.onClick}"
                 >
                   <vaadin-icon icon="vaadin:close-small"></vaadin-icon>

--- a/frontend/demo/component/badge/react/badge-counter.tsx
+++ b/frontend/demo/component/badge/react/badge-counter.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Tab, Tabs } from '@vaadin/react-components';
 
 const badgeStyle = {
-  marginInlineStart: 'var(--lumo-space-s)',
+  marginInlineStart: '0.5rem',
 };
 
 function Example() {

--- a/frontend/demo/component/badge/react/badge-icons-only-table.tsx
+++ b/frontend/demo/component/badge/react/badge-icons-only-table.tsx
@@ -43,7 +43,7 @@ function Example() {
       <Icon
         aria-label={title}
         icon={icon}
-        style={{ padding: 'var(--lumo-space-xs)' }}
+        style={{ padding: '0.25rem' }}
         theme={`badge ${theme}`}
         title={title}
       />

--- a/frontend/demo/component/badge/react/badge-icons-only.tsx
+++ b/frontend/demo/component/badge/react/badge-icons-only.tsx
@@ -10,7 +10,7 @@ function Example() {
       <Icon
         aria-label="Confirmed"
         icon="vaadin:check"
-        style={{ padding: 'var(--lumo-space-xs)' }}
+        style={{ padding: '0.25rem' }}
         theme="badge success"
         title="Confirmed"
       />
@@ -18,7 +18,7 @@ function Example() {
       <Icon
         aria-label="Cancelled"
         icon="vaadin:close-small"
-        style={{ padding: 'var(--lumo-space-xs)' }}
+        style={{ padding: '0.25rem' }}
         theme="badge error"
         title="Cancelled"
       />

--- a/frontend/demo/component/badge/react/badge-icons.tsx
+++ b/frontend/demo/component/badge/react/badge-icons.tsx
@@ -9,46 +9,46 @@ function Example() {
     <VerticalLayout theme="spacing">
       <HorizontalLayout theme="spacing">
         <span {...{ theme: 'badge' }}>
-          <Icon icon="vaadin:clock" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:clock" style={{ padding: '0.25rem' }} />
           <span>Pending</span>
         </span>
         <span {...{ theme: 'badge success' }}>
-          <Icon icon="vaadin:check" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:check" style={{ padding: '0.25rem' }} />
           <span>Confirmed</span>
         </span>
         <span {...{ theme: 'badge warning' }}>
-          <Icon icon="vaadin:warning" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:warning" style={{ padding: '0.25rem' }} />
           <span>Warning</span>
         </span>
         <span {...{ theme: 'badge error' }}>
-          <Icon icon="vaadin:exclamation-circle-o" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:exclamation-circle-o" style={{ padding: '0.25rem' }} />
           <span>Denied</span>
         </span>
         <span {...{ theme: 'badge contrast' }}>
-          <Icon icon="vaadin:hand" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:hand" style={{ padding: '0.25rem' }} />
           <span>On hold</span>
         </span>
       </HorizontalLayout>
       <HorizontalLayout theme="spacing">
         <span {...{ theme: 'badge' }}>
           <span>Pending</span>
-          <Icon icon="vaadin:clock" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:clock" style={{ padding: '0.25rem' }} />
         </span>
         <span {...{ theme: 'badge success' }}>
           <span>Confirmed</span>
-          <Icon icon="vaadin:check" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:check" style={{ padding: '0.25rem' }} />
         </span>
         <span {...{ theme: 'badge warning' }}>
           <span>Warning</span>
-          <Icon icon="vaadin:warning" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:warning" style={{ padding: '0.25rem' }} />
         </span>
         <span {...{ theme: 'badge error' }}>
           <span>Denied</span>
-          <Icon icon="vaadin:exclamation-circle-o" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:exclamation-circle-o" style={{ padding: '0.25rem' }} />
         </span>
         <span {...{ theme: 'badge contrast' }}>
           <span>On hold</span>
-          <Icon icon="vaadin:hand" style={{ padding: 'var(--lumo-space-xs)' }} />
+          <Icon icon="vaadin:hand" style={{ padding: '0.25rem' }} />
         </span>
       </HorizontalLayout>
     </VerticalLayout>

--- a/frontend/demo/component/badge/react/badge-interactive.tsx
+++ b/frontend/demo/component/badge/react/badge-interactive.tsx
@@ -60,7 +60,7 @@ function Example() {
               data-profession={profession}
               theme="contrast tertiary-inline"
               title={`Clear filter: ${profession}`}
-              style={{ marginInlineStart: 'var(--lumo-space-xs)' }}
+              style={{ marginInlineStart: '0.25rem' }}
               onClick={onClick}
             >
               <Icon icon="vaadin:close-small" />

--- a/frontend/demo/component/card/card-features.ts
+++ b/frontend/demo/component/card/card-features.ts
@@ -56,7 +56,7 @@ export class Example extends LitElement {
 
     .wrapper {
       display: flex;
-      max-height: calc(100svh - var(--docs-header-height, 0px) * 2.5 - var(--lumo-space-l) * 2);
+      max-height: calc(100svh - var(--docs-header-height, 0px) * 2.5 - 1.5rem * 2);
       min-height: 400px;
       container-type: inline-size;
       position: relative;
@@ -94,8 +94,8 @@ export class Example extends LitElement {
     .options {
       overflow: auto;
       width: min-content;
-      padding: var(--lumo-space-m) var(--lumo-space-l);
-      padding-top: var(--lumo-space-s);
+      padding: 1rem 1.5rem;
+      padding-top: 0.5rem;
       box-sizing: border-box;
     }
 
@@ -140,14 +140,14 @@ export class Example extends LitElement {
       justify-content: center;
       flex: 1;
       overflow: auto;
-      padding: var(--lumo-space-l);
+      padding: 1.5rem;
       box-sizing: border-box;
     }
 
     @container (max-width: 600px) {
       .options {
         position: absolute;
-        inset: var(--lumo-space-s);
+        inset: 0.5rem;
         inset-inline-start: auto;
         background: var(--lumo-base-color)
           linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct));

--- a/frontend/demo/component/card/card-variants.ts
+++ b/frontend/demo/component/card/card-variants.ts
@@ -36,7 +36,7 @@ export class Example extends LitElement {
     .card-variant-layout {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(12ch, 1fr));
-      gap: var(--lumo-space-m);
+      gap: 1rem;
     }
   `;
 }

--- a/frontend/demo/component/card/react/card-variants.tsx
+++ b/frontend/demo/component/card/react/card-variants.tsx
@@ -25,7 +25,7 @@ function Example() {
         .card-variant-layout {
           display: grid;
           grid-template-columns: repeat(auto-fit, minmax(12ch, 1fr));
-          gap: var(--lumo-space-m);
+          gap: 1rem;
         }
       `}</style>
     </>

--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -65,7 +65,7 @@ export class Example extends LitElement {
   private renderer: ComboBoxLitRenderer<Person> = (person) => html`
     <div style="display: flex;">
       <img
-        style="height: 2.25rem; margin-right: var(--lumo-space-s);"
+        style="height: 2.25rem; margin-right: 0.5rem;"
         src="${person.pictureUrl}"
         alt="Portrait of ${person.firstName} ${person.lastName}"
       />

--- a/frontend/demo/component/combobox/react/combo-box-presentation.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-presentation.tsx
@@ -12,7 +12,7 @@ function renderPerson({ item: person }: { item: Person }) {
   return (
     <div style={{ display: 'flex' }}>
       <img
-        style={{ height: '2.25rem', marginRight: 'var(--lumo-space-s)' }}
+        style={{ height: '2.25rem', marginRight: '0.5rem' }}
         src={person.pictureUrl}
         alt={`Portrait of ${person.firstName} ${person.lastName}`}
       />

--- a/frontend/demo/component/contextmenu/context-menu-presentation.ts
+++ b/frontend/demo/component/contextmenu/context-menu-presentation.ts
@@ -115,8 +115,8 @@ export class Example extends LitElement {
     const icon = document.createElement('vaadin-icon');
 
     icon.style.color = 'var(--lumo-secondary-text-color)';
-    icon.style.marginInlineEnd = 'var(--lumo-space-s)';
-    icon.style.padding = 'var(--lumo-space-xs)';
+    icon.style.marginInlineEnd = '0.5rem';
+    icon.style.padding = '0.25rem';
 
     icon.setAttribute('icon', iconName);
     item.appendChild(icon);

--- a/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
@@ -42,8 +42,8 @@ function createItem(iconName: string, text: string) {
         icon={iconName}
         style={{
           color: 'var(--lumo-secondary-text-color)',
-          marginInlineEnd: 'var(--lumo-space-s)',
-          padding: 'var(--lumo-space-xs)',
+          marginInlineEnd: '0.5rem',
+          padding: '0.25rem',
         }}
       />
       {text}

--- a/frontend/demo/component/dashboard/dashboard-variants.ts
+++ b/frontend/demo/component/dashboard/dashboard-variants.ts
@@ -41,27 +41,25 @@ export class Example extends LitElement {
 
   render() {
     return html`
-      <div style="display:flex; align-items:baseline; gap:1rem; padding-inline:var(--lumo-space-m);">
+      <div style="display: flex; align-items: baseline; gap: 1rem; padding-inline: 1rem;">
         <vaadin-select
-            label="Widget variant"
-            .items="${this.items}"
-            value=" "
-            @change="${this.onWidgetVariantChange}"
+          label="Widget variant"
+          .items="${this.items}"
+          value=" "
+          @change="${this.onWidgetVariantChange}"
         ></vaadin-select>
         <vaadin-checkbox
-            label="Shaded board background"
-            @change="${this.onShadedBgChange}"
+          label="Shaded board background"
+          @change="${this.onShadedBgChange}"
         ></vaadin-checkbox>
       </div>
-      <vaadin-dashboard-layout theme="${this.widgetVariant} ${this.shadedBoard}"
+      <vaadin-dashboard-layout
+        theme="${this.widgetVariant} ${this.shadedBoard}"
         style=" width:100%; --vaadin-dashboard-row-min-height:200px; --vaadin-dashboard-col-min-width: 100px; --vaadin-dashboard-col-max-count: 3;"
       >
-        <vaadin-dashboard-widget widget-title="Visitors">
-        </vaadin-dashboard-widget>
-        <vaadin-dashboard-widget widget-title="Downloads">
-        </vaadin-dashboard-widget>
-        <vaadin-dashboard-widget widget-title="Conversions">
-        </vaadin-dashboard-widget>
+        <vaadin-dashboard-widget widget-title="Visitors"></vaadin-dashboard-widget>
+        <vaadin-dashboard-widget widget-title="Downloads"></vaadin-dashboard-widget>
+        <vaadin-dashboard-widget widget-title="Conversions"></vaadin-dashboard-widget>
       </vaadin-dashboard-layout>
     `;
   }

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -43,11 +43,11 @@ export class Example extends LitElement {
             <span>Contact information</span>
 
             <vaadin-horizontal-layout
-              style="color: var(--lumo-error-text-color); margin-left: var(--lumo-space-s)"
+              style="color: var(--lumo-error-text-color); margin-left: 0.5rem"
             >
               <vaadin-icon
                 icon="vaadin:exclamation-circle"
-                style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s); margin-right: var(--lumo-space-xs)"
+                style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s); margin-right: 0.25rem"
               ></vaadin-icon>
               <span>2 errors</span>
             </vaadin-horizontal-layout>

--- a/frontend/demo/component/details/react/details-summary.tsx
+++ b/frontend/demo/component/details/react/details-summary.tsx
@@ -35,15 +35,13 @@ function Example() {
         <HorizontalLayout style={{ justifyContent: 'space-between', width: '100%' }}>
           <span>Contact information</span>
 
-          <HorizontalLayout
-            style={{ color: 'var(--lumo-error-text-color)', marginLeft: 'var(--lumo-space-s)' }}
-          >
+          <HorizontalLayout style={{ color: 'var(--lumo-error-text-color)', marginLeft: '0.5rem' }}>
             <Icon
               icon="vaadin:exclamation-circle"
               style={{
                 width: 'var(--lumo-icon-size-s)',
                 height: 'var(--lumo-icon-size-s)',
-                marginRight: 'var(--lumo-space-xs)',
+                marginRight: '0.25rem',
               }}
             />
             <span>2 errors</span>

--- a/frontend/demo/component/dialog/dialog-closing.ts
+++ b/frontend/demo/component/dialog/dialog-closing.ts
@@ -33,7 +33,7 @@ export class Example extends LitElement {
               theme="spacing"
               style="width: 300px; max-width: 100%; align-items: stretch;"
             >
-              <h2 style="margin: var(--lumo-space-m) 0; font-size: 1.5em; font-weight: bold;">
+              <h2 style="margin: 1rem 0; font-size: 1.5em; font-weight: bold;">
                 System maintenance
               </h2>
               <p>

--- a/frontend/demo/component/dialog/dialog-draggable.ts
+++ b/frontend/demo/component/dialog/dialog-draggable.ts
@@ -35,7 +35,7 @@ export class Example extends LitElement {
           () => html`
             <h2
               class="draggable"
-              style="flex: 1; cursor: move; margin: 0; font-size: 1.5em; font-weight: bold; padding: var(--lumo-space-m) 0;"
+              style="flex: 1; cursor: move; margin: 0; font-size: 1.5em; font-weight: bold; padding: 1rem 0;"
             >
               Add note
             </h2>

--- a/frontend/demo/component/dialog/react/dialog-closing.tsx
+++ b/frontend/demo/component/dialog/react/dialog-closing.tsx
@@ -31,7 +31,7 @@ function Example() {
           theme="spacing"
           style={{ width: '300px', maxWidth: '100%', alignItems: 'stretch' }}
         >
-          <h2 style={{ margin: 'var(--lumo-space-m) 0', fontSize: '1.5em', fontWeight: 'bold' }}>
+          <h2 style={{ margin: '1rem 0', fontSize: '1.5em', fontWeight: 'bold' }}>
             System maintenance
           </h2>
           <p>

--- a/frontend/demo/component/dialog/react/dialog-draggable.tsx
+++ b/frontend/demo/component/dialog/react/dialog-draggable.tsx
@@ -40,7 +40,7 @@ function Example() {
               margin: 0,
               fontSize: '1.5em',
               fontWeight: 'bold',
-              padding: 'var(--lumo-space-m) 0',
+              padding: '1rem 0',
             }}
           >
             Add note

--- a/frontend/demo/component/grid/grid-tooltip-generator.ts
+++ b/frontend/demo/component/grid/grid-tooltip-generator.ts
@@ -75,7 +75,7 @@ export class Example extends LitElement {
     return html`
       <vaadin-icon
         icon="vaadin:${icon}"
-        style="padding: var(--lumo-space-xs)"
+        style="padding: 0.25rem"
         theme="badge ${theme}"
       ></vaadin-icon>
     `;

--- a/frontend/demo/component/grid/react/grid-tooltip-generator.tsx
+++ b/frontend/demo/component/grid/react/grid-tooltip-generator.tsx
@@ -16,11 +16,7 @@ const statusRenderer = ({ item: { status } }: { item: Person }) => {
   const theme = status === 'Available' ? 'success' : 'error';
 
   return (
-    <Icon
-      icon={`vaadin:${icon}`}
-      style={{ padding: 'var(--lumo-space-xs)' }}
-      {...{ theme: `badge ${theme}` }}
-    />
+    <Icon icon={`vaadin:${icon}`} style={{ padding: '0.25rem' }} {...{ theme: `badge ${theme}` }} />
   );
 };
 

--- a/frontend/demo/component/horizontal-layout/react/layoutExampleStyle.ts
+++ b/frontend/demo/component/horizontal-layout/react/layoutExampleStyle.ts
@@ -26,7 +26,7 @@ const layoutExampleStyles = css`
     background: var(--lumo-primary-color);
     color: var(--lumo-primary-contrast-color);
     border-radius: var(--lumo-border-radius-m);
-    padding: var(--lumo-space-s) var(--lumo-space-l);
+    padding: 0.5rem 1.5rem;
     white-space: nowrap;
   }
 `;

--- a/frontend/demo/component/login/login-basic.ts
+++ b/frontend/demo/component/login/login-basic.ts
@@ -11,7 +11,7 @@ export class Example extends LitElement {
       background-color: var(--lumo-contrast-5pct);
       display: flex !important;
       justify-content: center;
-      padding: var(--lumo-space-l);
+      padding: 1.5rem;
     }
   `;
 

--- a/frontend/demo/component/login/login-internationalization.ts
+++ b/frontend/demo/component/login/login-internationalization.ts
@@ -12,7 +12,7 @@ export class Example extends LitElement {
       background-color: var(--lumo-contrast-5pct);
       display: flex !important;
       justify-content: center;
-      padding: var(--lumo-space-l);
+      padding: 1.5rem;
     }
   `;
 

--- a/frontend/demo/component/login/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/login-overlay-mockup.ts
@@ -13,7 +13,7 @@ export class LoginOverlayMockupElement extends LitElement {
         linear-gradient(var(--lumo-shade-5pct), var(--lumo-shade-5pct));
       display: flex;
       justify-content: center;
-      padding: var(--lumo-space-m);
+      padding: 1rem;
     }
 
     [part='card'] {
@@ -24,7 +24,7 @@ export class LoginOverlayMockupElement extends LitElement {
       box-sizing: border-box;
       display: flex;
       flex-direction: column;
-      margin: var(--lumo-space-s);
+      margin: 0.5rem;
       max-width: 100%;
       overflow: hidden;
       height: max-content;
@@ -42,7 +42,7 @@ export class LoginOverlayMockupElement extends LitElement {
       justify-content: flex-end;
       min-height: calc(2.25rem * 5);
       overflow: hidden;
-      padding: var(--lumo-space-l) var(--lumo-space-xl) var(--lumo-space-l) var(--lumo-space-l);
+      padding: 1.5rem 2.5rem 1.5rem 1.5rem;
     }
 
     [part='brand'] h1 {

--- a/frontend/demo/component/login/react/login-host-styles.ts
+++ b/frontend/demo/component/login/react/login-host-styles.ts
@@ -5,6 +5,6 @@ export const loginHostStyles = css`
     background-color: var(--lumo-contrast-5pct);
     display: flex !important;
     justify-content: center;
-    padding: var(--lumo-space-l);
+    padding: 1.5rem;
   }
 `;

--- a/frontend/demo/component/login/react/login-overlay-mockup.ts
+++ b/frontend/demo/component/login/react/login-overlay-mockup.ts
@@ -13,7 +13,7 @@ export class LoginOverlayMockupElement extends LitElement {
         linear-gradient(var(--lumo-shade-5pct), var(--lumo-shade-5pct));
       display: flex;
       justify-content: center;
-      padding: var(--lumo-space-m);
+      padding: 1rem;
     }
 
     [part='card'] {
@@ -24,7 +24,7 @@ export class LoginOverlayMockupElement extends LitElement {
       box-sizing: border-box;
       display: flex;
       flex-direction: column;
-      margin: var(--lumo-space-s);
+      margin: 0.5rem;
       max-width: 100%;
       overflow: hidden;
       height: max-content;
@@ -42,7 +42,7 @@ export class LoginOverlayMockupElement extends LitElement {
       justify-content: flex-end;
       min-height: calc(2.25rem * 5);
       overflow: hidden;
-      padding: var(--lumo-space-l) var(--lumo-space-xl) var(--lumo-space-l) var(--lumo-space-l);
+      padding: 1.5rem 2.5rem 1.5rem 1.5rem;
     }
 
     [part='brand'] h1 {

--- a/frontend/demo/component/master-detail-layout/react/PersonList.tsx
+++ b/frontend/demo/component/master-detail-layout/react/PersonList.tsx
@@ -12,9 +12,11 @@ interface PersonListProps {
 function PersonList({ people, selectedPerson, onSelect }: PersonListProps) {
   return (
     <VerticalLayout style={{ height: '100%', border: '1px solid var(--lumo-contrast-20pct)' }}>
-      <div style={{padding:'var(--lumo-space-m)', fontWeight:'bold'}}>Select a person to view their details:</div>
+      <div style={{ padding: '1rem', fontWeight: 'bold' }}>
+        Select a person to view their details:
+      </div>
       <Grid
-        theme='no-border'
+        theme="no-border"
         items={people}
         style={{ height: '100%' }}
         selectedItems={selectedPerson ? [selectedPerson] : []}

--- a/frontend/demo/component/menubar/menu-bar-icons.ts
+++ b/frontend/demo/component/menubar/menu-bar-icons.ts
@@ -45,7 +45,7 @@ export class Example extends LitElement {
     if (isChild) {
       icon.style.width = 'var(--lumo-icon-size-s)';
       icon.style.height = 'var(--lumo-icon-size-s)';
-      icon.style.marginRight = 'var(--lumo-space-s)';
+      icon.style.marginRight = '0.5rem';
     }
 
     if (iconName === 'copy') {

--- a/frontend/demo/component/menubar/react/menu-bar-icons.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-icons.tsx
@@ -8,7 +8,7 @@ function createItem(iconName: string, text: string, isChild = false) {
   const iconStyle: React.CSSProperties = {
     width: isChild ? 'var(--lumo-icon-size-s)' : '',
     height: isChild ? 'var(--lumo-icon-size-s)' : '',
-    marginRight: isChild ? 'var(--lumo-space-s)' : '',
+    marginRight: isChild ? '0.5rem' : '',
   };
 
   let ariaLabel = '';

--- a/frontend/demo/component/notification/notification-keyboard-a11y.ts
+++ b/frontend/demo/component/notification/notification-keyboard-a11y.ts
@@ -50,11 +50,7 @@ export class Example extends LitElement {
   renderer: NotificationLitRenderer = () => html`
     <vaadin-horizontal-layout style="align-items: center;">
       <div>5 tasks deleted</div>
-      <vaadin-button
-        style="margin-left: var(--lumo-space-xl);"
-        theme="primary"
-        @click="${this.close}"
-      >
+      <vaadin-button style="margin-left: 2.5rem;" theme="primary" @click="${this.close}">
         Undo
         <!-- Ideally, this should be hidden if the
                  device does not have a physical keyboard -->

--- a/frontend/demo/component/notification/notification-popup.ts
+++ b/frontend/demo/component/notification/notification-popup.ts
@@ -36,7 +36,7 @@ export class Example2 extends LitElement {
       <vaadin-context-menu
         open-on="click"
         ${contextMenuRenderer(
-          () => html`<div style="padding: var(--lumo-space-l);">Show notifications here</div>`,
+          () => html`<div style="padding: 1.5rem;">Show notifications here</div>`,
           []
         )}
       >

--- a/frontend/demo/component/notification/notification-retry.ts
+++ b/frontend/demo/component/notification/notification-retry.ts
@@ -47,11 +47,7 @@ export class Example extends LitElement {
   renderer: NotificationLitRenderer = () => html`
     <vaadin-horizontal-layout theme="spacing" style="align-items: center;">
       <div>Failed to generate report</div>
-      <vaadin-button
-        theme="tertiary-inline"
-        style="margin-left: var(--lumo-space-xl);"
-        @click="${this.close}"
-      >
+      <vaadin-button theme="tertiary-inline" style="margin-left: 2.5rem;" @click="${this.close}">
         Retry
       </vaadin-button>
       <vaadin-button theme="tertiary-inline icon" @click="${this.close}" aria-label="Close">

--- a/frontend/demo/component/notification/notification-rich-preview.ts
+++ b/frontend/demo/component/notification/notification-rich-preview.ts
@@ -23,7 +23,7 @@ export class Example extends LitElement {
         <vaadin-horizontal-layout theme="spacing" style="align-items: center">
           <vaadin-icon icon="vaadin:check-circle"></vaadin-icon>
           <div>Application submitted!</div>
-          <vaadin-button style="margin: 0 0 0 var(--lumo-space-l)">View</vaadin-button>
+          <vaadin-button style="margin: 0 0 0 1.5rem">View</vaadin-button>
           <vaadin-button theme="tertiary-inline">
             <vaadin-icon icon="lumo:cross"></vaadin-icon>
           </vaadin-button>
@@ -34,7 +34,7 @@ export class Example extends LitElement {
         <vaadin-horizontal-layout theme="spacing" style="align-items: center">
           <vaadin-icon icon="vaadin:warning"></vaadin-icon>
           <div>Failed to generate report</div>
-          <vaadin-button style="margin: 0 0 0 var(--lumo-space-l)">Retry</vaadin-button>
+          <vaadin-button style="margin: 0 0 0 1.5rem">Retry</vaadin-button>
           <vaadin-button theme="tertiary-inline">
             <vaadin-icon icon="lumo:cross"></vaadin-icon>
           </vaadin-button>

--- a/frontend/demo/component/notification/notification-rich.ts
+++ b/frontend/demo/component/notification/notification-rich.ts
@@ -29,10 +29,7 @@ export class Example extends LitElement {
             <vaadin-horizontal-layout theme="spacing" style="align-items: center">
               <vaadin-icon icon="vaadin:check-circle"></vaadin-icon>
               <div>Application submitted!</div>
-              <vaadin-button
-                style="margin: 0 0 0 var(--lumo-space-l)"
-                @click="${() => notification.close()}"
-              >
+              <vaadin-button style="margin: 0 0 0 1.5rem" @click="${() => notification.close()}">
                 View
               </vaadin-button>
               <vaadin-button
@@ -56,10 +53,7 @@ export class Example extends LitElement {
             <vaadin-horizontal-layout theme="spacing" style="align-items: center">
               <vaadin-icon icon="vaadin:warning"></vaadin-icon>
               <div>Failed to generate report</div>
-              <vaadin-button
-                style="margin: 0 0 0 var(--lumo-space-l)"
-                @click="${() => notification.close()}"
-              >
+              <vaadin-button style="margin: 0 0 0 1.5rem" @click="${() => notification.close()}">
                 Retry
               </vaadin-button>
               <vaadin-button

--- a/frontend/demo/component/notification/notification-undo.ts
+++ b/frontend/demo/component/notification/notification-undo.ts
@@ -46,11 +46,7 @@ export class Example extends LitElement {
   renderer: NotificationLitRenderer = () => html`
     <vaadin-horizontal-layout theme="spacing" style="align-items: center;">
       <div>5 tasks deleted</div>
-      <vaadin-button
-        theme="tertiary-inline"
-        style="margin-left: var(--lumo-space-xl);"
-        @click="${this.close}"
-      >
+      <vaadin-button theme="tertiary-inline" style="margin-left: 2.5rem;" @click="${this.close}">
         Undo
       </vaadin-button>
       <vaadin-button theme="tertiary-inline" aria-label="Close" @click="${this.close}">

--- a/frontend/demo/component/notification/react/notification-keyboard-a11y.tsx
+++ b/frontend/demo/component/notification/react/notification-keyboard-a11y.tsx
@@ -52,7 +52,7 @@ function Example() {
       >
         <HorizontalLayout style={{ alignItems: 'center' }}>
           <div>5 tasks deleted</div>
-          <Button style={{ marginLeft: 'var(--lumo-space-xl)' }} theme="primary" onClick={close}>
+          <Button style={{ marginLeft: '2.5rem' }} theme="primary" onClick={close}>
             Undo
             {isMac ? '⌘' : 'Ctrl-'}Z
           </Button>

--- a/frontend/demo/component/notification/react/notification-popup.tsx
+++ b/frontend/demo/component/notification/react/notification-popup.tsx
@@ -10,7 +10,7 @@ function Example() {
     // tag::snippet[]
     <ContextMenu
       openOn="click"
-      renderer={() => <div style={{ padding: 'var(--lumo-space-l)' }}>Show notifications here</div>}
+      renderer={() => <div style={{ padding: '1.5rem' }}>Show notifications here</div>}
     >
       <Button aria-label="notifications" theme="tertiary">
         <Icon icon="vaadin:bell-o" />

--- a/frontend/demo/component/notification/react/notification-retry.tsx
+++ b/frontend/demo/component/notification/react/notification-retry.tsx
@@ -39,11 +39,7 @@ function Example() {
       >
         <HorizontalLayout theme="spacing" style={{ alignItems: 'center' }}>
           <div>Failed to generate report</div>
-          <Button
-            theme="tertiary-inline"
-            style={{ marginLeft: 'var(--lumo-space-xl)' }}
-            onClick={close}
-          >
+          <Button theme="tertiary-inline" style={{ marginLeft: '2.5rem' }} onClick={close}>
             Retry
           </Button>
 

--- a/frontend/demo/component/notification/react/notification-rich.tsx
+++ b/frontend/demo/component/notification/react/notification-rich.tsx
@@ -35,7 +35,7 @@ function Example() {
         <HorizontalLayout theme="spacing" style={{ alignItems: 'center' }}>
           <Icon icon="vaadin:check-circle" />
           <div>Application submitted!</div>
-          <Button style={{ margin: '0 0 0 var(--lumo-space-l)' }} onClick={() => close(0)}>
+          <Button style={{ margin: '0 0 0 1.5rem' }} onClick={() => close(0)}>
             View
           </Button>
           <Button theme="tertiary-inline" onClick={() => close(0)} aria-label="Close">
@@ -55,7 +55,7 @@ function Example() {
         <HorizontalLayout theme="spacing" style={{ alignItems: 'center' }}>
           <Icon icon="vaadin:warning" />
           <div>Failed to generate report</div>
-          <Button style={{ margin: '0 0 0 var(--lumo-space-l)' }} onClick={() => close(1)}>
+          <Button style={{ margin: '0 0 0 1.5rem' }} onClick={() => close(1)}>
             Retry
           </Button>
           <Button theme="tertiary-inline" onClick={() => close(1)} aria-label="Close">

--- a/frontend/demo/component/notification/react/notification-undo.tsx
+++ b/frontend/demo/component/notification/react/notification-undo.tsx
@@ -38,11 +38,7 @@ function Example() {
       >
         <HorizontalLayout theme="spacing" style={{ alignItems: 'center' }}>
           <div>5 tasks deleted</div>
-          <Button
-            theme="tertiary-inline"
-            style={{ marginLeft: 'var(--lumo-space-xl)' }}
-            onClick={close}
-          >
+          <Button theme="tertiary-inline" style={{ marginLeft: '2.5rem' }} onClick={close}>
             Undo
           </Button>
 

--- a/frontend/demo/component/popover/popover-anchored-dialog.ts
+++ b/frontend/demo/component/popover/popover-anchored-dialog.ts
@@ -78,7 +78,7 @@ export class Example extends LitElement {
     const visibleColumns = columns.filter((column) => column.visible).map((column) => column.key);
 
     return html`
-      <div style="font-weight: 600; padding: var(--lumo-space-xs);">Configure columns</div>
+      <div style="font-weight: 600; padding: 0.25rem;">Configure columns</div>
       <vaadin-checkbox-group theme="vertical" .value="${visibleColumns}">
         ${columns.map(
           (column) => html`

--- a/frontend/demo/component/popover/popover-notification-panel.ts
+++ b/frontend/demo/component/popover/popover-notification-panel.ts
@@ -83,9 +83,7 @@ export class Example extends LitElement {
 
   renderNotifications(unread: MessageListItem[], all: MessageListItem[]) {
     return html`
-      <vaadin-horizontal-layout
-        style="align-items: center; padding: var(--lumo-space-m) var(--lumo-space-m) var(--lumo-space-xs)"
-      >
+      <vaadin-horizontal-layout style="align-items: center; padding: 1rem 1rem 0.25rem">
         <h4 style="margin: 0" id="notifications-heading">Notifications</h4>
         <vaadin-button theme="small" style="margin: 0 0 0 auto;" @click="${this.markAllRead}">
           Mark all read

--- a/frontend/demo/component/popover/popover-user-menu.ts
+++ b/frontend/demo/component/popover/popover-user-menu.ts
@@ -32,7 +32,7 @@ export class Example extends LitElement {
         <vaadin-button
           id="avatar"
           theme="icon tertiary-inline"
-          style="margin: var(--lumo-space-s); margin-inline-start: auto; border-radius: 50%;"
+          style="margin: 0.5rem; margin-inline-start: auto; border-radius: 50%;"
         >
           <vaadin-avatar
             tabindex="-1"

--- a/frontend/demo/component/popover/react/popover-anchored-dialog.tsx
+++ b/frontend/demo/component/popover/react/popover-anchored-dialog.tsx
@@ -52,7 +52,7 @@ function Example() {
 
       {/* tag::snippet[] */}
       <Popover for="toggle-columns" modal withBackdrop position="bottom-end">
-        <div style={{ fontWeight: '600', padding: 'var(--lumo-space-xs)' }}>Configure columns</div>
+        <div style={{ fontWeight: '600', padding: '0.25rem' }}>Configure columns</div>
         <CheckboxGroup theme="vertical" value={visibleColumns.value}>
           {columns.value.map((item) => (
             <Checkbox

--- a/frontend/demo/component/popover/react/popover-notification-panel.tsx
+++ b/frontend/demo/component/popover/react/popover-notification-panel.tsx
@@ -73,7 +73,7 @@ function Example() {
         <HorizontalLayout
           style={{
             alignItems: 'baseline',
-            padding: 'var(--lumo-space-m) var(--lumo-space-m) var(--lumo-space-xs)',
+            padding: '1rem 1rem 0.25rem',
           }}
         >
           <h4 style={{ margin: 0 }} id="notifications-heading">

--- a/frontend/demo/component/popover/react/popover-user-menu.tsx
+++ b/frontend/demo/component/popover/react/popover-user-menu.tsx
@@ -31,7 +31,7 @@ function Example() {
         <Button
           id="avatar"
           theme="icon tertiary-inline"
-          style={{ margin: 'var(--lumo-space-s)', marginInlineStart: 'auto', borderRadius: '50%' }}
+          style={{ margin: '0.5rem', marginInlineStart: 'auto', borderRadius: '50%' }}
         >
           <Avatar
             tabIndex={-1}

--- a/frontend/demo/component/select/react/select-custom-renderer-label.tsx
+++ b/frontend/demo/component/select/react/select-custom-renderer-label.tsx
@@ -31,7 +31,7 @@ function Example() {
               <img
                 src={person.pictureUrl}
                 alt={`Portrait of ${person.firstName} ${person.lastName}`}
-                style={{ width: '2.25rem', marginRight: 'var(--lumo-space-s)' }}
+                style={{ width: '2.25rem', marginRight: '0.5rem' }}
               />
 
               <div>

--- a/frontend/demo/component/select/react/select-presentation.tsx
+++ b/frontend/demo/component/select/react/select-presentation.tsx
@@ -28,7 +28,7 @@ function Example() {
               <img
                 src={person.pictureUrl}
                 alt={`Portrait of ${person.firstName} ${person.lastName}`}
-                style={{ width: '2.25rem', marginRight: 'var(--lumo-space-s)' }}
+                style={{ width: '2.25rem', marginRight: '0.5rem' }}
               />
 
               <div>

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -42,7 +42,7 @@ export class Example extends LitElement {
                       <img
                         src="${person.pictureUrl}"
                         alt="Portrait of ${formatPersonFullName(person)}"
-                        style="width: 2.25rem; margin-right: var(--lumo-space-s);"
+                        style="width: 2.25rem; margin-right: 0.5rem;"
                       />
                       <div>
                         ${formatPersonFullName(person)}

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -52,7 +52,7 @@ export class Example extends LitElement {
               <img
                 src="${person.pictureUrl}"
                 alt="Portrait of ${person.firstName} ${person.lastName}"
-                style="width: 2.25rem; margin-right: var(--lumo-space-s);"
+                style="width: 2.25rem; margin-right: 0.5rem;"
               />
               <div>
                 ${person.firstName} ${person.lastName}

--- a/frontend/demo/component/side-nav/react/side-nav-example-styles.ts
+++ b/frontend/demo/component/side-nav/react/side-nav-example-styles.ts
@@ -9,7 +9,7 @@ const styles = css`
   .side-nav-sample > * {
     background: var(--lumo-base-color);
     box-shadow: var(--lumo-box-shadow-s);
-    padding: var(--lumo-space-m);
+    padding: 1rem;
     width: 15em;
   }
 `;

--- a/frontend/demo/component/side-nav/react/side-nav-suffix.tsx
+++ b/frontend/demo/component/side-nav/react/side-nav-suffix.tsx
@@ -38,7 +38,7 @@ function Example() {
             <Icon
               icon="vaadin:bell"
               theme="badge error pill"
-              style={{ padding: 'var(--lumo-space-xs)' }}
+              style={{ padding: '0.25rem' }}
               aria-label="Upcoming appointment"
               slot="suffix"
             />

--- a/frontend/demo/component/side-nav/side-nav-suffix.ts
+++ b/frontend/demo/component/side-nav/side-nav-suffix.ts
@@ -38,7 +38,7 @@ export class Example extends LitElement {
               <vaadin-icon
                 icon="vaadin:bell"
                 theme="badge error pill"
-                style="padding:var(--lumo-space-xs)"
+                style="padding:0.25rem"
                 aria-label="Upcoming appointment"
                 slot="suffix"
               ></vaadin-icon>

--- a/frontend/demo/component/splitlayout/detail-content.ts
+++ b/frontend/demo/component/splitlayout/detail-content.ts
@@ -33,9 +33,9 @@ export class DetailContent extends LitElement {
     input {
       background: var(--lumo-contrast-10pct);
       border-radius: var(--lumo-border-radius-s);
-      padding: var(--lumo-space-s) 0;
+      padding: 0.5rem 0;
       border: none;
-      margin-top: var(--lumo-space-s);
+      margin-top: 0.5rem;
     }
   `;
 

--- a/frontend/demo/component/splitlayout/react/split-layout-example-styles.ts
+++ b/frontend/demo/component/splitlayout/react/split-layout-example-styles.ts
@@ -59,9 +59,9 @@ const styles = css`
   input {
     background: var(--lumo-contrast-10pct);
     border-radius: var(--lumo-border-radius-s);
-    padding: var(--lumo-space-s) 0;
+    padding: 0.5rem 0;
     border: none;
-    margin-top: var(--lumo-space-s);
+    margin-top: 0.5rem;
   }
 `;
 

--- a/frontend/demo/component/tabs/react/tabs-badges.tsx
+++ b/frontend/demo/component/tabs/react/tabs-badges.tsx
@@ -4,7 +4,7 @@ import { Tab } from '@vaadin/react-components/Tab.js';
 import { Tabs } from '@vaadin/react-components/Tabs.js';
 
 const badgeStyle = {
-  marginInlineStart: 'var(--lumo-space-xs)',
+  marginInlineStart: '0.25rem',
 };
 
 function Example() {

--- a/frontend/demo/component/tabs/tabs-badges.ts
+++ b/frontend/demo/component/tabs/tabs-badges.ts
@@ -8,7 +8,7 @@ export class Example extends LitElement {
   static override styles = [
     css`
       span[theme~='badge'] {
-        margin-inline-start: var(--lumo-space-xs);
+        margin-inline-start: 0.25rem;
       }
     `,
   ];

--- a/frontend/demo/component/tree-grid/react/tree-grid-rich-content.tsx
+++ b/frontend/demo/component/tree-grid/react/tree-grid-rich-content.tsx
@@ -43,7 +43,7 @@ function contactRenderer({ item: person }: { item: Person }) {
           icon="vaadin:envelope"
           style={{
             height: 'var(--lumo-icon-size-s)',
-            marginInlineEnd: 'var(--lumo-space-s)',
+            marginInlineEnd: '0.5rem',
             width: 'var(--lumo-icon-size-s)',
           }}
         />
@@ -54,7 +54,7 @@ function contactRenderer({ item: person }: { item: Person }) {
           icon="vaadin:phone"
           style={{
             height: 'var(--lumo-icon-size-s)',
-            marginInlineEnd: 'var(--lumo-space-s)',
+            marginInlineEnd: '0.5rem',
             width: 'var(--lumo-icon-size-s)',
           }}
         />

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -79,14 +79,14 @@ export class Example extends LitElement {
       <a href="mailto:${person.email}" style="align-items: center; display: flex;">
         <vaadin-icon
           icon="vaadin:envelope"
-          style="height: var(--lumo-icon-size-s); margin-inline-end: var(--lumo-space-s); width: var(--lumo-icon-size-s);"
+          style="height: var(--lumo-icon-size-s); margin-inline-end: 0.5rem; width: var(--lumo-icon-size-s);"
         ></vaadin-icon>
         <span>${person.email}</span>
       </a>
       <a href="tel:${person.address.phone}" style="align-items: center; display: flex;">
         <vaadin-icon
           icon="vaadin:phone"
-          style="height: var(--lumo-icon-size-s); margin-inline-end: var(--lumo-space-s); width: var(--lumo-icon-size-s);"
+          style="height: var(--lumo-icon-size-s); margin-inline-end: 0.5rem; width: var(--lumo-icon-size-s);"
         ></vaadin-icon>
         <span>${person.address.phone}</span>
       </a>

--- a/frontend/demo/component/vertical-layout/react/layoutExampleStyle.ts
+++ b/frontend/demo/component/vertical-layout/react/layoutExampleStyle.ts
@@ -26,7 +26,7 @@ const layoutExampleStyles = css`
     background: var(--lumo-primary-color);
     color: var(--lumo-primary-contrast-color);
     border-radius: var(--lumo-border-radius-m);
-    padding: var(--lumo-space-s) var(--lumo-space-l);
+    padding: 0.5rem 1.5rem;
     white-space: nowrap;
   }
 `;

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBottomNavbar.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBottomNavbar.java
@@ -21,7 +21,7 @@ public class AppLayoutBottomNavbar extends AppLayout {
                 "true"); // hidden-source-line
         H1 title = new H1("MyApp");
         title.getStyle().set("font-size", "1.125rem").set("margin",
-                "var(--lumo-space-m) var(--lumo-space-l)");
+                "1rem 1.5rem");
 
         HorizontalLayout nav = getNavigation();
         nav.getElement().executeJs("window.patchAppLayoutNavigation(this);"); // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightAuto.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightAuto.java
@@ -17,7 +17,7 @@ public class AppLayoutHeightAuto extends AppLayout {
     public AppLayoutHeightAuto() {
         H1 title = new H1("MyApp");
         title.getStyle().set("font-size", "1.125rem").set("margin",
-                "var(--lumo-space-m)");
+                "1rem");
         addToNavbar(title);
 
         Grid<Person> grid = new Grid<>(Person.class, false);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightFull.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutHeightFull.java
@@ -18,7 +18,7 @@ public class AppLayoutHeightFull extends AppLayout {
     public AppLayoutHeightFull() {
         H1 title = new H1("MyApp");
         title.getStyle().set("font-size", "1.125rem").set("margin",
-                "var(--lumo-space-m)");
+                "1rem");
         addToNavbar(title);
 
         Grid<Person> grid = new Grid<>(Person.class, false);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbar.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbar.java
@@ -15,7 +15,7 @@ public class AppLayoutNavbar extends AppLayout {
     public AppLayoutNavbar() {
         H1 title = new H1("MyApp");
         title.getStyle().set("font-size", "1.125rem")
-                .set("left", "var(--lumo-space-l)").set("margin", "0")
+                .set("left", "1.5rem").set("margin", "0")
                 .set("position", "absolute");
 
         HorizontalLayout navigation = getNavigation();

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
@@ -24,7 +24,7 @@ public class AppLayoutSecondaryNavigation extends AppLayout {
         H1 appTitle = new H1("MyApp");
         appTitle.getStyle().set("font-size", "1.125rem")
                 .set("line-height", "2.75rem")
-                .set("margin", "0 var(--lumo-space-m)");
+                .set("margin", "0 1rem");
 
         SideNav views = getPrimaryNavigation();
         views.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/badge/BadgeCounter.java
+++ b/src/main/java/com/vaadin/demo/component/badge/BadgeCounter.java
@@ -24,7 +24,7 @@ public class BadgeCounter extends Div {
         Span label = new Span(labelText);
         Span counter = new Span(String.valueOf(messageCount));
         counter.getElement().getThemeList().add("badge pill small contrast");
-        counter.getStyle().set("margin-inline-start", "var(--lumo-space-s)");
+        counter.getStyle().set("margin-inline-start", "0.5rem");
         // Accessible badge label
         String counterLabel = String.format("%d unread messages", messageCount);
         counter.getElement().setAttribute("aria-label", counterLabel);

--- a/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java
+++ b/src/main/java/com/vaadin/demo/component/badge/BadgeIcons.java
@@ -67,7 +67,7 @@ public class BadgeIcons extends VerticalLayout {
     // tag::snippet3[]
     private Icon createIcon(VaadinIcon vaadinIcon) {
         Icon icon = vaadinIcon.create();
-        icon.getStyle().set("padding", "var(--lumo-space-xs)");
+        icon.getStyle().set("padding", "0.25rem");
         return icon;
     }
 

--- a/src/main/java/com/vaadin/demo/component/badge/BadgeInteractive.java
+++ b/src/main/java/com/vaadin/demo/component/badge/BadgeInteractive.java
@@ -38,7 +38,7 @@ public class BadgeInteractive extends VerticalLayout {
         clearButton.addThemeVariants(ButtonVariant.LUMO_CONTRAST,
                 ButtonVariant.LUMO_TERTIARY_INLINE);
         clearButton.getStyle().set("margin-inline-start",
-                "var(--lumo-space-xs)");
+                "0.25rem");
         // Accessible button name
         clearButton.getElement().setAttribute("aria-label",
                 "Clear filter: " + profession);

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java
@@ -40,7 +40,7 @@ public class ComboBoxPresentation extends Div {
         StringBuilder tpl = new StringBuilder();
         tpl.append("<div style=\"display: flex;\">");
         tpl.append(
-                "  <img style=\"height: 2.25rem; margin-right: var(--lumo-space-s);\" src=\"${item.pictureUrl}\" alt=\"Portrait of ${item.firstName} ${item.lastName}\" />");
+                "  <img style=\"height: 2.25rem; margin-right: 0.5rem;\" src=\"${item.pictureUrl}\" alt=\"Portrait of ${item.firstName} ${item.lastName}\" />");
         tpl.append("  <div>");
         tpl.append("    ${item.firstName} ${item.lastName}");
         tpl.append(

--- a/src/main/java/com/vaadin/demo/component/details/DetailsSummary.java
+++ b/src/main/java/com/vaadin/demo/component/details/DetailsSummary.java
@@ -31,7 +31,7 @@ public class DetailsSummary extends Div {
                 new Span(" 2 errors"));
         errorBadge.setSpacing(false);
         errorBadge.getStyle().set("color", "var(--lumo-error-text-color)");
-        errorBadge.getStyle().set("margin-left", "var(--lumo-space-s)");
+        errorBadge.getStyle().set("margin-left", "0.5rem");
 
         summary.add(new Text("Contact information"), errorBadge);
 

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogClosing.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogClosing.java
@@ -27,7 +27,7 @@ public class DialogClosing extends Div {
 
     private static VerticalLayout createDialogLayout(Dialog dialog) {
         H2 headline = new H2("System maintenance");
-        headline.getStyle().set("margin", "var(--lumo-space-m) 0")
+        headline.getStyle().set("margin", "1rem 0")
                 .set("font-size", "1.5em").set("font-weight", "bold");
 
         Paragraph paragraph = new Paragraph(

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogDraggable.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogDraggable.java
@@ -40,7 +40,7 @@ public class DialogDraggable extends Div {
         // end::snippet2[]
         headline.getStyle().set("margin", "0").set("font-size", "1.5em")
                 .set("font-weight", "bold").set("cursor", "move")
-                .set("padding", "var(--lumo-space-m) 0").set("flex", "1");
+                .set("padding", "1rem 0").set("flex", "1");
 
         return headline;
     }

--- a/src/main/java/com/vaadin/demo/component/grid/GridColumnFiltering.java
+++ b/src/main/java/com/vaadin/demo/component/grid/GridColumnFiltering.java
@@ -54,7 +54,7 @@ public class GridColumnFiltering extends Div {
     private static Component createFilterHeader(String labelText,
             Consumer<String> filterChangeConsumer) {
         NativeLabel label = new NativeLabel(labelText);
-        label.getStyle().set("padding-top", "var(--lumo-space-m)")
+        label.getStyle().set("padding-top", "1rem")
                 .set("font-size", "var(--lumo-font-size-xs)");
         TextField textField = new TextField();
         textField.setValueChangeMode(ValueChangeMode.EAGER);

--- a/src/main/java/com/vaadin/demo/component/login/LoginBasic.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginBasic.java
@@ -12,7 +12,7 @@ public class LoginBasic extends Div {
         // Demo purposes only
         getStyle().set("background-color", "var(--lumo-contrast-5pct)")
                 .set("display", "flex").set("justify-content", "center")
-                .set("padding", "var(--lumo-space-l)");
+                .set("padding", "1.5rem");
 
         // tag::snippet[]
         LoginForm loginForm = new LoginForm();

--- a/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java
@@ -13,7 +13,7 @@ public class LoginInternationalization extends Div {
         // Demo purposes only
         getStyle().set("background-color", "var(--lumo-contrast-5pct)")
                 .set("display", "flex").set("justify-content", "center")
-                .set("padding", "var(--lumo-space-l)");
+                .set("padding", "1.5rem");
 
         // tag::snippet[]
         LoginI18n i18n = LoginI18n.createDefault();

--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarIcons.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarIcons.java
@@ -41,7 +41,7 @@ public class MenuBarIcons extends Div {
         if (isChild) {
             icon.getStyle().setWidth("var(--lumo-icon-size-s)");
             icon.getStyle().setHeight("var(--lumo-icon-size-s)");
-            icon.getStyle().setMarginRight("var(--lumo-space-s)");
+            icon.getStyle().setMarginRight("0.5rem");
         }
 
         MenuItem item = menu.addItem(icon, e -> {

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationKeyboardA11y.java
@@ -58,7 +58,7 @@ public class NotificationKeyboardA11y extends Div {
 
         public CloseButtonWithShortcutHint() {
             addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-            getStyle().set("margin-left", "var(--lumo-space-xl)");
+            getStyle().set("margin-left", "2.5rem");
             getElement().executeJs(
                     """
                             const isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(window.navigator.platform);

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationRetry.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationRetry.java
@@ -59,7 +59,7 @@ public class NotificationRetry extends Div {
         public RetryButton() {
             super("Retry");
             addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-            getElement().getStyle().set("margin-left", "var(--lumo-space-xl)");
+            getElement().getStyle().set("margin-left", "2.5rem");
             addClickListener(e -> findAncestor(Notification.class).close());
         }
     }

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationRich.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationRich.java
@@ -67,7 +67,7 @@ public class NotificationRich extends HorizontalLayout {
         Icon icon = VaadinIcon.CHECK_CIRCLE.create();
 
         Button viewBtn = new Button("View", clickEvent -> notification.close());
-        viewBtn.getStyle().setMargin("0 0 0 var(--lumo-space-l)");
+        viewBtn.getStyle().setMargin("0 0 0 1.5rem");
 
         var layout = new HorizontalLayout(icon,
                 new Text("Application submitted!"), viewBtn,
@@ -86,7 +86,7 @@ public class NotificationRich extends HorizontalLayout {
         Icon icon = VaadinIcon.WARNING.create();
         Button retryBtn = new Button("Retry",
                 clickEvent -> notification.close());
-        retryBtn.getStyle().setMargin("0 0 0 var(--lumo-space-l)");
+        retryBtn.getStyle().setMargin("0 0 0 1.5rem");
 
         var layout = new HorizontalLayout(icon,
                 new Text("Failed to generate report!"), retryBtn,

--- a/src/main/java/com/vaadin/demo/component/notification/NotificationUndo.java
+++ b/src/main/java/com/vaadin/demo/component/notification/NotificationUndo.java
@@ -59,7 +59,7 @@ public class NotificationUndo extends Div {
         public UndoButton() {
             super("Undo");
             addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-            getElement().getStyle().set("margin-left", "var(--lumo-space-xl)");
+            getElement().getStyle().set("margin-left", "2.5rem");
         }
     }
 

--- a/src/main/java/com/vaadin/demo/component/popover/PopoverAnchoredDialog.java
+++ b/src/main/java/com/vaadin/demo/component/popover/PopoverAnchoredDialog.java
@@ -67,12 +67,12 @@ public class PopoverAnchoredDialog extends Div {
 
         Div heading = new Div("Configure columns");
         heading.getStyle().set("font-weight", "600");
-        heading.getStyle().set("padding", "var(--lumo-space-xs)");
+        heading.getStyle().set("padding", "0.25rem");
 
         List<String> columns = List.of("firstName", "lastName", "email",
                 "phone", "birthday", "profession");
         // tag::gridsnippet[]
-        
+
         CheckboxGroup<String> group = new CheckboxGroup<>();
         group.addThemeVariants(CheckboxGroupVariant.LUMO_VERTICAL);
         group.setItems(columns);

--- a/src/main/java/com/vaadin/demo/component/popover/PopoverNotificationPanel.java
+++ b/src/main/java/com/vaadin/demo/component/popover/PopoverNotificationPanel.java
@@ -103,7 +103,7 @@ public class PopoverNotificationPanel extends Div {
         layout.setSpacing(false);
         layout.setAlignItems(FlexComponent.Alignment.CENTER);
         layout.getStyle().set("padding",
-                "var(--lumo-space-m) var(--lumo-space-m) var(--lumo-space-xs)");
+                "1rem 1rem 0.25rem");
 
         popover.add(layout, tabSheet);
 

--- a/src/main/java/com/vaadin/demo/component/popover/PopoverUserMenu.java
+++ b/src/main/java/com/vaadin/demo/component/popover/PopoverUserMenu.java
@@ -39,7 +39,7 @@ public class PopoverUserMenu extends HorizontalLayout {
         Button button = new Button(avatar);
         button.addThemeVariants(ButtonVariant.LUMO_ICON,
                 ButtonVariant.LUMO_TERTIARY_INLINE);
-        button.getStyle().set("margin", "var(--lumo-space-s)");
+        button.getStyle().set("margin", "0.5rem");
         button.getStyle().set("margin-inline-start", "auto");
         button.getStyle().set("border-radius", "50%");
 

--- a/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java
@@ -47,7 +47,7 @@ public class SelectCustomRendererLabel extends Div {
             image.setAlt("Portrait of " + person.getFirstName() + " "
                     + person.getLastName());
             image.setWidth("2.25rem");
-            image.getStyle().set("margin-right", "var(--lumo-space-s)");
+            image.getStyle().set("margin-right", "0.5rem");
 
             Div info = new Div();
             info.setText(person.getFirstName() + " " + person.getLastName());

--- a/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java
@@ -36,7 +36,7 @@ public class SelectPresentation extends Div {
             image.setAlt("Portrait of " + person.getFirstName() + " "
                     + person.getLastName());
             image.setWidth("2.25rem");
-            image.getStyle().set("margin-right", "var(--lumo-space-s)");
+            image.getStyle().set("margin-right", "0.5rem");
 
             Div info = new Div();
             info.setText(person.getFirstName() + " " + person.getLastName());

--- a/src/main/java/com/vaadin/demo/component/tabs/TabsBadges.java
+++ b/src/main/java/com/vaadin/demo/component/tabs/TabsBadges.java
@@ -27,7 +27,7 @@ public class TabsBadges extends Div {
     private Span createBadge(int value) {
         Span badge = new Span(String.valueOf(value));
         badge.getElement().getThemeList().add("badge small contrast");
-        badge.getStyle().set("margin-inline-start", "var(--lumo-space-xs)");
+        badge.getStyle().set("margin-inline-start", "0.25rem");
         return badge;
     }
 

--- a/src/main/java/com/vaadin/demo/component/treegrid/TreeGridColumn.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/TreeGridColumn.java
@@ -40,7 +40,7 @@ public class TreeGridColumn extends Div {
         HorizontalLayout header = new HorizontalLayout(employees, expand,
                 collapse);
         header.setAlignItems(FlexComponent.Alignment.CENTER);
-        header.setHeight("var(--lumo-space-xl)");
+        header.setHeight("2.5rem");
         header.setFlexGrow(1, employees);
 
         add(header, treeGrid);

--- a/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java
@@ -83,7 +83,7 @@ public class TreeGridRichContent extends Div {
 
     private Icon createIcon(VaadinIcon vaadinIcon) {
         Icon icon = vaadinIcon.create();
-        icon.getStyle().set("margin-inline-end", "var(--lumo-space-s)");
+        icon.getStyle().set("margin-inline-end", "0.5rem");
         icon.setSize("var(--lumo-icon-size-s)");
         return icon;
     }


### PR DESCRIPTION
Part of https://github.com/vaadin/docs/issues/4833

Replaced `--lumo-space` custom CSS properties with rem values.