### PR TITLE
docs: document accessibleDisabledMenuItems feature flag

### DIFF
--- a/articles/components/context-menu/index.adoc
+++ b/articles/components/context-menu/index.adoc
@@ -189,7 +189,7 @@ endif::[]
 
 See the <<../tooltip#,Tooltips documentation page>> for details on tooltip configuration.
 
-Tooltips are especially useful on disabled menu items to explain why an action is unavailable, but they are not shown by default. See <<#disabled-menu-items,Disabled Menu Items>> for how to enable them.
+Tooltips are also useful on disabled menu items to explain why an action is unavailable, but they are not shown by default. See <<#disabled-menu-items,Disabled Menu Items>> for how to enable them.
 
 
 == Custom Items

--- a/articles/components/context-menu/index.adoc
+++ b/articles/components/context-menu/index.adoc
@@ -189,6 +189,8 @@ endif::[]
 
 See the <<../tooltip#,Tooltips documentation page>> for details on tooltip configuration.
 
+Tooltips are especially useful on disabled menu items to explain why an action is unavailable, but they are not shown by default. See <<#disabled-menu-items,Disabled Menu Items>> for how to enable them.
+
 
 == Custom Items
 
@@ -308,6 +310,25 @@ ifdef::react[]
 include::{root}/frontend/demo/component/contextmenu/react/context-menu-disabled.tsx[render,tags=snippet,indent=0,group=React]
 ----
 endif::[]
+--
+
+By default, disabled menu items aren't focusable or hoverable, which hides them from assistive technologies and prevents Tooltips on disabled items from showing. Enable the `accessibleDisabledMenuItems` feature flag to make them focusable and hoverable without allowing them to be triggered:
+
+[.example]
+--
+.`Flow`
+[source,properties]
+----
+# Add this line to src/main/resources/vaadin-featureflags.properties
+com.vaadin.experimental.accessibleDisabledMenuItems=true
+----
+
+.`Lit & React`
+[source,js]
+----
+// Set before any menu is added to the DOM
+window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+----
 --
 
 

--- a/articles/components/context-menu/index.adoc
+++ b/articles/components/context-menu/index.adoc
@@ -312,7 +312,7 @@ include::{root}/frontend/demo/component/contextmenu/react/context-menu-disabled.
 endif::[]
 --
 
-By default, disabled menu items aren't focusable or hoverable, which hides them from assistive technologies and prevents Tooltips on disabled items from showing. The `accessibleDisabledMenuItems` feature flag can be enabled to make them focusable and hoverable without allowing them to be triggered:
+By default, disabled menu items aren't focusable or hoverable, which hides them from assistive technologies and prevents Tooltips on disabled items from showing. The [since:com.vaadin:vaadin@V25.2]#`accessibleDisabledMenuItems`# feature flag can be enabled to make them focusable and hoverable without allowing them to be triggered:
 
 [.example]
 --

--- a/articles/components/context-menu/index.adoc
+++ b/articles/components/context-menu/index.adoc
@@ -312,7 +312,7 @@ include::{root}/frontend/demo/component/contextmenu/react/context-menu-disabled.
 endif::[]
 --
 
-By default, disabled menu items aren't focusable or hoverable, which hides them from assistive technologies and prevents Tooltips on disabled items from showing. Enable the `accessibleDisabledMenuItems` feature flag to make them focusable and hoverable without allowing them to be triggered:
+By default, disabled menu items aren't focusable or hoverable, which hides them from assistive technologies and prevents Tooltips on disabled items from showing. The `accessibleDisabledMenuItems` feature flag can be enabled to make them focusable and hoverable without allowing them to be triggered:
 
 [.example]
 --

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -184,7 +184,7 @@ include::{root}/frontend/demo/component/menubar/react/menu-bar-disabled.tsx[rend
 endif::[]
 --
 
-By default, disabled buttons (i.e., root-level items) aren't focusable or hoverable, which hides them from assistive technologies and prevents Tooltips on disabled buttons from showing. Enable the `accessibleDisabledButtons` feature flag to make them focusable and hoverable without allowing them to be triggered:
+By default, disabled buttons (i.e., root-level items) aren't focusable or hoverable, which hides them from assistive technologies and prevents Tooltips on disabled buttons from showing. The `accessibleDisabledButtons` feature flag can be enabled to make them focusable and hoverable without allowing them to be triggered:
 
 [.example]
 --

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -203,7 +203,7 @@ window.Vaadin.featureFlags.accessibleDisabledButtons = true;
 ----
 --
 
-Disabled sub-menu items behave similarly. Enable the `accessibleDisabledMenuItems` feature flag to make them focusable and hoverable without allowing them to be triggered:
+Similarly, the `accessibleDisabledMenuItems` feature flag can be enabled to make disabled sub-menu items focusable and hoverable without allowing them to be triggered:
 
 [.example]
 --

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -362,7 +362,7 @@ endif::[]
 
 See the <<../tooltip#,Tooltips documentation page>> for details on tooltip configuration.
 
-Tooltips are especially useful on disabled menu items to explain why an action is unavailable, but they are not shown by default. See <<#disabled-items,Disabled Items>> for how to enable them.
+Tooltips are also useful on disabled menu items to explain why an action is unavailable, but they are not shown by default. See <<#disabled-items,Disabled Items>> for how to enable them.
 
 
 == Keyboard Usage

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -203,7 +203,7 @@ window.Vaadin.featureFlags.accessibleDisabledButtons = true;
 ----
 --
 
-Similarly, the `accessibleDisabledMenuItems` feature flag can be enabled to make disabled sub-menu items focusable and hoverable without allowing them to be triggered:
+Similarly, the [since:com.vaadin:vaadin@V25.2]#`accessibleDisabledMenuItems`# feature flag can be enabled to make disabled sub-menu items focusable and hoverable without allowing them to be triggered:
 
 [.example]
 --

--- a/articles/components/menu-bar/index.adoc
+++ b/articles/components/menu-bar/index.adoc
@@ -184,7 +184,7 @@ include::{root}/frontend/demo/component/menubar/react/menu-bar-disabled.tsx[rend
 endif::[]
 --
 
-By default, disabled buttons (i.e., root-level items) are not focusable and cannot react to hover events. This can cause accessibility issues by making them entirely invisible to assistive technologies, and prevents the use of Tooltips to explain why the action is not available. This can be addressed by enabling the feature flag `accessibleDisabledButtons`, which allows focusing and hovering on disabled buttons, while preventing them from being triggered:
+By default, disabled buttons (i.e., root-level items) aren't focusable or hoverable, which hides them from assistive technologies and prevents Tooltips on disabled buttons from showing. Enable the `accessibleDisabledButtons` feature flag to make them focusable and hoverable without allowing them to be triggered:
 
 [.example]
 --
@@ -200,6 +200,25 @@ com.vaadin.experimental.accessibleDisabledButtons=true
 ----
 // Set before any button is added to the DOM
 window.Vaadin.featureFlags.accessibleDisabledButtons = true;
+----
+--
+
+Disabled sub-menu items behave similarly. Enable the `accessibleDisabledMenuItems` feature flag to make them focusable and hoverable without allowing them to be triggered:
+
+[.example]
+--
+.`Flow`
+[source,properties]
+----
+# Add this line to src/main/resources/vaadin-featureflags.properties
+com.vaadin.experimental.accessibleDisabledMenuItems=true
+----
+
+.`Lit & React`
+[source,js]
+----
+// Set before any menu is added to the DOM
+window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
 ----
 --
 
@@ -342,6 +361,8 @@ endif::[]
 --
 
 See the <<../tooltip#,Tooltips documentation page>> for details on tooltip configuration.
+
+Tooltips are especially useful on disabled menu items to explain why an action is unavailable, but they are not shown by default. See <<#disabled-items,Disabled Items>> for how to enable them.
 
 
 == Keyboard Usage


### PR DESCRIPTION
## Summary
- Document the `accessibleDisabledMenuItems` feature flag in Menu Bar (sub-menu items) and Context Menu disabled sections.
- Note in both Tooltips sections that tooltips on disabled items aren't shown by default, with cross-references to the disabled-items section.
- Tighten existing prose for the `accessibleDisabledButtons` flag in Menu Bar.

Follow-up to https://github.com/vaadin/web-components/issues/10415