### PR TITLE
docs: add Slider component to the list of feature flags

### DIFF
--- a/articles/flow/configuration/feature-flags.adoc
+++ b/articles/flow/configuration/feature-flags.adoc
@@ -40,6 +40,9 @@ Experimental Vaadin Copilot features.
 `masterDetailLayoutComponent`::
 Enables the <<{articles}/components/master-detail-layout#, Master-Detail Layout>> component.
 
+`sliderComponent`::
+Enables the <<{articles}/components/slider#, Slider>> component.
+
 `tailwindCss`::
 Enables experimental <<{articles}/styling/utility-classes#tailwind, Tailwind CSS support>>.
 


### PR DESCRIPTION
Added mention of `sliderComponent` feature flag to the list of all supported feature flags.