### PR TITLE
docs: remove theme selector and align charts examples

### DIFF
--- a/articles/components/charts/styling/index.adoc
+++ b/articles/components/charts/styling/index.adoc
@@ -17,16 +17,26 @@ Charts can be styled using CSS, and in Flow applications also through the Java A
 While no error is thrown if different styling methods are used in the same chart, *only one method should be used in any chart*, since having both could lead to unexpected results.
 
 == Theme Variants
-The following theme variants are available for Charts:
 
-* Default colors (defined in built-in styles or provided by the theme)
-* Gradient variant with colors varying in hue (`theme="gradient"` / `ChartVariant.LUMO_GRADIENT`)
-* Monotone variant with colors varying in brightness (`theme="monotone"` / `ChartVariant.LUMO_MONOTONE`)
-* Classic variant with colors matching those in older versions (`theme="classic"` / `ChartVariant.LUMO_CLASSIC`)
+[cols="1,3,1"]
+|===
+| Variant | Description | Supported by
+
+|`gradient`
+|Colors varying in hue
+|Lumo
+
+|`monotone`
+|Colors varying in brightness
+|Lumo
+
+|`classic`
+|Colors matching those in older versions
+|Lumo
+
+|===
 
 image::charts_theme_variants.png[]
-
-See a <<{articles}/components/charts#,live demo of the variants>>.
 
 
 == Java Styling API in Flow

--- a/frontend/demo/component/charts/charts-overview.ts
+++ b/frontend/demo/component/charts/charts-overview.ts
@@ -19,26 +19,12 @@ export class Example extends LitElement {
       grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
       background-color: var(--docs-surface-color-2);
       padding: 0.5rem;
-      padding-top: 1.5rem;
-      position: relative;
+      box-sizing: border-box;
     }
 
     vaadin-chart {
       padding: 0.5rem;
       box-sizing: border-box;
-    }
-
-    label {
-      position: absolute;
-      z-index: 1;
-      top: 0.5rem;
-      left: 1rem;
-      font-size: var(--docs-font-size-2xs);
-      font-weight: var(--docs-font-weight-emphasis);
-    }
-
-    select {
-      font: inherit;
     }
   `;
 
@@ -118,12 +104,6 @@ export class Example extends LitElement {
     },
   };
 
-  changeTheme(e: InputEvent) {
-    [...this.renderRoot.querySelectorAll('vaadin-chart')].forEach((chart) => {
-      chart.setAttribute('theme', (e.target as HTMLSelectElement).value);
-    });
-  }
-
   // tag::snippet[]
   protected override render() {
     return html`
@@ -143,7 +123,6 @@ export class Example extends LitElement {
         .categories="${this.months}"
         .additionalOptions="${this.areaOptions}"
         tooltip
-        no-legend
       >
         <vaadin-chart-series
           title="United States dollar"
@@ -179,16 +158,6 @@ export class Example extends LitElement {
         <vaadin-chart-series type="area" title="Area" .values="${[1, 8, 2, 7, 3, 6, 4, 5]}">
         </vaadin-chart-series>
       </vaadin-chart>
-
-      <label>
-        Theme:
-        <select @change="${this.changeTheme}">
-          <option value="">Default</option>
-          <option value="gradient">Gradient</option>
-          <option value="monotone">Monotone</option>
-          <option value="classic">Classic</option>
-        </select>
-      </label>
     `;
     // end::snippet[]
   }

--- a/frontend/demo/component/charts/react/charts-overview.tsx
+++ b/frontend/demo/component/charts/react/charts-overview.tsx
@@ -1,8 +1,6 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
-import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
 import type { Options, PointOptionsObject, SeriesOptionsType } from 'highcharts';
-import { useSignal } from '@vaadin/hilla-react-signals';
 import { Chart } from '@vaadin/react-components-pro/Chart.js';
 import { ChartSeries } from '@vaadin/react-components-pro/ChartSeries.js';
 
@@ -13,26 +11,12 @@ const hostStyle: React.CSSProperties = {
   gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
   backgroundColor: 'var(--docs-surface-color-2)',
   padding: '0.5rem',
-  paddingTop: '1.5rem',
-  position: 'relative',
+  boxSizing: 'border-box',
 };
 
 const chartStyle: React.CSSProperties = {
   padding: '0.5rem',
   boxSizing: 'border-box',
-};
-
-const labelStyle: React.CSSProperties = {
-  zIndex: 1,
-  top: '0.5rem',
-  left: '1rem',
-  fontSize: 'var(--docs-font-size-2xs)',
-  fontWeight: 'var(--docs-font-weight-emphasis)',
-  position: 'absolute',
-};
-
-const selectStyle = {
-  font: 'inherit',
 };
 
 const columnOptions: Options = { yAxis: { title: { text: '' } } };
@@ -96,18 +80,10 @@ const seriesOptions: SeriesOptionsType = {
 };
 
 function Example() {
-  useSignals(); // hidden-source-line
-  const theme = useSignal('');
-
-  function changeTheme(e: React.ChangeEvent<HTMLSelectElement>) {
-    theme.value = e.target.value;
-  }
-
   return (
     <div style={hostStyle}>
       {/* tag::snippet[] */}
       <Chart
-        theme={theme.value}
         style={chartStyle}
         type="column"
         categories={['Jan', 'Feb', 'Mar']}
@@ -121,7 +97,6 @@ function Example() {
       <Chart
         type="area"
         stacking="normal"
-        theme={theme.value}
         style={chartStyle}
         categories={months}
         additionalOptions={areaOptions}
@@ -142,7 +117,6 @@ function Example() {
       </Chart>
 
       <Chart
-        theme={theme.value}
         style={chartStyle}
         type="pie"
         tooltip
@@ -151,7 +125,7 @@ function Example() {
         <ChartSeries title="Brands" values={pieValues} />
       </Chart>
 
-      <Chart theme={theme.value} style={chartStyle} polar additionalOptions={polarOptions}>
+      <Chart style={chartStyle} polar additionalOptions={polarOptions}>
         <ChartSeries
           type="column"
           title="Column"
@@ -161,16 +135,6 @@ function Example() {
         <ChartSeries type="line" title="Line" values={[1, 2, 3, 4, 5, 6, 7, 8]} />
         <ChartSeries type="area" title="Area" values={[1, 8, 2, 7, 3, 6, 4, 5]} />
       </Chart>
-
-      <label style={labelStyle}>
-        Theme:
-        <select style={selectStyle} onChange={changeTheme}>
-          <option value="">Default</option>
-          <option value="gradient">Gradient</option>
-          <option value="monotone">Monotone</option>
-          <option value="classic">Classic</option>
-        </select>
-      </label>
       {/* end::snippet[] */}
     </div>
   );


### PR DESCRIPTION
This PR:

- Removes Lumo-specific theme selector from Charts overview demo
- Updates variants section to use a table like other components
- Aligns Lit and React versions of Charts overview example by adding legend to the Lit example