### PR TITLE
chore: remove unnecessary copyright headers from Java examples

### DIFF
--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttBasicDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttBasicDemo.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCurrentDateIndicationDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCurrentDateIndicationDemo.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCustomDataDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCustomDataDemo.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCustomLabelsDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttCustomLabelsDemo.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttDragAndDropDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttDragAndDropDemo.java
@@ -1,11 +1,3 @@
-/**
- * Copyright 2000-2025 Vaadin Ltd.
- *
- * This program is available under Vaadin Commercial License and Service Terms.
- *
- * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
- * license.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttHorizontalAxisConfiguration.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttHorizontalAxisConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttProcessManagementDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttProcessManagementDemo.java
@@ -1,11 +1,3 @@
-/**
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * This program is available under Vaadin Commercial License and Service Terms.
- *
- * See {@literal <https://vaadin.com/commercial-license-and-service-terms>} for the full
- * license.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttProgressIndicatorDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttProgressIndicatorDemo.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttSmallTaskDependenciesDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttSmallTaskDependenciesDemo.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttVerticalCategoriesGrouping.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttVerticalCategoriesGrouping.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttWithNavigationDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttWithNavigationDemo.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttYAxisAsGridDemo.java
+++ b/src/main/java/com/vaadin/demo/component/charts/charttypes/gantt/GanttYAxisAsGridDemo.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2024 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.demo.component.charts.charttypes.gantt;
 
 import com.vaadin.demo.DemoExporter; // hidden-source-line


### PR DESCRIPTION
Removed license headers from Gantt charts examples: they are misaligned with the other code (we don't use license headers in any examples) and also have inconsistent license (Apache 2 vs commercial), as well as outdated year.