### PR TITLE
docs: add JUnit Vintage Engine requirement for E2E JUnit 4 tests

### DIFF
--- a/articles/flow/testing/end-to-end/getting-started.adoc
+++ b/articles/flow/testing/end-to-end/getting-started.adoc
@@ -26,6 +26,12 @@ To start using TestBench in an existing project, you need to add the TestBench d
     <artifactId>vaadin-testbench</artifactId>
     <scope>test</scope>
 </dependency>
+<!-- Required for Vaadin 25+ with Spring Boot 4 (JUnit 6) -->
+<dependency>
+    <groupId>org.junit.vintage</groupId>
+    <artifactId>junit-vintage-engine</artifactId>
+    <scope>test</scope>
+</dependency>
 ----
 [source,xml]
 ----
@@ -41,6 +47,8 @@ To start using TestBench in an existing project, you need to add the TestBench d
 [NOTE]
 ====
 Starting with Vaadin 25 and Spring Boot 4, the default test framework is JUnit 6 (JUnit Platform). JUnit 6 maintains API compatibility with JUnit 5, so `vaadin-testbench-junit5` and `vaadin-testbench-junit6` work with both, but have transitive JUnit dependencies aligned with the respective versions.
+
+For JUnit 4 tests using [classname]`TestBenchTestCase`, the `junit-vintage-engine` dependency is required because JUnit 6 doesn't natively execute JUnit 4 tests. Without it, tests won't be detected or executed.
 ====
 
 The `test` scope and version number are predefined by the Vaadin BOM.

--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -982,7 +982,9 @@ public class MainLayout extends AppLayout {
 
 === JUnit 6 and Vintage Engine for JUnit 4 Tests
 
-Vaadin 25 with Spring Boot 4 uses JUnit 6 (JUnit Platform) as the default test framework. If you have UI Unit tests using [classname]`UIUnit4Test` (JUnit 4 base class), they won't be detected or executed without adding the JUnit Vintage Engine dependency. See <<{articles}/flow/testing/ui-unit/getting-started#,Getting Started with UI Unit Testing>> for the required dependencies.
+Vaadin 25 with Spring Boot 4 uses JUnit 6 (JUnit Platform) as the default test framework. If you have JUnit 4 tests using [classname]`UIUnit4Test` (UI Unit) or [classname]`TestBenchTestCase` (End-to-End), they won't be detected or executed without adding the JUnit Vintage Engine dependency.
+
+See <<{articles}/flow/testing/ui-unit/getting-started#,Getting Started with UI Unit Testing>> and <<{articles}/flow/testing/end-to-end/getting-started#,Getting Started with End-to-End Testing>> for the required dependencies.
 
 === ComponentTester Click Method
 


### PR DESCRIPTION
End-to-End Testing (getting-started.adoc):
- Add junit-vintage-engine to JUnit 4 snippet (required for Vaadin 25+)
- Add note about vintage engine requirement for TestBenchTestCase

Upgrading Guide (index.adoc):
- Update TestBench section to mention both UIUnit4Test and TestBenchTestCase
- Add link to E2E getting-started alongside UI Unit getting-started


