### PR TITLE
docs: update RealtimeDashboard example to use Badge component

### DIFF
--- a/articles/flow/ui-state/usage-examples/realtime-dashboard.adoc
+++ b/articles/flow/ui-state/usage-examples/realtime-dashboard.adoc
@@ -221,8 +221,8 @@ The highlight card also demonstrates using component binding methods instead of 
 Span valueSpan = new Span();
 valueSpan.bindText(signal.map(format::apply));
 
-Span percentageSpan = new Span();
-percentageSpan.bindText(prefixSignal.map(prefix -> prefix + percentageSignal.get()));
+Badge badge = new Badge();
+badge.bindText(prefixSignal.map(prefix -> prefix + percentageSignal.get()));
 
 // Icon constructor accepts Signal<VaadinIcon>
 Icon icon = new Icon(iconSignal);

--- a/src/main/java/com/vaadin/demo/flow/signals/usecase/RealtimeDashboard.java
+++ b/src/main/java/com/vaadin/demo/flow/signals/usecase/RealtimeDashboard.java
@@ -1,6 +1,7 @@
 package com.vaadin.demo.flow.signals.usecase;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.badge.Badge;
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.Configuration;
@@ -202,23 +203,18 @@ public class RealtimeDashboard extends VerticalLayout {
             valueSpan.addClassNames(FontWeight.SEMIBOLD, FontSize.XXXLARGE);
             valueSpan.bindText(signal.map(format::apply));
 
-            // Bind percentage text with prefix
-            Span percentageSpan = new Span();
-            percentageSpan.bindText(prefixSignal
-                    .map(prefix -> prefix + percentageSignal.get()));
-
             // Bind icon to computed signal
             Icon icon = new Icon(iconSignal);
-            icon.setSize("10px");
-            icon.getStyle().setMarginRight("4px").setMarginLeft("0");
 
             // Create badge with conditional theme binding
-            Span badge = new Span();
-            badge.add(icon, percentageSpan);
-            badge.getElement().getThemeList().add("badge");
+            Badge badge = new Badge(icon);
             badge.getElement().getThemeList().bind("success", successSignal);
             badge.getElement().getThemeList().bind("error",
                     Signal.not(successSignal));
+
+            // Bind percentage text with prefix
+            badge.bindText(prefixSignal
+                    .map(prefix -> prefix + percentageSignal.get()));
 
             add(h2, valueSpan, badge);
             getStyle().setGap("5px");


### PR DESCRIPTION
Let's use new `Badge` component instead of the `Span` for the `RealtimeDashboard` example.