### PR TITLE
docs: add Lumo enabling example to Lumo page (CP: 25.0)

### DIFF
--- a/articles/styling/themes/lumo/index.adoc
+++ b/articles/styling/themes/lumo/index.adoc
@@ -21,6 +21,21 @@ The built-in dark and compact variants are predefined sets of style property val
 The Lumo theme also includes a comprehensive set of CSS utility classes that can be applied to HTML elements and layout components through Java, to change their styling without writing any CSS of your own.
 
 
+== Enabling Lumo
+
+Lumo can be enabled by adding a [annotationname]`@StyleSheet` annotation to your main application class. The [classname]`Lumo` class provides a constant for the path to the Lumo stylesheet:
+
+[source,java]
+----
+import com.vaadin.flow.theme.lumo.Lumo;
+
+@StyleSheet(Lumo.STYLESHEET)
+public class Application implements AppShellConfigurator {
+    ...
+}
+----
+
+
 == Light & Dark Color Schemes
 
 In the screenshot here, you can see the difference between the default light color variant on the left, and the dark variant on the right -- which are both built into Lumo.
@@ -36,6 +51,8 @@ Lumo also has a compact preset that reduces fonts sizes -- and proportionally al
 
 [source,java]
 ----
+import com.vaadin.flow.theme.lumo.Lumo;
+
 @StyleSheet(Lumo.STYLESHEET)
 @StyleSheet(Lumo.COMPACT_STYLESHEET)
 public class Application implements AppShellConfigurator {


### PR DESCRIPTION
## Summary

Backport of the **Lumo** portion of #5612 to v25.0.

The `@StyleSheet` example for enabling Lumo previously existed only on the Themes overview page (`styling/themes/index.adoc`), not on the individual Lumo page — where users most often land from search.

This adds:
- An **Enabling Lumo** section with a `@StyleSheet(Lumo.STYLESHEET)` example, including `import com.vaadin.flow.theme.lumo.Lumo;`
- The same import to the existing Compact Preset example, for consistency

### Notes
- **Aura is not backported.** The Aura page is a stub (front matter only) in v25.0, so an enabling section there would float on an otherwise empty page.
- The "themes should be loaded before other styles" load-order note is **omitted**, matching the latest version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)