### PR TITLE
declare overlay root element

### DIFF
--- a/articles/components/combo-box/styling.adoc
+++ b/articles/components/combo-box/styling.adoc
@@ -107,6 +107,8 @@ include::../_styling-section-intros.adoc[tag=selectors]
 
 Root element:: `vaadin-combo-box`
 
+Overlay root element:: `vaadin-combo-box-overlay`
+
 
 === States
 


### PR DESCRIPTION
If it is a "rule" for all elements that root element name + overlay is the overlay root element name, maybe it should be documented in https://vaadin.com/docs/latest/styling?