### PR TITLE
Fix incorrect advice

### DIFF
--- a/articles/building-apps/forms-data/add-form/fields-and-binding.adoc
+++ b/articles/building-apps/forms-data/add-form/fields-and-binding.adoc
@@ -355,7 +355,7 @@ public class ProposalForm extends Composite<FormLayout> {
 // tag::snippet[]
     public Optional<Proposal> getFormDataObject() {
         if (binder.getBean() == null) {
-            binder.setBean(new Proposal()); // <1>
+            throw new IllegalStateException("No form data object"); // <1>
         }
         if (binder.validate().isOk()) {
             return Optional.of(binder.getBean()); // <2>
@@ -366,7 +366,7 @@ public class ProposalForm extends Composite<FormLayout> {
 // end::snippet[]
 }
 ----
-<1> Creates a new, empty `Proposal` if `setFormDataObject()` was never called.
+<1> Throws an exception if `setFormDataObject()` was never called. If you called `setBean()` here with an empty FDO, you'd reset the form.
 <2> Returns the updated `Proposal` if validation succeeds.
 <3> Returns an empty `Optional` if validation fails.
 


### PR DESCRIPTION
The old example of calling `setBean()` to read a form effectively reset the form.