### PR TITLE
fix: fix "Sorting In-Memory Data" heading level

### DIFF
--- a/articles/flow/binding-data/data-provider.adoc
+++ b/articles/flow/binding-data/data-provider.adoc
@@ -303,7 +303,7 @@ cb.setItemsWithFilterConverter(
 
 With the lazy data binding described above, the component doesn't know how many items are actually available. When a user scrolls to the end of the scrollable area, the component (e.g. `Grid` or `ComboBox`) polls your callbacks for more items. If new items are found, these are added to the component. This pattern, often called infinite scrolling, causes the scrollbar to be updated when new items are added on the fly and does not allow the user to immediately scroll to the end.
 
-The usability can be improved by either providing the exact number of items available or providing an estimate of the number of items. 
+The usability can be improved by either providing the exact number of items available or providing an estimate of the number of items.
 
 If your service is able to provide the exact number of items available, you can add an additional "count" callback to `setItems` or `setItemsPageable` like this:
 
@@ -487,7 +487,7 @@ Span itemCountSpan = new Span("Total Item Count: " + dataView.getItemCount());
 ----
 
 
-=== Sorting In-Memory Data
+== Sorting In-Memory Data
 
 Consider the `Grid` as an example of a component with a sorting API. `Grid` rows are automatically sortable by columns that have a property type that implements [interfacename]`Comparable`. By defining a custom [classname]`Comparator`, you can also make other columns sortable.
 


### PR DESCRIPTION
The heading "Sorting In-Memory Data" should match the level of "Filtering In-Memory Data" for consistency.
