### PR TITLE
refactor: convert property tables to definition lists

### DIFF
--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -149,7 +149,7 @@ Mode: Development
 
 `**devmode.frontendExtraFileExtensions**`::
 Define additional frontend file extensions to copy from jar files to the application `frontend/generated/jar-resources`. Default extension copied are `.js`, `.js.map`, `.ts`, `.ts.map`, `.tsx`, `.tsx.map`, `.css`, and `.css.map`. +
-Default: `` +
+Default: `""` +
 Mode: Development
 
 `**devmode.hostsAllowed**`::
@@ -219,7 +219,7 @@ Mode: Development
 
 `**frontend.hotdeploy.dependencies**`::
 A comma-separated list of module directories to watch for frontend file changes when detecting hot-deployable resources. Entries need to point to directories relative to the module that starts the Vaadin application, and can point to the module itself as well, in case it provides frontend files as resources. The value could be for example "./,./component-module-1,./component-module-2". Flow will watch for changes in both `src/main/resources/META-INF/resources/frontend` and the legacy `src/main/resources/META-INF/frontend` directories under the given three directory entries. Do note that if this parameter is not defined, Vaadin watches for changes under `src/main/resources/META-INF/` in the module that starts the Vaadin application, but when you provide a custom value for the parameter you need to add "./" to the list of directories to watch for the same effect. +
-Default: `` +
+Default: `""` +
 Mode: Development
 
 `**heartbeatInterval**`::
@@ -334,7 +334,7 @@ Mode: Runtime
 
 `**sessionLockCheckStrategy**`::
 When production mode is enabled, the Vaadin session lock check is done according to this setting. By default, the check is performed only if assertions are also enabled. This is to avoid the small performance impact of checking continuously the lock status. Alternative values are `log` to log a warning, or `throw` to fail with an `IllegalStateException`. The `log` option also logs a full stack trace, enabling you to determine any problematic calls to Vaadin UI components from background threads. This is since Vaadin Flow version 24.4. +
-Default: assert +
+Default: `assert` +
 Mode: Runtime
 
 [[vaadin-plugin-properties]]


### PR DESCRIPTION
The lists are easier to read, especially on small viewport sizes.