### PR TITLE
docs: sort Button style props table, remove feature column

### DIFF
--- a/articles/components/button/styling.adoc
+++ b/articles/components/button/styling.adoc
@@ -313,65 +313,51 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 
 === Common Properties
 
-[cols="1,3,1"]
+[cols="2,1"]
 |===
-| Feature | Property | Supported by
+| Property | Supported by
 
-|Background
 |`--vaadin-button-background`
 |Aura, Lumo
 
-|Text Color
-|`--vaadin-button-text-color`
-|Aura, Lumo
-
-|Font Weight
-|`--vaadin-button-font-weight`
-|Aura, Lumo
-
-|Font Size
-|`--vaadin-button-font-size`
-|Aura, Lumo
-
-|Border
 |`--vaadin-button-border`
 |Lumo
 
-|Border
 |`--vaadin-button-border-color`
 |Aura
 
-|Border
-|`--vaadin-button-border-width`
-|Aura
-
-|Border Radius
 |`--vaadin-button-border-radius`
 |Aura, Lumo
 
-|Padding
-|`--vaadin-button-padding`
+|`--vaadin-button-border-width`
+|Aura
+
+|`--vaadin-button-font-size`
 |Aura, Lumo
 
-|Margin
-|`--vaadin-button-margin`
+|`--vaadin-button-font-weight`
 |Aura, Lumo
 
-|Gap
 |`--vaadin-button-gap`
 |Aura
 
-|Height
 |`--vaadin-button-height`
 |Aura, Lumo
 
-|Line Height
 |`--vaadin-button-line-height`
 |Aura
 
-|Min-Width
+|`--vaadin-button-margin`
+|Aura, Lumo
+
 |`--vaadin-button-min-width`
 |Lumo
+
+|`--vaadin-button-padding`
+|Aura, Lumo
+
+|`--vaadin-button-text-color`
+|Aura, Lumo
 
 |===
 


### PR DESCRIPTION
- Removed redundant "feature" column from the Style properties table, as property names are self-explanatory,
- Reordered the table to keep the alphabetical order (vs grouping by property purpose) for better readability.