### PR TITLE
docs: clarify detail sizing in overlay mode for MasterDetailLayout

### DIFF
--- a/articles/components/master-detail-layout/index.adoc
+++ b/articles/components/master-detail-layout/index.adoc
@@ -139,6 +139,8 @@ ifdef::react[]
 endif::[]
 --
 
+These settings apply only while the master and detail areas are shown side by side. In overlay mode, the detail's size is controlled separately by `overlaySize`, as described in the next section.
+
 [role="since:com.vaadin:vaadin@V25.2"]
 == Overlay Size
 


### PR DESCRIPTION
The PR clarifies that the expand settings only apply in split mode, and that the detail's size in overlay mode is controlled separately by `overlaySize`.

Addresses a hackathon finding.