### PR TITLE
Update limitations section for Analyzer for Maven

### DIFF
--- a/articles/tools/modernization-toolkit/analyzer-for-maven.adoc
+++ b/articles/tools/modernization-toolkit/analyzer-for-maven.adoc
@@ -20,7 +20,7 @@ The Analyzer report is something you can copy and share with colleagues, applica
 
 For organizations with strict security policies on installing tools in their network, the Modernization Toolkit Analyzer for Maven is limited in two ways.
 
-First, the Analyzer doesn't change your code. It writes all output to the console, not the disk.
+First, the Analyzer doesn't change your code. It writes all output to the console, a detailed report is only saved to disk when requested.
 
 Second, by requesting a free detailed report, you agree to be contacted by email by a Vaadin expert. Vaadin receives your email address and the attached data for the purpose of contacting you about it. For details on how Vaadin uses and protects your data, see Vaadin's privacy policy at https://vaadin.com/privacy-policy.
 


### PR DESCRIPTION
Clarified that a detailed report is saved to disk only when requested.


