### PR TITLE
docs: add new Aura overlay text color custom CSS properties

### DIFF
--- a/articles/components/confirm-dialog/styling.adoc
+++ b/articles/components/confirm-dialog/styling.adoc
@@ -37,6 +37,9 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-dialog-shadow`
 |Aura
 
+|`--vaadin-dialog-text-color`
+|Aura
+
 |`--vaadin-dialog-title-color`
 |Aura
 

--- a/articles/components/dialog/styling.adoc
+++ b/articles/components/dialog/styling.adoc
@@ -79,6 +79,9 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-dialog-shadow`
 |Aura
 
+|`--vaadin-dialog-text-color`
+|Aura
+
 |`--vaadin-dialog-title-color`
 |Aura
 

--- a/articles/components/login/styling.adoc
+++ b/articles/components/login/styling.adoc
@@ -99,6 +99,9 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 | `--vaadin-login-overlay-shadow`
 | Aura
 
+|`--vaadin-login-overlay-text-color`
+|Aura
+
 | `--vaadin-login-overlay-title-color`
 | Aura
 

--- a/articles/components/popover/styling.adoc
+++ b/articles/components/popover/styling.adoc
@@ -68,6 +68,9 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-popover-shadow`
 |Aura
 
+|`--vaadin-popover-text-color`
+|Aura
+
 |`--vaadin-overlay-backdrop-background`
 |Aura
 


### PR DESCRIPTION
Added the following custom CSS properties introduced in https://github.com/vaadin/web-components/pull/11265:

- `--vaadin-dialog-text-color`
- `--vaadin-login-overlay-text-color`
- `--vaadin-popover-text-color`