### PR TITLE
refactor: basic dark mode support for examples with Aura theme

### DIFF
--- a/dspublisher/theme/global.css
+++ b/dspublisher/theme/global.css
@@ -90,6 +90,8 @@ html {
   --docs-before-background-color: var(--red-50);
   --docs-after-background-color: var(--green-100);
   --docs-before-after-border-color: var(--gray-300);
+
+  --docs-example-render-background-color: white;
 }
 
 ::-moz-selection {
@@ -274,6 +276,8 @@ html[theme~='dark'] {
   --docs-before-background-color: #301821;
   --docs-after-background-color: #172e1f;
   --docs-before-after-border-color: var(--gray-600);
+
+  --docs-example-render-background-color: black;
 }
 
 /* Vaadin logo text color (adapt to dark mode) */

--- a/frontend/demo/init.ts
+++ b/frontend/demo/init.ts
@@ -8,9 +8,10 @@ import client from 'Frontend/generated/connect-client.default';
 // @ts-expect-error Inserted by DS Publisher
 client.prefix = __VAADIN_CONNECT_PREFIX__; // eslint-disable-line no-undef
 
-document.body.style.setProperty('--docs-example-render-font-family', 'var(--lumo-font-family)');
-document.body.style.setProperty('--docs-example-render-color', 'var(--lumo-body-text-color)');
-document.body.style.setProperty('--docs-example-render-background-color', 'var(--lumo-base-color)');
+// TODO: These props are not defined in global scope and we don't want to load the whole theme into
+// the global styles. Needs checking whether / when these are actually needed.
+// document.body.style.setProperty('--docs-example-render-font-family', 'var(--aura-font-family)');
+// document.body.style.setProperty('--docs-example-render-color', 'var(--vaadin-text-color)');
 
 // Ensures standalone UI sample pags have a lang attribute
 document.documentElement.setAttribute('lang', 'en');

--- a/frontend/themes/docs/styles.css
+++ b/frontend/themes/docs/styles.css
@@ -19,3 +19,16 @@
 @import './popover-notification-panel.css';
 @import './popover-user-menu.css';
 @import './text-area.css';
+
+/* Tweak Aura background to work better with example container styles */
+/* Exact same colors are set for --docs-example-render-background-color in global.css */
+:host {
+  --aura-background-color-light: white;
+  --aura-background-color-dark: black;
+}
+
+/* Aura requires setting color-scheme when dark mode is active */
+/* Consider updating DSP to set color-scheme in addition to theme attribute */
+:host([theme='dark']) {
+  color-scheme: dark;
+}


### PR DESCRIPTION
Changes Aura background colors to work better with the example container styles and makes dark mode work in examples.

This will require a second pass by Jouni at some point to either tweak the Aura backgrounds and / or the docs styles.