### PR TITLE
docs: update split layout examples to support both Lumo and Aura

### DIFF
--- a/articles/components/split-layout/index.adoc
+++ b/articles/components/split-layout/index.adoc
@@ -48,7 +48,7 @@ The orientation can also be vertical.
 Orientation should be set based on the content and the screen size.
 The user can also be allowed to choose which orientation they want to use.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -83,7 +83,7 @@ When using vertical orientation, the split layout must have an explicit height f
 This can be either an absolute or a percentage value.
 When using a percentage value, ensure that ancestors have an explicit height as well.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -110,7 +110,7 @@ endif::[]
 
 The splitter respects the minimum and maximum size of the content area components.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -138,7 +138,7 @@ endif::[]
 The split can be adjusted programmatically, for example by using a Button.
 This is useful when the user wants to toggle between certain positions.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]

--- a/articles/components/split-layout/styling.adoc
+++ b/articles/components/split-layout/styling.adoc
@@ -31,7 +31,7 @@ The `small` theme variant makes the visual divider smaller, giving more space to
 
 Please note that this variant shows the split handle only on hover, which isn't ideal for touch devices.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 [source,html]

--- a/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutThemeVariants.java
+++ b/src/main/java/com/vaadin/demo/component/splitlayout/SplitLayoutThemeVariants.java
@@ -15,7 +15,7 @@ public class SplitLayoutThemeVariants extends Div {
         DetailContent detail = new DetailContent();
 
         SplitLayout splitLayout = new SplitLayout(master, detail);
-        splitLayout.addThemeVariants(SplitLayoutVariant.LUMO_SMALL);
+        splitLayout.addThemeVariants(SplitLayoutVariant.SMALL);
         // end::snippet[]
 
         splitLayout.setMaxHeight("280px");


### PR DESCRIPTION
- update split layout examples to support both Lumo and Aura