### PR TITLE
fix: remove loadtest-helper

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -62,7 +62,6 @@ Add the load test support library as a dependency:
 <dependency>
     <groupId>com.vaadin</groupId>
     <artifactId>testbench-loadtest-support</artifactId>
-    <optional>true</optional>
 </dependency>
 ----
 
@@ -495,7 +494,7 @@ When using <<running,combined scenarios>>, each scenario's CSV data is loaded wi
 
 The `testbench-loadtest-support` library enhances your Vaadin application for load testing. In addition to test-time features (proxy configuration, `@Destructive` annotation), it provides two runtime features: error propagation (so k6 can detect server-side failures) and Vaadin-specific metrics (exposed via Spring Boot Actuator). It auto-registers via ServiceLoader -- no code changes are needed.
 
-The <<setup,project setup>> section configures `testbench-loadtest-support` as `optional`, which makes it available both in test code and at runtime. Only include this dependency in builds used for load testing, as it changes error handling behavior.
+The <<setup,project setup>> section configures `testbench-loadtest-support`, which makes it available both in test code and at runtime. Only include this dependency in builds used for load testing, as it changes error handling behavior.
 
 
 [[error-handler]]

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -55,29 +55,22 @@ Add the plugin to your Maven project:
 </plugin>
 ----
 
-Add the load test helper as a test dependency. It provides [classname]`LoadTestItHelper` for <<proxy-configuration,proxy driver configuration>> in your tests:
-
-[source,xml]
-----
-<dependency>
-    <groupId>com.vaadin</groupId>
-    <artifactId>loadtest-helper</artifactId>
-    <scope>test</scope>
-</dependency>
-----
-
-To enable the `@Destructive` annotation and automatic WebDriver cleanup during recording, add the load test support library as a test dependency:
+Add the load test support library as a dependency:
 
 [source,xml]
 ----
 <dependency>
     <groupId>com.vaadin</groupId>
     <artifactId>testbench-loadtest-support</artifactId>
-    <scope>test</scope>
+    <optional>true</optional>
 </dependency>
 ----
 
-This JUnit 5 extension auto-detects when the recording proxy is active and skips tests annotated with <<destructive,`@Destructive`>>. It also ensures the WebDriver is properly closed after each test to prevent orphaned browser processes during recording.
+This library provides [classname]`LoadTestItHelper` for <<proxy-configuration,proxy driver configuration>> in your tests, the `@Destructive` annotation for <<destructive,excluding tests from recording>>, and automatic WebDriver cleanup during recording.
+It also includes runtime features such as <<error-handler,error propagation>> and <<metrics,server metrics>> for load testing.
+
+The JUnit 5 extension auto-detects when the recording proxy is active and skips tests annotated with `@Destructive`.
+It auto-registers via ServiceLoader -- no code changes are needed.
 
 
 [[writing-tests]]
@@ -102,7 +95,7 @@ During recording, the plugin captures HTTP traffic by routing the browser throug
 The browser driver must be configured to use this proxy.
 Without proxy configuration, the browser connects directly to the server and the plugin cannot capture traffic.
 
-The [classname]`LoadTestItHelper` class (from the `loadtest-helper` dependency) handles proxy driver configuration.
+The [classname]`LoadTestItHelper` class (from the `testbench-loadtest-support` dependency) handles proxy driver configuration.
 Its [methodname]`openWithProxy()` method checks whether the `k6.proxy.host` system property is set.
 When it is, it replaces the current driver with one configured to route traffic through the recording proxy, including the necessary Chrome flags for MITM proxy support.
 When the property is not set, it navigates the existing driver to the given URL, so the tests run normally.
@@ -500,21 +493,9 @@ When using <<running,combined scenarios>>, each scenario's CSV data is loaded wi
 [[load-test-helper]]
 == Load Test Helper
 
-The `loadtest-helper` library is a drop-in dependency that enhances your Vaadin application for load testing. It provides two features: error propagation (so k6 can detect server-side failures) and Vaadin-specific metrics (exposed via Spring Boot Actuator). It auto-registers via ServiceLoader -- no code changes are needed.
+The `testbench-loadtest-support` library enhances your Vaadin application for load testing. In addition to test-time features (proxy configuration, `@Destructive` annotation), it provides two runtime features: error propagation (so k6 can detect server-side failures) and Vaadin-specific metrics (exposed via Spring Boot Actuator). It auto-registers via ServiceLoader -- no code changes are needed.
 
-The error handler and metrics features require the dependency with `runtime` scope so that it is deployed with the application:
-
-[source,xml]
-----
-<dependency>
-    <groupId>com.vaadin</groupId>
-    <artifactId>loadtest-helper</artifactId>
-    <scope>runtime</scope>
-</dependency>
-----
-
-[NOTE]
-The <<setup,project setup>> section shows `loadtest-helper` with `test` scope for using [classname]`LoadTestItHelper` in test code. If you also want error propagation and `vaadin.view.count` metrics at runtime, add the dependency a second time with `runtime` scope, or use the default (compile) scope to cover both cases. Only include the `runtime` dependency in builds used for load testing, as it changes error handling behavior.
+The <<setup,project setup>> section configures `testbench-loadtest-support` as `optional`, which makes it available both in test code and at runtime. Only include this dependency in builds used for load testing, as it changes error handling behavior.
 
 
 [[error-handler]]

--- a/articles/flow/testing/load-testing/response-checks.adoc
+++ b/articles/flow/testing/load-testing/response-checks.adoc
@@ -22,7 +22,7 @@ They participate in the k6 `checks` threshold, meaning a failing custom check ca
 .Command line
 [source,bash]
 ----
-mvn k6:record \
+mvn loadtest:record \
   -Dk6.testClass=MyScenarioIT \
   -Dk6.checks.custom="INIT|has page title|(r) => r.body.includes('<title>')"
 ----
@@ -104,12 +104,12 @@ Avoid using literal `|` or `;` inside check names or expressions.
 [source,bash]
 ----
 # Single check
-mvn k6:record \
+mvn loadtest:record \
   -Dk6.testClass=MyScenarioIT \
   -Dk6.checks.custom="INIT|has title|(r) => r.body.includes('<title>')"
 
 # Multiple checks
-mvn k6:record \
+mvn loadtest:record \
   -Dk6.testClass=MyScenarioIT \
   -Dk6.checks.custom="INIT|has title|(r) => r.body.includes('<title>');UIDL|no timeout|(r) => !r.body.includes('timeout');ALL|fast|(r) => r.timings.duration < 3000"
 ----

--- a/articles/flow/testing/load-testing/thresholds.adoc
+++ b/articles/flow/testing/load-testing/thresholds.adoc
@@ -60,16 +60,16 @@ You can change the default threshold values with Maven properties or through con
 [source,bash]
 ----
 # Tighter response time requirements
-mvn k6:convert -Dk6.harFile=recording.har \
+mvn loadtest:convert -Dk6.harFile=recording.har \
     -Dk6.threshold.httpReqDurationP95=1000 \
     -Dk6.threshold.httpReqDurationP99=3000
 
 # Allow checks to fail without aborting the test
-mvn k6:convert -Dk6.harFile=recording.har \
+mvn loadtest:convert -Dk6.harFile=recording.har \
     -Dk6.threshold.checksAbortOnFail=false
 
 # Disable the p95 threshold entirely (set to 0)
-mvn k6:convert -Dk6.harFile=recording.har \
+mvn loadtest:convert -Dk6.harFile=recording.har \
     -Dk6.threshold.httpReqDurationP95=0
 ----
 
@@ -126,11 +126,11 @@ metric1:expression1,metric2:expression2,...
 [source,bash]
 ----
 # Fail if more than 1% of requests fail
-mvn k6:run -Dk6.testFile=test.js \
+mvn loadtest:run -Dk6.testFile=test.js \
     -Dk6.threshold.custom="http_req_failed:rate<0.01"
 
 # Multiple custom thresholds
-mvn k6:run -Dk6.testFile=test.js \
+mvn loadtest:run -Dk6.testFile=test.js \
     -Dk6.threshold.custom="http_req_failed:rate<0.01,http_req_waiting:p(95)<500,http_reqs:count>100"
 ----
 
@@ -159,7 +159,7 @@ If you add a custom `http_req_duration` expression, it is merged with the defaul
 [source,bash]
 ----
 # Adds a median threshold alongside the existing p95 and p99
-mvn k6:convert -Dk6.harFile=recording.har \
+mvn loadtest:convert -Dk6.harFile=recording.har \
     -Dk6.threshold.custom="http_req_duration:p(50)<1000"
 ----
 
@@ -180,7 +180,7 @@ If a custom threshold contains same target as the default, the default gets over
 [source,bash]
 ----
 # Overrides existing default p95 median threshold
-mvn k6:convert -Dk6.harFile=recording.har \
+mvn loadtest:convert -Dk6.harFile=recording.har \
     -Dk6.threshold.custom="http_req_duration:p(95)<500"
 ----
 
@@ -204,7 +204,7 @@ Below are commonly used threshold configurations for Vaadin load tests.
 
 [source,bash]
 ----
-mvn k6:run -Dk6.testFile=test.js \
+mvn loadtest:run -Dk6.testFile=test.js \
     -Dk6.threshold.httpReqDurationP95=500 \
     -Dk6.threshold.httpReqDurationP99=1000 \
     -Dk6.threshold.custom="http_req_failed:rate<0.001,http_req_waiting:p(95)<300"
@@ -225,7 +225,7 @@ thresholds: {
 
 [source,bash]
 ----
-mvn k6:run -Dk6.testFile=test.js \
+mvn loadtest:run -Dk6.testFile=test.js \
     -Dk6.threshold.httpReqDurationP95=10000 \
     -Dk6.threshold.httpReqDurationP99=0 \
     -Dk6.threshold.checksAbortOnFail=false \
@@ -246,7 +246,7 @@ thresholds: {
 
 [source,bash]
 ----
-mvn k6:run -Dk6.testFile=test.js \
+mvn loadtest:run -Dk6.testFile=test.js \
     -Dk6.threshold.custom="http_reqs:count>1000"
 ----
 


### PR DESCRIPTION
loadtest-helper dependency
no longer exists, remove
any mentions of it from the
base documentation


