### PR TITLE
Fix #5079 - min width / height on resizable dialog examples

### DIFF
--- a/frontend/demo/component/dialog/dialog-resizable.ts
+++ b/frontend/demo/component/dialog/dialog-resizable.ts
@@ -31,8 +31,16 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
+      <style>
+        vaadin-dialog.resizable-dialog::part(overlay) {
+          min-height: 300px;
+          min-width: 200px;
+        }
+      </style>
+
       <!-- tag::snippet[] -->
       <vaadin-dialog
+        class="resizable-dialog"
         header-title="Employee list"
         resizable
         draggable

--- a/frontend/demo/component/dialog/react/dialog-resizable.tsx
+++ b/frontend/demo/component/dialog/react/dialog-resizable.tsx
@@ -1,6 +1,7 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React, { useEffect } from 'react';
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
+import { css } from 'lit';
 import { useSignal } from '@vaadin/hilla-react-signals';
 import { Button } from '@vaadin/react-components/Button.js';
 import { Dialog } from '@vaadin/react-components/Dialog.js';
@@ -9,6 +10,14 @@ import { GridColumn } from '@vaadin/react-components/GridColumn.js';
 import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
+
+const styles = css`
+  /* Set smallest allowed size for the dialog */
+  vaadin-dialog.resizable-dialog::part(overlay) {
+    min-height: 300px;
+    min-width: 200px;
+  }
+`;
 
 function Example() {
   useSignals(); // hidden-source-line
@@ -29,6 +38,7 @@ function Example() {
     <>
       {/* tag::snippet[] */}
       <Dialog
+        className="resizable-dialog"
         headerTitle="Employee list"
         resizable
         draggable
@@ -57,4 +67,4 @@ function Example() {
   );
 }
 
-export default reactExample(Example); // hidden-source-line
+export default reactExample(Example, styles); // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/dialog/DialogResizable.java
+++ b/src/main/java/com/vaadin/demo/component/dialog/DialogResizable.java
@@ -26,6 +26,9 @@ public class DialogResizable extends Div {
         dialog.setDraggable(true);
         dialog.setResizable(true);
         // end::snippet[]
+        // Set limits for dialog min size
+        dialog.setMinWidth("200px");
+        dialog.setMinHeight("300px");
 
         Button button = new Button("Show dialog", e -> dialog.open());
         add(dialog, button);


### PR DESCRIPTION
Fixes #5079

Sets min height and width to fit at least the title. 

<img width="627" height="767" alt="image" src="https://github.com/user-attachments/assets/39392709-7f0d-47b9-a8dd-5fab5824dbe2" />
