### PR TITLE
doc: Make debug tool auto-install info more prominent

### DIFF
--- a/articles/tools/kubernetes/session-replication-debug-tool.adoc
+++ b/articles/tools/kubernetes/session-replication-debug-tool.adoc
@@ -16,7 +16,7 @@ The tester tries to serialize and deserialize the HTTP session. The `RequestHand
 
 == Enabling Debug Tool
 
-The debug tool won't work in production builds. During development, it works only if a couple of conditions are met.
+The debug tool is installed automatically on Spring Boot projects by Kubernetes Kit autoconfiguration. No manual registration is required. However, the debug tool won't work in production builds, and during development it works only if a couple of conditions are met.
 
 First, `vaadin.devmode.sessionSerialization.enabled` application configuration property has to be set to `true`. You may set it either in a properties file or in a YAML file like so:
 
@@ -82,12 +82,16 @@ java \
 
 include::_shared.adoc[tag=extended-debug-info]
 
-The debug tool is installed automatically on Spring Boot projects by Kubernetes Kit autoconfiguration. No manual registration is required.
+[[non-spring-boot-projects]]
+=== Non-Spring Boot Projects
 
 For other project types, the debug tool must be installed manually. Configure the provided <<{articles}/flow/advanced/service-init-listener#,Service Init Listener>>, either by adding an entry in `META-INF/services/VaadinServiceInitListener` or by defining a bean if using the Vaadin Spring add-on.
 
 Additionally, the HTTP filter must be registered either as a Spring bean, or with a [classname]`ServletContextListener`.
 
+.Manual registration code
+[%collapsible]
+====
 [.example]
 --
 .`AppConfig.java`
@@ -137,6 +141,7 @@ public class SerializationDebugToolFilterRegistration implements ServletContextL
 }
 ----
 --
+====
 
 
 == Session Serialization Timeout


### PR DESCRIPTION
Users on Spring Boot projects tend to copy the manual registration snippets even though the debug tool is installed automatically.

Move the auto-install note to the top of the "Enabling Debug Tool" section, add a "Non-Spring Boot Projects" subsection for manual setup, and collapse the registration code behind a collapsible block so it doesn't draw unnecessary attention.


