### PR TITLE
docs: document Maven Daemon and Maven Shell support for Vaadin Maven plugin

### DIFF
--- a/articles/flow/configuration/maven.adoc
+++ b/articles/flow/configuration/maven.adoc
@@ -39,6 +39,33 @@ The best way to set persistent configuration properties for a Maven project is t
 See the <<properties,full list of properties>>.
 
 
+== Maven Daemon and Maven Shell Support
+
+https://github.com/apache/maven-mvnd[Maven Daemon] (`mvnd`) and Maven Shell (`mvnsh`, introduced in Maven 4) keep the JVM alive across builds to improve performance. This can cause stale build metadata to persist between builds. For example, the production mode token file created during a production build may not be removed, causing a subsequent development mode run to incorrectly start in production mode.
+
+To avoid this, add `<extensions>true</extensions>` to the Vaadin Maven plugin declaration. This enables a lifecycle participant that cleans up build metadata after each Maven session, regardless of whether the JVM exits.
+
+.Enabling extensions for Maven Daemon support
+[source,xml]
+----
+<plugin>
+    <groupId>com.vaadin</groupId>
+    <artifactId>vaadin-maven-plugin</artifactId>
+    <version>${vaadin.version}</version>
+    <extensions>true</extensions>
+    <executions>
+        <execution>
+            <goals>
+                <goal>build-frontend</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+----
+
+This setting is harmless for standard Maven builds and is recommended for all projects that use `mvnd` or `mvnsh`.
+
+
 == Plugin Goals
 
 The Vaadin Maven plugin provides the following goals:


### PR DESCRIPTION
Add a section to the Maven configuration page explaining how to enable `<extensions>true</extensions>` on the Vaadin Maven plugin. This activates a lifecycle participant that cleans up stale build metadata after each Maven session, preventing issues when using `mvnd` or `mvnsh` where the JVM stays alive across builds.

Related to vaadin/flow#21021


