### PR TITLE
docs: add theme enabling examples to Aura and Lumo pages

### DIFF
--- a/articles/styling/themes/aura/index.adoc
+++ b/articles/styling/themes/aura/index.adoc
@@ -29,8 +29,6 @@ public class Application implements AppShellConfigurator {
 }
 ----
 
-Themes should always be loaded _before_ any other styles in your application.
-
 == Style Properties
 
 Together with <<../base#,base styles>>, Aura defines a set of style properties, prefixed with `--vaadin-` and `--aura-` for visual features like color, typography, sizing, whitespace. These style properties define the look and feel of Vaadin components. You can assign new values to these properties to customize the look and feel of Aura. You can also use these properties as CSS values in your stylesheets, to style your application's custom UI features.

--- a/articles/styling/themes/aura/index.adoc
+++ b/articles/styling/themes/aura/index.adoc
@@ -17,7 +17,7 @@ Aura is designed to work at a high level by default. Colors, contrast, and surfa
 
 == Enabling Aura
 
-Aura can be enabled by adding a [annotationname]`@StyleSheet` annotation to your main application class. The [classname]`Aura` class provides a constant for the path to the Aura stylesheet:
+Aura is loaded automatically when no [interfacename]`AppShellConfigurator` is defined in your application. Once an [interfacename]`AppShellConfigurator` is added, the theme needs to be enabled explicitly by adding a [annotationname]`@StyleSheet` annotation to it. The [classname]`Aura` class provides a constant for the path to the Aura stylesheet:
 
 [source,java]
 ----

--- a/articles/styling/themes/aura/index.adoc
+++ b/articles/styling/themes/aura/index.adoc
@@ -15,6 +15,22 @@ Aura is a theme for Vaadin applications that provides default styles and variant
 
 Aura is designed to work at a high level by default. Colors, contrast, and surface hierarchy are derived from a small set of base values, so you don't have to manage every detail manually. At the same time, you can override individual style properties when you need more precise control.
 
+== Enabling Aura
+
+Aura can be enabled by adding a [annotationname]`@StyleSheet` annotation to your main application class. The [classname]`Aura` class provides a constant for the path to the Aura stylesheet:
+
+[source,java]
+----
+import com.vaadin.flow.theme.aura.Aura;
+
+@StyleSheet(Aura.STYLESHEET)
+public class Application implements AppShellConfigurator {
+    ...
+}
+----
+
+Themes should always be loaded _before_ any other styles in your application.
+
 == Style Properties
 
 Together with <<../base#,base styles>>, Aura defines a set of style properties, prefixed with `--vaadin-` and `--aura-` for visual features like color, typography, sizing, whitespace. These style properties define the look and feel of Vaadin components. You can assign new values to these properties to customize the look and feel of Aura. You can also use these properties as CSS values in your stylesheets, to style your application's custom UI features.

--- a/articles/styling/themes/lumo/index.adoc
+++ b/articles/styling/themes/lumo/index.adoc
@@ -21,6 +21,23 @@ The built-in dark and compact variants are predefined sets of style property val
 The Lumo theme also includes a comprehensive set of CSS utility classes that can be applied to HTML elements and layout components through Java, to change their styling without writing any CSS of your own.
 
 
+== Enabling Lumo
+
+Lumo can be enabled by adding a [annotationname]`@StyleSheet` annotation to your main application class. The [classname]`Lumo` class provides a constant for the path to the Lumo stylesheet:
+
+[source,java]
+----
+import com.vaadin.flow.theme.lumo.Lumo;
+
+@StyleSheet(Lumo.STYLESHEET)
+public class Application implements AppShellConfigurator {
+    ...
+}
+----
+
+Themes should always be loaded _before_ any other styles in your application.
+
+
 == Light & Dark Color Schemes
 
 In the screenshot here, you can see the difference between the default light color variant on the left, and the dark variant on the right -- which are both built into Lumo.
@@ -36,6 +53,8 @@ Lumo also has a compact preset that reduces fonts sizes -- and proportionally al
 
 [source,java]
 ----
+import com.vaadin.flow.theme.lumo.Lumo;
+
 @StyleSheet(Lumo.STYLESHEET)
 @StyleSheet(Lumo.COMPACT_STYLESHEET)
 public class Application implements AppShellConfigurator {

--- a/articles/styling/themes/lumo/index.adoc
+++ b/articles/styling/themes/lumo/index.adoc
@@ -35,9 +35,6 @@ public class Application implements AppShellConfigurator {
 }
 ----
 
-Themes should always be loaded _before_ any other styles in your application.
-
-
 == Light & Dark Color Schemes
 
 In the screenshot here, you can see the difference between the default light color variant on the left, and the dark variant on the right -- which are both built into Lumo.


### PR DESCRIPTION
The `@StyleSheet` examples for enabling each theme previously existed only on the Themes overview page (`styling/themes/index.adoc`), with no mention on the individual Aura and Lumo pages — which is where users most often land from search.

This adds an **Enabling** section with a `@StyleSheet` example (including the theme class import) to both individual theme pages:

- `articles/styling/themes/aura/index.adoc` → `import com.vaadin.flow.theme.aura.Aura;`
- `articles/styling/themes/lumo/index.adoc` → `import com.vaadin.flow.theme.lumo.Lumo;`

Also added the `Lumo` import to the existing Compact Preset example for consistency.