### PR TITLE
docs: add theme switcher to virtual list page

### DIFF
--- a/articles/components/virtual-list/index.adoc
+++ b/articles/components/virtual-list/index.adoc
@@ -18,7 +18,7 @@ Each item is rendered on the fly as the user scrolls the list.
 
 To use this component, you need to assign it a set of data items and a _renderer_ that's used to render each individual data item. The height of an item is determined by its content and can change dynamically.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]


### PR DESCRIPTION
Add theme switcher to virtual list page.
Virtual list itself doesn't have theme-specific styling so the switcher only affects the component contents in the example.