### PR TITLE
docs: link to thresholds documentation for checksAbortOnFail

### DIFF
--- a/articles/flow/testing/load-testing/response-checks.adoc
+++ b/articles/flow/testing/load-testing/response-checks.adoc
@@ -217,7 +217,7 @@ Add a per-request response time check (complementing the aggregate p95/p99 thres
 ** Checks with scope `UIDL` (or `ALL`) are appended to each UIDL request check block.
 . The generated k6 script includes custom checks alongside the built-in Vaadin checks.
 . When k6 runs, custom checks are evaluated per-request and contribute to the `checks` pass rate metric.
-. If <<{articles}/flow/testing/load-testing/thresholds#_default_threshold_parameters,`checksAbortOnFail`>> is enabled (default: `true`), any failing check -- built-in or custom -- aborts the test.
+. If <<{articles}/flow/testing/load-testing/thresholds#default-threshold-parameters,`checksAbortOnFail`>> is enabled (default: `true`), any failing check -- built-in or custom -- aborts the test.
 
 === Built-in Checks Reference
 

--- a/articles/flow/testing/load-testing/response-checks.adoc
+++ b/articles/flow/testing/load-testing/response-checks.adoc
@@ -217,7 +217,7 @@ Add a per-request response time check (complementing the aggregate p95/p99 thres
 ** Checks with scope `UIDL` (or `ALL`) are appended to each UIDL request check block.
 . The generated k6 script includes custom checks alongside the built-in Vaadin checks.
 . When k6 runs, custom checks are evaluated per-request and contribute to the `checks` pass rate metric.
-. If `checksAbortOnFail` is enabled (default: `true`), any failing check -- built-in or custom -- aborts the test.
+. If <<{articles}/flow/testing/load-testing/thresholds#_default_threshold_parameters,`checksAbortOnFail`>> is enabled (default: `true`), any failing check -- built-in or custom -- aborts the test.
 
 === Built-in Checks Reference
 


### PR DESCRIPTION
Make mentioned `checksAbortOnFail` parameter a link to thresholds page for more details.