### PR TITLE
docs: replace usage of lumo-space-s CSS property

### DIFF
--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -65,7 +65,7 @@ export class Example extends LitElement {
   private renderer: ComboBoxLitRenderer<Person> = (person) => html`
     <div style="display: flex;">
       <img
-        style="height: 2.25rem; margin-right: var(--lumo-space-s);"
+        style="height: 2.25rem; margin-right: var(--vaadin-gap-s);"
         src="${person.pictureUrl}"
         alt="Portrait of ${person.firstName} ${person.lastName}"
       />

--- a/frontend/demo/component/combobox/react/combo-box-presentation.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-presentation.tsx
@@ -12,7 +12,7 @@ function renderPerson({ item: person }: { item: Person }) {
   return (
     <div style={{ display: 'flex' }}>
       <img
-        style={{ height: '2.25rem', marginRight: 'var(--lumo-space-s)' }}
+        style={{ height: '2.25rem', marginRight: 'var(--vaadin-gap-s)' }}
         src={person.pictureUrl}
         alt={`Portrait of ${person.firstName} ${person.lastName}`}
       />

--- a/frontend/demo/component/contextmenu/context-menu-presentation.ts
+++ b/frontend/demo/component/contextmenu/context-menu-presentation.ts
@@ -115,7 +115,7 @@ export class Example extends LitElement {
     const icon = document.createElement('vaadin-icon');
 
     icon.style.color = 'var(--lumo-secondary-text-color)';
-    icon.style.marginInlineEnd = 'var(--lumo-space-s)';
+    icon.style.marginInlineEnd = 'var(--vaadin-gap-s)';
     icon.style.padding = 'var(--lumo-space-xs)';
 
     icon.setAttribute('icon', iconName);

--- a/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
+++ b/frontend/demo/component/contextmenu/react/context-menu-presentation.tsx
@@ -42,7 +42,7 @@ function createItem(iconName: string, text: string) {
         icon={iconName}
         style={{
           color: 'var(--lumo-secondary-text-color)',
-          marginInlineEnd: 'var(--lumo-space-s)',
+          marginInlineEnd: 'var(--vaadin-gap-s)',
           padding: 'var(--lumo-space-xs)',
         }}
       />

--- a/frontend/demo/component/details/details-summary.ts
+++ b/frontend/demo/component/details/details-summary.ts
@@ -43,7 +43,7 @@ export class Example extends LitElement {
             <span>Contact information</span>
 
             <vaadin-horizontal-layout
-              style="color: var(--lumo-error-text-color); margin-left: var(--lumo-space-s)"
+              style="color: var(--lumo-error-text-color); margin-left: var(--vaadin-gap-s)"
             >
               <vaadin-icon
                 icon="vaadin:exclamation-circle"

--- a/frontend/demo/component/details/react/details-summary.tsx
+++ b/frontend/demo/component/details/react/details-summary.tsx
@@ -36,7 +36,7 @@ function Example() {
           <span>Contact information</span>
 
           <HorizontalLayout
-            style={{ color: 'var(--lumo-error-text-color)', marginLeft: 'var(--lumo-space-s)' }}
+            style={{ color: 'var(--lumo-error-text-color)', marginLeft: 'var(--vaadin-gap-s)' }}
           >
             <Icon
               icon="vaadin:exclamation-circle"

--- a/frontend/demo/component/menubar/menu-bar-icons.ts
+++ b/frontend/demo/component/menubar/menu-bar-icons.ts
@@ -45,7 +45,7 @@ export class Example extends LitElement {
     if (isChild) {
       icon.style.width = 'var(--lumo-icon-size-s)';
       icon.style.height = 'var(--lumo-icon-size-s)';
-      icon.style.marginRight = 'var(--lumo-space-s)';
+      icon.style.marginRight = 'var(--vaadin-gap-s)';
     }
 
     if (iconName === 'copy') {

--- a/frontend/demo/component/menubar/react/menu-bar-icons.tsx
+++ b/frontend/demo/component/menubar/react/menu-bar-icons.tsx
@@ -8,7 +8,7 @@ function createItem(iconName: string, text: string, isChild = false) {
   const iconStyle: React.CSSProperties = {
     width: isChild ? 'var(--lumo-icon-size-s)' : '',
     height: isChild ? 'var(--lumo-icon-size-s)' : '',
-    marginRight: isChild ? 'var(--lumo-space-s)' : '',
+    marginRight: isChild ? 'var(--vaadin-gap-s)' : '',
   };
 
   let ariaLabel = '';

--- a/frontend/demo/component/popover/popover-user-menu.ts
+++ b/frontend/demo/component/popover/popover-user-menu.ts
@@ -32,7 +32,7 @@ export class Example extends LitElement {
         <vaadin-button
           id="avatar"
           theme="icon tertiary-inline"
-          style="margin: var(--lumo-space-s); margin-inline-start: auto; border-radius: 50%;"
+          style="margin: var(--vaadin-gap-s); margin-inline-start: auto; border-radius: 50%;"
         >
           <vaadin-avatar
             tabindex="-1"

--- a/frontend/demo/component/popover/react/popover-user-menu.tsx
+++ b/frontend/demo/component/popover/react/popover-user-menu.tsx
@@ -31,7 +31,7 @@ function Example() {
         <Button
           id="avatar"
           theme="icon tertiary-inline"
-          style={{ margin: 'var(--lumo-space-s)', marginInlineStart: 'auto', borderRadius: '50%' }}
+          style={{ margin: 'var(--vaadin-gap-s)', marginInlineStart: 'auto', borderRadius: '50%' }}
         >
           <Avatar
             tabIndex={-1}

--- a/frontend/demo/component/select/react/select-custom-renderer-label.tsx
+++ b/frontend/demo/component/select/react/select-custom-renderer-label.tsx
@@ -31,7 +31,7 @@ function Example() {
               <img
                 src={person.pictureUrl}
                 alt={`Portrait of ${person.firstName} ${person.lastName}`}
-                style={{ width: '2.25rem', marginRight: 'var(--lumo-space-s)' }}
+                style={{ width: '2.25rem', marginRight: 'var(--vaadin-gap-s)' }}
               />
 
               <div>

--- a/frontend/demo/component/select/react/select-presentation.tsx
+++ b/frontend/demo/component/select/react/select-presentation.tsx
@@ -28,7 +28,7 @@ function Example() {
               <img
                 src={person.pictureUrl}
                 alt={`Portrait of ${person.firstName} ${person.lastName}`}
-                style={{ width: '2.25rem', marginRight: 'var(--lumo-space-s)' }}
+                style={{ width: '2.25rem', marginRight: 'var(--vaadin-gap-s)' }}
               />
 
               <div>

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -42,7 +42,7 @@ export class Example extends LitElement {
                       <img
                         src="${person.pictureUrl}"
                         alt="Portrait of ${formatPersonFullName(person)}"
-                        style="width: 2.25rem; margin-right: var(--lumo-space-s);"
+                        style="width: 2.25rem; margin-right: var(--vaadin-gap-s);"
                       />
                       <div>
                         ${formatPersonFullName(person)}

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -52,7 +52,7 @@ export class Example extends LitElement {
               <img
                 src="${person.pictureUrl}"
                 alt="Portrait of ${person.firstName} ${person.lastName}"
-                style="width: 2.25rem; margin-right: var(--lumo-space-s);"
+                style="width: 2.25rem; margin-right: var(--vaadin-gap-s);"
               />
               <div>
                 ${person.firstName} ${person.lastName}

--- a/frontend/demo/component/tree-grid/react/tree-grid-rich-content.tsx
+++ b/frontend/demo/component/tree-grid/react/tree-grid-rich-content.tsx
@@ -43,7 +43,7 @@ function contactRenderer({ item: person }: { item: Person }) {
           icon="vaadin:envelope"
           style={{
             height: 'var(--lumo-icon-size-s)',
-            marginInlineEnd: 'var(--lumo-space-s)',
+            marginInlineEnd: 'var(--vaadin-gap-s)',
             width: 'var(--lumo-icon-size-s)',
           }}
         />
@@ -54,7 +54,7 @@ function contactRenderer({ item: person }: { item: Person }) {
           icon="vaadin:phone"
           style={{
             height: 'var(--lumo-icon-size-s)',
-            marginInlineEnd: 'var(--lumo-space-s)',
+            marginInlineEnd: 'var(--vaadin-gap-s)',
             width: 'var(--lumo-icon-size-s)',
           }}
         />

--- a/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
+++ b/frontend/demo/component/tree-grid/tree-grid-rich-content.ts
@@ -79,14 +79,14 @@ export class Example extends LitElement {
       <a href="mailto:${person.email}" style="align-items: center; display: flex;">
         <vaadin-icon
           icon="vaadin:envelope"
-          style="height: var(--lumo-icon-size-s); margin-inline-end: var(--lumo-space-s); width: var(--lumo-icon-size-s);"
+          style="height: var(--lumo-icon-size-s); margin-inline-end: var(--vaadin-gap-s); width: var(--lumo-icon-size-s);"
         ></vaadin-icon>
         <span>${person.email}</span>
       </a>
       <a href="tel:${person.address.phone}" style="align-items: center; display: flex;">
         <vaadin-icon
           icon="vaadin:phone"
-          style="height: var(--lumo-icon-size-s); margin-inline-end: var(--lumo-space-s); width: var(--lumo-icon-size-s);"
+          style="height: var(--lumo-icon-size-s); margin-inline-end: var(--vaadin-gap-s); width: var(--lumo-icon-size-s);"
         ></vaadin-icon>
         <span>${person.address.phone}</span>
       </a>

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java
@@ -40,7 +40,7 @@ public class ComboBoxPresentation extends Div {
         StringBuilder tpl = new StringBuilder();
         tpl.append("<div style=\"display: flex;\">");
         tpl.append(
-                "  <img style=\"height: 2.25rem; margin-right: var(--lumo-space-s);\" src=\"${item.pictureUrl}\" alt=\"Portrait of ${item.firstName} ${item.lastName}\" />");
+                "  <img style=\"height: 2.25rem; margin-right: var(--vaadin-gap-s);\" src=\"${item.pictureUrl}\" alt=\"Portrait of ${item.firstName} ${item.lastName}\" />");
         tpl.append("  <div>");
         tpl.append("    ${item.firstName} ${item.lastName}");
         tpl.append(

--- a/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/contextmenu/ContextMenuPresentation.java
@@ -68,7 +68,7 @@ public class ContextMenuPresentation extends Div {
     private Component createIcon(VaadinIcon vaadinIcon) {
         Icon icon = vaadinIcon.create();
         icon.getStyle().set("color", "var(--lumo-secondary-text-color)")
-                .set("margin-inline-end", "var(--lumo-space-s")
+                .set("margin-inline-end", "var(--vaadin-gap-s")
                 .set("padding", "var(--lumo-space-xs");
         return icon;
     }

--- a/src/main/java/com/vaadin/demo/component/details/DetailsSummary.java
+++ b/src/main/java/com/vaadin/demo/component/details/DetailsSummary.java
@@ -31,7 +31,7 @@ public class DetailsSummary extends Div {
                 new Span(" 2 errors"));
         errorBadge.setSpacing(false);
         errorBadge.getStyle().set("color", "var(--lumo-error-text-color)");
-        errorBadge.getStyle().set("margin-left", "var(--lumo-space-s)");
+        errorBadge.getStyle().set("margin-left", "var(--vaadin-gap-s)");
 
         summary.add(new Text("Contact information"), errorBadge);
 

--- a/src/main/java/com/vaadin/demo/component/menubar/MenuBarIcons.java
+++ b/src/main/java/com/vaadin/demo/component/menubar/MenuBarIcons.java
@@ -41,7 +41,7 @@ public class MenuBarIcons extends Div {
         if (isChild) {
             icon.getStyle().setWidth("var(--lumo-icon-size-s)");
             icon.getStyle().setHeight("var(--lumo-icon-size-s)");
-            icon.getStyle().setMarginRight("var(--lumo-space-s)");
+            icon.getStyle().setMarginRight("var(--vaadin-gap-s)");
         }
 
         MenuItem item = menu.addItem(icon, e -> {

--- a/src/main/java/com/vaadin/demo/component/popover/PopoverUserMenu.java
+++ b/src/main/java/com/vaadin/demo/component/popover/PopoverUserMenu.java
@@ -39,7 +39,7 @@ public class PopoverUserMenu extends HorizontalLayout {
         Button button = new Button(avatar);
         button.addThemeVariants(ButtonVariant.LUMO_ICON,
                 ButtonVariant.LUMO_TERTIARY_INLINE);
-        button.getStyle().set("margin", "var(--lumo-space-s)");
+        button.getStyle().set("margin", "var(--vaadin-gap-s)");
         button.getStyle().set("margin-inline-start", "auto");
         button.getStyle().set("border-radius", "50%");
 

--- a/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectCustomRendererLabel.java
@@ -47,7 +47,7 @@ public class SelectCustomRendererLabel extends Div {
             image.setAlt("Portrait of " + person.getFirstName() + " "
                     + person.getLastName());
             image.setWidth("2.25rem");
-            image.getStyle().set("margin-right", "var(--lumo-space-s)");
+            image.getStyle().set("margin-right", "var(--vaadin-gap-s)");
 
             Div info = new Div();
             info.setText(person.getFirstName() + " " + person.getLastName());

--- a/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/select/SelectPresentation.java
@@ -36,7 +36,7 @@ public class SelectPresentation extends Div {
             image.setAlt("Portrait of " + person.getFirstName() + " "
                     + person.getLastName());
             image.setWidth("2.25rem");
-            image.getStyle().set("margin-right", "var(--lumo-space-s)");
+            image.getStyle().set("margin-right", "var(--vaadin-gap-s)");
 
             Div info = new Div();
             info.setText(person.getFirstName() + " " + person.getLastName());

--- a/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/TreeGridRichContent.java
@@ -83,7 +83,7 @@ public class TreeGridRichContent extends Div {
 
     private Icon createIcon(VaadinIcon vaadinIcon) {
         Icon icon = vaadinIcon.create();
-        icon.getStyle().set("margin-inline-end", "var(--lumo-space-s)");
+        icon.getStyle().set("margin-inline-end", "var(--vaadin-gap-s)");
         icon.setSize("var(--lumo-icon-size-s)");
         return icon;
     }


### PR DESCRIPTION
Replaced `var(--lumo-space-s)` with `var(--vaadin-gap-s)` in some examples where this is used as gap between items, for example icon and text, or image and some text in combo-box / context-menu custom item presentation examples etc.