### PR TITLE
docs: fix properties table in Spreadsheet page

### DIFF
--- a/articles/components/spreadsheet/styling.adoc
+++ b/articles/components/spreadsheet/styling.adoc
@@ -11,7 +11,7 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 
 === Color Properties
 
-[cols="1,2,2"]
+[cols="1,2"]
 |===
 | Feature | Property
 


### PR DESCRIPTION
There's an extra column in the table.