### PR TITLE
docs: add overlay viewport inset custom CSS property

### DIFF
--- a/articles/components/confirm-dialog/styling.adoc
+++ b/articles/components/confirm-dialog/styling.adoc
@@ -52,6 +52,9 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-overlay-backdrop-background`
 |Aura
 
+|`--vaadin-overlay-viewport-inset`
+|Aura, Lumo
+
 |===
 
 See also <<../dialog/styling#style-properties,Dialog Style Properties>> for common properties that can be applied to Confirm Dialog.

--- a/articles/components/dialog/styling.adoc
+++ b/articles/components/dialog/styling.adoc
@@ -94,6 +94,9 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-overlay-backdrop-background`
 |Aura
 
+|`--vaadin-overlay-viewport-inset`
+|Aura, Lumo
+
 |===
 
 


### PR DESCRIPTION
This property is useful to reset the default viewport inset to `0` in certain cases, let's document it.