### PR TITLE
docs: extract hierarchical data provider examples to source files

### DIFF
--- a/articles/components/tree-grid/data-binding.adoc
+++ b/articles/components/tree-grid/data-binding.adoc
@@ -333,45 +333,7 @@ Below is an example of a simple in-memory data provider using the nested hierarc
 [source,java]
 .FolderDataProvider.java
 ----
-public class FolderDataProvider extends AbstractHierarchicalDataProvider<Folder, Void> {
-    public FolderTreeData folderTreeData = new FolderTreeData();
-
-    @Override
-    public boolean isInMemory() {
-        // Indicate that this data provider uses an in-memory data source.
-        return true;
-    }
-
-    @Override
-    public HierarchyFormat getHierarchyFormat() {
-        // Indicate that this data provider uses the nested hierarchy format.
-        // This is also the default value, so this method can be omitted.
-        return HierarchyFormat.NESTED;
-    }
-
-    @Override
-    public boolean hasChildren(Folder folder) {
-        // Return whether the given folder has child folders.
-        return folderTreeData.getChildren(folder).size() > 0;
-    }
-
-    @Override
-    public Stream<Folder> fetchChildren(HierarchicalQuery<Folder, Void> query) {
-        // Return the direct children of the requested parent folder.
-        // The query object also includes parameters for sorting and filtering,
-        // which can be applied here if needed.
-        return folderTreeData.getChildren(query.getParent()).stream()
-                .skip(query.getOffset()).limit(query.getLimit());
-    }
-
-    @Override
-    public int getChildCount(HierarchicalQuery<Folder, Void> query) {
-        // Return the number of direct children of the requested parent folder.
-        // The query object also includes parameters for filtering, which can
-        // be applied here if needed.
-        return folderTreeData.getChildren(query.getParent()).size();
-    }
-}
+include::{root}/src/main/java/com/vaadin/demo/component/treegrid/databinding/nested/FolderDataProvider.java[tags=body,indent=0]
 ----
 
 [source,java]
@@ -428,71 +390,7 @@ Below is an example of a simple in-memory data provider using the flattened hier
 [source,java]
 .FolderDataProvider.java
 ----
-public class FolderDataProvider extends AbstractHierarchicalDataProvider<Folder, Void> {
-    public FolderTreeData folderTreeData = new FolderTreeData();
-
-    @Override
-    public boolean isInMemory() {
-        // Indicate that this data provider uses an in-memory data source.
-        return true;
-    }
-
-    @Override
-    public HierarchyFormat getHierarchyFormat() {
-        // Indicate that this data provider uses the flattened hierarchy format.
-        return HierarchyFormat.FLATTENED;
-    }
-
-    @Override
-    public boolean hasChildren(Folder folder) {
-        // Return whether the given folder has child folders.
-        return folderTreeData.getChildren(folder).size() > 0;
-    }
-
-    @Override
-    public Stream<Folder> fetchChildren(HierarchicalQuery<Folder, Void> query) {
-        // Return the flattened sub-tree of the requested parent folder based on
-        // the expanded folders.
-        return flatten(query.getParent(), query.getExpandedItemIds())
-                .skip(query.getOffset()).limit(query.getLimit());
-    }
-
-    @Override
-    public int getChildCount(HierarchicalQuery<Folder, Void> query) {
-        // Return the size of the flattened sub-tree of the requested parent
-        // folder based on the expanded folders.
-        return (int) flatten(query.getParent(), query.getExpandedItemIds())
-                .count();
-    }
-
-    @Override
-    public int getDepth(Folder folder) {
-        // Return the depth of the given folder in the hierarchy for Tree Grid
-        // to apply the correct indentation.
-        int depth = 0;
-        while ((folder = folderTreeData.getParent(folder)) != null) {
-            depth++;
-        }
-        return depth;
-    }
-
-    private Stream<Folder> flatten(Folder parent,
-            Set<Object> expandedFolderIds) {
-        // Build the parent folder's sub-tree based on the provided expanded
-        // folders. The result is a flat stream of folders in depth-first order.
-        // Filtering and sorting can also be applied here if needed. Keep in
-        // mind that sorting must be applied to each hierarchy level separately
-        // to preserve depth-first order in the final flat list.
-        return folderTreeData.getChildren(parent).stream().flatMap(child -> {
-            if (expandedFolderIds.contains(getId(child))) {
-                return Stream.concat(Stream.of(child),
-                        flatten(child, expandedFolderIds));
-            } else {
-                return Stream.of(child);
-            }
-        });
-    }
-}
+include::{root}/src/main/java/com/vaadin/demo/component/treegrid/databinding/flattened/FolderDataProvider.java[tags=body,indent=0]
 ----
 
 [source,java]

--- a/src/main/java/com/vaadin/demo/component/treegrid/databinding/filter/FolderDataProvider.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/databinding/filter/FolderDataProvider.java
@@ -49,17 +49,25 @@ public class FolderDataProvider
     public Stream<Folder> fetchChildren(
             HierarchicalQuery<Folder, String> query) {
         // @formatter:off hidden-source-line
-        return flatten(query.getParent(), query.getExpandedItemIds(), query.getFilter())
-                .stream()
-                .skip(query.getOffset())
-                .limit(query.getLimit());
+        List<Folder> result = flatten(
+                query.getParent(),
+                query.getExpandedItemIds(),
+                query.getFilter());
         // @formatter:on hidden-source-line
+
+        return result.stream().skip(query.getOffset()).limit(query.getLimit());
     }
 
     @Override
     public int getChildCount(HierarchicalQuery<Folder, String> query) {
-        return flatten(query.getParent(), query.getExpandedItemIds(),
-                query.getFilter()).size();
+        // @formatter:off hidden-source-line
+        List<Folder> result = flatten(
+                query.getParent(),
+                query.getExpandedItemIds(),
+                query.getFilter());
+        // @formatter:on hidden-source-line
+
+        return result.size();
     }
 
     private List<Folder> flatten(Folder parent, Set<Object> expandedFolderIds,

--- a/src/main/java/com/vaadin/demo/component/treegrid/databinding/filter/FolderView.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/databinding/filter/FolderView.java
@@ -1,6 +1,5 @@
 package com.vaadin.demo.component.treegrid.databinding.filter;
 
-import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.component.treegrid.databinding.Folder;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
@@ -8,9 +7,9 @@ import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalConfigurableFilterDataProvider;
 import com.vaadin.flow.data.value.ValueChangeMode;
 
+// tag::body[]
 public class FolderView extends VerticalLayout {
     public FolderView() {
-        // tag::body[]
         TreeGrid<Folder> treeGrid = new TreeGrid<>();
         treeGrid.addHierarchyColumn(Folder::name).setHeader("Folder");
 
@@ -29,9 +28,6 @@ public class FolderView extends VerticalLayout {
                 event -> folderDataProvider.setFilter(event.getValue()));
 
         add(searchInput, treeGrid);
-        // end::body[]
     }
-
-    public static class Exporter extends DemoExporter<FolderView> { // hidden-source-line
-    } // hidden-source-line
 }
+// end::body[]

--- a/src/main/java/com/vaadin/demo/component/treegrid/databinding/flattened/FolderDataProvider.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/databinding/flattened/FolderDataProvider.java
@@ -45,7 +45,8 @@ public class FolderDataProvider
      */
     @Override
     public Stream<Folder> fetchChildren(HierarchicalQuery<Folder, Void> query) {
-        List<Folder> result = flatten(query.getParent(), query.getExpandedItemIds());
+        List<Folder> result = flatten(query.getParent(),
+                query.getExpandedItemIds());
 
         return result.stream().skip(query.getOffset()).limit(query.getLimit());
     }
@@ -56,7 +57,8 @@ public class FolderDataProvider
      */
     @Override
     public int getChildCount(HierarchicalQuery<Folder, Void> query) {
-        List<Folder> result = flatten(query.getParent(), query.getExpandedItemIds());
+        List<Folder> result = flatten(query.getParent(),
+                query.getExpandedItemIds());
 
         return result.size();
     }

--- a/src/main/java/com/vaadin/demo/component/treegrid/databinding/flattened/FolderDataProvider.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/databinding/flattened/FolderDataProvider.java
@@ -1,0 +1,97 @@
+package com.vaadin.demo.component.treegrid.databinding.flattened;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import com.vaadin.demo.component.treegrid.databinding.Folder;
+import com.vaadin.demo.component.treegrid.databinding.FolderTreeData;
+import com.vaadin.flow.data.provider.hierarchy.AbstractHierarchicalDataProvider;
+import com.vaadin.flow.data.provider.hierarchy.HierarchicalQuery;
+
+// tag::body[]
+public class FolderDataProvider
+        extends AbstractHierarchicalDataProvider<Folder, Void> {
+    private FolderTreeData folderTreeData = new FolderTreeData();
+
+    /**
+     * Indicates that this data provider uses an in-memory data source.
+     */
+    @Override
+    public boolean isInMemory() {
+        return true;
+    }
+
+    /**
+     * Indicates that this data provider uses the flattened hierarchy format.
+     */
+    @Override
+    public HierarchyFormat getHierarchyFormat() {
+        return HierarchyFormat.FLATTENED;
+    }
+
+    /**
+     * Returns whether the given folder has child folders.
+     */
+    @Override
+    public boolean hasChildren(Folder folder) {
+        return folderTreeData.getChildren(folder).size() > 0;
+    }
+
+    /**
+     * Returns the flattened sub-tree of the requested parent folder based on
+     * the expanded folders.
+     */
+    @Override
+    public Stream<Folder> fetchChildren(HierarchicalQuery<Folder, Void> query) {
+        List<Folder> result = flatten(query.getParent(), query.getExpandedItemIds());
+
+        return result.stream().skip(query.getOffset()).limit(query.getLimit());
+    }
+
+    /**
+     * Returns the size of the flattened sub-tree of the requested parent folder
+     * based on the expanded folders.
+     */
+    @Override
+    public int getChildCount(HierarchicalQuery<Folder, Void> query) {
+        List<Folder> result = flatten(query.getParent(), query.getExpandedItemIds());
+
+        return result.size();
+    }
+
+    /**
+     * Returns the depth of the given folder in the hierarchy for Tree Grid to
+     * apply the correct indentation.
+     */
+    @Override
+    public int getDepth(Folder folder) {
+        int depth = 0;
+        while ((folder = folderTreeData.getParent(folder)) != null) {
+            depth++;
+        }
+        return depth;
+    }
+
+    /**
+     * Builds the parent folder's sub-tree based on the provided expanded
+     * folders. The result is a flat list of folders in depth-first order.
+     */
+    private List<Folder> flatten(Folder parent, Set<Object> expandedFolderIds) {
+        List<Folder> result = new ArrayList<>();
+        List<Folder> children = folderTreeData.getChildren(parent);
+
+        for (Folder child : children) {
+            result.add(child);
+
+            var isExpanded = expandedFolderIds.contains(getId(child));
+            if (isExpanded) {
+                result.addAll(flatten(child, expandedFolderIds));
+            }
+        }
+
+        return result;
+    }
+}
+// end::body[]

--- a/src/main/java/com/vaadin/demo/component/treegrid/databinding/nested/FolderDataProvider.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/databinding/nested/FolderDataProvider.java
@@ -47,7 +47,8 @@ public class FolderDataProvider
     public Stream<Folder> fetchChildren(HierarchicalQuery<Folder, Void> query) {
         List<Folder> children = folderTreeData.getChildren(query.getParent());
 
-        return children.stream().skip(query.getOffset()).limit(query.getLimit());
+        return children.stream().skip(query.getOffset())
+                .limit(query.getLimit());
     }
 
     /**

--- a/src/main/java/com/vaadin/demo/component/treegrid/databinding/nested/FolderDataProvider.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/databinding/nested/FolderDataProvider.java
@@ -1,0 +1,65 @@
+package com.vaadin.demo.component.treegrid.databinding.nested;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.vaadin.demo.component.treegrid.databinding.Folder;
+import com.vaadin.demo.component.treegrid.databinding.FolderTreeData;
+import com.vaadin.flow.data.provider.hierarchy.AbstractHierarchicalDataProvider;
+import com.vaadin.flow.data.provider.hierarchy.HierarchicalQuery;
+
+// tag::body[]
+public class FolderDataProvider
+        extends AbstractHierarchicalDataProvider<Folder, Void> {
+    private FolderTreeData folderTreeData = new FolderTreeData();
+
+    /**
+     * Indicates that this data provider uses an in-memory data source.
+     */
+    @Override
+    public boolean isInMemory() {
+        return true;
+    }
+
+    /**
+     * Indicates that this data provider uses the nested hierarchy format. This
+     * is also the default value, so this method override can be omitted.
+     */
+    @Override
+    public HierarchyFormat getHierarchyFormat() {
+        return HierarchyFormat.NESTED;
+    }
+
+    /**
+     * Returns whether the given folder has child folders.
+     */
+    @Override
+    public boolean hasChildren(Folder folder) {
+        return folderTreeData.getChildren(folder).size() > 0;
+    }
+
+    /**
+     * Returns the direct children of the requested parent folder. The query
+     * object also includes parameters for sorting and filtering, which can be
+     * applied here if needed.
+     */
+    @Override
+    public Stream<Folder> fetchChildren(HierarchicalQuery<Folder, Void> query) {
+        List<Folder> children = folderTreeData.getChildren(query.getParent());
+
+        return children.stream().skip(query.getOffset()).limit(query.getLimit());
+    }
+
+    /**
+     * Returns the number of direct children of the requested parent folder. The
+     * query object also includes parameters for filtering, which can be applied
+     * here if needed.
+     */
+    @Override
+    public int getChildCount(HierarchicalQuery<Folder, Void> query) {
+        List<Folder> children = folderTreeData.getChildren(query.getParent());
+
+        return children.size();
+    }
+}
+// end::body[]

--- a/src/main/java/com/vaadin/demo/component/treegrid/databinding/sort/FolderDataProvider.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/databinding/sort/FolderDataProvider.java
@@ -49,19 +49,27 @@ public class FolderDataProvider
     @Override
     public Stream<Folder> fetchChildren(HierarchicalQuery<Folder, Void> query) {
         // @formatter:off hidden-source-line
-        return flatten(query.getParent(), query.getExpandedItemIds(), query.getSortOrders())
-                .stream()
-                .skip(query.getOffset())
-                .limit(query.getLimit());
+        List<Folder> result = flatten(
+                query.getParent(),
+                query.getExpandedItemIds(),
+                query.getSortOrders());
         // @formatter:on hidden-source-line
+
+        return result.stream().skip(query.getOffset()).limit(query.getLimit());
     }
 
     @Override
     public int getChildCount(HierarchicalQuery<Folder, Void> query) {
-        // Sorting doesn't affect the count, so pass null as sortOrders
-        // to skip it
-        return flatten(query.getParent(), query.getExpandedItemIds(), null)
-                .size();
+        // @formatter:off hidden-source-line
+        List<Folder> result = flatten(
+                query.getParent(),
+                query.getExpandedItemIds(),
+                // Sorting doesn't affect the count, so pass null as sortOrders
+                // to skip it
+                null);
+        // @formatter:on hidden-source-line
+
+        return result.size();
     }
 
     private List<Folder> flatten(Folder parent, Set<Object> expandedFolderIds,

--- a/src/main/java/com/vaadin/demo/component/treegrid/databinding/sort/FolderView.java
+++ b/src/main/java/com/vaadin/demo/component/treegrid/databinding/sort/FolderView.java
@@ -1,21 +1,19 @@
 package com.vaadin.demo.component.treegrid.databinding.sort;
 
-import com.vaadin.demo.DemoExporter; // hidden-source-line
 import com.vaadin.demo.component.treegrid.databinding.Folder;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 
+// tag::body[]
 public class FolderView extends VerticalLayout {
     public FolderView() {
-        // tag::body[]
         TreeGrid<Folder> treeGrid = new TreeGrid<>();
         treeGrid.addHierarchyColumn(Folder::name).setHeader("Folder")
                 .setKey("name").setSortable(true);
-        treeGrid.setDataProvider(new FolderDataProvider());
-        add(treeGrid);
-        // end::body[]
-    }
 
-    public static class Exporter extends DemoExporter<FolderView> { // hidden-source-line
-    } // hidden-source-line
+        treeGrid.setDataProvider(new FolderDataProvider());
+
+        add(treeGrid);
+    }
 }
+// end::body[]


### PR DESCRIPTION
Move inline nested and flattened FolderDataProvider examples from data-binding.adoc into compilable source files. Align filter and sort variants with same formatting.

Related to https://github.com/vaadin/flow-components/issues/1886


