### PR TITLE
docs: add field properties section to date-time-picker styling docs

### DIFF
--- a/articles/components/date-time-picker/styling.adoc
+++ b/articles/components/date-time-picker/styling.adoc
@@ -47,6 +47,7 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |Aura
 |===
 
+include::../_styling-section-theming-props.adoc[tag=label-helper-error]
 
 include::../_styling-section-intros.adoc[tag=selectors]
 


### PR DESCRIPTION
Same as https://github.com/vaadin/docs/pull/5026 but for `vaadin-date-time-picker` - added missing props (label, helper, error).