### PR TITLE
docs: update Login examples to support both Lumo and Aura

### DIFF
--- a/articles/components/login/index.adoc
+++ b/articles/components/login/index.adoc
@@ -65,7 +65,7 @@ The basic Login component consists of a title (i.e., "Log In"), two input fields
 
 You can customize the form's title and labels using internationalization.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -92,7 +92,7 @@ endif::[]
 
 The basic Login component can be used to create log-in pages featuring rich content.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -163,7 +163,7 @@ endif::[]
 
 The overlay has a header and the log-in form. By default, the header contains placeholders for the application's title and description. Both properties are configurable.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -193,7 +193,7 @@ endif::[]
 
 The overlay provides a custom form area for adding fields in addition to username and password. This area is placed above the "Submit" button. Use the `name` attribute to ensure the custom field's `value` is submitted with the form.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -221,9 +221,9 @@ endif::[]
 
 === Footer
 
-The footer area can be used for placing additional custom content, such as text, buttons, etc. Adding components after the overlay is opened is not supported.
+The footer area can be used for placing additional custom content, such as text, buttons, etc.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -253,7 +253,7 @@ endif::[]
 
 Login shows an error message when authentication fails. The error message includes a title in addition to the message. It's displayed directly below the title of the form.
 
-[.example.validation]
+[.example.validation,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -282,7 +282,7 @@ The error message is customizable using internationalization. It should contain 
 
 More information can be provided to the user, for example, by linking to a page with helpful material or by displaying contact information.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -313,7 +313,7 @@ endif::[]
 Login's titles, descriptions, labels, and messages are all customizable using internationalization.
 
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]

--- a/frontend/demo/component/login/login-rich-content.ts
+++ b/frontend/demo/component/login/login-rich-content.ts
@@ -1,12 +1,18 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/horizontal-layout';
 import '@vaadin/login/vaadin-login-form.js';
-import { html, LitElement } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { applyTheme } from 'Frontend/demo/theme';
 
 @customElement('login-rich-content')
 export class Example extends LitElement {
+  static override styles = css`
+    :host {
+      color-scheme: dark;
+    }
+  `;
+
   protected override createRenderRoot() {
     const root = super.createRenderRoot();
     applyTheme(root);

--- a/frontend/demo/component/login/react/login-rich-content.tsx
+++ b/frontend/demo/component/login/react/login-rich-content.tsx
@@ -1,5 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react';
+import { css } from 'lit'; // hidden-source-line
 import { LoginForm } from '@vaadin/react-components/LoginForm.js';
 
 function Example() {
@@ -12,4 +13,10 @@ function Example() {
   );
 }
 
-export default reactExample(Example); // hidden-source-line
+const hostStyles = css`
+  :host {
+    color-scheme: dark;
+  }
+`;
+
+export default reactExample(Example, hostStyles); // hidden-source-line

--- a/frontend/themes/docs/login-rich-content.css
+++ b/frontend/themes/docs/login-rich-content.css
@@ -9,7 +9,9 @@
   align-items: center;
   display: flex;
   max-width: 300px;
+  background: var(--vaadin-background-color);
 }
-.login-rich-content vaadin-login-form-wrapper {
-  background-image: none;
+.login-rich-content vaadin-login-form::part(form) {
+  height: 100%;
+  justify-content: center;
 }

--- a/src/main/java/com/vaadin/demo/component/login/LoginOverlayBasic.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginOverlayBasic.java
@@ -18,7 +18,7 @@ public class LoginOverlayBasic extends Div {
         Button login = new Button("Log in");
         login.addClickListener(event -> loginOverlay.setOpened(true));
         // end::snippet[]
-        login.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        login.addThemeVariants(ButtonVariant.PRIMARY);
         add(login);
     }
 

--- a/src/main/java/com/vaadin/demo/component/login/LoginRichContent.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginRichContent.java
@@ -20,6 +20,9 @@ public class LoginRichContent extends Div {
         // Prevent the example from stealing focus when browsing the
         // documentation
         loginForm.getElement().setAttribute("no-autofocus", "");
+        // hidden-source-line - set color-scheme on the exported WC for Aura
+        getElement().executeJs( // hidden-source-line
+                "this.getRootNode().host.style.colorScheme='dark'"); // hidden-source-line
     }
 
     public static class Exporter extends DemoExporter<LoginRichContent> { // hidden-source-line


### PR DESCRIPTION
- Updated Login examples to support Lumo and Aura, modified rich content example to set `color-scheme`
- Removed statement about not being able to add components while opened (this is possible in Vaadin 25)