### PR TITLE
docs: update articles to use un-prefixed theme variants

### DIFF
--- a/articles/building-apps/forms-data/add-form/dialogs-and-drawers.adoc
+++ b/articles/building-apps/forms-data/add-form/dialogs-and-drawers.adoc
@@ -38,7 +38,7 @@ public class ProposalDialog extends Dialog {
         form = new ProposalForm();
 
         var saveBtn = new Button("Create Proposal", event -> save());
-        saveBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveBtn.addThemeVariants(ButtonVariant.PRIMARY);
 
         var cancelBtn = new Button("Cancel", event -> close());
 
@@ -106,7 +106,7 @@ public class ProposalDrawer extends Section {
         setAriaLabeledBy("proposal-drawer-header");
 
         var saveBtn = new Button("Save", event -> save());
-        saveBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveBtn.addThemeVariants(ButtonVariant.PRIMARY);
 
         var closeBtn = new Button("Close", event -> close());
 

--- a/articles/building-apps/ui-basics/add-dialogs-popovers.adoc
+++ b/articles/building-apps/ui-basics/add-dialogs-popovers.adoc
@@ -172,7 +172,7 @@ dialog.setHeaderTitle("Details");
 Button closeButton = new Button(VaadinIcon.CLOSE.create(),
         e -> dialog.close());
 closeButton.setAriaLabel("Close");
-closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+closeButton.addThemeVariants(ButtonVariant.TERTIARY);
 dialog.getHeader().add(closeButton);
 ----
 
@@ -243,7 +243,7 @@ By default, the popover appears below the target, centered horizontally. Change 
 [source,java]
 ----
 popover.setPosition(PopoverPosition.END); // <1>
-popover.addThemeVariants(PopoverVariant.LUMO_ARROW); // <2>
+popover.addThemeVariants(PopoverVariant.ARROW); // <2>
 ----
 <1> Opens to the right of the target element.
 <2> Adds a wedge-shaped arrow pointing at the target.

--- a/articles/building-apps/ui-basics/add-keyboard-shortcuts.adoc
+++ b/articles/building-apps/ui-basics/add-keyboard-shortcuts.adoc
@@ -45,7 +45,7 @@ public class ShortcutExampleView extends VerticalLayout {
         // Click shortcut: Enter triggers the save button
         Button save = new Button("Save", event ->
                 Notification.show("Saved: " + name.getValue()));
-        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        save.addThemeVariants(ButtonVariant.PRIMARY);
         save.addClickShortcut(Key.ENTER);
 
         add(new Paragraph("Try Alt+N, Alt+E, and Enter."),

--- a/articles/building-apps/ui-basics/add-styling.adoc
+++ b/articles/building-apps/ui-basics/add-styling.adoc
@@ -30,7 +30,7 @@ public class StylingExampleView extends VerticalLayout {
     public StylingExampleView() {
         // 1. Theme variant — built-in component style (pure Java)
         Button saveButton = new Button("Save");
-        saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveButton.addThemeVariants(ButtonVariant.PRIMARY);
 
         // 2. Inline style — one-off styling (pure Java)
         Div accent = new Div("Accent bar");
@@ -70,17 +70,17 @@ Use `addThemeVariants()` with the variant constants for the component:
 [source,java]
 ----
 Button primary = new Button("Save");
-primary.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+primary.addThemeVariants(ButtonVariant.PRIMARY);
 ----
 
-You can combine multiple variants. For example, a small primary button:
+You can combine multiple variants. For example, an error primary button:
 
 [source,java]
 ----
-Button submit = new Button("Submit");
-submit.addThemeVariants(
-        ButtonVariant.LUMO_PRIMARY,
-        ButtonVariant.LUMO_SMALL);
+Button delete = new Button("Delete");
+delete.addThemeVariants(
+        ButtonVariant.PRIMARY,
+        ButtonVariant.ERROR);
 ----
 
 [TIP]

--- a/articles/building-apps/ui-basics/layouts.adoc
+++ b/articles/building-apps/ui-basics/layouts.adoc
@@ -59,7 +59,7 @@ public class LayoutExampleView extends VerticalLayout {
         // Footer bar: buttons aligned to the right
         Button cancel = new Button("Cancel");
         Button save = new Button("Save");
-        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        save.addThemeVariants(ButtonVariant.PRIMARY);
         HorizontalLayout footer = new HorizontalLayout(cancel, save);
         footer.setJustifyContentMode(
                 FlexComponent.JustifyContentMode.END);

--- a/articles/getting-started/tutorial/add-data.adoc
+++ b/articles/getting-started/tutorial/add-data.adoc
@@ -46,7 +46,7 @@ class AddProductDialog extends Dialog {
         // Create components
         form = new ProductForm();
         var saveButton = new Button("Save");
-        saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveButton.addThemeVariants(ButtonVariant.PRIMARY);
         var cancelButton = new Button("Cancel");
 
         // Layout dialog
@@ -252,7 +252,7 @@ class AddProductDialog extends Dialog {
         form.setFormDataObject(new ProductDetails()); // <2>
         var saveButton = new Button("Save", e -> save());
 // end::snippet[]
-        saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveButton.addThemeVariants(ButtonVariant.PRIMARY);
 // tag::snippet[]
         var cancelButton = new Button("Cancel", e -> close());
 // end::snippet[]

--- a/articles/getting-started/tutorial/edit-details.adoc
+++ b/articles/getting-started/tutorial/edit-details.adoc
@@ -173,7 +173,7 @@ class ProductFormDrawer extends Composite<VerticalLayout> {
 
 // tag::snippet[]
         var saveButton = new Button("Save", e -> save()); // <2>
-        saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveButton.addThemeVariants(ButtonVariant.PRIMARY);
 // end::snippet[]
 
         var layout = getContent();
@@ -384,7 +384,7 @@ class ProductFormDrawer extends Composite<VerticalLayout> {
         form = new ProductForm();
 
         var saveButton = new Button("Save", e -> save());
-        saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveButton.addThemeVariants(ButtonVariant.PRIMARY);
 
         var layout = getContent();
         layout.add(header);
@@ -645,7 +645,7 @@ class ProductFormDrawer extends Composite<VerticalLayout> {
         form = new ProductForm();
 
         var saveButton = new Button("Save", e -> save());
-        saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveButton.addThemeVariants(ButtonVariant.PRIMARY);
 
         var layout = getContent();
         layout.add(header);

--- a/articles/styling/styling-components.adoc
+++ b/articles/styling/styling-components.adoc
@@ -41,7 +41,7 @@ image::_images/component-variants.png[width=50%]
 ----
 <source-info group="Flow"></source-info>
 Button button = new Button("Save");
-button.addThemeVariants(ButtonVariant.AURA_PRIMARY);
+button.addThemeVariants(ButtonVariant.PRIMARY);
 ----
 
 [source,tsx]


### PR DESCRIPTION
Replaced `LUMO_` variants with un-prefixed variants supported by Aura where possible.