### PR TITLE
chore: bump SB version in swing-bridge.adoc

### DIFF
--- a/articles/tools/modernization-toolkit/swing-bridge.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge.adoc
@@ -129,7 +129,7 @@ Add the following parent section, properties, and dependencies to your `pom.xml`
 <parent>
   <groupId>org.springframework.boot</groupId>
   <artifactId>spring-boot-starter-parent</artifactId>
-  <version>4.0.3</version>
+  <version>4.0.4</version>
   <relativePath/>
 </parent>
 
@@ -141,13 +141,6 @@ Add the following parent section, properties, and dependencies to your `pom.xml`
       <version>${vaadin.version}</version>
       <type>pom</type>
       <scope>import</scope>
-    </dependency>
-    <dependency>
-        <groupId>tools.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>3.1.0</version>
-        <type>pom</type>
-        <scope>import</scope>
     </dependency>
   </dependencies>
 </dependencyManagement>


### PR DESCRIPTION
Vaadin 25.1.0 and SpringBoot 4.0.3 have a misalignment in jackson 3 versioning which was preventing the Vaadin app from properly starting / bootstraping. So we had to pin the jackson version to alleviate the situation, but bumping the SpringBoot to 4.0.4 fixed the issue, so no need for extra version pin.