### PR TITLE
docs: dialog keepInViewport (CP: 24)

### DIFF
--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -296,6 +296,41 @@ Make non-modal dialogs draggable so the user can interact with content that migh
 Modal dialogs don't benefit from being draggable, as their modality curtain (the dark overlay behind the dialog) obscures the underlying user interface.
 
 
+[role="since:com.vaadin:vaadin@V24.10"]
+=== Constraining a Dialog to the Viewport
+
+By default, dialogs are not constrained to the viewport, which means they can become partially invisible when dragging the dialog or when resizing the viewport. To prevent this, set the `keepInViewport` property to `true` to always keep the dialog fully visible within the viewport. Note that enabling this option may also adjust the dialog's size and position if it can not fit the viewport otherwise.
+
+[.example]
+--
+
+ifdef::lit[]
+[source,html]
+----
+<source-info group="Lit"></source-info>
+<vaadin-dialog keep-in-viewport>...</vaadin-dialog>
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+<source-info group="Flow"></source-info>
+Dialog dialog = new Dialog();
+dialog.setKeepInViewport(true);
+----
+endif::[]
+
+ifdef::react[]
+[source,html]
+----
+<source-info group="React"></source-info>
+<Dialog keepInViewport>...</Dialog>
+----
+endif::[]
+--
+
+
 == Size
 
 The Dialog size can be set with the width and height on the Dialog itself (__since V24.6 for React and Lit__). You can also set the size of the content of Dialog, whereby the Dialog scales to accommodate it. In both cases, the Dialog can also be made resizable.


### PR DESCRIPTION
Cherry-pick the docs for the Dialog `keepInViewport` feature to 24, add since tag for specific version that includes the feature.