### PR TITLE
docs: move size variants from lumo to general section

### DIFF
--- a/articles/components/button/styling.adoc
+++ b/articles/components/button/styling.adoc
@@ -195,11 +195,6 @@ endif::[]
 The standard Button colors can be adjusted using <<{articles}/styling/themes/lumo/lumo-style-properties/color#,the Lumo color properties>> or <<{articles}/styling/themes/aura/color#,the Aura color properties>>. Therefore, these variants shouldn't be used to replace standard buttons only to achieve a different color.
 
 
-== Additional Lumo Variants
-
-The following variants are only available in the Lumo theme.
-
-
 === Size Variants
 
 The following size variants are available for Button instances whose size needs to be different from the default:
@@ -246,7 +241,12 @@ endif::[]
 
 .Customize Default Button Size
 [TIP]
-Size variants should only be used in special cases. See <<{articles}/styling/themes/lumo/lumo-style-properties/size-space#,Size and Space>> for details on how to change the default button size.
+Size variants should only be used in special cases. For Lumo, see <<{articles}/styling/themes/lumo/lumo-style-properties/size-space#,Size and Space>> for details on how to change the default button size.
+
+
+== Additional Lumo Variants
+
+The following variants are only available in the Lumo theme.
 
 
 === Tertiary Inline Variant


### PR DESCRIPTION
Moves size variants section from "Additional Lumo Variants" to general variants section.