### PR TITLE
docs: update confusing mentions of feature flag in form-layout docs

### DIFF
--- a/articles/components/form-layout/index.adoc
+++ b/articles/components/form-layout/index.adoc
@@ -40,7 +40,7 @@ Form Layout automatically adjusts how fields are laid out in columns and rows to
 
 .Default mode depends on feature flag
 [NOTE]
-In V24.8+, the default mode depends on the <<{articles}/flow/configuration/feature-flags#,feature flag>> `defaultAutoResponsiveFormLayout`. When enabled, auto-responsive mode is the default; otherwise, responsive steps mode is the default.
+The default mode depends on the <<{articles}/flow/configuration/feature-flags#,feature flag>> `defaultAutoResponsiveFormLayout`. When enabled, auto-responsive mode is the default; otherwise, responsive steps mode is the default.
 
 == Auto-Responsive Mode
 
@@ -69,7 +69,7 @@ formLayout.setAutoResponsive(true);
 
 .Feature Flag Controls Default Mode
 [NOTE]
-In V24.8+, auto-responsive mode can be set as default by setting the <<{articles}/flow/configuration/feature-flags#,feature flag>> `defaultAutoResponsiveFormLayout` to true. This is recommended for new projects as auto-responsive will be the default mode in V25.
+Auto-responsive mode can be set as default by setting the <<{articles}/flow/configuration/feature-flags#,feature flag>> `defaultAutoResponsiveFormLayout` to true.
 
 The sections below describe features available in auto-responsive mode.
 
@@ -241,7 +241,7 @@ The default breakpoint configuration is one column below a layout width of `40em
 
 .Feature Flag Controls Default Mode
 [NOTE]
-In V24.8+, the <<{articles}/flow/configuration/feature-flags#,feature flag>> `defaultAutoResponsiveFormLayout` makes auto-responsive mode the default. With the flag enabled, individual Form Layouts can be switched to responsive steps mode by defining the responsive steps manually.
+The <<{articles}/flow/configuration/feature-flags#,feature flag>> `defaultAutoResponsiveFormLayout` makes auto-responsive mode the default. With the flag enabled, individual Form Layouts can be switched to responsive steps mode by defining the responsive steps manually.
 
 === Setting the Breakpoints
 


### PR DESCRIPTION
Removed confusing mention of V25 which isn't true. Also removed mentions of 24.8+ as not needed.