### PR TITLE
docs: add missing grid and item custom CSS properties

### DIFF
--- a/articles/components/grid/styling.adoc
+++ b/articles/components/grid/styling.adoc
@@ -288,6 +288,9 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-grid-cell-padding`
 |Aura, Lumo
 
+|`--vaadin-grid-cell-text-overflow`
+|Aura, Lumo
+
 |`--vaadin-grid-column-resize-handle-color`
 |Aura
 

--- a/articles/components/list-box/styling.adoc
+++ b/articles/components/list-box/styling.adoc
@@ -34,6 +34,9 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-item-padding`
 |Aura
 
+|`--vaadin-item-text-align`
+|Aura
+
 |===
 
 


### PR DESCRIPTION
Added custom CSS properties introduced in following PRs:

- https://github.com/vaadin/web-components/pull/10787
- https://github.com/vaadin/web-components/pull/10613