### PR TITLE
docs: update Node.js documentation for Vaadin 25.0 changes

### DIFF
--- a/articles/flow/configuration/development-mode/node-js.adoc
+++ b/articles/flow/configuration/development-mode/node-js.adoc
@@ -22,22 +22,22 @@ For global installation, Node.js can be downloaded from `https://nodejs.org/en/d
 
 === Automatic Installation
 
-When Vaadin installs Node.js automatically, it extracts the complete Node.js distribution into a version-specific directory under `~/.vaadin/`. For example, if the requested version is `v22.13.1`, it's installed into `~/.vaadin/node-v22.13.1/`.
+When Vaadin installs Node.js automatically, it extracts the complete Node.js distribution into a version-specific directory under `~/.vaadin/`. For example, if the requested version is `v24.14.0`, it's installed into `~/.vaadin/node-v24.14.0/`.
 
 The full distribution is extracted, including `node`, `npm`, `npx`, and `corepack` on Unix, or `node.exe`, `npm.cmd`, `npx.cmd`, and `corepack.cmd` on Windows. This means you can use `npm`, `npx`, and `corepack` directly from the installation directory if needed. For example:
 
 [source,terminal]
 ----
-~/.vaadin/node-v22.13.1/bin/npm install some-package
-~/.vaadin/node-v22.13.1/bin/npx some-tool
+~/.vaadin/node-v24.14.0/bin/npm install some-package
+~/.vaadin/node-v24.14.0/bin/npx some-tool
 ----
 
 On Windows, the executables are in the root of the installation directory:
 
 [source,terminal]
 ----
-%USERPROFILE%\.vaadin\node-v22.13.1\npm.cmd install some-package
-%USERPROFILE%\.vaadin\node-v22.13.1\npx.cmd some-tool
+%USERPROFILE%\.vaadin\node-v24.14.0\npm.cmd install some-package
+%USERPROFILE%\.vaadin\node-v24.14.0\npx.cmd some-tool
 ----
 
 Since each version is installed into its own directory, multiple Node.js versions can coexist side by side under `~/.vaadin/`.
@@ -49,7 +49,7 @@ Vaadin resolves which Node.js installation to use in the following order:
 
 . If <<node-folder,`node.folder`>> is set, use exclusively that directory. If the Node.js binary isn't found there, the build fails with no fallback.
 . If `require.home.node` is _not_ set, check for a suitable global Node.js on the system `PATH`.
-. Check `~/.vaadin/` for the exact requested version (e.g., `~/.vaadin/node-v22.13.1/`).
+. Check `~/.vaadin/` for the exact requested version (e.g., `~/.vaadin/node-v24.14.0/`).
 . Fall back to any compatible installed version found in `~/.vaadin/`.
 . If nothing is found, download and install the requested version into `~/.vaadin/node-v<version>/`.
 

--- a/articles/flow/configuration/gradle.adoc
+++ b/articles/flow/configuration/gradle.adoc
@@ -299,8 +299,8 @@ Java source folders for connect scanning.
 `generatedTsFolder: File = File(project.projectDir, "src/main/frontend/generated")`::
 The folder where Flow puts TS API files for client projects. The legacy location `"${project.basedir}/frontend/generated"` is used if the default location doesn't exist and this parameter isn't set.
 
-`nodeVersion: String = "v22.13.1"`::
-The Node.js version to be used when Node.js is installed automatically by Vaadin, for example `"v22.13.1"`. Defaults to `[FrontendTools.DEFAULT_NODE_VERSION]`.
+`nodeVersion: String = "v24.14.0"`::
+The Node.js version to be used when Node.js is installed automatically by Vaadin, for example `"v24.14.0"`. Defaults to `[FrontendTools.DEFAULT_NODE_VERSION]`.
 
 `nodeDownloadRoot: String = "https://nodejs.org/dist/"`::
 URL to download Node.js from. This can be needed in corporate environments where the Node.js download is provided from an intranet mirror. Defaults to `[NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT]`.

--- a/articles/flow/configuration/maven.adoc
+++ b/articles/flow/configuration/maven.adoc
@@ -89,7 +89,7 @@ URL to use for downloading Node.js. In environments behind a firewall, the Node.
 The folder containing the Node.js executable to use. When specified, Node.js is exclusively used from this folder. If the binary isn't found there, the build fails with no fallback. Defaults to `null`.
 
 `nodeVersion`::
-The Node.js version to be used when Node.js is installed automatically. Should be in the format `"v22.13.1"`. Defaults to `FrontendTools.DEFAULT_NODE_VERSION`.
+The Node.js version to be used when Node.js is installed automatically. Should be in the format `"v24.14.0"`. Defaults to `FrontendTools.DEFAULT_NODE_VERSION`.
 
 `npmExcludeWebComponents`::
 Excludes all Vaadin professional and core components from the `package.json`. Lumo theme is not excluded. Excluded packages aren't installed by npm, which makes development bundles smaller. This property alone doesn't remove any Maven dependencies. See <<development-mode/index.adoc#exclude-vaadin-components, Optimize Bundle>> for more information. Defaults to `false`.

--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -318,7 +318,7 @@ Default: `true` for development mode; `false` for production mode +
 Mode: Runtime
 
 `**require.home.node**`::
-Skip global Node.js lookup and use only Vaadin-managed installations in `~/.vaadin/`. When set to `true`, the global `PATH` is not checked and Node.js is resolved from version-specific directories under `~/.vaadin/` (e.g., `~/.vaadin/node-v22.13.1/`). If a suitable version isn't found, it's downloaded and installed automatically. +
+Skip global Node.js lookup and use only Vaadin-managed installations in `~/.vaadin/`. When set to `true`, the global `PATH` is not checked and Node.js is resolved from version-specific directories under `~/.vaadin/` (e.g., `~/.vaadin/node-v24.14.0/`). If a suitable version isn't found, it's downloaded and installed automatically. +
 Default: `false` +
 Mode: Build
 

--- a/articles/flow/production/production-build.adoc
+++ b/articles/flow/production/production-build.adoc
@@ -202,7 +202,7 @@ This section contains a list of plugin goals and their parameters.
 
 === `prepare-frontend`
 
-This goal validates whether the `node` and `npm` tools are installed and aren't too old (i.e., not earlier than `node` version `16.14`, and not older than `npm` version `8.3`). It installs them in the `.vaadin` folder in the user's home directory if they're missing. If they're already installed globally, but too old, an error message is generated suggesting that you install newer versions.
+This goal validates whether the `node` and `npm` tools are installed and aren't too old (i.e., not earlier than `node` version `24`, and not older than `npm` version `11`). It installs them in the `.vaadin` folder in the user's home directory if they're missing. If they're already installed globally, but too old, an error message is generated suggesting that you install newer versions.
 
 `Node.js` is needed to run `npm` to install frontend dependencies and Vite, which bundles the frontend files served to the client.
 

--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -43,11 +43,11 @@ Vaadin 25 requires Node.js 24 or later for building the frontend part of the app
 The way Vaadin installs and manages Node.js has also changed:
 +
 --
-- Node.js is now installed into version-specific directories (e.g., `~/.vaadin/node-v22.13.1/`) instead of a single `~/.vaadin/node/` directory. Multiple versions can coexist side by side.
+- Node.js is now installed into version-specific directories (e.g., `~/.vaadin/node-v24.14.0/`) instead of a single `~/.vaadin/node/` directory. Multiple versions can coexist side by side.
 - The complete Node.js distribution is now extracted, including `npm`, `npx`, and `corepack`, so these tools can be used directly from the installation directory.
 - The `node.auto.update` configuration property has been removed. Auto-update is no longer needed since each version is installed into its own directory.
 - A new `node.folder` configuration property allows pointing to a custom Node.js installation directory. See <<{articles}/flow/configuration/development-mode/node-js.adoc#node-folder, Custom Node.js Folder>> for details.
-- If you have scripts or CI configurations that reference `~/.vaadin/node/bin/node`, update them to use the version-specific path (e.g., `~/.vaadin/node-v22.13.1/bin/node`).
+- If you have scripts or CI configurations that reference `~/.vaadin/node/bin/node`, update them to use the version-specific path (e.g., `~/.vaadin/node-v24.14.0/bin/node`).
 --
 
 React 19::


### PR DESCRIPTION
Rewrite Node.js configuration docs to reflect new installation behavior: version-specific directories (~/.vaadin/node-v<version>/), complete distribution extraction, new resolution order, and new node.folder property. Remove deprecated node.auto.update property and Travis CI section.


