### PR TITLE
doc: Improve Gradle plugin documentation (V24)

### DIFF
--- a/articles/flow/configuration/development-mode/index.adoc
+++ b/articles/flow/configuration/development-mode/index.adoc
@@ -126,6 +126,15 @@ vaadin.frontend.hotdeploy=true
 </plugin>
 ----
 
+[source,groovy]
+.build.gradle
+----
+<source-info group="Vaadin Gradle Plugin"></source-info>
+vaadin {
+    frontendHotdeploy = true
+}
+----
+
 [source,xml]
 .pom.xml
 ----

--- a/articles/flow/configuration/gradle.adoc
+++ b/articles/flow/configuration/gradle.adoc
@@ -41,6 +41,9 @@ vaadin {
 
 If the parameter is `true`, it enables development using the frontend development server instead of an application bundle. This applies only to development mode.
 
+[IMPORTANT]
+The Vaadin Gradle plugin does not read configuration from `application.properties`. Setting `vaadin.frontend.hotdeploy=true` in `application.properties` only affects the application at runtime. To control plugin behavior during builds, set the corresponding property in the `vaadin {}` block in [filename]`build.gradle`.
+
 
 [[build-file.repositories]]
 === Configuring Repositories
@@ -88,6 +91,8 @@ The Vaadin-related tasks handled by the plugin are as follows:
 
 `vaadinPrepareFrontend`::
 This step verifies that Node.js and `npm` are installed, copies the frontend resources, and, if needed, creates or updates the [filename]`package.json` file and Vite configuration files (i.e., [filename]`vite.config.ts` and [filename]`vite.generated.ts`). The frontend resources are located within `.jar` dependencies and are copied to `src/main/frontend/generated/jar-resources`.
++
+This task is automatically attached to the `processResources` Gradle lifecycle task. This means it runs on every compilation, including when your IDE triggers an automatic build (e.g., IntelliJ IDEA's default Gradle build delegation). In hot deploy mode, this can cause generated frontend files like `index.ts` to be deleted if `frontendHotdeploy` is not set in the `vaadin {}` block. See <<known-issues,Known Issues>> for workarounds.
 
 `vaadinBuildFrontend`::
 This builds the frontend bundle with the `Vite` utility. Vaadin frontend resources (e.g., HTML, JavaScript, CSS, and images) are bundled to optimize loading the frontend. This task isn't executed automatically on the `build` and other targets, so you'll need to run it, explicitly.
@@ -242,6 +247,9 @@ Indicates that the application is running in production mode. Defaults to `false
 `forceProductionBuild: Boolean = false`::
 Whether to generate a production bundle even if an existing pre-compiled bundle could be used. A value of 'true' forces bundle generation without validating if there is a usable production bundle already.
 
+`frontendHotdeploy: Boolean = false`::
+Enables development using the frontend development server instead of an application bundle. This applies only to development mode. This must be set in the `vaadin {}` block; the Gradle plugin does not read the corresponding `vaadin.frontend.hotdeploy` property from `application.properties`.
+
 `frontendOutputDirectory: File = null`::
 The folder where Vite should output [filename]`index.js` and other generated files. Defaults to `null`, which uses the automatically detected value of the main SourceSet, usually `build/resources/main/META-INF/VAADIN/webapp/`.
 
@@ -320,4 +328,15 @@ Use the `include` and `exclude` functions to specify the scanned classpath. Supp
 When the list of dependencies causes the classpath to go over a set limit on Windows, the build automatically generates a JAR containing a manifest with the classpath. Sometimes, when running a Spring Boot application, the resource loader doesn't load the classpath packages correctly from the manifest. The failed annotation scanning makes the required `npm` packages unavailable.
 
 You can fix this in two ways: add the repository `mavenLocal()` to <<#build-file.repositories,build file repositories>>; or specify the `vaadin.allowed-packages` property, see <<{articles}/flow/integrations/spring/configuration#,Vaadin Spring Configuration>>.
+
+=== IntelliJ IDEA and Gradle
+
+By default, IntelliJ IDEA delegates build and run actions to Gradle. This means that every time you edit a file or switch focus, IDEA may trigger a Gradle compilation, which in turn executes `vaadinPrepareFrontend`. This can interfere with hot deploy by deleting and regenerating frontend files.
+
+To avoid this:
+
+1. Set `frontendHotdeploy = true` in the `vaadin {}` block in [filename]`build.gradle` (not only in [filename]`application.properties`). This ensures the Gradle plugin is aware of hot deploy mode during builds.
+2. Alternatively, configure IntelliJ IDEA to build using its own compiler instead of Gradle: go to *Settings* > *Build, Execution, Deployment* > *Build Tools* > *Gradle* and under *Build and run using*, select *IntelliJ IDEA*.
+
+See <<{articles}/getting-started/run/intellij#,Run in IntelliJ IDEA>> for more details.
 

--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -221,7 +221,7 @@ Bundle parameter controls parts of frontend bundle creation.
 
 |`frontend.hotdeploy`
 |`vaadin.frontend.hotdeploy`
-|Enables development using the frontend development server instead of an application bundle. This applies only to development mode. Hilla always forces frontend `hotdeploy` to true.
+|Enables development using the frontend development server instead of an application bundle. This applies only to development mode. Hilla always forces frontend `hotdeploy` to true. This is a runtime property read by the application. For Gradle projects, the Gradle plugin requires separate configuration via the `frontendHotdeploy` option in the `vaadin {}` block (see <<{articles}/flow/configuration/gradle#build-file.vaadin-options,Vaadin Plugin Configuration>>).
 |`false`
 |Development
 

--- a/articles/getting-started/run/intellij.adoc
+++ b/articles/getting-started/run/intellij.adoc
@@ -14,6 +14,21 @@ image::images/idea-debug.png[Debug button in IntelliJ IDEA]
 
 The application starts up and you can access it at http://localhost:8080. Hot deploy of the frontend files is enabled automatically. However, to enable Java hotswap, you have to take some additional actions.
 
+== Gradle Projects
+
+By default, IntelliJ IDEA delegates build and run actions to Gradle for Gradle-based projects. For a better development experience, configure IntelliJ IDEA to build and run using its own compiler instead:
+
+1. Go to *Settings* > *Build, Execution, Deployment* > *Build Tools* > *Gradle*.
+2. Under *Build and run using*, select *IntelliJ IDEA*.
+3. Under *Run tests using*, select *IntelliJ IDEA*.
+
+This avoids unnecessary Gradle task execution during development and provides faster compilation.
+
+[TIP]
+====
+When using hot deploy with Gradle, ensure that `frontendHotdeploy` is set to `true` in the `vaadin {}` block in [filename]`build.gradle`, not only in [filename]`application.properties`. The Gradle plugin does not read `application.properties`. See <<{articles}/flow/configuration/gradle#build-file.vaadin-options,Vaadin Plugin Configuration>> for details.
+====
+
 
 == Enabling Hotswap
 


### PR DESCRIPTION
The Vaadin Gradle plugin does not read `application.properties`, so settings like `vaadin.frontend.hotdeploy=true` only take effect at runtime, not during Gradle builds. This was not documented, causing issues where `vaadinPrepareFrontend` would delete generated frontend files during IDE-triggered builds.

- Clarify that the Gradle plugin requires configuration via the `vaadin {}` block in `build.gradle`, not `application.properties`
- Add missing `frontendHotdeploy` to the plugin configuration options
- Add Gradle tab to the "Disabling the Pre-Compiled Bundle" section
- Document that `vaadinPrepareFrontend` is bound to `processResources` and runs on every compilation
- Add IntelliJ IDEA workarounds to Known Issues and run guide

Part of vaadin/flow#24108


