### PR TITLE
docs: update MDL docs for expandMaster/expandDetail API

### DIFF
--- a/articles/components/master-detail-layout/index.adoc
+++ b/articles/components/master-detail-layout/index.adoc
@@ -99,12 +99,12 @@ endif::[]
 The default `masterSize` is `30rem`. If `detailSize` is not set, it is automatically determined based on the detail content's minimum width and cached until new detail content is set.
 
 [NOTE]
-In earlier versions, `setMasterMinSize` and `setDetailMinSize` were used to set minimum sizes for each area. These have been replaced by the expanding area API described below.
+In earlier versions, `setMasterMinSize` and `setDetailMinSize` were used to set minimum sizes for each area. These have been replaced by `setMasterSize` / `setDetailSize` overloads that accept a boolean `expand` parameter, controlling whether the area expands to fill remaining space.
 
 [role="since:com.vaadin:vaadin@V25.2"]
-=== Expanding Area
+=== Expanding the Master or Detail Area
 
-By default, the master area expands to fill any available space beyond the specified sizes. This can be changed so that the detail area expands instead, or both areas expand proportionally.
+By default, both areas have fixed sizes. The master or detail area can be configured to expand and fill any available space beyond the specified sizes. When both are set to expand, they share the available space equally.
 
 [.example]
 --
@@ -114,8 +114,7 @@ ifdef::flow[]
 <source-info group="Flow"></source-info>
 // Detail area expands to fill remaining space
 layout.setMasterSize("300px");
-layout.setDetailSize("400px");
-layout.setExpandDetail(true);
+layout.setDetailSize("400px", true);
 
 // Both areas expand proportionally
 layout.setExpandMaster(true);

--- a/articles/components/master-detail-layout/styling.adoc
+++ b/articles/components/master-detail-layout/styling.adoc
@@ -47,9 +47,8 @@ Horizontal orientation:: `vaadin-master-detail-layout+++<wbr>+++**[orientation="
 Vertical orientation:: `vaadin-master-detail-layout+++<wbr>+++**[orientation="vertical"]**`
 Default (layout) containment:: `vaadin-master-detail-layout+++<wbr>+++**[overlay-containment="layout"]**`
 Page containment:: `vaadin-master-detail-layout+++<wbr>+++**[overlay-containment="page"]**`
-Master area expanding:: `vaadin-master-detail-layout+++<wbr>+++**[expand="master"]**`
-Detail area expanding:: `vaadin-master-detail-layout+++<wbr>+++**[expand="detail"]**`
-Both areas expanding:: `vaadin-master-detail-layout+++<wbr>+++**[expand="both"]**`
+Master area expanding:: `vaadin-master-detail-layout+++<wbr>+++**[expand-master]**`
+Detail area expanding:: `vaadin-master-detail-layout+++<wbr>+++**[expand-detail]**`
 Layout with detail provided:: `vaadin-master-detail-layout+++<wbr>+++**[has-detail]**`
 Layout with detail placeholder:: `vaadin-master-detail-layout+++<wbr>+++**[has-detail-placeholder]**`
 


### PR DESCRIPTION
## Summary
- Replace references to the removed `expand` property / `ExpandingArea` enum with the new boolean `expandMaster` / `expandDetail` properties
- Update NOTE to mention the new `setMasterSize` / `setDetailSize` overloads that accept a boolean `expand` parameter
- Rename "Expanding Area" subsection to "Expanding the Master or Detail Area"
- Update `styling.adoc` states: `[expand="master"]` / `[expand="detail"]` / `[expand="both"]` → `[expand-master]` / `[expand-detail]`
- Update nested MDL demo (Flow and React) to use the new API

## Note

This needs docs to be updated to the new Vaadin 25.2 alpha including web component / Flow changes.

## Test plan
- [ ] Verify docs build successfully
- [ ] Check the nested MDL live demo renders correctly
- [ ] Confirm no stale references to `expandingArea` / `ExpandingArea` / `expand="..."` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)