### PR TITLE
docs: do not set scroller padding in app-layout examples

### DIFF
--- a/frontend/demo/component/app-layout/app-layout-basic.ts
+++ b/frontend/demo/component/app-layout/app-layout-basic.ts
@@ -35,8 +35,8 @@ export class Example extends LitElement {
       <vaadin-app-layout>
         <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
         <h1 slot="navbar">MyApp</h1>
-        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
-          <vaadin-side-nav>
+        <vaadin-scroller slot="drawer">
+          <vaadin-side-nav style="margin: var(--vaadin-gap-s)">
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>
               Dashboard

--- a/frontend/demo/component/app-layout/app-layout-drawer.ts
+++ b/frontend/demo/component/app-layout/app-layout-drawer.ts
@@ -35,8 +35,8 @@ export class Example extends LitElement {
       <vaadin-app-layout primary-section="drawer">
         <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
         <h1 slot="navbar">Dashboard</h1>
-        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
-          <vaadin-side-nav>
+        <vaadin-scroller slot="drawer">
+          <vaadin-side-nav style="margin: var(--vaadin-gap-s)">
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>
               Dashboard

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement-side.ts
@@ -35,8 +35,8 @@ export class Example extends LitElement {
       <vaadin-app-layout primary-section="drawer">
         <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
         <h1 slot="navbar">Dashboard</h1>
-        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
-          <vaadin-side-nav>
+        <vaadin-scroller slot="drawer">
+          <vaadin-side-nav style="margin: var(--vaadin-gap-s)">
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>
               Dashboard

--- a/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
+++ b/frontend/demo/component/app-layout/app-layout-navbar-placement.ts
@@ -35,8 +35,8 @@ export class Example extends LitElement {
       <vaadin-app-layout>
         <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
         <h1 slot="navbar">MyApp</h1>
-        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
-          <vaadin-side-nav>
+        <vaadin-scroller slot="drawer">
+          <vaadin-side-nav style="margin: var(--vaadin-gap-s)">
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>
               <span>Dashboard</span>

--- a/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
+++ b/frontend/demo/component/app-layout/app-layout-secondary-navigation.ts
@@ -44,8 +44,8 @@ export class Example extends LitElement {
       <!-- tag::snippet[] -->
       <vaadin-app-layout primary-section="drawer">
         <h1 slot="drawer">MyApp</h1>
-        <vaadin-scroller slot="drawer" style="padding: 0.5rem">
-          <vaadin-side-nav>
+        <vaadin-scroller slot="drawer">
+          <vaadin-side-nav style="margin: var(--vaadin-gap-s)">
             <vaadin-side-nav-item path="/dashboard">
               <vaadin-icon icon="vaadin:dashboard" slot="prefix"></vaadin-icon>
               Dashboard

--- a/frontend/demo/component/app-layout/react/app-layout-basic.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-basic.tsx
@@ -34,8 +34,8 @@ function Example() {
       <h1 slot="navbar" style={h1Style}>
         MyApp
       </h1>
-      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
-        <SideNav ref={sideNavRef}>
+      <Scroller slot="drawer">
+        <SideNav ref={sideNavRef} style={{ margin: 'var(--vaadin-gap-s)' }}>
           <SideNavItem path="/dashboard">
             <Icon icon="vaadin:dashboard" slot="prefix" />
             Dashboard

--- a/frontend/demo/component/app-layout/react/app-layout-drawer.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-drawer.tsx
@@ -35,8 +35,8 @@ function Example() {
         Dashboard
       </h1>
 
-      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
-        <SideNav ref={sideNavRef}>
+      <Scroller slot="drawer">
+        <SideNav ref={sideNavRef} style={{ margin: 'var(--vaadin-gap-s)' }}>
           <SideNavItem path="/dashboard">
             <Icon icon="vaadin:dashboard" slot="prefix" />
             Dashboard

--- a/frontend/demo/component/app-layout/react/app-layout-navbar-placement-side.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-navbar-placement-side.tsx
@@ -36,8 +36,8 @@ function Example() {
         Dashboard
       </h1>
 
-      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
-        <SideNav ref={sideNavRef}>
+      <Scroller slot="drawer">
+        <SideNav ref={sideNavRef} style={{ margin: 'var(--vaadin-gap-s)' }}>
           <SideNavItem path="/dashboard">
             <Icon icon="vaadin:dashboard" slot="prefix" />
             Dashboard

--- a/frontend/demo/component/app-layout/react/app-layout-navbar-placement.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-navbar-placement.tsx
@@ -35,8 +35,8 @@ function Example() {
         MyApp
       </h1>
 
-      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
-        <SideNav ref={sideNavRef}>
+      <Scroller slot="drawer">
+        <SideNav ref={sideNavRef} style={{ margin: 'var(--vaadin-gap-s)' }}>
           <SideNavItem path="/dashboard">
             <Icon icon="vaadin:dashboard" slot="prefix" />
             Dashboard

--- a/frontend/demo/component/app-layout/react/app-layout-secondary-navigation.tsx
+++ b/frontend/demo/component/app-layout/react/app-layout-secondary-navigation.tsx
@@ -58,8 +58,8 @@ function Example() {
       <h1 style={h1Style} slot="drawer">
         MyApp
       </h1>
-      <Scroller slot="drawer" style={{ padding: '0.5rem' }}>
-        <SideNav ref={sideNavRef}>
+      <Scroller slot="drawer">
+        <SideNav ref={sideNavRef} style={{ margin: 'var(--vaadin-gap-s)' }}>
           <SideNavItem>
             <Icon icon="vaadin:dashboard" slot="prefix" />
             Dashboard

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutBasic.java
@@ -22,9 +22,9 @@ public class AppLayoutBasic extends AppLayout {
 
         SideNav nav = getSideNav();
         nav.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
+        nav.getStyle().set("margin", "var(--vaadin-gap-s)");
 
         Scroller scroller = new Scroller(nav);
-        scroller.getStyle().set("padding", "0.5rem");
 
         addToDrawer(scroller);
         addToNavbar(toggle, title);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutDrawer.java
@@ -22,9 +22,9 @@ public class AppLayoutDrawer extends AppLayout {
 
         SideNav nav = getTabs();
         nav.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
+        nav.getStyle().set("margin", "var(--vaadin-gap-s)");
 
         Scroller scroller = new Scroller(nav);
-        scroller.getStyle().set("padding", "0.5rem");
 
         addToDrawer(scroller);
         addToNavbar(toggle, title);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacement.java
@@ -22,9 +22,9 @@ public class AppLayoutNavbarPlacement extends AppLayout {
 
         SideNav nav = getSideNav();
         nav.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
+        nav.getStyle().set("margin", "var(--vaadin-gap-s)");
 
         Scroller scroller = new Scroller(nav);
-        scroller.getStyle().set("padding", "0.5rem");
 
         addToDrawer(scroller);
         addToNavbar(toggle, title);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutNavbarPlacementSide.java
@@ -22,9 +22,9 @@ public class AppLayoutNavbarPlacementSide extends AppLayout {
 
         SideNav nav = getSideNav();
         nav.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
+        nav.getStyle().set("margin", "var(--vaadin-gap-s)");
 
         Scroller scroller = new Scroller(nav);
-        scroller.getStyle().set("padding", "0.5rem");
 
         addToDrawer(scroller);
         addToNavbar(toggle, title);

--- a/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
+++ b/src/main/java/com/vaadin/demo/component/applayout/AppLayoutSecondaryNavigation.java
@@ -27,9 +27,9 @@ public class AppLayoutSecondaryNavigation extends AppLayout {
 
         SideNav views = getPrimaryNavigation();
         views.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
+        views.getStyle().set("margin", "var(--vaadin-gap-s)");
 
         Scroller scroller = new Scroller(views);
-        scroller.getStyle().set("padding", "0.5rem");
 
         DrawerToggle toggle = new DrawerToggle();
 


### PR DESCRIPTION
Setting `padding` on the scroller is problematic in Aura as it causes scrollbar indicators to take more space:

<img width="324" height="324" alt="Screenshot 2025-12-08 at 11 33 37" src="https://github.com/user-attachments/assets/688038d0-bb3d-4fd7-b8c7-a948a3b9289f" />

This is related to https://github.com/vaadin/web-components/pull/10433 - setting `padding` on scroller requires using custom CSS properties. Let's update examples to not use `margin` on the side-nav component instead.