### PR TITLE
fix: fix Tomcat AJP configuration example

### DIFF
--- a/articles/flow/production/reverse-proxy.adoc
+++ b/articles/flow/production/reverse-proxy.adoc
@@ -82,7 +82,7 @@ public class TomcatConfig implements WebServerFactoryCustomizer<TomcatServletWeb
         AbstractAjpProtocol<?> ajpProtocol = (AbstractAjpProtocol<?>) ajpConnector.getProtocolHandler();
         ajpProtocol.setSecret(ajpSecret);
         ajpProtocol.setAddress(ajpAddress);
-        factory.addAdditionalTomcatConnectors(ajpConnector);
+        factory.addAdditionalConnectors(ajpConnector);
     }
 }
 ----


### PR DESCRIPTION
Spring Boot 4 introduced some breaking changes in Tomcat configuration classes: classes moved to different packages and methods renamed. This change fixes the example code to fix compilation errors.


