### PR TITLE
chore: align component names for related components

### DIFF
--- a/articles/components/combo-box/index.adoc
+++ b/articles/components/combo-box/index.adoc
@@ -529,7 +529,7 @@ Combo Box is an input field component, not a generic menu component. Use the Men
 |<<../select#,Select>>
 |Simpler overlay selection field without filtering, lazy loading or custom value entry.
 
-|<<../radio-button#,Radio Button>>
+|<<../radio-button#,Radio Button Group>>
 |Better accessibility than Combo Box, as all options are visible without user interaction.
 
 |<<../list-box#,List Box>>

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -503,7 +503,7 @@ endif::[]
 
 == Best Practices
 
-Menu Bar shouldn't be used for navigation. Use <<../tabs#,Tabs>> to switch between content, or anchor elements for regular navigation. It isn't an input field. Use instead <<../select#,Select>>, <<../combo-box#,Combo Box>>, or <<../radio-button#,Radio Button>>.
+Menu Bar shouldn't be used for navigation. Use <<../tabs#,Tabs>> to switch between content, or anchor elements for regular navigation. It isn't an input field. Use instead <<../select#,Select>>, <<../combo-box#,Combo Box>>, or <<../radio-button#,Radio Button Group>>.
 
 Menu Bar is an interactive component. Using other interactive components like Combo Box as menu items is not advised as this may produce conflicts in keyboard navigation and interaction. Although items are children of Menu Bar, it's not supposed to act as a layout component.
 

--- a/articles/components/radio-button/index.adoc
+++ b/articles/components/radio-button/index.adoc
@@ -399,7 +399,7 @@ In a Horizontal Layout, Radio Button Groups also align better with other input f
 |<<../list-box#,List Box>>
 |A scrollable list of options. Supports single and multi-select.
 
-|<<../checkbox#,Checkbox>>
+|<<../checkbox#,Checkbox Group>>
 |A corresponding component for multi-select options.
 |===
 

--- a/articles/components/select/index.adoc
+++ b/articles/components/select/index.adoc
@@ -479,7 +479,7 @@ Select is an input field component, not a generic menu component. Use <<../menu-
 |===
 |Component |Usage Recommendation
 
-|<<../radio-button#,Radio Button>>
+|<<../radio-button#,Radio Button Group>>
 |Better accessibility than Select, as all options are visible without user interaction.
 
 |<<../combo-box#,Combo Box>>


### PR DESCRIPTION
Replaced some cases of `Radio Button` with `Radio Button Group` and `Checkbox` with `Checkbox Group`.