### PR TITLE
Use the right frontend location for add-ons

### DIFF
--- a/articles/flow/component-internals/web-components/index.adoc
+++ b/articles/flow/component-internals/web-components/index.adoc
@@ -49,7 +49,7 @@ The `@Tag` annotation here defines the name of the HTML element. The `@JsModule`
 
 == Adding Frontend Files
 
-Your component may require in-project frontend files, such as additional JavaScript modules. In which case, add them to the `src/main/resources/META-INF/frontend` directory so that they're packaged in the component JAR if you choose to make an add-on of your component.
+Your component may require in-project frontend files, such as additional JavaScript modules. In which case, add them to the `src/main/resources/META-INF/resources/frontend` directory so that they're packaged in the component JAR if you choose to make an add-on of your component.
 
 As a example, you might use the `@JsModule` annotation to add a local JavaScript module like so:
 [source,java]


### PR DESCRIPTION
Same location as used in https://github.com/vaadin/client-server-addon-template


