### PR TITLE
docs: add missing checkbox and radio button style properties

### DIFF
--- a/articles/components/checkbox/styling.adoc
+++ b/articles/components/checkbox/styling.adoc
@@ -70,10 +70,10 @@ include::../_styling-section-theming-props.adoc[tag=input-fields]
 |Lumo
 
 |`--vaadin-checkbox-checkmark-color`
-|Aura, Lumo
+|Lumo
 
 |`--vaadin-checkbox-checkmark-size`
-|Aura, Lumo
+|Lumo
 
 |`--vaadin-checkbox-disabled-background`
 |Lumo

--- a/articles/components/radio-button/styling.adoc
+++ b/articles/components/radio-button/styling.adoc
@@ -66,10 +66,10 @@ include::../_styling-section-theming-props.adoc[tag=input-fields]
 |Lumo
 
 |`--vaadin-radio-button-dot-color`
-|Aura, Lumo
+|Lumo
 
 |`--vaadin-radio-button-dot-size`
-|Aura, Lumo
+|Lumo
 
 |`--vaadin-radio-button-gap`
 |Aura


### PR DESCRIPTION
1. Added the following custom CSS properties that were missing:

- `--vaadin-checkbox-border-width`
- `--vaadin-checkbox-gap`
- `--vaadin-checkbox-label-font-weight`
- `--vaadin-checkbox-label-line-height`
- `--vaadin-radio-button-gap`
- `--vaadin-radio-button-label-font-weight`
- `--vaadin-radio-button-label-line-height`

2. Modified some properties as supported by [both Lumo and Aura](https://github.com/vaadin/web-components/pull/10344):

- `--vaadin-checkbox-border-radius`
- `--vaadin-checkbox-label-color`
- `--vaadin-checkbox-label-font-size`
- `--vaadin-radio-button-dot-color`
- `--vaadin-radio-button-dot-size`
- `--vaadin-radio-button-label-color`
- `--vaadin-radio-button-label-font-size`

3. Sorted the `vaadin-checkbox` style properties table alphabetically.