### PR TITLE
Added clarifications to theme and styling changes in Upgrading Guide.

### DIFF
--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -233,7 +233,7 @@ Below are the main highlights of the changes and more detailed instructions are 
 
 The special `frontend/themes` folder, and the `components` sub-folder for CSS shadow-DOM injection, is deprecated (but still supported).
 
-Injecting CSS into Vaadin components’ shadow DOM through the components sub-folder in your theme folder is disabled by default. Shadow DOM styling is no longer recommended (as of V24), but if you still need to use it, it can be enabled with the feature flag `themeComponentStyles`.
+Injecting CSS into Vaadin components’ shadow DOM through the components sub-folder in your `frontend/themes/<mytheme>` folder is disabled by default. Shadow DOM styling is no longer recommended (as of V24), but if you still need to use it, it can be enabled with the feature flag `themeComponentStyles`.
 
 The [classname]`@Theme` annotation is deprecated. Instead, [classname]`StyleSheet` annotation to be used for loading one or more stylesheets from public static resources locations (e.g. `META-INF/resources/`), whereas [classname]`CssImport` loads one or more stylesheets from the `src/main/frontend/` folder and use mechanisms native to HTML, CSS, and React (e.g. `@import url("morestyles.css")` in CSS).
 
@@ -265,7 +265,7 @@ Stylesheets referenced by [annotationname]`@StyleSheet` annotation are loaded by
 public class Application implements AppShellConfigurator {}
 ----
 
-The [filename]`theme.json` configuration file is deprecated (but still supported, except the `lumoImports` property).
+The [filename]`theme.json` configuration file is deprecated (but still supported in the `frontend/themes/<mytheme>/` folder, except for the `lumoImports` property).
 
 The `themeFor` parameter of the [classname]`@CssImport` annotation (for shadow-DOM injection) is deprecated (but still supported).
 
@@ -369,10 +369,13 @@ One exception is the `@vaadin/react-components/css/lumo/Utility.module.css` CSS 
 
 These changes are optional, as old approaches still work (with the exceptions listed in the Breaking Changes section), but recommended to get your application to the new best practices in Vaadin 25, and to avoid breaking changes in later major versions.
 
-* Refactor component styles from shadow DOM styles to normal CSS (this was the recommended approach already in V24)
+* Refactor component styles from shadow DOM styles to normal CSS (this was the recommended approach already in V24). (The _Styling_ sub-pages in the component documentation provide lists of css selectors and style properties that can be used to style components this way.)
+* Move stylesheets from `frontend/themes/<mytheme>` to `src/main/resources/META-INF/resources`
 * Load custom styles through a master stylesheet with [classname]`@StyleSheet` instead of [classname]`@Theme` or multiple [classname]`@CssImport`-s
 * Load additional custom stylesheets through master stylesheet with `@import`
-* Move stylesheets from `frontend/themes/<mytheme>` to `src/main/resources/META-INF/resources`
+
+Note that `theme.json` and shadow-DOM styling of components through the `components` folder do not work in the new stylesheet location.
+
 
 == Components
 


### PR DESCRIPTION
- Clarified that theme.json only works in the legacy theme folder
- Clarified that shadow DOM styling only works in the legacy theme folder.