### PR TITLE
refactor: add theme switcher to all Combo Box examples

### DIFF
--- a/articles/components/combo-box/index.adoc
+++ b/articles/components/combo-box/index.adoc
@@ -61,7 +61,7 @@ The overlay opens when the user clicks the field using a pointing device. Using 
 
 Combo Box can be configured to allow entering custom values that aren't included in the list of options.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -90,7 +90,7 @@ Allowing custom entry is useful when you need to present the most common choices
 
 Custom values can also be stored and added to the list of options:
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -121,7 +121,7 @@ See <<../select#custom-item-presentation, Select, Custom Item Presentation.>>
 
 Items can be customized to display more information than a single line of text.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -175,7 +175,7 @@ Use a custom filter to allow the user to search by the rendered properties. It's
 
 Items can be styled dynamically, based on application logic and the data in the combo box, through custom class names.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -209,7 +209,7 @@ include::{root}/frontend/themes/docs/combo-box-item-class-name.css[]
 
 The overlay opens automatically when the field is focused using a pointer (i.e., mouse or touch), or when the user types in the field. You can disable this so that the overlay opens only when the toggle button or the kbd:[Up]/kbd:[Down] arrow keys are pressed.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -250,7 +250,7 @@ endif::[]
 The width of the popup is, by default, the same width as the input field. The popup width can be overridden to any fixed width in cases where the default width is too narrow.
 
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -290,7 +290,7 @@ endif::[]
 
 Combo Box's filtering, by default, is configured to show only items that contain the entered value:
 
-[.example.render-only]
+[.example.render-only,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,html, role=render-only]
@@ -309,7 +309,7 @@ endif::[]
 
 Custom filtering is also possible. For example, if you only want to show items that start with the user's input you could do something like this:
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -339,7 +339,7 @@ endif::[]
 
 Combo Box supports lazy loading, which is useful when dealing with large datasets. This avoids loading the whole dataset into memory and only fetches data for the current filter and viewport.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]
@@ -392,7 +392,7 @@ endif::[]
 
 include::{articles}/components/_input-field-common-features.adoc[tags=basic-intro;label;helper;placeholder;tooltip;clear-button;prefix;aria-labels]
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]
@@ -426,7 +426,7 @@ Below is a list of supported constraints with more detailed information:
 
 include::{articles}/components/_input-field-common-features.adoc[tags=required;allowed-chars]
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]
@@ -457,7 +457,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=binder]
 
 include::{articles}/components/_input-field-common-features.adoc[tag=readonly-and-disabled]
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]

--- a/articles/components/combo-box/styling.adoc
+++ b/articles/components/combo-box/styling.adoc
@@ -12,7 +12,7 @@ order: 50
 
 include::{articles}/components/_input-field-common-features.adoc[tags=styles-start;text-alignment;small-variant;helper-above-field;styles-end]
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 ifdef::lit[]
 [source,typescript]


### PR DESCRIPTION
Lumo variants were replaced in #5288 so this PR just adds theme switchers.