### PR TITLE
chore: run mvn spotless:apply for recent changes

### DIFF
--- a/src/main/java/com/vaadin/demo/component/accordion/AccordionNoPaddingPanels.java
+++ b/src/main/java/com/vaadin/demo/component/accordion/AccordionNoPaddingPanels.java
@@ -60,6 +60,7 @@ public class AccordionNoPaddingPanels extends Div {
         add(accordion);
     }
 
-    public static class Exporter extends DemoExporter<AccordionNoPaddingPanels> { // hidden-source-line
+    public static class Exporter // hidden-source-line
+            extends DemoExporter<AccordionNoPaddingPanels> { // hidden-source-line
     } // hidden-source-line
 }

--- a/src/main/java/com/vaadin/demo/component/button/ButtonImages.java
+++ b/src/main/java/com/vaadin/demo/component/button/ButtonImages.java
@@ -1,7 +1,6 @@
 package com.vaadin.demo.component.button;
 
 import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.router.Route;

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxHorizontal.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxHorizontal.java
@@ -14,7 +14,8 @@ public class CheckboxHorizontal extends Div {
         CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
         checkboxGroup.setLabel("Permissions");
         checkboxGroup.setItems("Read", "Edit", "Delete");
-        checkboxGroup.addThemeVariants(CheckboxGroupVariant.AURA_HORIZONTAL); // Only for Aura
+        // Only for Aura
+        checkboxGroup.addThemeVariants(CheckboxGroupVariant.AURA_HORIZONTAL);
         add(checkboxGroup);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/checkbox/CheckboxVertical.java
+++ b/src/main/java/com/vaadin/demo/component/checkbox/CheckboxVertical.java
@@ -15,7 +15,8 @@ public class CheckboxVertical extends Div {
         checkboxGroup.setLabel("Working days");
         checkboxGroup.setItems("Monday", "Tuesday", "Wednesday", "Thursday",
                 "Friday", "Saturday", "Sunday");
-        checkboxGroup.addThemeVariants(CheckboxGroupVariant.LUMO_VERTICAL); // Only for Lumo
+        // Only for Lumo
+        checkboxGroup.addThemeVariants(CheckboxGroupVariant.LUMO_VERTICAL);
         add(checkboxGroup);
         // end::snippet[]
     }

--- a/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonHorizontal.java
+++ b/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonHorizontal.java
@@ -12,7 +12,8 @@ public class RadioButtonHorizontal extends Div {
     public RadioButtonHorizontal() {
         // tag::snippet[]
         RadioButtonGroup<String> radioGroup = new RadioButtonGroup<>();
-        radioGroup.addThemeVariants(RadioGroupVariant.AURA_HORIZONTAL); // Only for Aura
+        // Only for Aura
+        radioGroup.addThemeVariants(RadioGroupVariant.AURA_HORIZONTAL);
         radioGroup.setLabel("Status");
         radioGroup.setItems("Pending", "Submitted", "Confirmed");
         radioGroup.setValue("Pending");

--- a/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonVertical.java
+++ b/src/main/java/com/vaadin/demo/component/radiobutton/RadioButtonVertical.java
@@ -12,7 +12,8 @@ public class RadioButtonVertical extends Div {
     public RadioButtonVertical() {
         // tag::snippet[]
         RadioButtonGroup<String> radioGroup = new RadioButtonGroup<>();
-        radioGroup.addThemeVariants(RadioGroupVariant.LUMO_VERTICAL); // Only for Lumo
+        // Only for Lumo
+        radioGroup.addThemeVariants(RadioGroupVariant.LUMO_VERTICAL);
         radioGroup.setLabel("Status");
         radioGroup.setItems("Pending", "Submitted", "Confirmed");
         radioGroup.setValue("Pending");

--- a/src/main/java/com/vaadin/demo/component/tooltip/TooltipPositioning.java
+++ b/src/main/java/com/vaadin/demo/component/tooltip/TooltipPositioning.java
@@ -17,7 +17,8 @@ public class TooltipPositioning extends AppLayout {
 
         SideNav nav = getSideNav();
         nav.getElement().executeJs("window.patchSideNavNavigation(this);"); // hidden-source-line
-        nav.getStyle().set("margin", "0 var(--vaadin-gap-xs)").set("--vaadin-icon-size", "1.5rem");
+        nav.getStyle().set("margin", "0 var(--vaadin-gap-xs)")
+                .set("--vaadin-icon-size", "1.5rem");
 
         addToDrawer(nav);
         addToNavbar(toggle);
@@ -37,8 +38,7 @@ public class TooltipPositioning extends AppLayout {
     private SideNavItem createItem(VaadinIcon viewIcon, String viewName,
             String path) {
         // tag::snippet[]
-        SideNavItem item = new SideNavItem(viewName, path,
-                viewIcon.create());
+        SideNavItem item = new SideNavItem(viewName, path, viewIcon.create());
         item.setTooltipText(viewName).withPosition(TooltipPosition.END);
         // end::snippet[]
         return item;

--- a/src/main/java/com/vaadin/demo/flow/signals/usecase/BinderIntegrationExample.java
+++ b/src/main/java/com/vaadin/demo/flow/signals/usecase/BinderIntegrationExample.java
@@ -67,9 +67,12 @@ public class BinderIntegrationExample extends VerticalLayout {
 
         // Cross-field validation using Binder.Binding.valueSignal()
         // Runs each time the password field changes
-        binder.forField(confirmPasswordField).withValidator(
-                value -> value != null && value.equals(pwBinding.valueSignal().get()),
-                "Passwords do not match").bind("confirmPassword");
+        binder.forField(confirmPasswordField)
+                .withValidator(
+                        value -> value != null
+                                && value.equals(pwBinding.valueSignal().get()),
+                        "Passwords do not match")
+                .bind("confirmPassword");
 
         binder.forField(accountTypeSelect).bind("accountType");
 
@@ -93,8 +96,8 @@ public class BinderIntegrationExample extends VerticalLayout {
             binder.writeBeanIfValid(userRegistration);
             // Handle registration...
         });
-        submitButton.bindEnabled(
-                binder.validationStatusSignal().map(BinderValidationStatus::isOk));
+        submitButton.bindEnabled(binder.validationStatusSignal()
+                .map(BinderValidationStatus::isOk));
 
         // Form status display with reactive styling
         Div statusDiv = new Div();


### PR DESCRIPTION
Fixed formatting in some recently changed Java examples using `mvn spotless:apply`.
I had to move comments `"Only for Lumo"` to separate lines, as otherwise they were wrapped.

