### PR TITLE
docs: improve SwingBridge guide with prerequisites, debugging, and Maven Wrapper

### DIFF
--- a/articles/tools/modernization-toolkit/swing-bridge.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge.adoc
@@ -306,8 +306,6 @@ Navigate to `http://localhost:8888` to see the application. If you configured a 
 
 SwingBridge requires special JVM flags to access internal Java modules. Because of this, running the application by clicking the green play button in IntelliJ IDEA or the equivalent in VS Code is not supported at this time.
 
-However, the skeleton starter project includes an Eclipse run configuration that supports running and debugging directly through the IDE.
-
 To run the application, use Maven from the command line as described in the <<using-the-skeleton-starter,skeleton starter>> or <<setting-up-from-scratch,from scratch>> sections.
 
 [NOTE]


### PR DESCRIPTION
## Summary
- Add a **Prerequisites** section documenting Java 21+ requirement and optional Maven installation
- Update skeleton starter section to use **Maven Wrapper** (`./mvnw` / `mvnw.cmd`) instead of `mvn`, with OS-specific tabs
- Fix skeleton starter port from `8080` to `8888` and add port note for from-scratch setup
- Add **cross-links** between skeleton starter and from-scratch subsections, recommend skeleton starter for first-time users
- Add **Running and Debugging** section covering IDE run limitations, Eclipse support, and remote debug setup for IntelliJ IDEA and VS Code

## Test plan
- [ ] Verify the page renders correctly by browsing the Preview Deployment's provided link, or in case deployment had a problem clone the branch locally and run with `npm run dspublisher:start`.
- [ ] Confirm cross-reference links (`<<using-the-skeleton-starter>>`, `<<setting-up-from-scratch>>`) resolve correctly
- [ ] Confirm OS-specific tabs render for Maven Wrapper commands
- [ ] Run Vale to check for style issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)