### PR TITLE
fix: sample test working directory

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -663,7 +663,7 @@ Below is a complete example that starts the application server, records two Test
                         </testClasses>
                         <proxyPort>6000</proxyPort>
                         <appPort>${serverPort}</appPort>
-                        <testWorkDir>${project.basedir}/../my-app</testWorkDir>
+                        <testWorkDir>${project.basedir}</testWorkDir>
                     </configuration>
                 </execution>
 


### PR DESCRIPTION
Have test working directory
as project.basedir as the
../my-app referenced the
same project and made the
setting sample confusing.


