### PR TITLE
docs: remove llmprovider factory methods

### DIFF
--- a/articles/building-apps/ai/quickstart-guide.adoc
+++ b/articles/building-apps/ai/quickstart-guide.adoc
@@ -121,7 +121,7 @@ package org.vaadin.example;
 
 import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.ai.orchestrator.AIOrchestrator;
-import com.vaadin.flow.component.ai.provider.LLMProvider;
+import com.vaadin.flow.component.ai.provider.SpringAILLMProvider;
 import com.vaadin.flow.component.messages.MessageInput;
 import com.vaadin.flow.component.messages.MessageList;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
@@ -146,7 +146,7 @@ public class MainView extends Composite<VerticalLayout> {
         messageInput.setWidthFull();
 
         // Create the LLM provider
-        var provider = LLMProvider.from(chatModel);
+        var provider = new SpringAILLMProvider(chatModel);
 
         // Wire everything together
         AIOrchestrator.builder(provider,

--- a/articles/flow/ai-support/index.adoc
+++ b/articles/flow/ai-support/index.adoc
@@ -28,7 +28,7 @@ ifdef::flow[]
 The AI support module consists of three parts:
 
 * **Orchestrator** -- [classname]`AIOrchestrator` is a non-visual coordination engine that connects UI components to an LLM provider. It has no DOM element and should not be added to a layout.
-* **Provider** -- [classname]`LLMProvider` is the interface for communicating with LLM frameworks. Use the static [methodname]`LLMProvider.from(...)` factory methods to create a provider from a Spring AI or LangChain4j model. You can also implement this interface to connect to any other LLM framework.
+* **Provider** -- [classname]`LLMProvider` is the interface for communicating with LLM frameworks. Create a provider by instantiating [classname]`SpringAILLMProvider` or [classname]`LangChain4JLLMProvider` directly. You can also implement this interface to connect to any other LLM framework.
 * **Component interfaces** -- [classname]`AIInput`, [classname]`AIMessageList`, [classname]`AIMessage`, and [classname]`AIFileReceiver` define contracts for UI components that the orchestrator can work with. The builder also accepts standard Vaadin components ([classname]`MessageInput`, [classname]`MessageList`, [classname]`UploadManager`, [classname]`Upload`) directly.
 
 Add the UI components to your layout and pass them to the orchestrator through its builder. The orchestrator wires them together and manages the LLM interaction.
@@ -36,7 +36,7 @@ Add the UI components to your layout and pass them to the orchestrator through i
 
 == Basic Usage
 
-Create an AI Orchestrator by passing an LLM provider and optional UI components to the builder. The following example uses a mock provider -- replace it with a real provider via [methodname]`LLMProvider.from(...)` in production (see <<llm-providers#,LLM Providers>>).
+Create an AI Orchestrator by passing an LLM provider and optional UI components to the builder. The following example uses a mock provider -- replace it with a real provider such as [classname]`SpringAILLMProvider` or [classname]`LangChain4JLLMProvider` in production (see <<llm-providers#,LLM Providers>>).
 
 [.example.show-code]
 --

--- a/articles/flow/ai-support/llm-providers.adoc
+++ b/articles/flow/ai-support/llm-providers.adoc
@@ -10,7 +10,7 @@ order: 20
 
 ifdef::flow[]
 
-The orchestrator uses the [classname]`LLMProvider` interface to communicate with LLM frameworks. Use the static [methodname]`LLMProvider.from(...)` factory methods to create a provider from a vendor-specific model or client object. Two implementations are provided: one for Spring AI and one for LangChain4j.
+The orchestrator uses the [classname]`LLMProvider` interface to communicate with LLM frameworks. Create a provider by instantiating the appropriate implementation directly. Two implementations are provided: one for Spring AI and one for LangChain4j.
 
 .Memory Window Limit
 [IMPORTANT]
@@ -26,12 +26,12 @@ Both built-in providers maintain a 30-message memory window. Older messages are 
 // From ChatModel - use an implementation of Spring AI ChatModel
 ChatModel chatModel = OpenAiChatModel.builder()
     .openAiApi(...).defaultOptions(...).build();
-SpringAILLMProvider provider = LLMProvider.from(chatModel);
+SpringAILLMProvider provider = new SpringAILLMProvider(chatModel);
 
 // From ChatClient - use a Spring AI ChatClient
 ChatClient chatClient = ChatClient.builder(...)
     .defaultAdvisors(...).build();
-SpringAILLMProvider provider = LLMProvider.from(chatClient);
+SpringAILLMProvider provider = new SpringAILLMProvider(chatClient);
 ----
 
 When created from a [classname]`ChatModel`, the provider manages its own conversation memory using a 30-message window. When created from a [classname]`ChatClient`, memory must be configured externally on the client.
@@ -45,24 +45,24 @@ provider.setStreaming(false);
 
 .History Restoration with ChatClient
 [NOTE]
-History restoration via [methodname]`withHistory()` is only supported when creating the provider from a [classname]`ChatModel`. Providers created from a [classname]`ChatClient` do not provide access to internal memory, so calling [methodname]`setHistory()` throws an [classname]`UnsupportedOperationException`. Use [methodname]`LLMProvider.from(chatModel)` if you need to restore conversation history across sessions.
+History restoration via [methodname]`withHistory()` is only supported when creating the provider from a [classname]`ChatModel`. Providers created from a [classname]`ChatClient` do not provide access to internal memory, so calling [methodname]`setHistory()` throws an [classname]`UnsupportedOperationException`. Use `new SpringAILLMProvider(chatModel)` if you need to restore conversation history across sessions.
 
 
 == LangChain4j
 
-[classname]`LangChain4JLLMProvider` supports both streaming and synchronous LangChain4j models. The mode is determined by the model type passed to the factory method:
+[classname]`LangChain4JLLMProvider` supports both streaming and synchronous LangChain4j models. The mode is determined by the model type passed to the constructor:
 
 [source,java]
 ----
 // Streaming mode - use an implementation of LangChain4j StreamingChatModel
 StreamingChatModel streamingChatModel = OpenAiStreamingChatModel.builder()
     .apiKey(...).modelName(...).build();
-LangChain4JLLMProvider provider = LLMProvider.from(streamingChatModel);
+LangChain4JLLMProvider provider = new LangChain4JLLMProvider(streamingChatModel);
 
 // Synchronous mode - use an implementation of LangChain4j ChatModel
 ChatModel chatModel = OpenAiChatModel.builder()
     .apiKey(...).modelName(...).build();
-LangChain4JLLMProvider provider = LLMProvider.from(chatModel);
+LangChain4JLLMProvider provider = new LangChain4JLLMProvider(chatModel);
 ----
 
 The provider manages its own conversation memory using a 30-message window.


### PR DESCRIPTION
Replaces the references to LLMProvider factory methods with explicit constructors.

Follow-up to https://github.com/vaadin/flow-components/pull/9012.