### PR TITLE
Added high-level Vaadin version comparison for migration

### DIFF
--- a/articles/upgrading/version-comparison.adoc
+++ b/articles/upgrading/version-comparison.adoc
@@ -9,26 +9,26 @@ order: 900
 
 = Vaadin Version Comparison
 
-This comparison highlights the concrete technical and platform-level differences between Vaadin major versions over time to help you understand the impact effort and risk. 
-Using the table, you can quickly scope viable target versions, identify breaking changes, and produce a realistic migration plan and work estimates.
+This comparison table highlights the technical and platform-level differences between major Vaadin versions. It helps you assess the effort and risk of upgrading to a newer version. You can scope viable target versions, identify breaking changes, and produce a realistic migration plan and work estimates.
 
-[cols="1,1,1,1,1,1", options="header"]
+[%autowidth]
+[cols="1,1,1,1,1,1",options="header"]
 |===
-| | Vaadin 8 | Vaadin 14 (Long-Term Support) | Vaadin 23 | Vaadin 24 | Vaadin 25
+| | Vaadin 8 | Vaadin 14 +++<abbr title="Long-Term Support">LTS</abbr>+++ | Vaadin 23 | Vaadin 24 | Vaadin 25
 
 | *Architecture*
-| GWT-based widgets.
-| Vaadin Flow.
+| GWT-based widgets
+| Vaadin Flow
 | Vaadin Flow + Hilla
 | Vaadin Flow + Hilla
 | Latest Vaadin Flow + Hilla (opt-in)
 
 | *Browser Support*
-| Legacy (including IE11).
-| Evergreen browsers.
-| Evergreen browsers.
-| Evergreen browsers.
-| Evergreen browsers. Chrome, Firefox, Safari 15+, Edge (Chromium)
+| Legacy (including IE11)
+| Evergreen browsers
+| Evergreen browsers (Chrome, Edge, Firefox), Safari 14.1+
+| Evergreen browsers (Chrome, Edge, Firefox), Safari 15+
+| Evergreen browsers (Chrome, Edge, Firefox), Safari 17+
 
 | *Java Version*
 | Java 6–8
@@ -52,21 +52,21 @@ Using the table, you can quickly scope viable target versions, identify breaking
 | Servlet 6.1+, jakarta.servlet.*
 
 | *Spring Support*
-| Integration add-on.
+| Integration add-on
 | Spring Boot 2.x / Spring Framework 5
 | Spring Boot 2.x / Spring Framework 5
 | Spring Boot 3 / Spring Framework 6
 | Spring Boot 4 / Spring Framework 7
 
 | *Component APIs*
-| GWT widgets, server-side Java components.
-| Web Components, Polymer, Lit, server-side Java components.
-| Web Components, Polymer, Lit, server-side Java components.
-| Web Components, Lit, server-side Java components.
-| Web Components, Lit, server-side Java components.
+| GWT widgets, server-side Java components
+| Web Components, Polymer, Lit, server-side Java components
+| Web Components, Polymer, Lit, server-side Java components
+| Web Components, Lit, server-side Java components
+| Web Components, Lit, server-side Java components
 
 | *Frontend Build*
-| GWT Java to JavaScript compiler.
+| GWT Java-to-JavaScript compiler
 | npm, webpack
 | npm, pnpm, Vite
 | npm, pnpm, Vite, precompiled frontend
@@ -74,7 +74,7 @@ Using the table, you can quickly scope viable target versions, identify breaking
 
 | *Node Version*
 | NA
-| Node 14+ 
+| Node 14+
 | Node 16+
 | Node 24+
 | Node 24+
@@ -96,15 +96,29 @@ Using the table, you can quickly scope viable target versions, identify breaking
 
 | *Backward Interop Tools*
 | NA
-| Multiplatform Runtime for V7/8.
+| Multiplatform Runtime for V7/8
 | Multiplatform Runtime for V7/8, Modernization Toolkit
 | Multiplatform Runtime for V7/8, Modernization Toolkit
 | Multiplatform Runtime for V7/8, Modernization Toolkit, Analyzer
 
 | *License & Maintenance*
-| Extended maintenance until 2032.
-| Extended maintenance until 2032.
-| Extended maintenance until 2034.
+| Extended maintenance until 2032
+| Extended maintenance until 2032
+| Extended maintenance until 2034
 | Free support until June 2026. Extended maintenance until 2035.
 | Free support. New major baseline with long future support.
 |===
+
+++++
+<style>
+.tableblock.fit-content {
+  font-size: var(--docs-font-size-s);
+  display: block;
+  overflow: auto;
+
+  col {
+    xmin-width: 10em;
+  }
+}
+</style>
+++++


### PR DESCRIPTION
Added a high-level comparison of Vaadin version features from Vaadin 8, Vaadin 14, Vaadin 23 and Vaadin 24 to Vaadin 25 to help us understand the scope of the migration effort.


