### PR TITLE
shared-signals.adoc: Replace ValueSignal with SharedValueSignal

### DIFF
--- a/articles/flow/ui-state/shared-signals.adoc
+++ b/articles/flow/ui-state/shared-signals.adoc
@@ -272,17 +272,17 @@ Use `@VaadinSessionScope` to create one signal instance per user session, i.e. s
 @Component
 @VaadinSessionScope
 public class CurrentUserSignal {
-    private final ValueSignal<String> usernameSignal;
+    private final SharedValueSignal<String> usernameSignal;
 
     public CurrentUserSignal(AuthenticationContext authContext) {
-        this.usernameSignal = new ValueSignal<>(
+        this.usernameSignal = new SharedValueSignal<>(
             authContext.getAuthenticatedUser(UserDetails.class)
                 .map(UserDetails::getUsername)
                 .orElse("anonymous")
         );
     }
 
-    public ValueSignal<String> getUsernameSignal() {
+    public SharedValueSignal<String> getUsernameSignal() {
         return usernameSignal;
     }
 }
@@ -301,13 +301,13 @@ Use `@Component` (singleton) or static fields to create signals shared by all us
 ----
 @Component
 public class SystemStatusSignal {
-    private final ValueSignal<String> statusSignal;
+    private final SharedValueSignal<String> statusSignal;
 
     public SystemStatusSignal() {
-        this.statusSignal = new ValueSignal<>("ONLINE");
+        this.statusSignal = new SharedValueSignal<>("ONLINE");
     }
 
-    public ValueSignal<String> getStatusSignal() {
+    public SharedValueSignal<String> getStatusSignal() {
         return statusSignal;
     }
 }
@@ -326,7 +326,7 @@ Declare signals as private instance fields in your view or component class.
 ----
 @Route("dashboard")
 public class DashboardView extends VerticalLayout {
-    private final ValueSignal<Integer> counterSignal = new ValueSignal<>(0);
+    private final SharedValueSignal<Integer> counterSignal = new SharedValueSignal<>(0);
 
     public DashboardView() {
         Button increment = new Button("Increment");


### PR DESCRIPTION
This documentation describes the usage of Shared Signals. So it is really confusing and probably a mistake, that in some of the examples Local Signals are used.


