### PR TITLE
docs: use correct tag name for vaadin-radio-group

### DIFF
--- a/articles/components/radio-button/index.adoc
+++ b/articles/components/radio-button/index.adoc
@@ -7,7 +7,7 @@ page-links:
   - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/radio-group}/elements/vaadin-radio-group[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/radiobutton/RadioButtonGroup.html[Java]'
   - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/radio-group}/packages/radio-group[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-radio-button-flow-parent[Java]'
 ---
-:tag-name: vaadin-radio-button-group
+:tag-name: vaadin-radio-group
 
 
 = Radio Button


### PR DESCRIPTION
This is shown in the "External & Invisible Labels (ARIA)" code example.