### PR TITLE
Replace broken Claude Code documentation link

### DIFF
--- a/articles/building-apps/mcp/supported-tools/claude-code.adoc
+++ b/articles/building-apps/mcp/supported-tools/claude-code.adoc
@@ -79,5 +79,5 @@ You can verify that the MCP server is connected by checking the status indicator
 
 == Resources
 
-* https://docs.claude.ai/docs/build-with-claude/claude-code[Claude Code Documentation]
+* https://platform.claude.com/docs/en/home[Claude Code Documentation]
 * https://github.com/vaadin/vaadin-mcp[Vaadin MCP Server Repository]


### PR DESCRIPTION
Replace broken Claude Code documentation link here:
https://vaadin.com/docs/latest/building-apps/mcp/supported-tools/claude-code

Broken link: https://docs.claude.ai/docs/build-with-claude/claude-code
New link: https://platform.claude.com/docs/en/home
