### PR TITLE
chore: remove outdated since tags from V25 components docs

### DIFF
--- a/articles/components/_input-field-common-features.adoc
+++ b/articles/components/_input-field-common-features.adoc
@@ -105,7 +105,7 @@ Suffix elements typically don't work well with assistive technologies like scree
 
 // tag::aria-labels[]
 [#aria-labels]
-.[since:com.vaadin:vaadin@V24.1]#External & Invisible Labels (ARIA)#
+.External & Invisible Labels (ARIA)
 [%collapsible]
 ====
 Visible labels are strongly recommended for all input fields. In situations where the built-in label cannot be used, an external element can be associated as the field's label through its element `id`. Fields without any visible label should be provided an invisible label for assistive technologies like screen readers.
@@ -262,7 +262,7 @@ The helper can be rendered above the field, and below the label.
 
 // tag::borders[]
 [#borders]
-.[since:com.vaadin:vaadin@V24.1]#Borders#
+.Borders
 [%collapsible]
 ====
 Borders can be applied to the field surface by providing a value (e.g., `1px`) to the `--vaadin-input-field-border-width` CSS property. This can be applied globally to all input fields using the `html` selector, or to individual component instances. Borders are required to achieve https://www.w3.org/TR/WCAG21/#non-text-contrast[WCAG 2.1 level AA] conformant color contrast with the default Lumo styling of fields.

--- a/articles/components/_styling-section-theming-props.adoc
+++ b/articles/components/_styling-section-theming-props.adoc
@@ -39,7 +39,7 @@ Style properties whose names start with `--vaadin-input-field` are shared among 
 |`--vaadin-input-field-invalid-hover-highlight`
 |`--lumo-error-color-50pct`
 
-|[since:com.vaadin:vaadin@V24.5]#Background, disabled#
+|Background, disabled
 |`--vaadin-input-field-disabled-background`
 |`--lumo-contrast-5pct`
 
@@ -63,7 +63,7 @@ Style properties whose names start with `--vaadin-input-field` are shared among 
 |`--vaadin-input-field-value-color`
 |`--lumo-body-text-color`
 
-|[since:com.vaadin:vaadin@V24.5]#Value text color, disabled#
+|Value text color, disabled
 |`--vaadin-input-field-disabled-value-color`
 |`--lumo-disabled-text-color`
 

--- a/articles/components/accordion/index.adoc
+++ b/articles/components/accordion/index.adoc
@@ -241,7 +241,7 @@ Details can be used instead of Accordion when there is a need to see content fro
 
 Accordions can be used to break a complex form into smaller step-by-step sections.
 
-The expandable and collapsible nature of accordions can sometimes be difficult for users to discover. Use the <<filled-panels,filled variant>> and apply [since:com.vaadin:vaadin@V23.3]##<<../tooltip#,tooltips>>## on the panels to make this more discoverable.
+The expandable and collapsible nature of accordions can sometimes be difficult for users to discover. Use the <<filled-panels,filled variant>> and apply <<../tooltip#,tooltips>> on the panels to make this more discoverable.
 
 
 == Related Components

--- a/articles/components/app-layout/index.adoc
+++ b/articles/components/app-layout/index.adoc
@@ -58,7 +58,7 @@ App Layout is designed to be the application's root layout, within which most or
 
 === Flow
 
-With Flow, the root layout can be defined using the <<{articles}/flow/routing/layout#automatic-layout-using-layout,`@Layout` annotation>>, [since:com.vaadin:vaadin@V24.5]#which tells the router to render all routes or views inside of it#.
+With Flow, the root layout can be defined using the <<{articles}/flow/routing/layout#automatic-layout-using-layout,`@Layout` annotation>>, which tells the router to render all routes or views inside of it.
 
 [source,java]
 ----

--- a/articles/components/button/index.adoc
+++ b/articles/components/button/index.adoc
@@ -119,7 +119,6 @@ endif::[]
 Primary danger buttons should only be used when a dangerous action is the most likely action. An example of this would be the affirmative *Delete* action in a deletion confirmation dialog. Secondary and Tertiary variants can be used for actions related to current errors, such as resolving them or viewing their details.
 
 
-[role="since:com.vaadin:vaadin@V24.5"]
 === Warning Variant
 
 This is a style for distinguishing actions related to warnings: for example, in dialogs that are intended to warn the user, or to provide information that requires extra attention.
@@ -324,7 +323,7 @@ Use icons sparingly. Most actions are difficult to represent reliably with icons
 
 Icon-only buttons should be used primarily for common recurring actions with highly standardized, universally understood icons (e.g., a cross for *close*), and for actions that are repeated, such as in lists and tables. They should also include a textual alternative for screen readers using the `aria-label` attribute (see the first two buttons in the previous example).
 
-Additionally, [since:com.vaadin:vaadin@V23.3]##<<../tooltip#,tooltips>>## can be added to provide a description of the action that the button triggers (see the [guilabel]*Close* button in the previous example).
+Additionally, <<../tooltip#,tooltips>> can be added to provide a description of the action that the button triggers (see the [guilabel]*Close* button in the previous example).
 
 .Icon-Only Button Style Variant
 [NOTE]

--- a/articles/components/button/styling.adoc
+++ b/articles/components/button/styling.adoc
@@ -148,4 +148,4 @@ Large:: `vaadin-button+++<wbr>+++**[theme~="large"]**`
 Contrast:: `vaadin-button+++<wbr>+++**[theme~="contrast"]**`
 Success:: `vaadin-button+++<wbr>+++**[theme~="success"]**`
 Danger / Error:: `vaadin-button+++<wbr>+++**[theme~="error"]**`
-[since:com.vaadin:vaadin@V24.5]#Warning#:: `vaadin-button+++<wbr>+++**[theme~="warning"]**`
+Warning:: `vaadin-button+++<wbr>+++**[theme~="warning"]**`

--- a/articles/components/card/index.adoc
+++ b/articles/components/card/index.adoc
@@ -3,7 +3,6 @@ title: Card
 page-title: Card component | Vaadin components
 description: The Card component is a versatile container for grouping related content and actions, with several customization options for layout and appearance.
 meta-description: The Card component is a versatile container for grouping related content and actions, with several customization options for layout and appearance.
-version: since:com.vaadin:vaadin@V24.8
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/card}/elements/vaadin-card[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/card/Card.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/card}/packages/card[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-card-flow-parent[Java]'

--- a/articles/components/charts/charttypes.adoc
+++ b/articles/components/charts/charttypes.adoc
@@ -940,7 +940,6 @@ The result is illustrated in <<figure.charts.charttypes.pie.donut>>.
 [.fill.white]
 image::img/charts-donut.png[width="60%"]
 
-[role="since:com.vaadin:vaadin@V24.7"]
 [[charts.charttypes.gantt]]
 == Gantt Charts
 
@@ -2136,7 +2135,7 @@ Tree map charts have plot options type [classname]`PlotOptionsTreeMap`, which ex
 [parameter]`allowDrillToNode`:: When enabled, the user can click on a point which is a parent and zoom in on its children. Defaults to false.
 [parameter]`alternateStartingDirection`:: Enabling this option makes the tree map alternate the drawing direction between vertical and horizontal. The next level's starting direction is always the opposite of the previous. The default value is [literal]`++false++`.
 [parameter]`layoutAlgorithm`:: This option specifies which algorithm is used for setting the position and dimensions of the points. Available algorithms are defined in [classname]`TreeMapLayoutAlgorithm` enum: [literal]`++SLICEANDDICE++`, [literal]`++STRIPES++`, [literal]`++SQUARIFIED++` and [literal]`++STRIP++`. The default value is [literal]`++SLICEANDDICE++`.
-[parameter]`layoutStartingDirection`:: Defines which direction the layout algorithm starts drawing. Possible values are defined in [classname]`TreeMapLayoutStartingDirection` enum: [literal]`++HORIZONTAL++` and [literal]`++VERTICAL++`. The default value is [literal]`++VERTICAL++`. 
+[parameter]`layoutStartingDirection`:: Defines which direction the layout algorithm starts drawing. Possible values are defined in [classname]`TreeMapLayoutStartingDirection` enum: [literal]`++HORIZONTAL++` and [literal]`++VERTICAL++`. The default value is [literal]`++VERTICAL++`.
 [parameter]`levelIsConstant`:: Used together with the [methodname]`setLevels()` and [methodname]`setAllowDrillToNode()` options. When set to [literal]`++false++`, the first level visible when drilling is considered to be level one. Otherwise, the level is the same as the tree structure. The default value is [literal]`++true++`.
 [parameter]`levels`:: Set options on specific levels. Takes precedence over series options, but not point options.
 

--- a/articles/components/charts/gantt.adoc
+++ b/articles/components/charts/gantt.adoc
@@ -4,12 +4,11 @@ page-title: Create Gantt Charts with Vaadin Charts
 description: Vaadin Charts support for creating Gantt charts.
 meta-description: Discover how to design and customize Gantt charts in Vaadin applications.
 order: 9
-version: since:com.vaadin:vaadin@V24.7
 ---
 
 [[charts.gantt]]
 
-= [since:com.vaadin:vaadin@V24.7]#Gantt Chart#
+= Gantt Chart
 
 A Gantt chart is a type of bar chart that can represent a project schedule. It's used for planning and scheduling projects, for displaying the start and finish dates of a project's various elements. It can help in visualizing a project's timeline, task dependencies, and progress.
 
@@ -31,7 +30,7 @@ Gantt charts are particularly useful for complex projects with multiple tasks an
 You can add Gantt chart to your application by performing the following steps:
 
 - Specify the chart type with [parameter]`ChartType.GANTT`;
-- Create [class]`GanttSeries` with [class]`GanttSeriesItems` to represent the tasks; and 
+- Create [class]`GanttSeries` with [class]`GanttSeriesItems` to represent the tasks; and
 - Then add the series to the chart.
 
 You can alternatively configure the chart using options in the [class]`PlotOptionsGantt` configuration object.

--- a/articles/components/charts/usage-with-lit.adoc
+++ b/articles/components/charts/usage-with-lit.adoc
@@ -56,7 +56,6 @@ include::{root}/frontend/demo/component/charts/charts-polar.ts[render,tags=snipp
 ----
 --
 
-[role="since:com.vaadin:vaadin@V24.7"]
 == Gantt Chart
 
 [.example]

--- a/articles/components/charts/usage-with-react.adoc
+++ b/articles/components/charts/usage-with-react.adoc
@@ -53,7 +53,6 @@ include::{root}/frontend/demo/component/charts/react/charts-polar.tsx[render,tag
 ----
 --
 
-[role="since:com.vaadin:vaadin@V24.7"]
 == Gantt Chart
 
 [.example]

--- a/articles/components/checkbox/index.adoc
+++ b/articles/components/checkbox/index.adoc
@@ -110,7 +110,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.4"]
 === Read-Only
 
 Fields used to display values should be set to read-only mode to prevent editing. Read-only fields are focusable and visible to screen readers.
@@ -143,7 +142,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.4"]
 === Required
 
 Individual checkboxes can be marked as required. This is commonly used for checkboxes that must be checked in order to proceed with an operation, such as submitting a form. Required checkboxes become invalid when validated or if left unchecked after being focused.

--- a/articles/components/checkbox/styling.adoc
+++ b/articles/components/checkbox/styling.adoc
@@ -25,7 +25,7 @@ include::../_styling-section-theming-props.adoc[tag=input-fields]
 |`--vaadin-checkbox-background-hover`
 |`--lumo-contrast-30pct`
 
-|[since:com.vaadin:vaadin@V24.5]#Background, disabled#
+|Background, disabled
 |`--vaadin-checkbox-disabled-background`
 |`--lumo-contrast-10pct`
 
@@ -45,7 +45,7 @@ include::../_styling-section-theming-props.adoc[tag=input-fields]
 |`--vaadin-checkbox-checkmark-color`
 |`--lumo-primary-contrast-color`
 
-|[since:com.vaadin:vaadin@V24.5]#Checkmark color, disabled#
+|Checkmark color, disabled
 |`--vaadin-checkbox-disabled-checkmark-color`
 |`--lumo-contrast-30pct`
 

--- a/articles/components/combo-box/index.adoc
+++ b/articles/components/combo-box/index.adoc
@@ -166,7 +166,6 @@ endif::[]
 
 Use a custom filter to allow the user to search by the rendered properties. It's recommended to make filtering case insensitive.
 
-[role="since:com.vaadin:vaadin@V24.5"]
 == Item Class Names
 
 Items can be styled dynamically, based on application logic and the data in the combo box, through custom class names.

--- a/articles/components/context-menu/index.adoc
+++ b/articles/components/context-menu/index.adoc
@@ -196,7 +196,7 @@ endif::[]
 
 == Styling Menu Items
 
-Individual menu items can be styled by [since:com.vaadin:vaadin@V24.3]#applying custom class names# to them, and writing CSS style blocks targeting those class names.
+Individual menu items can be styled by applying custom class names to them, and writing CSS style blocks targeting those class names.
 
 [.example]
 --
@@ -269,7 +269,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.6"]
 === Disable on Click (Flow)
 
 To prevent duplicate clicks while the server is processing a request, call the `setDisableOnClick(true)` method on a menu item instance to disable immediately that menu item on the client-side when it's clicked.
@@ -324,7 +323,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.7"]
 == Custom Item Data
 
 Context Menu allows you to associate custom data with menu items. This can be useful for storing additional information about the item, such as an item type or a value. The data can then be used to trigger actions when an item is selected.

--- a/articles/components/dashboard/index.adoc
+++ b/articles/components/dashboard/index.adoc
@@ -5,7 +5,6 @@ page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/dashboard}/elements/vaadin-dashboard[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/dashboard/Dashboard.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/dashboard}/packages/dashboard[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-dashboard-flow-parent[Java]'
 section-nav: commercial
-version: since:com.vaadin:vaadin@V24.8
 ---
 
 

--- a/articles/components/date-picker/date-formats.adoc
+++ b/articles/components/date-picker/date-formats.adoc
@@ -107,7 +107,6 @@ Other characters, such as separators (e.g., `/`, `.`, `-`) or spaces may be used
 Custom date patterns take precedence over the configured locale. When using both at the same time, the custom date pattern is used to display and parse dates.
 endif::[]
 
-[role="since:com.vaadin:vaadin@V24.6"]
 == Server-Side Parsing in Flow
 
 The Flow version of Date Picker also allows you to provide a server-side parser that may be used as a fallback when user input can't be parsed using the methods described previously. The parser is a function that receives the user entered string and returns either a parsed date or an error message. Successfully parsed dates are displayed in the field using the same pattern as other dates.
@@ -151,7 +150,7 @@ The previous example uses the third-party library https://date-fns.org/[date-fns
 
 Date Picker supports date formats with 2-digit years (e.g., `dd.MM.yy`). When parsing a 2-digit year, the component must decide as to which century the year belongs. For example, a year entered as `62` could be interpreted either as 1862, 1962, or 2062.
 
-[since:com.vaadin:vaadin@V23.3]#Two-digit years are interpreted as being within a one-hundred year range whose midpoint is called the _reference date_#. For example, a reference date of `2000-01-01` means that the date entered is interpreted as being within the range `1950-01-01` to `2049-12-31`. Given that parameter, the year `50` is parsed to `1950` while `49` is parsed to `2049`.
+Two-digit years are interpreted as being within a one-hundred year range whose midpoint is called the _reference date_. For example, a reference date of `2000-01-01` means that the date entered is interpreted as being within the range `1950-01-01` to `2049-12-31`. Given that parameter, the year `50` is parsed to `1950` while `49` is parsed to `2049`.
 
 The reference date defaults to the current date, but you can set it to a different date with the <<index#i18n,internationalization API>>:
 

--- a/articles/components/date-picker/styling.adoc
+++ b/articles/components/date-picker/styling.adoc
@@ -104,7 +104,7 @@ Disabled date:: `vaadin-month-calendar+++<wbr>+++**::part(disabled date)**`
 Focused date:: `vaadin-month-calendar+++<wbr>+++**::part(focused date)**`
 Selected date:: `vaadin-month-calendar+++<wbr>+++**::part(selected date)**`
 Today's date:: `vaadin-month-calendar+++<wbr>+++**::part(today date)**`
-[since:com.vaadin:vaadin@V24.5]#Past date#:: `vaadin-month-calendar+++<wbr>+++**::part(past date)**`
-[since:com.vaadin:vaadin@V24.5]#Future date#:: `vaadin-month-calendar+++<wbr>+++**::part(future date)**`
+Past date:: `vaadin-month-calendar+++<wbr>+++**::part(past date)**`
+Future date:: `vaadin-month-calendar+++<wbr>+++**::part(future date)**`
 Focused date:: `vaadin-month-calendar+++<wbr>+++**::part(date focused)**`
 Hovered date:: `vaadin-month-calendar+++<wbr>+++**::part(date):hover**`

--- a/articles/components/date-time-picker/index.adoc
+++ b/articles/components/date-time-picker/index.adoc
@@ -322,7 +322,7 @@ See also how to <<../date-picker#date-format,configure a custom date format>>.
 include::{articles}/components/_input-field-common-features.adoc[tags=basic-intro;label;helper;placeholder;tooltip;]
 
 [#aria-labels]
-.[since:com.vaadin:vaadin@V24.1]#Invisible Labels (ARIA)#
+.Invisible Labels (ARIA)
 [%collapsible]
 ====
 If the built-in label cannot be used, an invisible label should be provided for users of assistive technologies like screen readers. The date and time sub-fields can also be assigned invisible suffixes (e.g., `date` and `time`) that are appended to their invisible labels.

--- a/articles/components/details/index.adoc
+++ b/articles/components/details/index.adoc
@@ -244,7 +244,7 @@ Use Details to group related content and to reduce the chance of overwhelming th
 
 Details can be used instead of Accordion if there's a need to see content from multiple collapsible content areas, simultaneously.
 
-The expandable and collapsible nature of Details can sometimes be difficult for users to discover. Use the <<filled,filled variant>> and apply a [since:com.vaadin:vaadin@V23.3]##<<../tooltip#,tooltips>>## to make this more discoverable.
+The expandable and collapsible nature of Details can sometimes be difficult for users to discover. Use the <<filled,filled variant>> and apply a <<../tooltip#,tooltips>> to make this more discoverable.
 
 
 

--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -56,7 +56,6 @@ endif::[]
 The Dialog component has static header and footer areas, and a scrolling content area between them. The header and footer are optional, and are hidden if empty and not explicitly enabled.
 
 
-[role="since:com.vaadin:vaadin@V23.1"]
 === Header
 
 The header contains an optional title element, and a slot next to it for custom header content, such as a close button.
@@ -89,7 +88,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V23.1"]
 === Footer
 
 Buttons for closure actions (e.g., _Save_, _Cancel_, _Delete_) should be placed in the footer. See the <<../button#buttons-in-dialogs,Button>> component for guidelines for the placement of buttons in Dialogs. Footer content is right-aligned by default. Components can be left-aligned by applying a margin like so:
@@ -213,7 +211,7 @@ Dialog is not modal in server side by default. In some use cases you may want to
 
 == Position
 
-By default, dialogs open in the center of the viewport. [since:com.vaadin:vaadin@V24.6]##A different positioning can be set programmatically##. Dialogs can also be made draggable, allowing the end user to move them around.
+By default, dialogs open in the center of the viewport. A different positioning can be set programmatically. Dialogs can also be made draggable, allowing the end user to move them around.
 
 The position of the dialog can be set using the `top` and `left` properties:
 
@@ -292,7 +290,7 @@ Modal dialogs don't benefit from being draggable, as their modality curtain (the
 
 == Size
 
-The Dialog size can be set with the width and height on the Dialog itself (__since V24.6 for React and Lit__). You can also set the size of the content of Dialog, whereby the Dialog scales to accommodate it. In both cases, the Dialog can also be made resizable.
+The Dialog size can be set with the width and height on the Dialog itself. You can also set the size of the content of Dialog, whereby the Dialog scales to accommodate it. In both cases, the Dialog can also be made resizable.
 
 [.example]
 --

--- a/articles/components/form-layout/index.adoc
+++ b/articles/components/form-layout/index.adoc
@@ -35,14 +35,13 @@ include::{root}/frontend/demo/component/formlayout/form-layout-basic.ts[render,t
 
 Form Layout automatically adjusts how fields are laid out in columns and rows to utilize the available space and avoid overflow. There are two discrete layouting modes that determine how this works:
 
-- [since:com.vaadin:vaadin@V24.8]#<<#auto-responsive-mode,Auto-responsive mode>>#, based on column width
+- <<#auto-responsive-mode,Auto-responsive mode>>, based on column width
 - <<#responsive-steps-mode,Responsive steps mode>>, based on defined breakpoints
 
 .Default mode depends on feature flag
 [NOTE]
 In V24.8+, the default mode depends on the <<{articles}/flow/configuration/feature-flags#,feature flag>> `defaultAutoResponsiveFormLayout`. When enabled, auto-responsive mode is the default; otherwise, responsive steps mode is the default.
 
-[role="since:com.vaadin:vaadin@V24.8"]
 == Auto-Responsive Mode
 
 In auto-responsive mode, Form Layout automatically determines the appropriate number of columns based on the <<#column-width,column width>> and spacing, and the available horizontal space.

--- a/articles/components/grid-pro/index.adoc
+++ b/articles/components/grid-pro/index.adoc
@@ -256,7 +256,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.4"]
 == Conditional Editability
 
 In some situations you may need to disable editing of specific cells in an edit column. This can be done through a function that determines the editability of each cell. This function is automatically re-evaluated when an item in the Grid is modified.  As a result, modifying the value in one cell can immediately affect the editability of other cells.

--- a/articles/components/grid/columns.adoc
+++ b/articles/components/grid/columns.adoc
@@ -47,7 +47,7 @@ endif::[]
 
 == Column Freezing
 
-Columns and column groups can be frozen -- made _sticky_ -- to exclude them from horizontally scrolling a grid. This can be useful for keeping the most important columns always visible in a grid that contains so many columns they might otherwise scroll out of view. [since:com.vaadin:vaadin@V23.1]#Freezing columns at the end of the grid# is useful, for example, for keeping row actions always visible.
+Columns and column groups can be frozen -- made _sticky_ -- to exclude them from horizontally scrolling a grid. This can be useful for keeping the most important columns always visible in a grid that contains so many columns they might otherwise scroll out of view. Freezing columns at the end of the grid is useful, for example, for keeping row actions always visible.
 
 In the example here, try scrolling the data to the right and back left. Notice that the name of each person is stationary so that you can see easily which data relates to which person as you scroll. The _Edit_ button at the end also remains in place so that it's available at any point while scrolling.
 

--- a/articles/components/grid/index.adoc
+++ b/articles/components/grid/index.adoc
@@ -135,7 +135,7 @@ Multi-sort mode allows the Grid to be sorted by multiple columns simultaneously.
 
 In normal multi-sort mode, additional sorting columns are applied simply by clicking their headers.
 
-A separate [since:com.vaadin:vaadin@V23.3]#multi-sort on shift-click mode# combines single and multi-column sorting by adding more sorting columns only when the user holds the kbd:[Shift] key while clicking their headers.
+A separate multi-sort on shift-click mode combines single and multi-column sorting by adding more sorting columns only when the user holds the kbd:[Shift] key while clicking their headers.
 
 The order in which multi-sort columns (known as sorting criteria) are evaluated is determined by the multi-sort priority setting.
 
@@ -328,7 +328,6 @@ To learn more about data providers in Flow, see the <<{articles}/flow/binding-da
 endif::[]
 
 
-[role="since:com.vaadin:vaadin@V24.1"]
 === Lazy Column Rendering
 
 Grids containing a large number of columns can sometimes exhibit performance issues. If many of the columns are typically outside the visible viewport, rendering performance can be optimized by using "lazy column rendering" mode.
@@ -476,7 +475,6 @@ endif::[]
 <<tooltips,Tooltips>> can be used as a lightweight alternative to the item details panel.
 
 
-[role="since:com.vaadin:vaadin@V24.5"]
 == Empty State
 
 When there's no data available for the grid to display any rows, the space between the header and footer is left blank by default. You can use the empty state feature to provide a message or other content in this area to inform the user that there are no items to show.
@@ -547,7 +545,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V23.3"]
 == Tooltips
 
 Tooltips on cells can be useful in many situations: They can be used to give more details on the contents of a cell -- if an <<item-details,item details panel>> would be overkill or otherwise undesirable. They can show the full text of a cell if it's too long to fit feasibly into the cell itself -- if <<styling#wrap-cell-content,wrapping the cell contents>> is insufficient or otherwise undesirable. Or they can give textual explanations for non-text content, such as status icons.

--- a/articles/components/grid/selection.adoc
+++ b/articles/components/grid/selection.adoc
@@ -136,7 +136,6 @@ Each selection mode is represented by a [classname]`GridSelectionModel`, accessi
 To use Grid with [classname]`Binder` in Flow, you can use [methodname]`asSingleSelect()` or [methodname]`asMultiSelect()`, depending on the currently defined selection mode. Both methods return interfaces that implement the [interfacename]`HasValue` interface for use with `Binder`.
 
 
-[role="since:com.vaadin:vaadin@V24.6"]
 == Conditional Selection
 
 Grid allows you to configure a predicate to control which rows users may select or deselect. The predicate receives an item and must return `true` to allow selection -- `false` to prevent it. This doesn't, however, prohibit programmatic selection changes.

--- a/articles/components/grid/styling.adoc
+++ b/articles/components/grid/styling.adoc
@@ -239,7 +239,7 @@ Selected row:: `vaadin-grid+++<wbr>+++**::part(selected-row)**`
 Hovered row:: `vaadin-grid+++<wbr>+++**::part(row):hover**`
 
 Note:
-To set background colors based on row selectors, use the [since:com.vaadin:vaadin@V24.3]#`--vaadin-grid-cell-background` style property#.
+To set background colors based on row selectors, use the `--vaadin-grid-cell-background` style property.
 
 
 === Cells
@@ -303,7 +303,7 @@ The following terminology is used in the description of these part names:
 The cells in the “ghost” row::
 `vaadin-grid+++<wbr>+++**::part(dragstart-row-cell)**`
 
-[since:com.vaadin:vaadin@V24.5]#The cells in the drag source row#::
+The cells in the drag source row::
 `vaadin-grid+++<wbr>+++**::part(drag-source-row-cell)**`
 
 The cells of a row when the drop target is between this row and the row before it (i.e., above this row)::
@@ -378,7 +378,6 @@ include::{root}/frontend/themes/docs/grid-styling.css[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.3"]
 == Styling Header & Footer Cells
 
 Header and footer cells can be similarly styled through their own custom part names.

--- a/articles/components/horizontal-layout/_troubleshooting.adoc
+++ b/articles/components/horizontal-layout/_troubleshooting.adoc
@@ -188,7 +188,6 @@ endif::[]
 --
 endif::[]
 
-[role="since:com.vaadin:vaadin@V24.7"]
 ==== Enable Layout Improvements (Flow only, experimental)
 
 By enabling the `layoutComponentImprovements` <<{articles}/flow/configuration/feature-flags#,feature flag>>, the Flow APIs `setWidthFull`, `setHeightFull` and `setSizeFull` are rewired to automatically apply `flex:1` to the component. This prevents fixed-size components from shrinking and makes the full-size component take up the remaining space in the layout.
@@ -295,7 +294,6 @@ ifdef::react[]
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.7"]
 ==== Enable Layout Improvements (Flow only, experimental)
 
 By enabling the `layoutComponentImprovements` <<{articles}/flow/configuration/feature-flags#,feature flag>>, the Flow APIs `setWidthFull`, `setHeightFull` and `setSizeFull` are rewired to also set the minimum size of nested Horizontal and Vertical Layouts to 0, allowing them to shrink below the size of their contents.

--- a/articles/components/horizontal-layout/index.adoc
+++ b/articles/components/horizontal-layout/index.adoc
@@ -127,7 +127,6 @@ endif::[]
 There are two ways to align items horizontally: _individual alignment_ of items, and _justification_. These two methods cannot be used simultaneously.
 
 
-[role="since:com.vaadin:vaadin@V24.7"]
 === Aligning Individual Items
 
 Each item in the layout can be grouped to the start, center and end of the layout.
@@ -305,7 +304,7 @@ endif::[]
 
 --
 
-[since:com.vaadin:vaadin@V24.7]#Alternatively, the spacing can be set to a custom value:#
+Alternatively, the spacing can be set to a custom value:
 
 [.example]
 --
@@ -397,7 +396,6 @@ include::{root}/frontend/demo/component/horizontal-layout/react/horizontal-layou
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.6"]
 == Wrapping
 
 By default, components in a layout either shrink or overflow when there isn't enough horizontal space. Enable wrapping to allow components to flow onto a new line when space runs out, preventing overflow.

--- a/articles/components/icons/index.adoc
+++ b/articles/components/icons/index.adoc
@@ -116,7 +116,6 @@ Lumo Icons are rendered on a 24&times;24 pixel canvas, with a 16&times;16 pixel 
 The <<./default-icons#,Default Icons>> contains a list of the full Lumo Icons collection.
 
 
-[role="since:com.vaadin:vaadin@V24.2"]
 == Using Third-Party Icons
 
 Third-party icons can be rendered with the icon component. Three common formats are supported: standalone SVG files; SVG sprites; and icon fonts.
@@ -404,7 +403,6 @@ endif::[]
 
 
 ifdef::flow[]
-[role="since:com.vaadin:vaadin@V24.2"]
 == Custom Icon Collection APIs
 
 Within the application context, various icon libraries -- including FontAwesome, Material Symbol, and others -- may be utilized. Implementing custom icon libraries, as exemplified by the `VaadinIcon` enumeration, simplifies developer workflows by eliminating the need to recall specific URL paths, or to remember which CSS classes to apply when working with font icons:

--- a/articles/components/login/index.adoc
+++ b/articles/components/login/index.adoc
@@ -189,7 +189,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.2"]
 === Custom Form Area
 
 The overlay provides a custom form area for adding fields in addition to username and password. This area is placed above the "Submit" button. Use the `name` attribute to ensure the custom field's `value` is submitted with the form.
@@ -220,7 +219,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.2"]
 === Footer
 
 The footer area can be used for placing additional custom content, such as text, buttons, etc. Adding components after the overlay is opened is not supported.

--- a/articles/components/map/index.adoc
+++ b/articles/components/map/index.adoc
@@ -238,7 +238,6 @@ For example, when adding multiple markers that use the same image, it's sufficie
 Creating a separate icon instance for each marker can increase memory usage and degrade performance in the browser.
 ====
 
-[role="since:com.vaadin:vaadin@V24.1"]
 === Marker Text
 
 Markers can be configured to show text, which is displayed below the marker icon by default.
@@ -259,7 +258,6 @@ include::{root}/src/main/java/com/vaadin/demo/component/map/MapMarkerText.java[r
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.1"]
 === Marker Drag & Drop
 
 Markers can be configured to be draggable, allowing users to pick them up and move them around the map.
@@ -283,7 +281,6 @@ include::{root}/src/main/java/com/vaadin/demo/component/map/MapMarkerDragDrop.ja
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.8"]
 == Polygons
 
 Polygons can be used to highlight areas on the map, such as geographical features, zones or corridors. A polygon is defined by a list of coordinates that form a linear ring, where the first and the last coordinate must be equivalent. Additional linear rings can be passed to define holes in the polygon. Polygons support the same features as markers, such as text labels, click events and drag-and-drop.
@@ -422,7 +419,6 @@ include::{root}/src/main/java/com/vaadin/demo/component/map/MapEvents.java[rende
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V23.2"]
 == Coordinate Systems
 
 The default coordinate system, or projection, for all coordinates passed to or received from the component is EPSG:4326, also referred to as GPS coordinates or latitude and longitude.

--- a/articles/components/markdown/index.adoc
+++ b/articles/components/markdown/index.adoc
@@ -6,9 +6,8 @@ meta-description: Use the Vaadin Markdown component to display Markdown formatte
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/markdown}/elements/vaadin-markdown[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/markdown/Markdown.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/markdown}/packages/markdown[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-markdown-flow-parent[Java]'
-version: since:com.vaadin:vaadin@V24.8
 ---
-= [since:com.vaadin:vaadin@V24.8]#Markdown#
+= Markdown
 
 // tag::description[]
 The Markdown component renders content written in the Markdown syntax as HTML.

--- a/articles/components/master-detail-layout/index.adoc
+++ b/articles/components/master-detail-layout/index.adoc
@@ -4,7 +4,6 @@ page-title: Master-Detail component | Vaadin components
 description: Master-Detail Layout makes it easy to create responsive horizontally or vertically split UIs.
 meta-description: Learn to create layouts in your Vaadin application with the Master-Detail Layout component.
 section-nav: badge-preview
-version: since:com.vaadin:vaadin@V24.8
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/master-detail-layout}/elements/vaadin-master-detail-layout[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayout.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/master-detail-layout}/packages/master-detail-layout[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-master-detail-layout-flow-parent[Java]'

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -126,7 +126,7 @@ endif::[]
 
 === Styling Menu Items
 
-Individual menu items can be styled by [since:com.vaadin:vaadin@V24.3]##applying custom class names to them##, and writing CSS style blocks targeting those class names. Notice that root-level menu items in the Menu Bar are wrapped in `vaadin-menu-bar-button` elements, which inherit the class names from the items within them.
+Individual menu items can be styled by applying custom class names to them, and writing CSS style blocks targeting those class names. Notice that root-level menu items in the Menu Bar are wrapped in `vaadin-menu-bar-button` elements, which inherit the class names from the items within them.
 
 [.example]
 --
@@ -160,7 +160,6 @@ include::{root}/frontend/themes/docs/menu-bar-class-name.css[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.5"]
 === Drop-down Indicators
 
 Menu buttons with sub-menu can be visually identified from items that trigger an action immediately using `dropdown-indicators` theme variant.
@@ -194,7 +193,7 @@ endif::[]
 
 Items that don't fit into the current width of the menu bar collapse into an overflow menu at the end.
 
-By default, collapsed items are removed from the end of the menu bar, but the component can be configured to [since:com.vaadin:vaadin@V24.4]##remove items from the start instead##.
+By default, collapsed items are removed from the end of the menu bar, but the component can be configured to remove items from the start instead.
 
 
 [.example]
@@ -450,7 +449,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V23.3"]
 == Tooltips
 
 Tooltips can be configured on top-level items to provide additional information, especially for icon-only items. When a top-level item is disabled, the corresponding tooltip isn't shown.
@@ -619,7 +617,6 @@ include::{root}/frontend/demo/component/menubar/react/menu-bar-internationalizat
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.7"]
 == Custom Item Data
 
 Menu Bar allows you to associate custom data with menu items. This can be useful for storing additional information about the item, such as an item type or a value. The data can then be used to trigger actions when an item is selected.

--- a/articles/components/message-list/index.adoc
+++ b/articles/components/message-list/index.adoc
@@ -73,11 +73,7 @@ include::{root}/frontend/demo/component/messages/react/message-list-with-theme-c
 endif::[]
 --
 
-.Use Theme Names, Not Class Names pre-V24.3
-[NOTE]
-In versions prior to 24.3, theme names must be used instead of class names (`theme` property / `addThemeNames` Java method). The CSS syntax for targeting a theme name is `[theme~="custom-theme"]`.
 
-[role="since:com.vaadin:vaadin@V24.8"]
 == Markdown
 
 Use Markdown formatting in Message List to display rich text instead of plain text.
@@ -110,7 +106,6 @@ include::{root}/frontend/demo/component/messages/react/message-list-markdown.tsx
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.8"]
 == Usage for AI Chats
 
 Combine Message List with Message Input to create effective AI chat interfaces. Build your AI chat interface with:

--- a/articles/components/multi-select-combo-box/index.adoc
+++ b/articles/components/multi-select-combo-box/index.adoc
@@ -9,7 +9,7 @@ page-links:
 ---
 
 
-= [since:com.vaadin:vaadin@V23.2]#Multi-Select Combo Box#
+= Multi-Select Combo Box
 :experimental:
 
 // tag::description[]
@@ -187,8 +187,6 @@ include::{root}/frontend/demo/component/multi-select-combo-box/react/multi-selec
 endif::[]
 --
 
-
-[role="since:com.vaadin:vaadin@V24.3"]
 == Auto Expand
 
 The component can be configured to auto-expand so as to accommodate chips for selected items. It's possible to expand both horizontally (i.e., until max-width is reached) and vertically -- in which case the field with chips wraps in multiple lines. These modes can be used together.
@@ -220,7 +218,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.3"]
 == Selected Items on Top
 
 The component can be configured to group selected items at the top of the overlay. When the selection changes, a set of items to be shown in the top group is only updated after the overlay is closed.
@@ -251,7 +248,6 @@ include::{root}/frontend/demo/component/multi-select-combo-box/react/multi-selec
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.5"]
 == Item Class Names
 
 See <<../combo-box#item-class-names, Combo Box, Item Class Names>>. In addition to items in the overlay, custom class names also apply to chips representing selected items.

--- a/articles/components/notification/index.adoc
+++ b/articles/components/notification/index.adoc
@@ -109,7 +109,6 @@ endif::[]
 Users shouldn't be notified always, or even frequently, of successful operations. Too many notifications can be more distracting than helpful to users. Use success notifications only for operations whose successful completion may otherwise be difficult to discern.
 
 
-[role="since:com.vaadin:vaadin@V24.1"]
 === Warning
 
 The `warning` theme variant can be used to display warnings.

--- a/articles/components/popover/index.adoc
+++ b/articles/components/popover/index.adoc
@@ -3,7 +3,6 @@ title: Popover
 page-title: Popover component | Vaadin components
 description: Popover is a generic overlay whose position is anchored to an element in the UI.
 meta-description: Use the Vaadin Popover component as an overlay whose position is anchored to an element in the user interface.
-version: since:com.vaadin:vaadin@V24.5
 page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/popover}/elements/vaadin-popover[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/popover/Popover.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/popover}/packages/popover[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-popover-flow-parent[Java]'

--- a/articles/components/radio-button/styling.adoc
+++ b/articles/components/radio-button/styling.adoc
@@ -25,7 +25,7 @@ include::../_styling-section-theming-props.adoc[tag=input-fields]
 |`--vaadin-radio-button-background-hover`
 |`--lumo-contrast-30pct`
 
-|[since:com.vaadin:vaadin@V24.5]#Radio background, disabled#
+|Radio background, disabled
 |`--vaadin-radio-button-disabled-background`
 |`--lumo-contrast-10pct`
 
@@ -37,7 +37,7 @@ include::../_styling-section-theming-props.adoc[tag=input-fields]
 |`--vaadin-radio-button-dot-color`
 |`--lumo-primary-contrast-color`
 
-|[since:com.vaadin:vaadin@V24.5]#Radio dot color, disabled#
+|Radio dot color, disabled
 |`--vaadin-radio-button-disabled-dot-color`
 |`--lumo-contrast-30pct`
 

--- a/articles/components/rich-text-editor/index.adoc
+++ b/articles/components/rich-text-editor/index.adoc
@@ -386,7 +386,6 @@ e|Italicizes text.
 
 |===
 
-[role="since:com.vaadin:vaadin@V24.5"]
 === Color
 
 [cols="^.^1,4,8"]

--- a/articles/components/rich-text-editor/styling.adoc
+++ b/articles/components/rich-text-editor/styling.adoc
@@ -34,9 +34,9 @@ Bold button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-bold)**
 Italic button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-italic)**`
 Underline button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-underline)**`
 Strikeout button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-strike)**`
-[since:com.vaadin:vaadin@V24.5]#Style button group#:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-group-style)**`
-[since:com.vaadin:vaadin@V24.5]#Text color button#:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-color)**`
-[since:com.vaadin:vaadin@V24.5]#Background button#:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-background)**`
+Style button group:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-group-style)**`
+Text color button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-color)**`
+Background button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-background)**`
 Heading button group:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-group-heading)**`
 H1 button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-h1)**`
 H2 button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-h2)**`

--- a/articles/components/select/index.adoc
+++ b/articles/components/select/index.adoc
@@ -113,7 +113,6 @@ Some assistive technologies might not announce disabled options.
 
 You can customize the position and the width of the Select overlay, where the list of options is rendered. You can also add CSS class names to the overlay to customize its styles.
 
-[role="since:com.vaadin:vaadin@V24.5"]
 === Overlay Position
 
 The overlay is shown on top of the input field by default. You can configure the placement so that it doesn't cover the input field.
@@ -142,7 +141,6 @@ include::{root}/frontend/demo/component/select/react/select-no-vertical-overlap.
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.5"]
 === Overlay Width
 
 The overlay is as wide as the options in it and at least as wide as the input field. The overlay width can be overridden to any fixed width in cases where the default width is too narrow.

--- a/articles/components/side-nav/index.adoc
+++ b/articles/components/side-nav/index.adoc
@@ -53,7 +53,6 @@ The Side Navigation component can be used, for example, in a drawer of an <<../a
 The navigation item matching the current URL is highlighted automatically to indicate it's active.
 
 
-[role="since:com.vaadin:vaadin@V24.5"]
 === Nested Matching
 
 By default, items only match the exact path of the current URL. To enable matching of nested paths or routes, set the `matchNested` property to `true`. With nested matching, an item with the path `/parent` not only matches `/parent`, but also `/parent/child`, `/parent/child/grandchild`, etc.
@@ -91,7 +90,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.4"]
 === Query Parameters
 
 If an item's path contains <<{articles}/flow/routing/additional-guides/query-parameters#,query parameters>>, only URLs containing those parameters are considered a match. Additional parameters in the URL not specified in the item path are ignored -- the URL is considered a match.
@@ -223,7 +221,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V24.4"]
 == Another Browser Tab or Window
 
 A navigation link can be opened in another browser tab or window -- depending on the browser’s configuration -- by specifying the name of the tab or window as the link's target. A new, unnamed tab or window can be set as the target by providing the name `_blank`, for which the Flow API provides the shorthand method [methodname]`setOpenInNewBrowserTab()`.
@@ -319,7 +316,6 @@ endif::[]
 
 
 ifdef::react[]
-[role="since:com.vaadin:vaadin@V24.4"]
 == Client-Side Router Integration
 
 By default, clicking a navigation link in a client-side application triggers a full page reload. When using a client-side router (e.g., React Router), this might be undesirable as it disrupts the single-page application experience.

--- a/articles/components/tabs/index.adoc
+++ b/articles/components/tabs/index.adoc
@@ -46,7 +46,6 @@ endif::[]
 
 Use Tabs when you want to allow in-place navigation within a certain part of the UI -- that is to say, without having to load another page and instead of showing everything at once, or forcing the user to navigate to different views.
 
-[role="since:com.vaadin:vaadin@V23.3"]
 == Tab Sheet
 
 Tabs are most conveniently used as part of a Tab Sheet that includes automatically switched content areas for each tab. Try clicking on the tabs in the example below. Notice how different text is displayed for each tab.
@@ -488,7 +487,6 @@ endif::[]
 --
 
 
-[role="since:com.vaadin:vaadin@V23.3"]
 == Prefix & Suffix
 
 Custom content can be placed before or after the tabs in a Tab Sheet by placing that content in the `prefix` and `suffix` slots. Notice the additional content at both ends of the tab bar in this example.
@@ -546,7 +544,7 @@ endif::[]
 
 === Content Switching without Tab Sheet
 
-Using the integrated content areas in [since:com.vaadin:vaadin@V23.3]#Tab Sheet# is the easiest way to switch among the different content for each tab. Sometimes, such as when the tabs need to be separated structurally from their content areas, it may be necessary to use the stand-alone Tabs component and manually implement content switching.
+Using the integrated content areas in Tab Sheet is the easiest way to switch among the different content for each tab. Sometimes, such as when the tabs need to be separated structurally from their content areas, it may be necessary to use the stand-alone Tabs component and manually implement content switching.
 
 Try clicking on each tab here. Notice how the text content changes depending on which you select.
 

--- a/articles/components/text-area/index.adoc
+++ b/articles/components/text-area/index.adoc
@@ -100,7 +100,6 @@ include::{root}/frontend/demo/component/textarea/react/text-area-height.tsx[rend
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.6"]
 === Minimum & Maximum Rows
 
 Alternatively, the minimum and maximum height can be constrained to a specific number of text rows like so:

--- a/articles/components/tooltip/index.adoc
+++ b/articles/components/tooltip/index.adoc
@@ -9,7 +9,7 @@ page-links:
 ---
 
 
-= [since:com.vaadin:vaadin@V23.3]#Tooltip#
+= Tooltip
 
 // tag::description[]
 Tooltips are small pop-ups for providing additional information about other UI elements.

--- a/articles/components/tree-grid/styling.adoc
+++ b/articles/components/tree-grid/styling.adoc
@@ -13,7 +13,6 @@ include::../_styling-section-intros.adoc[tag=selectors]
 Root element:: `vaadin-grid`
 
 
-[role="since:com.vaadin:vaadin@V24.3"]
 === Parent Rows
 
 Collapsed parent row:: `vaadin-grid+++<wbr>+++**::part(collapsed-row)**`

--- a/articles/components/vertical-layout/index.adoc
+++ b/articles/components/vertical-layout/index.adoc
@@ -272,7 +272,7 @@ endif::[]
 
 --
 
-[since:com.vaadin:vaadin@V24.7]#Alternatively, the spacing can be set to a custom value:#
+Alternatively, the spacing can be set to a custom value:
 
 [.example]
 --
@@ -366,7 +366,6 @@ include::{root}/frontend/demo/component/vertical-layout/react/vertical-layout-ma
 endif::[]
 --
 
-[role="since:com.vaadin:vaadin@V24.6"]
 == Wrapping
 
 By default, components in a layout either shrink or overflow when there isn't enough vertical space. Enable wrapping to allow components to flow onto a new column when space runs out, preventing overflow.


### PR DESCRIPTION
Removed all `since` tags for V24 and V23, as they are not relevant.
Preserved those for `V25.0` to indicate newly available features.