### PR TITLE
chore: start docs in production mode

### DIFF
--- a/dspublisher/dspublisher-scripts.js
+++ b/dspublisher/dspublisher-scripts.js
@@ -171,7 +171,7 @@ const SCRIPTS = {
           '--kill-others',
           '--raw',
           `"npx -y @vaadin/dspublisher@${DSP_VERSION} --develop"`,
-          `"mvn -C -Dspring-boot.run.arguments=--server.port=${docsPort}"`,
+          `"mvn -C -Pproduction -Dspring-boot.run.arguments=--server.port=${docsPort}"`,
         ],
         phases: [
           {


### PR DESCRIPTION
Avoid local changes to `package.json` and `package-lock.json` when running `dspublisher:start`