### PR TITLE
docs: add style properties section to custom-field styling docs

### DIFF
--- a/articles/components/custom-field/styling.adoc
+++ b/articles/components/custom-field/styling.adoc
@@ -68,6 +68,10 @@ endif::[]
 [NOTE]
 Custom Field doesn't propagate its style variant to the individual field components it wraps. Each individual component's style variant must be set individually.
 
+include::../_styling-section-theming-props.adoc[tag=style-properties]
+
+include::../_styling-section-theming-props.adoc[tag=label-helper-error]
+
 include::../_styling-section-intros.adoc[tag=selectors]
 
 


### PR DESCRIPTION
We missed to add Style properties for `vaadin-custom-field` (label, helper, error message). This PR fixes that.