### PR TITLE
refactor: add theme switcher to all Slider examples

### DIFF
--- a/articles/components/slider/index.adoc
+++ b/articles/components/slider/index.adoc
@@ -80,7 +80,7 @@ endif::[]
 
 The minimum and maximum values can be displayed below the slider track to give users a sense of the available range.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -109,7 +109,7 @@ endif::[]
 
 By default, the value bubble appears only when the user interacts with the slider. It's possible to configure the slider to keep the value bubble visible at all times.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -138,7 +138,7 @@ endif::[]
 
 The `step` property controls the increment interval between selectable values. The default step is `1`. Fractional values like `0.5` are supported for finer control. Steps are calculated relative to the min value.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -167,7 +167,7 @@ endif::[]
 
 include::{articles}/components/_input-field-common-features.adoc[tags=basic-intro;label;helper]
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]
@@ -196,7 +196,7 @@ endif::[]
 
 include::{articles}/components/_input-field-common-features.adoc[tag=readonly-and-disabled]
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]
@@ -224,7 +224,7 @@ endif::[]
 
 Range Slider has two thumbs, each with a default accessible name derived from the label (e.g., "Price range min" and "Price range max"). It's possible to provide custom accessible names for each thumb to improve the experience for screen reader users.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]


### PR DESCRIPTION
There is no reason why all Slider examples couldn't have the theme switcher