### PR TITLE
docs: replace tabs with spaces in examples for consistency

### DIFF
--- a/articles/components/form-layout/index.adoc
+++ b/articles/components/form-layout/index.adoc
@@ -330,10 +330,10 @@ formLayout.add(new EmailField("Email address"));
 ----
 <source-info group="React"></source-info>
 <FormLayout>
-	<TextField label="First name" />
-	<TextField label="Last name" />
-	<br/> {/* row break */}
-	<EmailField label="Email address" />
+  <TextField label="First name" />
+  <TextField label="Last name" />
+  <br/> {/* row break */}
+  <EmailField label="Email address" />
 </FormLayout>
 ----
 
@@ -341,7 +341,7 @@ formLayout.add(new EmailField("Email address"));
 ----
 <source-info group="Lit"></source-info>
 <vaadin-form-layout>
-	<vaadin-text-field label="First name"></vaadin-text-field>
+  <vaadin-text-field label="First name"></vaadin-text-field>
   <vaadin-text-field label="Last name"></vaadin-text-field>
   <br/> <!-- row break -->
   <vaadin-email-field label="Email address"></vaadin-email-field>


### PR DESCRIPTION
Replaced tabs with spaces in FormLayout responsive steps code examples.