### PR TITLE
fix: Add information on scenario naming

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -234,6 +234,11 @@ mvn loadtest:record -Dk6.testClasses=HelloWorldIT,CrudExampleIT
 
 The plugin uses hash-based caching: if the test source code has not changed since the last recording, the test is skipped. Use `-Dk6.forceRecord=true` to force re-recording.
 
+The test class name determines the scenario name used in generated k6 scripts and report output.
+The plugin strips the `IT` suffix and converts the remainder to camelCase: `HelloWorldIT` becomes `helloWorld`, `CrudExampleIT` becomes `crudExample`.
+
+These derived names are what you reference when configuring <<running,combined scenarios>> and `scenarioWeights` (for example, `helloWorld:70,crudExample:30`).
+
 
 === Recording Parameters
 


### PR DESCRIPTION
Add paragraph explaining test name
to scenario name conversion.


