### PR TITLE
feat: add setupProxy method mention

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -95,12 +95,12 @@ The browser driver must be configured to use this proxy.
 Without proxy configuration, the browser connects directly to the server and the plugin cannot capture traffic.
 
 The [classname]`LoadTestItHelper` class (from the `testbench-loadtest-support` dependency) handles proxy driver configuration.
-Its [methodname]`openWithProxy()` method checks whether the `k6.proxy.host` system property is set.
+The [methodname]`setupProxy()` and [methodname]`openWithProxy()` methods checks whether the `k6.proxy.host` system property is set.
 When it is, it replaces the current driver with one configured to route traffic through the recording proxy, including the necessary Chrome flags for MITM proxy support.
 When the property is not set, it navigates the existing driver to the given URL, so the tests run normally.
 
-Open the test page with the [methodname]`openWithProxy()` and set the resulting driver as the test driver.
-The helper method will automatically set up a chromedriver with the proxy and open the view.
+Either start with [methodname]`setupProxy()`, or open the test page with the [methodname]`openWithProxy()`, and set the resulting driver as the test driver.
+The helper method will automatically set up a chromedriver with the proxy and open the view when [methodname]`openWithProxy()` is used.
 
 The [methodname]`getRootURL()` helper builds the server base URL from the `HOSTNAME` environment variable (defaults to `localhost`) and the `server.port` system property (defaults to `8080`):
 
@@ -118,6 +118,12 @@ public class HelloWorldIT {
                 + "/";
         setDriver(LoadTestItHelper.openWithProxy(
                 getDriver(), viewUrl));
+
+        /* or
+         * setDriver(LoadTestItHelper.setupProxy(getDriver()));
+         * // do driver setup before opening page
+         * getDriver().get(viewUrl);
+         */
     }
 
     @Test


### PR DESCRIPTION
Add documentation on the new
setupProxy method that doesn't
automatically navigate to the view.


documents vaadin/testbench#2224