### PR TITLE
Reorder browserless testing navigation

### DIFF
--- a/articles/flow/testing/browserless/optimizing-tests.adoc
+++ b/articles/flow/testing/browserless/optimizing-tests.adoc
@@ -3,7 +3,7 @@ title: Optimizing Tests
 page-title: How to optimize Vaadin browserless tests for faster execution
 description: Speed up browserless tests by restricting package scanning and using reduced application contexts.
 meta-description: Optimize Vaadin browserless tests with package scanning restrictions and reduced Spring application contexts.
-order: 12
+order: 85
 ---
 
 

--- a/articles/flow/testing/browserless/spring-security.adoc
+++ b/articles/flow/testing/browserless/spring-security.adoc
@@ -3,7 +3,7 @@ title: Spring Security Testing
 page-title: Browserless testing with Spring Security in Vaadin
 description: How to test view access control and Spring Security integration in browserless tests.
 meta-description: Test Vaadin view access control and Spring Security annotations in browserless tests.
-order: 45
+order: 28
 ---
 
 


### PR DESCRIPTION
Move "Optimizing Tests" down before "Migrating from UI Unit Testing" and "Spring Security Testing" up before "Snapshots".


