### PR TITLE
fix: standardize CTA text in MPR commercial banner

### DIFF
--- a/articles/tools/mpr/index.adoc
+++ b/articles/tools/mpr/index.adoc
@@ -10,7 +10,7 @@ order: 140
 = Multiplatform Runtime [badge-flow]#Flow#
 
 :commercial-banner-content: Multiplatform Runtime only works with the Extended Maintenance versions of Vaadin 7 and Vaadin 8.
-:trial-link: https://vaadin.com/vaadin-8-extended-maintenance[Read more]
+:trial-link: https://vaadin.com/vaadin-8-extended-maintenance[Learn More^]
 include::{articles}/_commercial-banner.adoc[]
 
 Multiplatform Runtime (MPR) makes it possible to run applications and components written with Vaadin 7/8 inside a Vaadin Flow application.


### PR DESCRIPTION
Change "Read more" to "Learn More" for consistency with other CTAs like "See Pricing", "Start Trial", etc.

https://claude.ai/code/session_01K2VPMgUauTChsrS1pVKWGT


