### PR TITLE
docs: clarify icon only badge screen reader support

### DIFF
--- a/articles/components/badge/index.adoc
+++ b/articles/components/badge/index.adoc
@@ -90,7 +90,7 @@ The benefit of using icons should be weighed against the visual noise it adds.
 
 Badges can also be used with icons without a label.
 For accessibility, the text should be still provided when using `icon-only` style variant.
-It's only hidden visually but available for screen readers to ensure that all users can identify meaning of the badge.
+It's only hidden visually but available for screen readers to ensure that all users can identify the meaning of the badge.
 
 [.example,themes="lumo,aura"]
 --


### PR DESCRIPTION
Replaced `aria-label` and tooltip recommendation with a note on adding the text to icon-only badges.