### PR TITLE
docs: add Accordion style properties table

### DIFF
--- a/articles/components/accordion/styling.adoc
+++ b/articles/components/accordion/styling.adoc
@@ -122,6 +122,43 @@ include::{root}/frontend/demo/component/accordion/react/accordion-reverse-panels
 endif::[]
 --
 
+include::../_styling-section-theming-props.adoc[tag=style-properties]
+
+[cols="2,1"]
+|===
+| Property | Supported by
+
+|`--vaadin-accordion-heading-background`
+|Aura
+
+|`--vaadin-accordion-heading-border-color`
+|Aura
+
+|`--vaadin-accordion-heading-border-radius`
+|Aura
+
+|`--vaadin-accordion-heading-border-width`
+|Aura
+
+|`--vaadin-accordion-heading-font-size`
+|Aura
+
+|`--vaadin-accordion-heading-font-weight`
+|Aura
+
+|`--vaadin-accordion-heading-gap`
+|Aura
+
+|`--vaadin-accordion-heading-height`
+|Aura
+
+|`--vaadin-accordion-heading-padding`
+|Aura
+
+|`--vaadin-accordion-heading-text-color`
+|Aura
+
+|===
 
 include::../_styling-section-intros.adoc[tag=selectors]
 


### PR DESCRIPTION
We missed to add `vaadin-accordion-heading` style properties in https://github.com/vaadin/docs/pull/4867. This PR fixes that.