### PR TITLE
docs: add JUnit 5 details to load testing page

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -669,6 +669,14 @@ The `testbench-loadtest-support` library enhances your Vaadin application for lo
 
 The <<setup,project setup>> section configures `testbench-loadtest-support`, which makes it available both in test code and at runtime. Only include this dependency in builds used for load testing, as it changes error handling behavior.
 
+The `testbench-loadtest-support` library includes a JUnit 5 extension that is registered via `ServiceLoader`. For it to be detected automatically, your project must enable extension auto-detection by adding the following property to `src/test/resources/junit-platform.properties`:
+
+[source,properties]
+----
+junit.jupiter.extensions.autodetection.enabled=true
+----
+
+This is only required when using JUnit 5. If your project uses a newer version of JUnit or runs with Spring Boot (which registers extensions differently), no additional configuration is needed.
 
 [[error-handler]]
 === Error Visibility
@@ -700,7 +708,6 @@ The following metrics are registered:
 - `vaadin.view.count` (tagged with `view`) -- Number of active instances per view class (for example, `view=MainView`).
 
 If Micrometer is not on the classpath, the helper still tracks UIs internally but does not expose metrics.
-
 
 ==== Enabling Actuator
 


### PR DESCRIPTION
JUnit 5 requires adding junit.jupiter.extensions.autodetection.enabled=true to the project to make testbench-loadtest-support dependency register JUnit extension automatically.


