### PR TITLE
fix: Make utilities doc and move har

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -419,60 +419,6 @@ Enabling `warmup` issues one full pass of every recorded scenario before the mea
 The numbers in the report then describe the application under sustained load — which is what a load test is meant to measure.
 
 
-=== Understanding k6 Output
-
-After a run, k6 reports metrics:
-
-----
-     scenarios: (100.00%) 1 scenario, 50 max VUs, 1m30s max duration
-
-     ✓ page load status equals 200
-     ✓ vaadin init status equals 200
-     ✓ valid init response
-     ✓ UIDL request succeeded
-     ✓ no server error
-     ✓ no exception
-     ✓ security key valid
-     ✓ valid UIDL response
-
-     http_req_duration..............: avg=45.23ms  min=12.34ms  max=234.56ms
-     http_req_failed................: 0.00%  ✓ 0   ✗ 1234
-     http_reqs......................: 1234   41.13/s
-----
-
-Key metrics:
-
-- *http_req_duration* -- Response time (average, minimum, maximum).
-- *http_req_failed* -- Percentage of failed requests.
-- *http_reqs* -- Total requests and throughput (requests per second).
-
-
-[[html-report]]
-=== HTML Report
-
-After each run, the plugin writes a JSON summary and a self-contained HTML report to a `report/` directory next to the k6 test files:
-
-----
-target/k6/tests/
-├── hello-world.js
-└── report/
-    ├── hello-world-summary.json
-    └── hello-world-summary.html
-----
-
-The HTML file embeds all data inline, so you can open it directly in a browser or share it without any additional files. It includes:
-
-- *Overview cards* -- Duration, max VUs, iterations, HTTP request count and rate, failure rate, and checks pass rate.
-- *Virtual Users timeline* -- VU count over the run, derived from k6's per-second samples.
-- *Response times over time* -- Average and maximum response time (lines) alongside stacked pass/fail request counts per second (bars), with hover tooltips.
-- *Thresholds* -- Pass/fail status for every configured threshold.
-- *Response Times (all requests)* -- Aggregate avg, min, median, max, p(95), and p(99).
-- *Per-Request Response Times* -- Per-endpoint breakdown grouped by scenario, sortable by any column.
-- *Checks* -- Pass and fail counts for each Vaadin response check.
-
-The timeline data comes from k6's CSV output, which the plugin captures during the run and merges into the summary JSON. When running <<running,combined scenarios>>, a single report is generated for the combined run with per-scenario sections in the per-request table.
-
-
 [[think-time]]
 == Realistic User Simulation
 
@@ -646,6 +592,60 @@ mvn loadtest:run -Dk6.collectVaadinMetrics=true
 
 The plugin collects a baseline before the load test starts, then samples metrics at the configured interval. After the test, it reports a time-series table with system metrics (CPU, heap, sessions) and per-view counts, along with summary statistics such as heap delta, session delta, and average/peak CPU usage.
 
+== Results And Tool Output
+
+=== Understanding k6 Output
+
+After a run, k6 reports metrics:
+
+----
+     scenarios: (100.00%) 1 scenario, 50 max VUs, 1m30s max duration
+
+     ✓ page load status equals 200
+     ✓ vaadin init status equals 200
+     ✓ valid init response
+     ✓ UIDL request succeeded
+     ✓ no server error
+     ✓ no exception
+     ✓ security key valid
+     ✓ valid UIDL response
+
+     http_req_duration..............: avg=45.23ms  min=12.34ms  max=234.56ms
+     http_req_failed................: 0.00%  ✓ 0   ✗ 1234
+     http_reqs......................: 1234   41.13/s
+----
+
+Key metrics:
+
+- *http_req_duration* -- Response time (average, minimum, maximum).
+- *http_req_failed* -- Percentage of failed requests.
+- *http_reqs* -- Total requests and throughput (requests per second).
+
+
+[[html-report]]
+=== HTML Report
+
+After each run, the plugin writes a JSON summary and a self-contained HTML report to a `report/` directory next to the k6 test files:
+
+----
+target/k6/tests/
+├── hello-world.js
+└── report/
+    ├── hello-world-summary.json
+    └── hello-world-summary.html
+----
+
+The HTML file embeds all data inline, so you can open it directly in a browser or share it without any additional files. It includes:
+
+- *Overview cards* -- Duration, max VUs, iterations, HTTP request count and rate, failure rate, and checks pass rate.
+- *Virtual Users timeline* -- VU count over the run, derived from k6's per-second samples.
+- *Response times over time* -- Average and maximum response time (lines) alongside stacked pass/fail request counts per second (bars), with hover tooltips.
+- *Thresholds* -- Pass/fail status for every configured threshold.
+- *Response Times (all requests)* -- Aggregate avg, min, median, max, p(95), and p(99).
+- *Per-Request Response Times* -- Per-endpoint breakdown grouped by scenario, sortable by any column.
+- *Checks* -- Pass and fail counts for each Vaadin response check.
+
+The timeline data comes from k6's CSV output, which the plugin captures during the run and merges into the summary JSON. When running <<running,combined scenarios>>, a single report is generated for the combined run with per-scenario sections in the per-request table.
 
 [[converting]]
 == Converting HAR Files

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -135,10 +135,13 @@ public void deletePatient() {
 }
 ----
 
-The `loadtest:record` and `loadtest:run` goals require the application server to be running. The plugin provides `loadtest:start-server` and `loadtest:stop-server` goals to manage the server lifecycle automatically -- see <<utilities#server-lifecycle,Load Testing Utilities>>.
+== Recording And Running Tests
+
+The `loadtest:record` and `loadtest:run` goals require the application server to be running.
+The plugin provides `loadtest:start-server` and `loadtest:stop-server` goals to manage the server lifecycle automatically -- see <<utilities#server-lifecycle,Load Testing Utilities>>.
 
 [[recording]]
-== Recording Tests
+=== Recording Tests
 
 The `loadtest:record` goal runs one or more TestBench test classes through a recording proxy, captures the HTTP traffic, and converts it into k6 scripts:
 
@@ -227,7 +230,7 @@ Force re-recording even if test sources are unchanged. Defaults to `false`.
 For CLI the parameters need to be given as `k6.[parameterName]`
 
 [[running]]
-== Running Load Tests
+=== Running Load Tests
 
 The `loadtest:run` goal executes k6 scripts with configurable virtual users and duration:
 

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -135,7 +135,7 @@ public void deletePatient() {
 }
 ----
 
-== Recording And Running Tests
+== Recording and Running Tests
 
 The `loadtest:record` and `loadtest:run` goals require the application server to be running.
 The plugin provides `loadtest:start-server` and `loadtest:stop-server` goals to manage the server lifecycle automatically -- see <<utilities#server-lifecycle,Load Testing Utilities>>.
@@ -592,7 +592,7 @@ mvn loadtest:run -Dk6.collectVaadinMetrics=true
 
 The plugin collects a baseline before the load test starts, then samples metrics at the configured interval. After the test, it reports a time-series table with system metrics (CPU, heap, sessions) and per-view counts, along with summary statistics such as heap delta, session delta, and average/peak CPU usage.
 
-== Results And Tool Output
+== Results and Tool Output
 
 === Understanding k6 Output
 

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -136,84 +136,7 @@ public void deletePatient() {
 ----
 
 
-[[server-lifecycle]]
-== Starting and Stopping the Server
-
-The `loadtest:record` and `loadtest:run` goals require the application server to be running. You can start and stop the server manually, or let the plugin manage it automatically using the `loadtest:start-server` and `loadtest:stop-server` goals.
-
-The `loadtest:start-server` goal starts a Spring Boot executable JAR, waits for the health endpoint to respond, and stores the process handle in the Maven build context. The `loadtest:stop-server` goal retrieves that handle and shuts the server down gracefully.
-
-[source,xml]
-----
-<groupId>com.vaadin</groupId>
-<artifactId>testbench-converter-plugin</artifactId>
-
-<executions>
-    <execution>
-        <id>start-server</id>
-        <goals>
-            <goal>start-server</goal>
-        </goals>
-        <configuration>
-            <serverJar>${project.build.directory}/my-app.jar</serverJar>
-            <serverPort>8081</serverPort>
-            <managementPort>8082</managementPort>
-        </configuration>
-    </execution>
-
-    <execution>
-        <id>stop-server</id>
-        <goals>
-            <goal>stop-server</goal>
-        </goals>
-    </execution>
-</executions>
-----
-
-By default, `loadtest:start-server` runs in the `pre-integration-test` phase and `loadtest:stop-server` runs in the `post-integration-test` phase, so the server lifecycle wraps around the recording and load test executions.
-
-==== Testing WAR-packaged Applications
-
-The tooling works equally well with WAR-packaged applications, since the load test itself is just HTTP traffic against a running server.
-The only difference from the JAR/Spring Boot workflow is that you are responsible for deploying the WAR to a servlet container (Tomcat, Jetty, WildFly, etc.) before recording -- the plugin can not start the application for you.
-
-Deploy the WAR locally for the `k6:record` step and point the plugin at it via `-Dk6.appPort` (and `-Dserver.host` if not on localhost), then run the generated k6 script against your separate load-test environment using `-Dk6.appIp` and `-Dk6.appPort`.
-
-Keep in mind that WARs are typically deployed under a context path (e.g. `/myapp`), so make sure `getViewName()` in your TestBench tests reflects the deployed path; the recorded HAR -- and therefore the generated k6 script -- will use whatever URLs the browser actually hits during recording.
-
-=== Start Server Parameters
-
-`serverJar`::
-Path to the executable JAR file to start. Required.
-
-`serverPort`::
-Application server port. Defaults to `8080`.
-
-`managementPort`::
-Spring Boot Actuator management port. Defaults to `8082`.
-
-`jvmArgs`::
-Extra JVM arguments (for example, `-Xmx512m`).
-
-`appArgs`::
-Extra application arguments.
-
-`startupTimeout`::
-Maximum time to wait for server startup, in seconds. Defaults to `120`.
-
-`healthPollInterval`::
-Interval for polling the health endpoint, in seconds. Defaults to `2`.
-
-[NOTE]
-For CLI the parameters need to be given as `k6.[parameterName]`
-
-=== Stop Server Parameters
-
-`gracePeriod`::
-Time to wait for graceful shutdown before force-killing, in seconds. Defaults to `10`.
-
-[NOTE]
-For CLI the parameters need to be given as `k6.[parameterName]`
+The `loadtest:record` and `loadtest:run` goals require the application server to be running. The plugin provides `loadtest:start-server` and `loadtest:stop-server` goals to manage the server lifecycle automatically -- see <<utilities#server-lifecycle,Load Testing Utilities>>.
 
 [[recording]]
 == Recording Tests
@@ -301,55 +224,6 @@ Timeout for test execution, in seconds. Defaults to `300`.
 
 `forceRecord`::
 Force re-recording even if test sources are unchanged. Defaults to `false`.
-
-[NOTE]
-For CLI the parameters need to be given as `k6.[parameterName]`
-
-[[converting]]
-== Converting HAR Files
-
-If you already have a HAR file (for example, recorded with browser developer tools), you can convert it directly into a k6 script without running a TestBench test:
-
-[.example]
---
-[source,xml]
-----
-<source-info group="Maven"></source-info>
-<configuration>
-    <harFile>recording.har</harFile>
-</configuration>
-----
-
-[source,bash]
-----
-<source-info group="Command Line"></source-info>
-mvn loadtest:convert -Dk6.harFile=recording.har
-----
---
-
-The conversion pipeline:
-
-. Filters out requests to external domains (analytics, CDN).
-. Generates a k6 script from the HAR entries.
-. Applies Vaadin-specific refactoring (session handling, configurable server address).
-
-
-=== Conversion Parameters
-
-`harFile`::
-Path to the HAR file to convert. Required.
-
-`outputDir`::
-Output directory for the k6 script. Defaults to `${project.build.directory}/k6/tests`.
-
-`outputName`::
-Output file base name. Defaults to a name derived from the HAR file.
-
-`skipFilter`::
-Skip filtering external domain requests. Defaults to `false`.
-
-`skipRefactor`::
-Skip Vaadin-specific session handling refactoring. Defaults to `false`.
 
 [NOTE]
 For CLI the parameters need to be given as `k6.[parameterName]`
@@ -791,6 +665,56 @@ mvn loadtest:run -Dk6.testDir=target/k6/tests \
 --
 
 The plugin collects a baseline before the load test starts, then samples metrics at the configured interval. After the test, it reports a time-series table with system metrics (CPU, heap, sessions) and per-view counts, along with summary statistics such as heap delta, session delta, and average/peak CPU usage.
+
+
+[[converting]]
+== Converting HAR Files
+
+If you already have a HAR file (for example, recorded with browser developer tools), you can convert it directly into a k6 script without running a TestBench test:
+
+[.example]
+--
+[source,xml]
+----
+<source-info group="Maven"></source-info>
+<configuration>
+    <harFile>recording.har</harFile>
+</configuration>
+----
+
+[source,bash]
+----
+<source-info group="Command Line"></source-info>
+mvn loadtest:convert -Dk6.harFile=recording.har
+----
+--
+
+The conversion pipeline:
+
+. Filters out requests to external domains (analytics, CDN).
+. Generates a k6 script from the HAR entries.
+. Applies Vaadin-specific refactoring (session handling, configurable server address).
+
+
+=== Conversion Parameters
+
+`harFile`::
+Path to the HAR file to convert. Required.
+
+`outputDir`::
+Output directory for the k6 script. Defaults to `${project.build.directory}/k6/tests`.
+
+`outputName`::
+Output file base name. Defaults to a name derived from the HAR file.
+
+`skipFilter`::
+Skip filtering external domain requests. Defaults to `false`.
+
+`skipRefactor`::
+Skip Vaadin-specific session handling refactoring. Defaults to `false`.
+
+[NOTE]
+For CLI the parameters need to be given as `k6.[parameterName]`
 
 
 [[full-example]]

--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -418,6 +418,61 @@ Worst case, those early outliers dominate the maximum, p(95), and p(99) figures 
 Enabling `warmup` issues one full pass of every recorded scenario before the measured run starts, so JIT, caches, and class loaders are primed when the virtual users ramp up.
 The numbers in the report then describe the application under sustained load — which is what a load test is meant to measure.
 
+== Results and Tool Output
+
+=== Understanding k6 Output
+
+After a run, k6 reports metrics:
+
+----
+     scenarios: (100.00%) 1 scenario, 50 max VUs, 1m30s max duration
+
+     ✓ page load status equals 200
+     ✓ vaadin init status equals 200
+     ✓ valid init response
+     ✓ UIDL request succeeded
+     ✓ no server error
+     ✓ no exception
+     ✓ security key valid
+     ✓ valid UIDL response
+
+     http_req_duration..............: avg=45.23ms  min=12.34ms  max=234.56ms
+     http_req_failed................: 0.00%  ✓ 0   ✗ 1234
+     http_reqs......................: 1234   41.13/s
+----
+
+Key metrics:
+
+- *http_req_duration* -- Response time (average, minimum, maximum).
+- *http_req_failed* -- Percentage of failed requests.
+- *http_reqs* -- Total requests and throughput (requests per second).
+
+
+[[html-report]]
+=== HTML Report
+
+After each run, the plugin writes a JSON summary and a self-contained HTML report to a `report/` directory next to the k6 test files:
+
+----
+target/k6/tests/
+├── hello-world.js
+└── report/
+    ├── hello-world-summary.json
+    └── hello-world-summary.html
+----
+
+The HTML file embeds all data inline, so you can open it directly in a browser or share it without any additional files. It includes:
+
+- *Overview cards* -- Duration, max VUs, iterations, HTTP request count and rate, failure rate, and checks pass rate.
+- *Virtual Users timeline* -- VU count over the run, derived from k6's per-second samples.
+- *Response times over time* -- Average and maximum response time (lines) alongside stacked pass/fail request counts per second (bars), with hover tooltips.
+- *Thresholds* -- Pass/fail status for every configured threshold.
+- *Response Times (all requests)* -- Aggregate avg, min, median, max, p(95), and p(99).
+- *Per-Request Response Times* -- Per-endpoint breakdown grouped by scenario, sortable by any column.
+- *Checks* -- Pass and fail counts for each Vaadin response check.
+
+The timeline data comes from k6's CSV output, which the plugin captures during the run and merges into the summary JSON. When running <<running,combined scenarios>>, a single report is generated for the combined run with per-scenario sections in the per-request table.
+
 
 [[think-time]]
 == Realistic User Simulation
@@ -591,61 +646,6 @@ mvn loadtest:run -Dk6.collectVaadinMetrics=true
 --
 
 The plugin collects a baseline before the load test starts, then samples metrics at the configured interval. After the test, it reports a time-series table with system metrics (CPU, heap, sessions) and per-view counts, along with summary statistics such as heap delta, session delta, and average/peak CPU usage.
-
-== Results and Tool Output
-
-=== Understanding k6 Output
-
-After a run, k6 reports metrics:
-
-----
-     scenarios: (100.00%) 1 scenario, 50 max VUs, 1m30s max duration
-
-     ✓ page load status equals 200
-     ✓ vaadin init status equals 200
-     ✓ valid init response
-     ✓ UIDL request succeeded
-     ✓ no server error
-     ✓ no exception
-     ✓ security key valid
-     ✓ valid UIDL response
-
-     http_req_duration..............: avg=45.23ms  min=12.34ms  max=234.56ms
-     http_req_failed................: 0.00%  ✓ 0   ✗ 1234
-     http_reqs......................: 1234   41.13/s
-----
-
-Key metrics:
-
-- *http_req_duration* -- Response time (average, minimum, maximum).
-- *http_req_failed* -- Percentage of failed requests.
-- *http_reqs* -- Total requests and throughput (requests per second).
-
-
-[[html-report]]
-=== HTML Report
-
-After each run, the plugin writes a JSON summary and a self-contained HTML report to a `report/` directory next to the k6 test files:
-
-----
-target/k6/tests/
-├── hello-world.js
-└── report/
-    ├── hello-world-summary.json
-    └── hello-world-summary.html
-----
-
-The HTML file embeds all data inline, so you can open it directly in a browser or share it without any additional files. It includes:
-
-- *Overview cards* -- Duration, max VUs, iterations, HTTP request count and rate, failure rate, and checks pass rate.
-- *Virtual Users timeline* -- VU count over the run, derived from k6's per-second samples.
-- *Response times over time* -- Average and maximum response time (lines) alongside stacked pass/fail request counts per second (bars), with hover tooltips.
-- *Thresholds* -- Pass/fail status for every configured threshold.
-- *Response Times (all requests)* -- Aggregate avg, min, median, max, p(95), and p(99).
-- *Per-Request Response Times* -- Per-endpoint breakdown grouped by scenario, sortable by any column.
-- *Checks* -- Pass and fail counts for each Vaadin response check.
-
-The timeline data comes from k6's CSV output, which the plugin captures during the run and merges into the summary JSON. When running <<running,combined scenarios>>, a single report is generated for the combined run with per-scenario sections in the per-request table.
 
 [[converting]]
 == Converting HAR Files

--- a/articles/flow/testing/load-testing/utilities.adoc
+++ b/articles/flow/testing/load-testing/utilities.adoc
@@ -1,0 +1,92 @@
+---
+title: Load Testing Utilities
+page-title: Load Testing Utility Goals
+description: Utility Maven goals for managing the application server during load tests.
+meta-description: Use the loadtest:start-server and loadtest:stop-server goals to manage the application server during Vaadin load tests.
+order: 140
+version: since:com.vaadin:vaadin@V25.2
+---
+
+= [since:com.vaadin:vaadin@V25.2]#Load Testing Utilities#
+
+[[server-lifecycle]]
+== Starting and Stopping the Server
+
+The `loadtest:record` and `loadtest:run` goals require the application server to be running. You can start and stop the server manually, or let the plugin manage it automatically using the `loadtest:start-server` and `loadtest:stop-server` goals.
+
+The `loadtest:start-server` goal starts a Spring Boot executable JAR, waits for the health endpoint to respond, and stores the process handle in the Maven build context. The `loadtest:stop-server` goal retrieves that handle and shuts the server down gracefully.
+
+[source,xml]
+----
+<groupId>com.vaadin</groupId>
+<artifactId>testbench-converter-plugin</artifactId>
+
+<executions>
+    <execution>
+        <id>start-server</id>
+        <goals>
+            <goal>start-server</goal>
+        </goals>
+        <configuration>
+            <serverJar>${project.build.directory}/my-app.jar</serverJar>
+            <serverPort>8081</serverPort>
+            <managementPort>8082</managementPort>
+        </configuration>
+    </execution>
+
+    <execution>
+        <id>stop-server</id>
+        <goals>
+            <goal>stop-server</goal>
+        </goals>
+    </execution>
+</executions>
+----
+
+By default, `loadtest:start-server` runs in the `pre-integration-test` phase and `loadtest:stop-server` runs in the `post-integration-test` phase, so the server lifecycle wraps around the recording and load test executions.
+
+=== Testing WAR-packaged Applications
+
+The tooling works equally well with WAR-packaged applications, since the load test itself is just HTTP traffic against a running server.
+The only difference from the JAR/Spring Boot workflow is that you are responsible for deploying the WAR to a servlet container (Tomcat, Jetty, WildFly, etc.) before recording -- the plugin can not start the application for you.
+
+Deploy the WAR locally for the `k6:record` step and point the plugin at it via `-Dk6.appPort` (and `-Dserver.host` if not on localhost), then run the generated k6 script against your separate load-test environment using `-Dk6.appIp` and `-Dk6.appPort`.
+
+Keep in mind that WARs are typically deployed under a context path (e.g. `/myapp`), so make sure `getViewName()` in your TestBench tests reflects the deployed path; the recorded HAR -- and therefore the generated k6 script -- will use whatever URLs the browser actually hits during recording.
+
+=== Start Server Parameters
+
+`serverJar`::
+Path to the executable JAR file to start. Required.
+
+`serverPort`::
+Spring Boot application server port. Required unless `httpPort` (Jetty) is set.
+
+`httpPort`::
+Jetty HTTP port. Required unless `serverPort` (Spring Boot) is set.
+
+`managementPort`::
+Spring Boot Actuator management port. Optional -- when set, `/actuator/health` is polled for readiness in addition to the application root.
+
+`jvmArgs`::
+Extra JVM arguments (for example, `-Xmx512m`).
+
+`appArgs`::
+Extra application arguments.
+
+`startupTimeout`::
+Maximum time to wait for server startup, in seconds. Defaults to `120`.
+
+`healthPollInterval`::
+Interval for polling the health endpoint, in seconds. Defaults to `2`.
+
+[NOTE]
+For CLI the parameters need to be given as `k6.[parameterName]`
+
+=== Stop Server Parameters
+
+`gracePeriod`::
+Time to wait for graceful shutdown before force-killing, in seconds. Defaults to `10`.
+
+[NOTE]
+For CLI the parameters need to be given as `k6.[parameterName]`

--- a/articles/flow/testing/load-testing/utilities.adoc
+++ b/articles/flow/testing/load-testing/utilities.adoc
@@ -50,7 +50,7 @@ By default, `loadtest:start-server` runs in the `pre-integration-test` phase and
 The tooling works equally well with WAR-packaged applications, since the load test itself is just HTTP traffic against a running server.
 The only difference from the JAR/Spring Boot workflow is that you are responsible for deploying the WAR to a servlet container (Tomcat, Jetty, WildFly, etc.) before recording -- the plugin can not start the application for you.
 
-Deploy the WAR locally for the `k6:record` step and point the plugin at it via `-Dk6.appPort` (and `-Dserver.host` if not on localhost), then run the generated k6 script against your separate load-test environment using `-Dk6.appIp` and `-Dk6.appPort`.
+Deploy the WAR locally for the `loadtest:record` step and point the plugin at it via `-Dk6.appPort` (and `-Dserver.host` if not on localhost), then run the generated k6 script against your separate load-test environment using `-Dk6.appIp` and `-Dk6.appPort`.
 
 Keep in mind that WARs are typically deployed under a context path (e.g. `/myapp`), so make sure `getViewName()` in your TestBench tests reflects the deployed path; the recorded HAR -- and therefore the generated k6 script -- will use whatever URLs the browser actually hits during recording.
 

--- a/articles/flow/testing/load-testing/utilities.adoc
+++ b/articles/flow/testing/load-testing/utilities.adoc
@@ -80,9 +80,6 @@ Maximum time to wait for server startup, in seconds. Defaults to `120`.
 `healthPollInterval`::
 Interval for polling the health endpoint, in seconds. Defaults to `2`.
 
-[NOTE]
-For CLI the parameters need to be given as `k6.[parameterName]`
-
 === Stop Server Parameters
 
 `gracePeriod`::


### PR DESCRIPTION
Make a utilities document for
the start and stop server goals.

Move the HAR conversion info
down in the documentation.


