### PR TITLE
docs: update UI Unit Testing for Vaadin 25 with JUnit 6 support

### DIFF
--- a/articles/flow/testing/ui-unit/getting-started.adoc
+++ b/articles/flow/testing/ui-unit/getting-started.adoc
@@ -21,13 +21,17 @@ To start creating UI unit tests in an existing project, you need to add the Test
     <artifactId>vaadin-testbench-unit</artifactId>
     <scope>test</scope>
 </dependency>
+<!-- Required for Vaadin 25+ with Spring Boot 4 (JUnit 6) -->
+<dependency>
+    <groupId>org.junit.vintage</groupId>
+    <artifactId>junit-vintage-engine</artifactId>
+    <scope>test</scope>
+</dependency>
 ----
-
-JUnit 5 support is added in Vaadin 24.
 
 [source,xml]
 ----
-<source-info group="JUnit 5"></source-info>
+<source-info group="JUnit 5/6"></source-info>
 <dependency>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-testbench-unit-junit5</artifactId>
@@ -35,6 +39,15 @@ JUnit 5 support is added in Vaadin 24.
 </dependency>
 ----
 --
+
+[NOTE]
+====
+Starting with Vaadin 25 and Spring Boot 4, the default test framework is JUnit 6 (JUnit Platform). JUnit 6 maintains API compatibility with JUnit 5, so `vaadin-testbench-unit-junit5` works with both.
+
+For JUnit 4 tests using [classname]`UIUnit4Test`, the `junit-vintage-engine` dependency is required because JUnit 6 doesn't natively execute JUnit 4 tests. Without it, tests won't be detected or executed.
+
+This wasn't required in Vaadin 24.x because Spring Boot 3 bundled the Vintage Engine with JUnit 5 by default.
+====
 
 
 == First UI Unit Test

--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -959,6 +959,12 @@ public class MainLayout extends AppLayout {
 
 == TestBench
 
+=== JUnit 6 and Vintage Engine for JUnit 4 Tests
+
+Vaadin 25 with Spring Boot 4 uses JUnit 6 (JUnit Platform) as the default test framework. If you have UI Unit tests using [classname]`UIUnit4Test` (JUnit 4 base class), they won't be detected or executed without adding the JUnit Vintage Engine dependency. See <<{articles}/flow/testing/ui-unit/getting-started#,Getting Started with UI Unit Testing>> for the required dependencies.
+
+=== ComponentTester Click Method
+
 [classname]`ComponentTester` in UI Unit test has been updated to prove a common [methodname]`void click()` method. However, the new method clashes with a similar existing method in [classname]`AnchorTester` and [classname]`RouterLinkTester` that returns an [classname]`HasElement` instance as a result of the navigation. Existing tests that rely on the return type have to migrate to the new [methodname]`navigate()` method; if the return value is not used, there is no need for changes.
 
 Because of the change, the [classname]`com.vaadin.flow.component.html.testbench.ClickHandler` class has been removed. The interface, meant to be used with [classname]`ComponentTester` subclasses, should not be needed anymore. In this case, [classname]`com.vaadin.testbench.unit.Clickable` is a valid substitute.


### PR DESCRIPTION
- Add junit-vintage-engine to JUnit 4 snippet in getting-started (required for Vaadin 25+)
- Rename JUnit 5 tab to JUnit 5/6 since both use same dependency
- Add note explaining JUnit 6 compatibility and vintage engine requirement
- Add migration guide section linking to getting-started for dependencies


