### PR TITLE
docs: add note on naming in load testing

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -653,6 +653,8 @@ Below is a complete example that starts the application server, records two Test
 
 Running `mvn verify` with this configuration executes the full workflow: start server, record scenarios, run load tests, and stop server.
 
+[NOTE]
+Name your test classes with the `IT` suffix, not `Test`. Classes ending in `Test` are picked up during the `test` phase, before the server starts.
 
 [[remote-testing]]
 == Remote Load Testing

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -654,7 +654,7 @@ Below is a complete example that starts the application server, records two Test
 Running `mvn verify` with this configuration executes the full workflow: start server, record scenarios, run load tests, and stop server.
 
 [NOTE]
-Name your test classes with the `IT` suffix, not `Test`. Classes ending in `Test` are picked up during the `test` phase, before the server starts.
+Name your test classes with the `IT` suffix, not `Test`. Classes ending in `Test` are picked up during the `test` phase, before the server starts. See the Maven https://maven.apache.org/surefire/maven-failsafe-plugin/examples/inclusion-exclusion.html[Failsafe] and https://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html[Surefire] inclusion-exclusion documentation for details on the default naming patterns.
 
 [[remote-testing]]
 == Remote Load Testing


### PR DESCRIPTION
Adds note to use `IT` suffix, not `Test`. Classes ending in `Test` are picked up during the `test` phase, before the server starts.