### PR TITLE
docs: Text Area Aura style variants and props

### DIFF
--- a/articles/components/text-area/index.adoc
+++ b/articles/components/text-area/index.adoc
@@ -16,7 +16,7 @@ page-links:
 Text Area is an input field component that allows entry of multiple lines of text.
 // end::description[]
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]
@@ -224,35 +224,6 @@ ifdef::react[]
 [source,tsx]
 ----
 include::{root}/frontend/demo/component/textarea/react/text-area-readonly-and-disabled.tsx[render,tags=snippet,indent=0,group=React]
-----
-endif::[]
---
-
-
-// Style Variants
-
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-start;text-alignment;small-variant;helper-above-field;styles-end]
-
-[.example]
---
-ifdef::lit[]
-[source,typescript]
-----
-include::{root}/frontend/demo/component/textarea/text-area-styles.ts[render,tags=snippet,indent=0,group=Lit]
-----
-endif::[]
-
-ifdef::flow[]
-[source,java]
-----
-include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaStyles.java[render,tags=snippet,indent=0,group=Flow]
-----
-endif::[]
-
-ifdef::react[]
-[source,tsx]
-----
-include::{root}/frontend/demo/component/textarea/react/text-area-styles.tsx[render,tags=snippet,indent=0,group=React]
 ----
 endif::[]
 --

--- a/articles/components/text-area/styling.adoc
+++ b/articles/components/text-area/styling.adoc
@@ -7,6 +7,35 @@ order: 50
 ---
 = Text Area Styling
 
+// Style Variants
+
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-start;text-alignment;small-variant;helper-above-field;styles-end]
+
+[.example]
+--
+ifdef::lit[]
+[source,typescript]
+----
+include::{root}/frontend/demo/component/textarea/text-area-styles.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/textarea/TextAreaStyles.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/textarea/react/text-area-styles.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
+
+
 include::../_styling-section-theming-props.adoc[tag=style-properties]
 
 include::../_styling-section-theming-props.adoc[tag=input-fields]


### PR DESCRIPTION
List style variants and props specific to Lumo / Aura.

Part of https://github.com/vaadin/docs/issues/4801