### PR TITLE
feat: set Aura accent color for component examples

### DIFF
--- a/frontend/themes/docs/styles.css
+++ b/frontend/themes/docs/styles.css
@@ -25,4 +25,7 @@
 :is(#id, :root, :host) {
   --aura-app-background: var(--docs-example-render-background-color);
   --lumo-base-color: var(--docs-example-render-background-color);
+
+  --aura-accent-color-light: var(--aura-blue);
+  --aura-accent-color-dark: var(--aura-blue);
 }


### PR DESCRIPTION
The expectation is that we’ll set a default accent color in our starters and other examples as well, so I would say it makes sense to set one in the documentation examples as well.