### PR TITLE
docs: add missing overlay base style properties tables

### DIFF
--- a/articles/components/_styling-section-theming-props.adoc
+++ b/articles/components/_styling-section-theming-props.adoc
@@ -220,6 +220,32 @@ Style properties whose names start with `--vaadin-input-field` are shared among 
 |===
 // end::input-icons[]
 
+// tag::overlay[]
+=== Overlay
+
+[cols="2,1"]
+|===
+| Property | Supported by
+
+|`--vaadin-overlay-background`
+|Aura
+
+|`--vaadin-overlay-border-color`
+|Aura
+
+|`--vaadin-overlay-border-radius`
+|Aura
+
+|`--vaadin-overlay-border-width`
+|Aura
+
+|`--vaadin-overlay-shadow`
+|Aura
+
+|===
+// end::overlay[]
+
+
 // tag::overlay-items[]
 === Overlay Items
 

--- a/articles/components/avatar/styling.adoc
+++ b/articles/components/avatar/styling.adoc
@@ -100,7 +100,14 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-avatar-size`
 |Aura, Lumo
 
+|`--vaadin-item-overlay-padding`
+|Aura
+
 |===
+
+include::../_styling-section-theming-props.adoc[tag=overlay]
+
+include::../_styling-section-theming-props.adoc[tag=overlay-items]
 
 === User Color Properties
 

--- a/articles/components/combo-box/styling.adoc
+++ b/articles/components/combo-box/styling.adoc
@@ -70,6 +70,21 @@ endif::[]
 |`--vaadin-item-overlay-padding`
 |Aura
 
+|`--vaadin-overlay-background`
+|Aura
+
+|`--vaadin-overlay-border-color`
+|Aura
+
+|`--vaadin-overlay-border-radius`
+|Aura
+
+|`--vaadin-overlay-border-width`
+|Aura
+
+|`--vaadin-overlay-shadow`
+|Aura
+
 |`--vaadin-spinner-color`
 |Aura
 

--- a/articles/components/context-menu/styling.adoc
+++ b/articles/components/context-menu/styling.adoc
@@ -7,6 +7,35 @@ order: 50
 ---
 = Context Menu Styling
 
+include::../_styling-section-theming-props.adoc[tag=style-properties]
+
+=== Menu
+
+[cols="2,1"]
+|===
+| Property | Supported by
+
+|`--vaadin-context-menu-offset-bottom`
+|Aura, Lumo
+
+|`--vaadin-context-menu-offset-end`
+|Aura, Lumo
+
+|`--vaadin-context-menu-offset-start`
+|Aura, Lumo
+
+|`--vaadin-context-menu-offset-top`
+|Aura, Lumo
+
+|`--vaadin-item-overlay-padding`
+|Aura
+
+|===
+
+include::../_styling-section-theming-props.adoc[tag=overlay]
+
+include::../_styling-section-theming-props.adoc[tag=overlay-items]
+
 include::../_styling-section-intros.adoc[tag=selectors]
 
 

--- a/articles/components/date-picker/styling.adoc
+++ b/articles/components/date-picker/styling.adoc
@@ -63,6 +63,29 @@ include::../_styling-section-theming-props.adoc[tag=input-icons]
 |`--vaadin-date-picker-toolbar-padding`
 |Aura
 
+|`--vaadin-overlay-background`
+|Aura
+
+|`--vaadin-overlay-border-color`
+|Aura
+
+|`--vaadin-overlay-border-radius`
+|Aura
+
+|`--vaadin-overlay-border-width`
+|Aura
+
+|`--vaadin-overlay-shadow`
+|Aura
+
+|===
+
+=== Years
+
+[cols="2,1"]
+|===
+| Property | Supported by
+
 |`--vaadin-date-picker-year-scroller-width`
 |Aura
 
@@ -73,7 +96,14 @@ include::../_styling-section-theming-props.adoc[tag=input-icons]
 |Aura
 
 |`--vaadin-date-picker-year-scroller-current-year-color`
-|Aura
+
+|===
+
+=== Months
+
+[cols="2,1"]
+|===
+| Property | Supported by
 
 |`--vaadin-date-picker-month-padding`
 |Aura

--- a/articles/components/menu-bar/styling.adoc
+++ b/articles/components/menu-bar/styling.adoc
@@ -181,6 +181,11 @@ include::{root}/frontend/themes/docs/menu-bar-class-name.css[]
 
 --
 
+include::../_styling-section-theming-props.adoc[tag=style-properties]
+
+include::../_styling-section-theming-props.adoc[tag=overlay]
+
+include::../_styling-section-theming-props.adoc[tag=overlay-items]
 
 include::../_styling-section-intros.adoc[tag=selectors]
 

--- a/articles/components/select/styling.adoc
+++ b/articles/components/select/styling.adoc
@@ -59,6 +59,21 @@ include::../_styling-section-theming-props.adoc[tag=input-icons]
 |`--vaadin-item-overlay-padding`
 |Aura
 
+|`--vaadin-overlay-background`
+|Aura
+
+|`--vaadin-overlay-border-color`
+|Aura
+
+|`--vaadin-overlay-border-radius`
+|Aura
+
+|`--vaadin-overlay-border-width`
+|Aura
+
+|`--vaadin-overlay-shadow`
+|Aura
+
 |===
 
 

--- a/articles/components/time-picker/styling.adoc
+++ b/articles/components/time-picker/styling.adoc
@@ -62,6 +62,21 @@ include::../_styling-section-theming-props.adoc[tag=input-icons]
 |`--vaadin-item-overlay-padding`
 |Aura
 
+|`--vaadin-overlay-background`
+|Aura
+
+|`--vaadin-overlay-border-color`
+|Aura
+
+|`--vaadin-overlay-border-radius`
+|Aura
+
+|`--vaadin-overlay-border-width`
+|Aura
+
+|`--vaadin-overlay-shadow`
+|Aura
+
 |===
 
 


### PR DESCRIPTION
There are some style properties that we missed to document for field components overlays. This PR fixes that.