### PR TITLE
v23: Update docs home callout banner to promote v24 extended maintenance

### DIFF
--- a/articles/index.asciidoc
+++ b/articles/index.asciidoc
@@ -34,14 +34,14 @@ image:_images/code-editor-illustration.svg["", opts=inline]
 --
 
 [.cards.quiet.large.callout.hide-title]
-== Request a Team Trial
+== Learn about Extended Maintenance
 
 [.card.large]
-=== Evaluate Vaadin the right way—with your team
+=== Secure your Vaadin 24.x minor version for 15 years
 
-Apply for the Team Trial and get expert-led guidance before you start building together.
+Extended Maintenance now covers individual minor versions—get security patches and critical fixes without upgrading.
 
-link:https://pages.vaadin.com/request-a-team-trial[Apply For a Free Consultation, role="button-link"]
+link:https://vaadin.com/blog/extended-maintenance-now-covers-vaadin-24-minor-versions-stability-on-your-terms[Learn about Extended Maintenance, role="button-link"]
 
 [.cards.quiet.large.components]
 == image:_images/components.svg["", opts=inline, role=icon, width=48] Components


### PR DESCRIPTION
Update callout banner content from Team Trial promotion to v24 Extended maintenance promotion


<img width="1289" height="779" alt="v23-banner-update" src="https://github.com/user-attachments/assets/3947a862-f8a1-4d98-b906-8724fd3f4806" />
