### PR TITLE
docs: correct security annotations inheritance on parent layouts

### DIFF
--- a/articles/flow/security/enabling-security.adoc
+++ b/articles/flow/security/enabling-security.adoc
@@ -351,7 +351,7 @@ public class UserListingView extends AbstractAdminView {
 }
 ----
 
-By design, the annotations aren't read from parent layouts or parent views. This would make it unnecessarily complex to determine which security level should be applied. If multiple annotations are specified on a single view class, the following rules are applied:
+Security annotations on parent layouts are also checked. This applies to auto-layouts (i.e., classes annotated with [annotationname]`@Layout`), to parent layouts set via the `layout` attribute in [annotationname]`@Route`, and to layouts defined with [annotationname]`@ParentLayout`. If a parent layout lacks an access annotation, the default [annotationname]`@DenyAll` logic is applied to the layout, and access to views within it is denied. Both the layout and the view must independently grant access for navigation to succeed. If multiple annotations are specified on a single view class, the following rules are applied:
 
 - `DenyAll` overrides other annotations;
 - `AnonymousAllowed` overrides `RolesAllowed`, as well as `PermitAll`; and


### PR DESCRIPTION
The documentation incorrectly stated that security annotations are not read from parent layouts. In practice, AnnotatedViewAccessChecker does check annotations on auto-layouts (@Layout), explicit parent layouts (@Route layout attribute), and @ParentLayout classes.

Fixes #5169


