### PR TITLE
refactor: update ComboBox examples to Aura theme

### DIFF
--- a/articles/components/combo-box/index.adoc
+++ b/articles/components/combo-box/index.adoc
@@ -478,35 +478,6 @@ endif::[]
 --
 
 
-// Style Variants
-
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
-
-[.example]
---
-ifdef::lit[]
-[source,typescript]
-----
-include::{root}/frontend/demo/component/combobox/combo-box-styles.ts[render,tags=snippet,indent=0,group=Lit]
-----
-endif::[]
-
-ifdef::flow[]
-[source,java]
-----
-include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxStyles.java[render,tags=snippet,indent=0,group=Flow]
-----
-endif::[]
-
-ifdef::react[]
-[source,tsx]
-----
-include::{root}/frontend/demo/component/combobox/react/combo-box-styles.tsx[render,tags=snippet,indent=0,group=React]
-----
-endif::[]
---
-
-
 == Usage as Autocomplete Field
 
 As the user is typing, the Combo Box filters out the options that don't match. Once the correct value has been found, the user can use the Up/Down arrow keys to navigate the list and the Enter key to set the value, essentially using the Combo Box as an autocomplete field.

--- a/articles/components/combo-box/styling.adoc
+++ b/articles/components/combo-box/styling.adoc
@@ -7,6 +7,35 @@ order: 50
 ---
 = Combo Box Styling
 
+// Style Variants
+
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-intro;text-alignment;small-variant;helper-above-field;borders]
+
+[.example]
+--
+ifdef::lit[]
+[source,typescript]
+----
+include::{root}/frontend/demo/component/combobox/combo-box-styles.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/combobox/ComboBoxStyles.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/combobox/react/combo-box-styles.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
+
+
 include::../_styling-section-theming-props.adoc[tag=style-properties]
 
 include::../_styling-section-theming-props.adoc[tag=input-fields]

--- a/frontend/demo/component/combobox/combo-box-presentation.ts
+++ b/frontend/demo/component/combobox/combo-box-presentation.ts
@@ -6,8 +6,8 @@ import type { ComboBoxFilterChangedEvent } from '@vaadin/combo-box';
 import type { ComboBoxLitRenderer } from '@vaadin/combo-box/lit.js';
 import { comboBoxRenderer } from '@vaadin/combo-box/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
-import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 import { applyTheme } from 'Frontend/demo/theme';
+import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
 @customElement('combo-box-presentation')
 export class Example extends LitElement {
@@ -65,13 +65,13 @@ export class Example extends LitElement {
   private renderer: ComboBoxLitRenderer<Person> = (person) => html`
     <div style="display: flex;">
       <img
-        style="height: 2.25rem; margin-right: var(--lumo-space-s);"
+        style="height: 36px; margin-right: var(--vaadin-gap-s);"
         src="${person.pictureUrl}"
         alt="Portrait of ${person.firstName} ${person.lastName}"
       />
       <div>
         ${person.firstName} ${person.lastName}
-        <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);">
+        <div style="font-size: var(--aura-font-size-s); color: var(--vaadin-text-color-secondary);">
           ${person.profession}
         </div>
       </div>

--- a/frontend/demo/component/combobox/combo-box-styles.ts
+++ b/frontend/demo/component/combobox/combo-box-styles.ts
@@ -16,14 +16,13 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-combo-box
-        theme="align-right small helper-above-field"
+        theme="helper-above-field"
         label="Label"
         helper-text="Helper text"
         .items="${['Value']}"
         value="Value"
-        style="--vaadin-input-field-border-width: 1px;"
-      >
-      </vaadin-combo-box>
+        style="--vaadin-input-field-border-width: 2px;"
+      ></vaadin-combo-box>
       <!-- end::snippet[] -->
     `;
   }

--- a/frontend/demo/component/combobox/react/combo-box-presentation.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-presentation.tsx
@@ -12,7 +12,7 @@ function renderPerson({ item: person }: { item: Person }) {
   return (
     <div style={{ display: 'flex' }}>
       <img
-        style={{ height: '2.25rem', marginRight: 'var(--lumo-space-s)' }}
+        style={{ height: '36px', marginRight: 'var(--vaadin-gap-s)' }}
         src={person.pictureUrl}
         alt={`Portrait of ${person.firstName} ${person.lastName}`}
       />
@@ -20,8 +20,8 @@ function renderPerson({ item: person }: { item: Person }) {
         {person.firstName} {person.lastName}
         <div
           style={{
-            fontSize: 'var(--lumo-font-size-s)',
-            color: 'var(--lumo-secondary-text-color)',
+            fontSize: 'var(--aura-font-size-s)',
+            color: 'var(--vaadin-text-color-secondary)',
           }}
         >
           {person.profession}

--- a/frontend/demo/component/combobox/react/combo-box-styles.tsx
+++ b/frontend/demo/component/combobox/react/combo-box-styles.tsx
@@ -6,12 +6,12 @@ function Example() {
   return (
     // tag::snippet[]
     <ComboBox
-      theme="align-right small helper-above-field"
+      theme="helper-above-field"
       label="Label"
       helperText="Helper text"
       items={['Value']}
       value="Value"
-      style={{ '--vaadin-input-field-border-width': '1px' } as React.CSSProperties}
+      style={{ '--vaadin-input-field-border-width': '2px' } as React.CSSProperties}
     />
     // end::snippet[]
   );

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxPresentation.java
@@ -40,11 +40,11 @@ public class ComboBoxPresentation extends Div {
         StringBuilder tpl = new StringBuilder();
         tpl.append("<div style=\"display: flex;\">");
         tpl.append(
-                "  <img style=\"height: 2.25rem; margin-right: var(--lumo-space-s);\" src=\"${item.pictureUrl}\" alt=\"Portrait of ${item.firstName} ${item.lastName}\" />");
+                "  <img style=\"height: 36px; margin-right: var(--vaadin-gap-s);\" src=\"${item.pictureUrl}\" alt=\"Portrait of ${item.firstName} ${item.lastName}\" />");
         tpl.append("  <div>");
         tpl.append("    ${item.firstName} ${item.lastName}");
         tpl.append(
-                "    <div style=\"font-size: 0.875rem; color: var(--lumo-secondary-text-color);\">${item.profession}</div>");
+                "    <div style=\"font-size: var(--aura-font-size-s); color: var(--vaadin-text-color-secondary);\">${item.profession}</div>");
         tpl.append("  </div>");
         tpl.append("</div>");
 

--- a/src/main/java/com/vaadin/demo/component/combobox/ComboBoxStyles.java
+++ b/src/main/java/com/vaadin/demo/component/combobox/ComboBoxStyles.java
@@ -14,10 +14,8 @@ public class ComboBoxStyles extends HorizontalLayout {
 
         // tag::snippet[]
         ComboBox<String> field = new ComboBox<>();
-        field.addThemeVariants(ComboBoxVariant.LUMO_SMALL,
-                ComboBoxVariant.LUMO_ALIGN_RIGHT,
-                ComboBoxVariant.LUMO_HELPER_ABOVE_FIELD);
-        field.getStyle().set("--vaadin-input-field-border-width", "1px");
+        field.addThemeVariants(ComboBoxVariant.AURA_HELPER_ABOVE_FIELD);
+        field.getStyle().set("--vaadin-input-field-border-width", "2px");
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");


### PR DESCRIPTION
- Moved "Style variants" to Styling sub-page
- Removed `align-right` and `small` variants
- Changed border width property to 2px
- Replaced Lumo custom CSS properties
- Changed the image size to use `36px`

Note: custom CSS properties tables reused by input fields pages should be updated in a separate PR.
IMO this could be done after we update individual field components to make reviewing easier.