### PR TITLE
Remove unused styles from avatar component documentation

### DIFF
--- a/articles/components/avatar/index.adoc
+++ b/articles/components/avatar/index.adoc
@@ -45,14 +45,6 @@ endif::[]
 [NOTE]
 This component is optimized for use with https://vaadin.com/collaboration[Collaboration Kit] — a simple way to build real-time collaboration into your app — but can also be used standalone as a regular component.
 
-++++
-<style>
-.example iframe {
-  height: 100px;
-}
-</style>
-++++
-
 == Content
 
 Avatar has three properties: *name*, *abbreviation*, and *image*.


### PR DESCRIPTION
This docs page doesn't contain any examples that are rendered in an iframe.


