### PR TITLE
docs: fix broken link

### DIFF
--- a/articles/flow/security/advanced-topics/vulnerabilities.adoc
+++ b/articles/flow/security/advanced-topics/vulnerabilities.adoc
@@ -196,7 +196,7 @@ A general security issue has been identified in programming language mechanics i
 
 If an application is set up to deserialize Java objects (e.g., using the libraries previously mentioned), an attacker can feed the system a malicious payload that may be deserialized into Java objects. The attacker can then execute arbitrary code using specific language features (e.g., reflection).
 
-Vaadin has published https://v.vaadin.com/security-alert-for-java-deserialization-of-untrusted-data-in-vaadin-severity-level-moderate[a security alert for this vulnerability]. It can't be fixed in Vaadin, but you can mitigate the risk by using the methods described in the alert's appendices.
+Vaadin has published https://vaadin.com/security/2018-11-13[a security alert for this vulnerability]. It can't be fixed in Vaadin, but you can mitigate the risk by using the methods described in the alert's appendices.
 // end::java-serialization[]
 
 

--- a/articles/hilla/lit/guides/security/vulnerabilities.adoc
+++ b/articles/hilla/lit/guides/security/vulnerabilities.adoc
@@ -98,7 +98,7 @@ The Java language isn't immune to this; as a non-exhaustive list, at least the J
 If the application is set up to deserialize Java objects (for example, using the libraries above), an attacker can feed the system a malicious payload that gets deserialized into Java objects.
 The attacker can then execute arbitrary code using specific language features (such as reflection).
 
-Vaadin has published a link:https://v.vaadin.com/security-alert-for-java-deserialization-of-untrusted-data-in-vaadin-severity-level-moderate[security alert] for this vulnerability.
+Vaadin has published a link:https://vaadin.com/security/2018-11-13[security alert] for this vulnerability.
 
 The vulnerability cannot be fixed in Vaadin.
 Developers need to mitigate the risk using methods described in the alert appendices.


### PR DESCRIPTION
Changed security alert page to https://vaadin.com/security/2018-11-13.