### PR TITLE
docs: update MDL docs for the overlay API and styling

### DIFF
--- a/articles/components/master-detail-layout/index.adoc
+++ b/articles/components/master-detail-layout/index.adoc
@@ -170,7 +170,7 @@ endif::[]
 
 == Forced Overlay Mode
 
-The layout can be configured to _always_ render the detail area as an overlay by setting `masterSize` to `100%`. This causes the combined sizes to always exceed the available space, triggering overlay mode regardless of the layout width.
+The layout can be configured to _always_ render the detail area as an overlay, even if there is enough space for master and detail to be shown next to each other using the default (split) mode:
 
 [.example]
 --
@@ -178,20 +178,17 @@ ifdef::flow[]
 [source,Java]
 ----
 <source-info group="Flow"></source-info>
-layout.setMasterSize("100%");
+layout.setForceOverlay(true);
 ----
 endif::[]
 ifdef::react[]
 [source,tsx]
 ----
 <source-info group="React"></source-info>
-<MasterDetailLayout masterSize="100%" />
+<MasterDetailLayout forceOverlay />
 ----
 endif::[]
 --
-
-[NOTE]
-In earlier versions, `setForceOverlay(boolean)` (Flow) and `forceOverlay` (React) were used to always render the detail area as an overlay. This API has been removed.
 
 == Overlay Containment Modes
 

--- a/articles/components/master-detail-layout/index.adoc
+++ b/articles/components/master-detail-layout/index.adoc
@@ -195,7 +195,7 @@ endif::[]
 The overlay can be configured to render in two different ways, called _containment modes_:
 
 * *Layout*: The overlay only covers the master area (default);
-* *Viewport*: The overlay covers the entire viewport (i.e. page).
+* *Page*: The overlay covers the entire page.
 
 [.example]
 --
@@ -203,21 +203,21 @@ ifdef::flow[]
 [source,Java]
 ----
 <source-info group="Flow"></source-info>
-layout.setOverlayContainment(MasterDetailLayout.OverlayContainment.VIEWPORT);
+layout.setOverlayContainment(MasterDetailLayout.OverlayContainment.PAGE);
 ----
 endif::[]
 ifdef::react[]
 [source,tsx]
 ----
 <source-info group="React"></source-info>
-<MasterDetailLayout overlayContainment="viewport" />
+<MasterDetailLayout overlayContainment="page" />
 ----
 endif::[]
 --
 
-.Limited Modality with Viewport-Containment
+.Limited Modality with Page-Containment
 [NOTE]
-Due to browser support constraints, the modality of the detail overlay in viewport containment mode is currently limited to pointer interactions. Elements behind the overlay can be focused by keyboard.
+The modality of the detail overlay in page containment mode is currently limited to pointer interactions. Elements behind the overlay can be focused by keyboard.
 
 
 == Orientation

--- a/articles/components/master-detail-layout/styling.adoc
+++ b/articles/components/master-detail-layout/styling.adoc
@@ -46,7 +46,7 @@ Overlay mode:: `vaadin-master-detail-layout+++<wbr>+++**[overlay]**`
 Horizontal orientation:: `vaadin-master-detail-layout+++<wbr>+++**[orientation="horizontal"]**`
 Vertical orientation:: `vaadin-master-detail-layout+++<wbr>+++**[orientation="vertical"]**`
 Default (layout) containment:: `vaadin-master-detail-layout+++<wbr>+++**[overlay-containment="layout"]**`
-Viewport containment:: `vaadin-master-detail-layout+++<wbr>+++**[overlay-containment="viewport"]**`
+Page containment:: `vaadin-master-detail-layout+++<wbr>+++**[overlay-containment="page"]**`
 Master area expanding:: `vaadin-master-detail-layout+++<wbr>+++**[expand="master"]**`
 Detail area expanding:: `vaadin-master-detail-layout+++<wbr>+++**[expand="detail"]**`
 Both areas expanding:: `vaadin-master-detail-layout+++<wbr>+++**[expand="both"]**`

--- a/articles/components/master-detail-layout/styling.adoc
+++ b/articles/components/master-detail-layout/styling.adoc
@@ -58,4 +58,5 @@ Layout with detail placeholder:: `vaadin-master-detail-layout+++<wbr>+++**[has-d
 
 Master area:: `vaadin-master-detail-layout+++<wbr>+++**::part(master)**`
 Detail area:: `vaadin-master-detail-layout+++<wbr>+++**::part(detail)**`
+Detail placeholder area:: `vaadin-master-detail-layout+++<wbr>+++**::part(detail-placeholder)**`
 Backdrop in the overlay mode:: `vaadin-master-detail-layout+++<wbr>+++**::part(backdrop)**`


### PR DESCRIPTION
Related to https://github.com/vaadin/web-components/pull/11489

We agreed to restore `forceOverlay` API, so let's update the docs accordingly.