### PR TITLE
docs: Document two-way signal mapping API

### DIFF
--- a/articles/flow/ui-state/building-ui.adoc
+++ b/articles/flow/ui-state/building-ui.adoc
@@ -333,7 +333,11 @@ Create rich list items with nested bindings:
 
 [source,java]
 ----
-record Todo(String text, boolean done) {}
+record Todo(String text, boolean done) {
+    Todo withDone(boolean done) {
+        return new Todo(this.text, done);
+    }
+}
 
 SharedListSignal<Todo> todos = new SharedListSignal<>(Todo.class);
 
@@ -343,11 +347,9 @@ ComponentEffect.bindChildren(todoList, todos, todoSignal -> {
     HorizontalLayout row = new HorizontalLayout();
     row.setAlignItems(FlexComponent.Alignment.CENTER);
 
+    // Two-way binding to the 'done' property using signal mapping
     Checkbox checkbox = new Checkbox();
-    checkbox.addValueChangeListener(e ->
-        todoSignal.update(t -> new Todo(t.text(), e.getValue())));
-    ComponentEffect.bind(checkbox, todoSignal,
-        (cb, todo) -> cb.setValue(todo.done()));
+    checkbox.bindValue(todoSignal.map(Todo::done, Todo::withDone));
 
     Span text = new Span();
     text.bindText(todoSignal.map(Todo::text));
@@ -370,6 +372,8 @@ ComponentEffect.bindChildren(todoList, todos, todoSignal -> {
     return row;
 });
 ----
+
+The [methodname]`map(getter, merger)` method creates a two-way mapping that enables direct binding between the checkbox and the `done` property. See <<local-signals#two-way-mapping,Two-Way Signal Mapping>> for more details.
 
 When you update a todo item using [methodname]`todoSignal.update()`, only the bound properties (text content, styling) are updated. The component itself is not recreated, maintaining its position and identity in the DOM.
 
@@ -446,11 +450,9 @@ public class TaskManager extends VerticalLayout {
             row.bindVisible(Signal.computed(() ->
                 showCompleted.value() || !taskSignal.value().done()));
 
+            // Two-way binding to the 'done' property
             Checkbox doneCheckbox = new Checkbox();
-            doneCheckbox.addValueChangeListener(e ->
-                taskSignal.update(t -> new Task(t.text(), e.getValue())));
-            ComponentEffect.bind(doneCheckbox, taskSignal,
-                (cb, task) -> cb.setValue(task.done()));
+            doneCheckbox.bindValue(taskSignal.map(Task::done, Task::withDone));
 
             Span taskText = new Span();
             taskText.bindText(taskSignal.map(Task::text));
@@ -467,14 +469,18 @@ public class TaskManager extends VerticalLayout {
         add(taskList);
     }
 
-    record Task(String text, boolean done) {}
+    record Task(String text, boolean done) {
+        Task withDone(boolean done) {
+            return new Task(this.text, done);
+        }
+    }
 }
 ----
 
 This example demonstrates:
 
 - Two-way binding with form fields ([methodname]`bindValue()`)
-- One-way binding with [methodname]`ComponentEffect.bind()`
+- Two-way property mapping with [methodname]`map(getter, merger)` (see <<local-signals#two-way-mapping,Two-Way Signal Mapping>>)
 - Conditional button enabling ([methodname]`bindEnabled()`)
 - Computed signals for derived values
 - List rendering with [methodname]`ComponentEffect.bindChildren()`

--- a/articles/flow/ui-state/effects-computed.adoc
+++ b/articles/flow/ui-state/effects-computed.adoc
@@ -153,6 +153,11 @@ Signal<Boolean> adult = age.map(a -> a >= 18);
 
 Use [methodname]`map()` for single-signal transformations. For transformations depending on multiple signals, use [methodname]`Signal.computed()` instead.
 
+[TIP]
+====
+The read-only [methodname]`map()` method shown above creates a one-way transformation. For two-way binding scenarios where changes need to flow in both directions (for example, binding a checkbox to a property of a record), use [methodname]`map(getter, merger)` or [methodname]`mapMutable(getter, modifier)`. See <<local-signals#two-way-mapping,Two-Way Signal Mapping>> for details.
+====
+
 
 == Negating Boolean Signals
 

--- a/articles/flow/ui-state/local-signals.adoc
+++ b/articles/flow/ui-state/local-signals.adoc
@@ -198,6 +198,95 @@ Signal<String> upperName = name.map(String::toUpperCase);
 Use `map()` for single-signal transformations. For transformations depending on multiple signals, use `Signal.computed()` instead.
 
 
+[[two-way-mapping]]
+== Two-Way Signal Mapping
+
+The read-only [methodname]`map()` method described above creates a derived signal that updates when the source changes, but changes to the derived signal don't propagate back. For two-way binding scenarios where you need changes to flow in both directions, use the two-way mapping variants.
+
+This is particularly useful when binding a form field to a property of a complex object stored in a signal. For example, binding a checkbox directly to the `done` property of a `Todo` record.
+
+
+=== Mapping Immutable Values (Records)
+
+For immutable values like Java records, use [methodname]`map(getter, merger)`:
+
+[source,java]
+----
+record Todo(String text, boolean done) {
+    Todo withDone(boolean done) {
+        return new Todo(this.text, done);
+    }
+}
+
+ValueSignal<Todo> todoSignal = new ValueSignal<>(new Todo("Write docs", false));
+
+// Create a two-way mapping to the 'done' property
+WritableSignal<Boolean> doneSignal = todoSignal.map(Todo::done, Todo::withDone);
+
+// Bind checkbox directly to the property
+Checkbox checkbox = new Checkbox();
+checkbox.bindValue(doneSignal);
+// Checking the box updates the todo's done property
+// Calling todoSignal.update(...) updates the checkbox
+----
+
+The `merger` function receives the current parent value and the new child value, and returns a new parent value with the child property updated. Using wither methods like `withDone()` is a common pattern for records.
+
+
+=== Mapping Mutable Values (Beans)
+
+For mutable beans with setters, use [methodname]`mapMutable(getter, modifier)`:
+
+[source,java]
+----
+public class User {
+    private String name;
+    private int age;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public int getAge() { return age; }
+    public void setAge(int age) { this.age = age; }
+}
+
+ValueSignal<User> userSignal = new ValueSignal<>(new User());
+
+// Create a two-way mapping to the 'name' property
+WritableSignal<String> nameSignal = userSignal.mapMutable(User::getName, User::setName);
+
+// Bind text field directly to the property
+TextField nameField = new TextField("Name");
+nameField.bindValue(nameSignal);
+----
+
+The `modifier` function receives the parent object and the new value, and mutates the parent in place. The signal framework handles change notification automatically.
+
+[NOTE]
+====
+Prefer immutable records over mutable beans when possible. Records are easier to reason about, naturally thread-safe, and work better with reactive patterns. Use `mapMutable()` only when working with existing mutable bean classes.
+====
+
+
+=== Comparison: Read-Only vs Two-Way Mapping
+
+[cols="1,1,1"]
+|===
+| Method | Use Case | Return Type
+
+| `map(getter)`
+| Read-only transformations
+| `Signal<T>` (read-only)
+
+| `map(getter, merger)`
+| Two-way binding with immutable values
+| `WritableSignal<T>`
+
+| `mapMutable(getter, modifier)`
+| Two-way binding with mutable beans
+| `WritableSignal<T>`
+|===
+
+
 == Organizing Signals as Fields
 
 Storing signals as class fields is recommended for better code organization. It keeps all reactive state together at the top of the class, making it easier to understand the component's state at a glance:


### PR DESCRIPTION
Add documentation for the new WritableSignal.map(getter, merger) and mapMutable(getter, modifier) methods that enable bidirectional property binding for signals.

- Add "Two-Way Signal Mapping" section to local-signals.adoc with examples for records and mutable beans, plus comparison table
- Update building-ui.adoc examples to use simplified binding pattern instead of manual listener + effect workaround
- Add cross-reference tip to effects-computed.adoc


