### PR TITLE
refactor: update all Date Time Picker examples to support Aura

### DIFF
--- a/articles/components/date-time-picker/index.adoc
+++ b/articles/components/date-time-picker/index.adoc
@@ -48,7 +48,7 @@ Date Time Picker's step parameter defines the time interval in seconds between t
 
 The default step is one hour (that is, `3600`). Unlike with <<../number-field#,Number Field>>, Date Time Picker accepts values that don't align with the specified step.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]
@@ -78,7 +78,7 @@ The step must divide evenly an hour or a day. For example, _"15 minutes"_, _"30 
 
 The displayed time format changes based on the step.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]
@@ -125,7 +125,7 @@ The overlay doesn't appear for steps less than 900 seconds (i.e., 15 minutes) to
 
 The overlay opens automatically when the field is focused using a pointer (i.e., mouse or touch), or when the user types in the field. You can disable this so that the overlay opens only when the toggle button or the kbd:[Up]/kbd:[Down] arrow keys are pressed.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]
@@ -168,7 +168,7 @@ The valid input range of Date Time Picker can be restricted by defining `min` an
 
 The following example demonstrates how to specify these constraints and provide error messages:
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]
@@ -199,7 +199,7 @@ It's important to ensure an appropriate error message is configured for each con
 
 For more complex cases where constraint validation isn't enough, Flow and Hilla offer the Binder API that allows you to define custom validation rules. This is useful, for example, when you want to restrict date selection to weekdays (i.e., Monday - Friday) and time selection to only certain hours. In the following example, try selecting a date that's on a weekend or a time that's outside opening hours to see a custom validation message.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]
@@ -230,7 +230,7 @@ Binder can also be used to organize data binding and validation for multiple fie
 
 You can configure Date Time Picker to show week numbers in the date picker overlay.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]
@@ -261,7 +261,7 @@ The week numbers are displayed according to https://www.iso.org/iso-8601-date-an
 
 Date Time Picker's initial position parameter defines which date is focused in the calendar overlay when the overlay is opened. Use this feature to minimize the need for any additional navigation or scrolling when the user's input is expected to be between certain dates.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]
@@ -290,7 +290,7 @@ endif::[]
 
 Date Time Picker allows localizing texts and labels, such as month names and button labels.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]
@@ -345,7 +345,7 @@ endif::[]
 --
 ====
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]
@@ -374,7 +374,7 @@ endif::[]
 
 include::{articles}/components/_input-field-common-features.adoc[tag=readonly-and-disabled]
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]
@@ -405,7 +405,7 @@ endif::[]
 
 You can accomplish a date time range picker using two Date Time Pickers.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]
@@ -448,7 +448,7 @@ For far off dates (i.e., years ago or years from now) and for known dates (i.e.,
 
 Use a helper text to show the expected date and time formats, and placeholders to help users identify the two sub-fields, correctly.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html]

--- a/articles/components/date-time-picker/styling.adoc
+++ b/articles/components/date-time-picker/styling.adoc
@@ -12,7 +12,7 @@ order: 50
 
 include::{articles}/components/_input-field-common-features.adoc[tags=styles-start;text-alignment;small-variant;helper-above-field;styles-end]
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]

--- a/frontend/demo/component/datetimepicker/date-time-picker-styles.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-styles.ts
@@ -16,7 +16,7 @@ export class Example extends LitElement {
     return html`
       <!-- tag::snippet[] -->
       <vaadin-date-time-picker
-        theme="align-right small helper-above-field"
+        theme="align-right helper-above-field"
         label="Label"
         helper-text="Helper text"
         value="2020-06-12T12:30"

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-styles.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-styles.tsx
@@ -6,7 +6,7 @@ function Example() {
   return (
     // tag::snippet[]
     <DateTimePicker
-      theme="align-right small helper-above-field"
+      theme="align-right helper-above-field"
       label="Label"
       helperText="Helper text"
       value="2020-06-12T12:30"

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerStyles.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerStyles.java
@@ -17,9 +17,8 @@ public class DateTimePickerStyles extends HorizontalLayout {
 
         // tag::snippet[]
         DateTimePicker field = new DateTimePicker();
-        field.addThemeVariants(DateTimePickerVariant.LUMO_SMALL,
-                DateTimePickerVariant.LUMO_ALIGN_RIGHT,
-                DateTimePickerVariant.LUMO_HELPER_ABOVE_FIELD);
+        field.addThemeVariants(DateTimePickerVariant.ALIGN_RIGHT,
+                DateTimePickerVariant.HELPER_ABOVE);
         // end::snippet[]
         field.setLabel("Label");
         field.setHelperText("Helper text");


### PR DESCRIPTION
## Summary
- Add `themes="lumo,aura"` to all rendered Date Time Picker examples in `index.adoc` and `styling.adoc`
- Update styling example to use non-Lumo-prefixed theme variants (`ALIGN_RIGHT`, `HELPER_ABOVE`) and remove `small` variant

## Test plan
- [ ] Verify all Date Time Picker examples render correctly with both Lumo and Aura themes
- [ ] Verify the styling example shows correct theme variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)