### PR TITLE
fix: Note order of arguments

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -842,6 +842,9 @@ Running `mvn verify` with this configuration executes the full workflow: start s
 [NOTE]
 Name your test classes with the `IT` suffix, not `Test`. Classes ending in `Test` are picked up during the `test` phase, before the server starts. See the Maven https://maven.apache.org/surefire/maven-failsafe-plugin/examples/inclusion-exclusion.html[Failsafe] and https://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html[Surefire] inclusion-exclusion documentation for details on the default naming patterns.
 
+[NOTE]
+Command line arguments have higher priority than pom configuration, so a configuration `<virtualUsers>100</virtualUsers>` and execution with command line `-Dk6.vus=200` the tests will use `200` virtual users.
+
 [[remote-testing]]
 == Remote Load Testing
 


### PR DESCRIPTION
Note the order in which
the argument values are
used. Command line vs pom
configuration.


