### PR TITLE
v24: Update banner in index.adoc to promote v24 extended maintenance

### DIFF
--- a/articles/index.adoc
+++ b/articles/index.adoc
@@ -50,14 +50,14 @@ link:/learn/training[Start video course]
 
 
 [.cards.quiet.large.callout.hide-title]
-== Request a Team Trial
+== Learn about Extended Maintenance
 
 [.card.large]
-=== Evaluate Vaadin the right way — with your team
+=== Secure your Vaadin 24.x minor version for 15 years
 
-Apply for the Team Trial and get expert-led guidance before you start building together.
+Extended Maintenance now covers individual minor versions—get security patches and critical fixes without upgrading.
 
-link:https://pages.vaadin.com/request-a-team-trial[Apply For a Free Consultation, role="button-link"]
+link:https://vaadin.com/blog/extended-maintenance-now-covers-vaadin-24-minor-versions-stability-on-your-terms[Learn about Extended Maintenance, role="button-link"]
 
 
 [.cards.quiet.large.components]


### PR DESCRIPTION
Update callout banner content from Team Trial promotion to v24 Extended maintenance promotion

<img width="1477" height="1064" alt="banner-updated" src="https://github.com/user-attachments/assets/5613a8c1-ac7d-473d-b47c-b7a8dbd30baf" />
