### PR TITLE
fix: Either commandline or maven

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -256,12 +256,6 @@ The `loadtest:record` goal runs one or more TestBench test classes through a rec
 
 [.example]
 --
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
-mvn loadtest:record -Dk6.testClass=HelloWorldIT -Dk6.appPort=8080
-----
-
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
@@ -270,18 +264,18 @@ mvn loadtest:record -Dk6.testClass=HelloWorldIT -Dk6.appPort=8080
     <appPort>8080</appPort>
 </configuration>
 ----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+mvn loadtest:record -Dk6.testClass=HelloWorldIT -Dk6.appPort=8080
+----
 --
 
 To record multiple tests:
 
 [.example]
 --
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
-mvn loadtest:record -Dk6.testClasses=HelloWorldIT,CrudExampleIT
-----
-
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
@@ -291,6 +285,12 @@ mvn loadtest:record -Dk6.testClasses=HelloWorldIT,CrudExampleIT
         <testClass>CrudExampleIT</testClass>
     </testClasses>
 </configuration>
+----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+mvn loadtest:record -Dk6.testClasses=HelloWorldIT,CrudExampleIT
 ----
 --
 
@@ -364,18 +364,18 @@ If you already have a HAR file (for example, recorded with browser developer too
 
 [.example]
 --
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
-mvn loadtest:convert -Dk6.harFile=recording.har
-----
-
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
 <configuration>
     <harFile>recording.har</harFile>
 </configuration>
+----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+mvn loadtest:convert -Dk6.harFile=recording.har
 ----
 --
 
@@ -436,12 +436,6 @@ The `loadtest:run` goal executes k6 scripts with configurable virtual users and 
 
 [.example]
 --
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
-mvn loadtest:run -Dk6.testFile=target/k6/tests/hello-world.js -Dk6.vus=50 -Dk6.duration=1m
-----
-
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
@@ -451,18 +445,18 @@ mvn loadtest:run -Dk6.testFile=target/k6/tests/hello-world.js -Dk6.vus=50 -Dk6.d
     <duration>1m</duration>
 </configuration>
 ----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+mvn loadtest:run -Dk6.testFile=target/k6/tests/hello-world.js -Dk6.vus=50 -Dk6.duration=1m
+----
 --
 
 To run all scripts in a directory:
 
 [.example]
 --
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
-mvn loadtest:run -Dk6.testDir=target/k6/tests -Dk6.vus=50 -Dk6.duration=1m
-----
-
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
@@ -472,20 +466,18 @@ mvn loadtest:run -Dk6.testDir=target/k6/tests -Dk6.vus=50 -Dk6.duration=1m
     <duration>1m</duration>
 </configuration>
 ----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+mvn loadtest:run -Dk6.testDir=target/k6/tests -Dk6.vus=50 -Dk6.duration=1m
+----
 --
 
 To run against a remote server:
 
 [.example]
 --
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
-mvn loadtest:run -Dk6.testFile=target/k6/tests/hello-world.js \
-    -Dk6.appIp=staging.example.com -Dk6.appPort=8080 \
-    -Dk6.vus=100 -Dk6.duration=5m
-----
-
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
@@ -496,6 +488,14 @@ mvn loadtest:run -Dk6.testFile=target/k6/tests/hello-world.js \
     <virtualUsers>100</virtualUsers>
     <duration>5m</duration>
 </configuration>
+----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+mvn loadtest:run -Dk6.testFile=target/k6/tests/hello-world.js \
+    -Dk6.appIp=staging.example.com -Dk6.appPort=8080 \
+    -Dk6.vus=100 -Dk6.duration=5m
 ----
 --
 
@@ -602,15 +602,6 @@ When running multiple test files, you can combine them into parallel k6 scenario
 
 [.example]
 --
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
-mvn loadtest:run -Dk6.testDir=target/k6/tests \
-    -Dk6.vus=100 -Dk6.duration=5m \
-    -Dk6.combineScenarios=true \
-    -Dk6.scenarioWeights=helloWorld:70,crudExample:30
-----
-
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
@@ -621,6 +612,15 @@ mvn loadtest:run -Dk6.testDir=target/k6/tests \
     <combineScenarios>true</combineScenarios>
     <scenarioWeights>helloWorld:70,crudExample:30</scenarioWeights>
 </configuration>
+----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+mvn loadtest:run -Dk6.testDir=target/k6/tests \
+    -Dk6.vus=100 -Dk6.duration=5m \
+    -Dk6.combineScenarios=true \
+    -Dk6.scenarioWeights=helloWorld:70,crudExample:30
 ----
 --
 

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -175,31 +175,77 @@ By default, `loadtest:start-server` runs in the `pre-integration-test` phase and
 
 === Start Server Parameters
 
-`k6.serverJar`::
+[.example]
+--
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <serverJar>${project.build.directory}/my-app.jar</serverJar>
+    <serverPort>8080</serverPort>
+    <managementPort>8082</managementPort>
+    <jvmArgs>-Xmx512m</jvmArgs>
+    <appArgs></appArgs>
+    <startupTimeout>120</startupTimeout>
+    <healthPollInterval>2</healthPollInterval>
+</configuration>
+----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+-Dk6.serverJar=target/my-app.jar
+-Dk6.serverPort=8080
+-Dk6.managementPort=8082
+-Dk6.jvmArgs=-Xmx512m
+-Dk6.appArgs=
+-Dk6.startupTimeout=120
+-Dk6.healthPollInterval=2
+----
+--
+
+`serverJar`::
 Path to the executable JAR file to start. Required.
 
-`k6.serverPort`::
+`serverPort`::
 Application server port. Defaults to `8080`.
 
-`k6.managementPort`::
+`managementPort`::
 Spring Boot Actuator management port. Defaults to `8082`.
 
-`k6.jvmArgs`::
+`jvmArgs`::
 Extra JVM arguments (for example, `-Xmx512m`).
 
-`k6.appArgs`::
+`appArgs`::
 Extra application arguments.
 
-`k6.startupTimeout`::
+`startupTimeout`::
 Maximum time to wait for server startup, in seconds. Defaults to `120`.
 
-`k6.healthPollInterval`::
+`healthPollInterval`::
 Interval for polling the health endpoint, in seconds. Defaults to `2`.
 
 
 === Stop Server Parameters
 
-`k6.gracePeriod`::
+[.example]
+--
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <gracePeriod>10</gracePeriod>
+</configuration>
+----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+-Dk6.gracePeriod=10
+----
+--
+
+`gracePeriod`::
 Time to wait for graceful shutdown before force-killing, in seconds. Defaults to `10`.
 
 
@@ -253,28 +299,62 @@ The plugin uses hash-based caching: if the test source code has not changed sinc
 
 === Recording Parameters
 
-`k6.testClass`::
-TestBench test class to record. Required unless `k6.testClasses` is specified.
+[.example]
+--
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <testClass>HelloWorldIT</testClass>
+    <testClasses>
+        <testClass>HelloWorldIT</testClass>
+        <testClass>CrudExampleIT</testClass>
+    </testClasses>
+    <proxyPort>6000</proxyPort>
+    <appPort>8080</appPort>
+    <testWorkDir>${project.basedir}</testWorkDir>
+    <outputDir>${project.build.directory}/k6/tests</outputDir>
+    <testTimeout>300</testTimeout>
+    <forceRecord>false</forceRecord>
+</configuration>
+----
 
-`k6.testClasses`::
-Comma-separated list of test classes to record.
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+-Dk6.testClass=HelloWorldIT
+-Dk6.testClasses=HelloWorldIT,CrudExampleIT
+-Dk6.proxyPort=6000
+-Dk6.appPort=8080
+-Dk6.testWorkDir=.
+-Dk6.outputDir=target/k6/tests
+-Dk6.testTimeout=300
+-Dk6.forceRecord=false
+----
+--
 
-`k6.proxyPort`::
+`testClass`::
+TestBench test class to record. Required unless `testClasses` is specified.
+
+`testClasses`::
+List of test classes to record.
+
+`proxyPort`::
 Port for the recording proxy. Defaults to `6000`.
 
-`k6.appPort`::
+`appPort`::
 Port where the application is running. Defaults to `8080`.
 
-`k6.testWorkDir`::
+`testWorkDir`::
 Working directory for Maven test execution. Defaults to `${project.basedir}`.
 
-`k6.outputDir`::
+`outputDir`::
 Output directory for generated k6 scripts. Defaults to `${project.build.directory}/k6/tests`.
 
-`k6.testTimeout`::
+`testTimeout`::
 Timeout for test execution, in seconds. Defaults to `300`.
 
-`k6.forceRecord`::
+`forceRecord`::
 Force re-recording even if test sources are unchanged. Defaults to `false`.
 
 [[converting]]
@@ -308,19 +388,44 @@ The conversion pipeline:
 
 === Conversion Parameters
 
-`k6.harFile`::
+[.example]
+--
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <harFile>recording.har</harFile>
+    <outputDir>${project.build.directory}/k6/tests</outputDir>
+    <outputName>my-test</outputName>
+    <skipFilter>false</skipFilter>
+    <skipRefactor>false</skipRefactor>
+</configuration>
+----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+-Dk6.harFile=recording.har
+-Dk6.outputDir=target/k6/tests
+-Dk6.outputName=my-test
+-Dk6.skipFilter=false
+-Dk6.skipRefactor=false
+----
+--
+
+`harFile`::
 Path to the HAR file to convert. Required.
 
-`k6.outputDir`::
+`outputDir`::
 Output directory for the k6 script. Defaults to `${project.build.directory}/k6/tests`.
 
-`k6.outputName`::
+`outputName`::
 Output file base name. Defaults to a name derived from the HAR file.
 
-`k6.skipFilter`::
+`skipFilter`::
 Skip filtering external domain requests. Defaults to `false`.
 
-`k6.skipRefactor`::
+`skipRefactor`::
 Skip Vaadin-specific session handling refactoring. Defaults to `false`.
 
 
@@ -407,43 +512,87 @@ k6 run -e APP_IP=192.168.1.100 -e APP_PORT=8080 target/k6/tests/hello-world.js
 
 === Run Parameters
 
-`k6.testFile`::
+[.example]
+--
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <testFile>${project.build.directory}/k6/tests/hello-world.js</testFile>
+    <testFiles>
+        <testFile>hello-world.js</testFile>
+        <testFile>crud-example.js</testFile>
+    </testFiles>
+    <testDir>${project.build.directory}/k6/tests</testDir>
+    <virtualUsers>10</virtualUsers>
+    <duration>30s</duration>
+    <appIp>localhost</appIp>
+    <appPort>8080</appPort>
+    <managementPort>8082</managementPort>
+    <collectVaadinMetrics>false</collectVaadinMetrics>
+    <metricsInterval>10</metricsInterval>
+    <failOnThreshold>true</failOnThreshold>
+    <combineScenarios>false</combineScenarios>
+    <scenarioWeights>helloWorld:70,crudExample:30</scenarioWeights>
+</configuration>
+----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+-Dk6.testFile=target/k6/tests/hello-world.js
+-Dk6.testFiles=hello-world.js,crud-example.js
+-Dk6.testDir=target/k6/tests
+-Dk6.vus=10
+-Dk6.duration=30s
+-Dk6.appIp=localhost
+-Dk6.appPort=8080
+-Dk6.managementPort=8082
+-Dk6.collectVaadinMetrics=false
+-Dk6.metricsInterval=10
+-Dk6.failOnThreshold=true
+-Dk6.combineScenarios=false
+-Dk6.scenarioWeights=helloWorld:70,crudExample:30
+----
+--
+
+`testFile`::
 Single k6 test file to run.
 
-`k6.testFiles`::
+`testFiles`::
 List of k6 test files to run.
 
-`k6.testDir`::
+`testDir`::
 Directory containing k6 test files. All `.js` files in the directory are executed.
 
-`k6.vus`::
+`virtualUsers` (CLI: `k6.vus`)::
 Number of virtual users. Defaults to `10`.
 
-`k6.duration`::
+`duration`::
 Test duration (for example, `30s`, `1m`, `5m`). Defaults to `30s`.
 
-`k6.appIp`::
+`appIp`::
 Target application IP address or hostname. Defaults to `localhost`.
 
-`k6.appPort`::
+`appPort`::
 Target application port. Defaults to `8080`.
 
-`k6.managementPort`::
+`managementPort`::
 Spring Boot Actuator management port for server metrics. Defaults to `8082`.
 
-`k6.collectVaadinMetrics`::
+`collectVaadinMetrics`::
 Enable Vaadin-specific server metrics collection via Actuator. Defaults to `false`.
 
-`k6.metricsInterval`::
+`metricsInterval`::
 Interval for server metrics collection, in seconds. Defaults to `10`.
 
-`k6.failOnThreshold`::
+`failOnThreshold`::
 Fail the Maven build if k6 thresholds are breached. Defaults to `true`.
 
-`k6.combineScenarios`::
+`combineScenarios`::
 Combine multiple test files into parallel scenarios with weighted virtual user distribution. Defaults to `false`.
 
-`k6.scenarioWeights`::
+`scenarioWeights`::
 Weights for combined scenarios (for example, `helloWorld:70,crudExample:30`).
 
 

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -208,17 +208,45 @@ Time to wait for graceful shutdown before force-killing, in seconds. Defaults to
 
 The `loadtest:record` goal runs one or more TestBench test classes through a recording proxy, captures the HTTP traffic, and converts it into k6 scripts:
 
+[.example]
+--
 [source,bash]
 ----
+<source-info group="Command Line"></source-info>
 mvn loadtest:record -Dk6.testClass=HelloWorldIT -Dk6.appPort=8080
 ----
 
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <testClass>HelloWorldIT</testClass>
+    <appPort>8080</appPort>
+</configuration>
+----
+--
+
 To record multiple tests:
 
+[.example]
+--
 [source,bash]
 ----
+<source-info group="Command Line"></source-info>
 mvn loadtest:record -Dk6.testClasses=HelloWorldIT,CrudExampleIT
 ----
+
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <testClasses>
+        <testClass>HelloWorldIT</testClass>
+        <testClass>CrudExampleIT</testClass>
+    </testClasses>
+</configuration>
+----
+--
 
 The plugin uses hash-based caching: if the test source code has not changed since the last recording, the test is skipped. Use `-Dk6.forceRecord=true` to force re-recording.
 
@@ -254,10 +282,22 @@ Force re-recording even if test sources are unchanged. Defaults to `false`.
 
 If you already have a HAR file (for example, recorded with browser developer tools), you can convert it directly into a k6 script without running a TestBench test:
 
+[.example]
+--
 [source,bash]
 ----
+<source-info group="Command Line"></source-info>
 mvn loadtest:convert -Dk6.harFile=recording.har
 ----
+
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <harFile>recording.har</harFile>
+</configuration>
+----
+--
 
 The conversion pipeline:
 
@@ -289,26 +329,70 @@ Skip Vaadin-specific session handling refactoring. Defaults to `false`.
 
 The `loadtest:run` goal executes k6 scripts with configurable virtual users and duration:
 
+[.example]
+--
 [source,bash]
 ----
+<source-info group="Command Line"></source-info>
 mvn loadtest:run -Dk6.testFile=target/k6/tests/hello-world.js -Dk6.vus=50 -Dk6.duration=1m
 ----
 
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <testFile>${project.build.directory}/k6/tests/hello-world.js</testFile>
+    <virtualUsers>50</virtualUsers>
+    <duration>1m</duration>
+</configuration>
+----
+--
+
 To run all scripts in a directory:
 
+[.example]
+--
 [source,bash]
 ----
+<source-info group="Command Line"></source-info>
 mvn loadtest:run -Dk6.testDir=target/k6/tests -Dk6.vus=50 -Dk6.duration=1m
 ----
 
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <testDir>${project.build.directory}/k6/tests</testDir>
+    <virtualUsers>50</virtualUsers>
+    <duration>1m</duration>
+</configuration>
+----
+--
+
 To run against a remote server:
 
+[.example]
+--
 [source,bash]
 ----
+<source-info group="Command Line"></source-info>
 mvn loadtest:run -Dk6.testFile=target/k6/tests/hello-world.js \
     -Dk6.appIp=staging.example.com -Dk6.appPort=8080 \
     -Dk6.vus=100 -Dk6.duration=5m
 ----
+
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <testFile>${project.build.directory}/k6/tests/hello-world.js</testFile>
+    <appIp>staging.example.com</appIp>
+    <appPort>8080</appPort>
+    <virtualUsers>100</virtualUsers>
+    <duration>5m</duration>
+</configuration>
+----
+--
 
 You can also run the generated scripts directly with k6:
 
@@ -367,8 +451,20 @@ Weights for combined scenarios (for example, `helloWorld:70,crudExample:30`).
 
 When running multiple test files, you can combine them into parallel k6 scenarios with weighted virtual user distribution. This simulates realistic traffic where different user workflows happen concurrently:
 
+[.example]
+--
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+mvn loadtest:run -Dk6.testDir=target/k6/tests \
+    -Dk6.vus=100 -Dk6.duration=5m \
+    -Dk6.combineScenarios=true \
+    -Dk6.scenarioWeights=helloWorld:70,crudExample:30
+----
+
 [source,xml]
 ----
+<source-info group="Maven"></source-info>
 <configuration>
     <testDir>${project.build.directory}/k6/tests</testDir>
     <virtualUsers>100</virtualUsers>
@@ -377,6 +473,7 @@ When running multiple test files, you can combine them into parallel k6 scenario
     <scenarioWeights>helloWorld:70,crudExample:30</scenarioWeights>
 </configuration>
 ----
+--
 
 In this example, 70 virtual users execute the `helloWorld` scenario while 30 execute the `crudExample` scenario simultaneously.
 
@@ -450,8 +547,11 @@ The plugin analyzes HAR content to identify user actions (clicks, text input) an
 
 Configure think times in the plugin configuration:
 
+[.example]
+--
 [source,xml]
 ----
+<source-info group="Maven"></source-info>
 <configuration>
     <!-- Enable or disable think times (default: true) -->
     <thinkTimeEnabled>true</thinkTimeEnabled>
@@ -466,16 +566,16 @@ Configure think times in the plugin configuration:
 </configuration>
 ----
 
-Or via command line:
-
 [source,bash]
 ----
+<source-info group="Command Line"></source-info>
 # Disable think times for maximum throughput testing
 mvn loadtest:record -Dk6.thinkTime.enabled=false
 
 # Custom delays
-mvn loadtest:record -Dk6.thinkTime.pageReadDelay=3.0 -Dk6.thinkTime.interactionDelay=1.0
+mvn loadtest:record -Dk6.thinkTime.pageReadDelay=2.0 -Dk6.thinkTime.interactionDelay=0.5
 ----
+--
 
 Disable think times when you want to stress test the server at maximum request rate.
 
@@ -582,8 +682,11 @@ The `loadtest:run` goal can collect server metrics from Actuator during the load
 
 Enable metrics collection via the plugin configuration:
 
+[.example]
+--
 [source,xml]
 ----
+<source-info group="Maven"></source-info>
 <configuration>
     <managementPort>8082</managementPort>
     <collectVaadinMetrics>true</collectVaadinMetrics>
@@ -591,15 +694,15 @@ Enable metrics collection via the plugin configuration:
 </configuration>
 ----
 
-Or via command line:
-
 [source,bash]
 ----
+<source-info group="Command Line"></source-info>
 mvn loadtest:run -Dk6.testDir=target/k6/tests \
     -Dk6.managementPort=8082 \
     -Dk6.collectVaadinMetrics=true \
     -Dk6.metricsInterval=10
 ----
+--
 
 The plugin collects a baseline before the load test starts, then samples metrics at the configured interval. After the test, it reports a time-series table with system metrics (CPU, heap, sessions) and per-view counts, along with summary statistics such as heap delta, session delta, and average/peak CPU usage.
 

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -175,35 +175,6 @@ By default, `loadtest:start-server` runs in the `pre-integration-test` phase and
 
 === Start Server Parameters
 
-[.example]
---
-[source,xml]
-----
-<source-info group="Maven"></source-info>
-<configuration>
-    <serverJar>${project.build.directory}/my-app.jar</serverJar>
-    <serverPort>8080</serverPort>
-    <managementPort>8082</managementPort>
-    <jvmArgs>-Xmx512m</jvmArgs>
-    <appArgs></appArgs>
-    <startupTimeout>120</startupTimeout>
-    <healthPollInterval>2</healthPollInterval>
-</configuration>
-----
-
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
--Dk6.serverJar=target/my-app.jar
--Dk6.serverPort=8080
--Dk6.managementPort=8082
--Dk6.jvmArgs=-Xmx512m
--Dk6.appArgs=
--Dk6.startupTimeout=120
--Dk6.healthPollInterval=2
-----
---
-
 `serverJar`::
 Path to the executable JAR file to start. Required.
 
@@ -225,29 +196,16 @@ Maximum time to wait for server startup, in seconds. Defaults to `120`.
 `healthPollInterval`::
 Interval for polling the health endpoint, in seconds. Defaults to `2`.
 
+[NOTE]
+For CLI the parameters need to be given as `k6.[parameterName]`
 
 === Stop Server Parameters
-
-[.example]
---
-[source,xml]
-----
-<source-info group="Maven"></source-info>
-<configuration>
-    <gracePeriod>10</gracePeriod>
-</configuration>
-----
-
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
--Dk6.gracePeriod=10
-----
---
 
 `gracePeriod`::
 Time to wait for graceful shutdown before force-killing, in seconds. Defaults to `10`.
 
+[NOTE]
+For CLI the parameters need to be given as `k6.[parameterName]`
 
 [[recording]]
 == Recording Tests
@@ -299,40 +257,6 @@ The plugin uses hash-based caching: if the test source code has not changed sinc
 
 === Recording Parameters
 
-[.example]
---
-[source,xml]
-----
-<source-info group="Maven"></source-info>
-<configuration>
-    <testClass>HelloWorldIT</testClass>
-    <testClasses>
-        <testClass>HelloWorldIT</testClass>
-        <testClass>CrudExampleIT</testClass>
-    </testClasses>
-    <proxyPort>6000</proxyPort>
-    <appPort>8080</appPort>
-    <testWorkDir>${project.basedir}</testWorkDir>
-    <outputDir>${project.build.directory}/k6/tests</outputDir>
-    <testTimeout>300</testTimeout>
-    <forceRecord>false</forceRecord>
-</configuration>
-----
-
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
--Dk6.testClass=HelloWorldIT
--Dk6.testClasses=HelloWorldIT,CrudExampleIT
--Dk6.proxyPort=6000
--Dk6.appPort=8080
--Dk6.testWorkDir=.
--Dk6.outputDir=target/k6/tests
--Dk6.testTimeout=300
--Dk6.forceRecord=false
-----
---
-
 `testClass`::
 TestBench test class to record. Required unless `testClasses` is specified.
 
@@ -356,6 +280,9 @@ Timeout for test execution, in seconds. Defaults to `300`.
 
 `forceRecord`::
 Force re-recording even if test sources are unchanged. Defaults to `false`.
+
+[NOTE]
+For CLI the parameters need to be given as `k6.[parameterName]`
 
 [[converting]]
 == Converting HAR Files
@@ -388,31 +315,6 @@ The conversion pipeline:
 
 === Conversion Parameters
 
-[.example]
---
-[source,xml]
-----
-<source-info group="Maven"></source-info>
-<configuration>
-    <harFile>recording.har</harFile>
-    <outputDir>${project.build.directory}/k6/tests</outputDir>
-    <outputName>my-test</outputName>
-    <skipFilter>false</skipFilter>
-    <skipRefactor>false</skipRefactor>
-</configuration>
-----
-
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
--Dk6.harFile=recording.har
--Dk6.outputDir=target/k6/tests
--Dk6.outputName=my-test
--Dk6.skipFilter=false
--Dk6.skipRefactor=false
-----
---
-
 `harFile`::
 Path to the HAR file to convert. Required.
 
@@ -428,6 +330,8 @@ Skip filtering external domain requests. Defaults to `false`.
 `skipRefactor`::
 Skip Vaadin-specific session handling refactoring. Defaults to `false`.
 
+[NOTE]
+For CLI the parameters need to be given as `k6.[parameterName]`
 
 [[running]]
 == Running Load Tests
@@ -512,50 +416,6 @@ k6 run -e APP_IP=192.168.1.100 -e APP_PORT=8080 target/k6/tests/hello-world.js
 
 === Run Parameters
 
-[.example]
---
-[source,xml]
-----
-<source-info group="Maven"></source-info>
-<configuration>
-    <testFile>${project.build.directory}/k6/tests/hello-world.js</testFile>
-    <testFiles>
-        <testFile>hello-world.js</testFile>
-        <testFile>crud-example.js</testFile>
-    </testFiles>
-    <testDir>${project.build.directory}/k6/tests</testDir>
-    <virtualUsers>10</virtualUsers>
-    <duration>30s</duration>
-    <appIp>localhost</appIp>
-    <appPort>8080</appPort>
-    <managementPort>8082</managementPort>
-    <collectVaadinMetrics>false</collectVaadinMetrics>
-    <metricsInterval>10</metricsInterval>
-    <failOnThreshold>true</failOnThreshold>
-    <combineScenarios>false</combineScenarios>
-    <scenarioWeights>helloWorld:70,crudExample:30</scenarioWeights>
-</configuration>
-----
-
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
--Dk6.testFile=target/k6/tests/hello-world.js
--Dk6.testFiles=hello-world.js,crud-example.js
--Dk6.testDir=target/k6/tests
--Dk6.vus=10
--Dk6.duration=30s
--Dk6.appIp=localhost
--Dk6.appPort=8080
--Dk6.managementPort=8082
--Dk6.collectVaadinMetrics=false
--Dk6.metricsInterval=10
--Dk6.failOnThreshold=true
--Dk6.combineScenarios=false
--Dk6.scenarioWeights=helloWorld:70,crudExample:30
-----
---
-
 `testFile`::
 Single k6 test file to run.
 
@@ -594,6 +454,9 @@ Combine multiple test files into parallel scenarios with weighted virtual user d
 
 `scenarioWeights`::
 Weights for combined scenarios (for example, `helloWorld:70,crudExample:30`).
+
+[NOTE]
+For CLI the parameters need to be given as `k6.[parameterName]`
 
 
 === Combined Scenarios

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -351,6 +351,10 @@ The `loadtest:run` goal executes k6 scripts with configurable virtual users and 
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
+<phase>integration-test</phase>
+<goals>
+    <goal>run</goal>
+</goals>
 <configuration>
     <testFile>${project.build.directory}/k6/tests/hello-world.js</testFile>
     <virtualUsers>50</virtualUsers>

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -217,6 +217,10 @@ The `loadtest:record` goal runs one or more TestBench test classes through a rec
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
+<phase>integration-test</phase>
+<goals>
+    <goal>record</goal>
+</goals>
 <configuration>
     <testClass>HelloWorldIT</testClass>
     <appPort>8080</appPort>
@@ -237,6 +241,10 @@ To record multiple tests:
 [source,xml]
 ----
 <source-info group="Maven"></source-info>
+<phase>integration-test</phase>
+<goals>
+    <goal>record</goal>
+</goals>
 <configuration>
     <testClasses>
         <testClass>HelloWorldIT</testClass>


### PR DESCRIPTION
Have maven and commandline examples
in different groups so it is less
confusing why they are shown in different
ways in the document.


