### PR TITLE
docs: add missing theme switchers to Badge styling examples

### DIFF
--- a/articles/components/badge/styling.adoc
+++ b/articles/components/badge/styling.adoc
@@ -61,7 +61,7 @@ The following variants are supported:
 Badges have four different color variants: default, `success`, `warning`, and `error`.
 The color variants can be paired with the `filled` theme variant for additional emphasis.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
@@ -125,7 +125,7 @@ If you are using colors and icons to convey information, provide the same info v
 
 The `dot` theme variant visually hides all the badge content, while keeping it accessible for screen readers.
 
-[.example]
+[.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]


### PR DESCRIPTION
I missed to add theme switchers to these examples in #5216, this PR fixes that.