### PR TITLE
refactor: configure page menu to show 2nd level headings

### DIFF
--- a/articles/components/tree-grid/data-providers.adoc
+++ b/articles/components/tree-grid/data-providers.adoc
@@ -5,6 +5,7 @@ order: 30
 ---
 
 = Data Providers (Flow)
+:toclevels: 2
 
 Tree Grid supports connecting to different types of data sources using hierarchical data providers. For simple use cases, it offers a built-in [classname]`TreeData` structure along with a ready-made [classname]`TreeDataProvider`, which together provide an easy way to create and manage hierarchies in memory. It also supports custom hierarchical data providers to fetch data from other sources, e.g. a database.
 


### PR DESCRIPTION
Configures the Tree Grid Data Provider page menu to display 2nd level headings:

| Before | After |
|--------|------|
| ![Screenshot 2025-11-28 at 20 37 53](https://github.com/user-attachments/assets/9d8da740-b857-4e63-906c-c3bca4ec8376) | ![Screenshot 2025-11-28 at 20 37 28](https://github.com/user-attachments/assets/10fa94c9-4fe9-4d79-956d-4dc13cfa6147) |
