### PR TITLE
chore: don't prefer "application" over "app"

### DIFF
--- a/.github/styles/Vaadin/Terms-App.yml
+++ b/.github/styles/Vaadin/Terms-App.yml
@@ -1,7 +1,0 @@
-# Need to keep this as a separate rule in order to allow for 'App Layout' and 'Google App Engine'
-extends: substitution
-message: "Prefer 'application' over 'app'."
-level: warning
-ignorecase: true
-swap:
-  '[aA]pp (?:[^\s]*)': 'App (Layout|Engine)'

--- a/.github/styles/Vaadin/Terms.yml
+++ b/.github/styles/Vaadin/Terms.yml
@@ -12,7 +12,6 @@ swap:
   '(?:WiFi|wifi)': Wi-Fi
   '3\-D': 3D
   Ajax: AJAX
-  apps: applications
   approx\.: approximately
   back[\s|-]end: backend
   cellular data: mobile data


### PR DESCRIPTION
"App" is such a common name it seems futile trying to avoid it in favor of the more formal "application".