### PR TITLE
docs: lead server-push "Pushing" guide with signals

### DIFF
--- a/articles/building-apps/server-push/callbacks.adoc
+++ b/articles/building-apps/server-push/callbacks.adoc
@@ -52,3 +52,6 @@ button.addClickListener(clickEvent -> {
 });
 ----
 <1> The `UI.accessLater()` method is explained on the <<updates#access-later,Pushing UI Updates>> documentation page.
+
+[TIP]
+When a callback only updates UI _state_ — such as a progress value or a status message — you can update a <</flow/ui-state#,signal>> from the callback instead of wrapping it in `UI.accessLater()`, and bind the component to that signal. See <<updates#pushing-state-with-signals,Pushing State with Signals>>.

--- a/articles/building-apps/server-push/futures.adoc
+++ b/articles/building-apps/server-push/futures.adoc
@@ -53,6 +53,9 @@ button.addClickListener(clickEvent -> {
 ----
 <1> The `UI.accessLater()` method is explained on the <<updates#access-later,Pushing UI Updates>> documentation page.
 
+[TIP]
+If completion only updates UI _state_, `thenAccept()` can set a <</flow/ui-state#,signal>> directly instead of going through `UI.accessLater()`, and the bound component updates automatically. See <<updates#pushing-state-with-signals,Pushing State with Signals>>.
+
 
 == Exceptional Completion
 

--- a/articles/building-apps/server-push/index.adoc
+++ b/articles/building-apps/server-push/index.adoc
@@ -49,6 +49,8 @@ You can also configure Flow to use manual pushing (`PushMode.MANUAL`). With manu
 
 For details on how to use `UI.access()` and `UI.push()`, see <<updates#,Pushing UI Updates>>.
 
+For state-driven updates, you usually don't need `UI.access()` at all: bind components to <</flow/ui-state#,signals>> and update the signals from any thread, and Flow pushes the changes automatically. See <<updates#pushing-state-with-signals,Pushing State with Signals>>.
+
 
 == Transport Options
 

--- a/articles/building-apps/server-push/reactive.adoc
+++ b/articles/building-apps/server-push/reactive.adoc
@@ -67,6 +67,28 @@ protected void onAttach(AttachEvent attachEvent) {
 }
 ----
 
+For a hot stream that several users share, you can instead feed the stream into a shared <</flow/ui-state#,signal>> once, in a singleton bean, and let each view bind to it. This removes the per-view subscribe/unsubscribe and `UI.accessLater()` bookkeeping:
+
+[source,java]
+----
+@Component // Singleton: subscribed once for the whole application
+public class ChatMessages {
+    private final SharedListSignal<ChatMessage> messages =
+            new SharedListSignal<>(ChatMessage.class);
+
+    ChatMessages(ChatService chatService) {
+        chatService.messages().subscribe(messages::insertLast); // <1>
+    }
+
+    public SharedListSignal<ChatMessage> messages() {
+        return messages;
+    }
+}
+----
+<1> The bean holds a single subscription for all users. Views bind to `messages()` with [methodname]`bindChildren()`, and Flow pushes new messages to every connected user automatically.
+
+See <<updates#broadcasting-to-all-users,Broadcasting to All Users>> for the matching view code. Note that the <<#buffering,buffering>> guidance below still applies: signals don't rate-limit updates, so buffer a high-frequency stream before feeding it into the signal.
+
 
 === Subscribing with Hilla
 

--- a/articles/building-apps/server-push/threads.adoc
+++ b/articles/building-apps/server-push/threads.adoc
@@ -104,3 +104,34 @@ The tasks that you execute in the task scheduler should be fast. If you need to 
 
 [CAUTION]
 Do not use the `@Scheduled` annotation in Flow views. It turns them into proxies that don't work with Vaadin.
+
+
+=== Updating the Scheduled Result With a Signal
+
+If the scheduled task only updates UI _state_, you can hold that state in a <</flow/ui-state#,signal>> and skip `UI.accessLater()` entirely. Bind the component to the signal once, then update the signal from the scheduled task. Flow pushes the change to the bound component automatically:
+
+[source,java]
+----
+private final ValueSignal<String> currentTime = new ValueSignal<>("");
+
+public MyView(TaskScheduler taskScheduler) {
+    this.taskScheduler = taskScheduler;
+    currentTimeLabel.bindText(currentTime); // <1>
+}
+
+@Override
+protected void onAttach(AttachEvent attachEvent) {
+    var task = taskScheduler.scheduleAtFixedRate(
+        () -> currentTime.set(Instant.now().toString()), // <2>
+        Duration.ofSeconds(1));
+    addDetachListener(detachEvent -> {
+        detachEvent.unregisterListener();
+        task.cancel(true); // <3>
+    });
+}
+----
+<1> Bind the label to the signal once. The binding is active only while the component is attached and is removed automatically on detach.
+<2> The scheduled task updates the signal directly — no `UI.accessLater()` and no captured `UI` instance.
+<3> You still cancel the scheduled task on detach. Signals manage the _binding_ lifecycle, not the scheduler.
+
+For more on binding components to signals, see <<updates#pushing-state-with-signals,Pushing State with Signals>>.

--- a/articles/building-apps/server-push/updates.adoc
+++ b/articles/building-apps/server-push/updates.adoc
@@ -11,7 +11,119 @@ order: 1
 
 Whenever you're using server push in Vaadin Flow, you're triggering it from a thread other than the normal HTTP request thread. Making changes to a UI from another thread and pushing them to the browser requires locking the user session. Otherwise, the UI update performed from another thread could conflict with a regular event-driven update and cause either data corruption, race conditions or deadlocks.
 
-Such errors are by nature hard to discover and fix, since they often occur randomly and under a heavy load. Because of this, you may only access a UI using the `UI.access()` method, which locks the session to prevent race conditions. You would use it like this:
+Such errors are by nature hard to discover and fix, since they often occur randomly and under a heavy load.
+
+There are two ways to push these updates:
+
+* For *state-driven* updates, use <</flow/ui-state#,signals>>. Signals are thread-safe and update any bound components automatically, so you don't have to lock the session yourself. This is the recommended approach for most cases, and the one this page leads with.
+* For *imperative* updates — such as adding or removing components, or calling component methods that aren't expressed as state — lock the session manually with the `UI.access()` method. Understanding `UI.access()` also helps you understand what signals do for you under the hood.
+
+[NOTE]
+The examples on this page only work with push enabled. This applies to signal-driven updates as well: when a signal is changed from a background thread, push is what delivers the change to the browser. For information about how to enable push, see the <<index.adoc#,Server Push>> documentation page.
+
+
+== Pushing State with Signals
+
+A <</flow/ui-state#,signal>> holds a piece of UI state. When you bind a component to a signal, the component updates itself whenever the signal's value changes — no matter which thread made the change. Signals are thread-safe and synchronize with the UI internally, so you don't need to call `UI.access()`, and you don't need to capture the `UI` instance in advance.
+
+Just as importantly, bindings are tied to the component lifecycle: a binding is active only while the component is attached, and it's removed automatically when the component is detached. This means there's no listener to unsubscribe and no `UI` reference left dangling, so the whole class of memory leaks described later on this page doesn't arise.
+
+
+=== Updating From a Background Job
+
+Hold the state that the background job produces in a signal, and bind a component to it. When the job updates the signal from its own thread, the bound component updates automatically:
+
+[source,java]
+----
+public class JobView extends VerticalLayout {
+    private final ValueSignal<String> status = new ValueSignal<>("Idle");
+
+    public JobView(MyService myService) {
+        Span statusLabel = new Span();
+        statusLabel.bindText(status); // <1>
+
+        Button start = new Button("Start job", click ->
+            myService.startBackgroundJob(() -> status.set("Done"))); // <2>
+
+        add(statusLabel, start);
+    }
+}
+----
+<1> The label's text is bound to the `status` signal.
+<2> The callback runs on a background thread and updates the signal directly. There's no `UI.access()` and no captured `UI` instance — the bound label updates on its own.
+
+
+=== Broadcasting to All Users
+
+For state that several users share, put a <</flow/ui-state#,shared signal>> in a Spring bean and let the view bind to it. A singleton bean shares one signal instance across the whole application, so a change made by one user — or by a background thread — is pushed to every connected user that's bound to it:
+
+[source,java]
+----
+@Component // Singleton: one instance shared by all users
+public class ChatMessages {
+    private final SharedListSignal<String> messages =
+            new SharedListSignal<>(String.class);
+
+    public SharedListSignal<String> messages() {
+        return messages;
+    }
+
+    public void post(String message) {
+        messages.insertLast(message);
+    }
+}
+----
+
+The view binds its component list to the shared signal with [methodname]`bindChildren()`:
+
+[source,java]
+----
+public class ChatView extends VerticalLayout {
+    public ChatView(ChatMessages chatMessages) {
+        VerticalLayout list = new VerticalLayout();
+        list.bindChildren(chatMessages.messages(), messageSignal -> {
+            Span message = new Span();
+            message.bindText(messageSignal);
+            return message;
+        });
+        add(list);
+
+        TextField input = new TextField();
+        Button send = new Button("Send", click -> {
+            chatMessages.post(input.getValue());
+            input.clear();
+        });
+        add(input, send);
+    }
+}
+----
+
+When any user calls `post()`, every open `ChatView` receives the new message. Compare this with the manual approach described in <<#avoiding-memory-leaks,Avoiding Memory Leaks>> below: there's no event bus to subscribe to, no `UI.access()`, and no detach handler to unsubscribe. The signal lives in the bean, so its lifetime is the bean's lifetime, and each view's binding is cleaned up automatically on detach.
+
+[NOTE]
+Use a `@Component` singleton for application-wide state, or a `@VaadinSessionScope` bean for state shared between the tabs of a single user. For more on scoping signals, see <</flow/ui-state/shared-signals#signal-scope-patterns,Signal Scope Patterns>>.
+
+
+=== Highlighting Background Changes
+
+Sometimes you want to draw attention to a value that changed because of a background update, rather than one the current user triggered. Binding methods provide an [methodname]`onChange()` callback whose context can tell the two apart:
+
+[source,java]
+----
+Span price = new Span();
+price.bindText(priceSignal.map(p -> "$" + p))
+    .onChange(ctx -> {
+        if (ctx.isBackgroundChange()) {
+            ctx.getElement().flashClass("highlight"); // <1>
+        }
+    });
+----
+<1> [methodname]`isBackgroundChange()` returns `true` when the change came from another session or a background thread. See <</flow/ui-state/effects-computed#,Effects and Computed Signals>> for details.
+
+
+== Pushing Manually With UI.access()
+
+Signals cover state-driven updates. When you need to make an imperative change from a background thread — for example, adding components to a layout — lock the session yourself with `UI.access()`:
 
 [source,java]
 ----
@@ -19,9 +131,6 @@ ui.access(() -> {
     // Update your UI here
 });
 ----
-
-[NOTE]
-The examples on this page only work with push enabled. For information about how to do that, see the <<index.adoc#,Server Push>> documentation page.
 
 By default, Flow uses automatic pushing. This means that any pending changes are pushed to the browser after the command passed to `UI.access()` finishes. You can also configure Flow to use manual pushing. This would give you more control over when changes are pushed to the browser. For example, you can push multiple times inside a single call to `UI.access()`.
 
@@ -46,7 +155,7 @@ ui.access(() -> {
 ----
 
 
-== Getting the UI Instance
+=== Getting the UI Instance
 
 Before you can call `access()`, you need to get the `UI` instance. You'd typically use `Component.getUI()` or `UI.getCurrent()` for this. However, both are problematic when it comes to server push.
 
@@ -73,8 +182,11 @@ button.addClickListener(clickEvent -> {
 <1> This is executed in an HTTP request thread. The user session is locked and `UI.getCurrent()` returns the current `UI`-instance.
 <2> This is executed in the background thread. `UI.getCurrent()` returns `null`, but the `UI` instance is stored in a local variable.
 
+[TIP]
+This is the kind of bookkeeping signals remove for you. When you push state through a signal instead, you don't capture the `UI` instance and you don't call `access()` — see <<#pushing-state-with-signals,Pushing State with Signals>>.
 
-== Access Later
+
+=== Access Later
 
 You probably often use server push in various types of event listeners and <<callbacks#,callbacks>>. A background job might inform you that it has finished processing.
 
@@ -125,7 +237,7 @@ var subscription = myEventBus.subscribe(UI.getCurrent().accessLater((message) ->
 ----
 
 
-== Avoiding Memory Leaks
+=== Avoiding Memory Leaks
 
 When you're using server push to update the user interface when an event has occurred, you would typically subscribe a listener to some broadcaster or event bus. When you do this, be sure to unsubscribe when the UI is detached. Otherwise, you'll have a memory leak that prevents your UI from being garbage collected. This is because the listener holds a reference to the `UI` instance.
 
@@ -150,12 +262,15 @@ protected void onAttach(AttachEvent attachEvent) { // <1>
 <3> Remove the detach listener itself, to prevent a memory leak in case the component is attached multiple times.
 <4> Unsubscribe when the view is detached from the UI.
 
+[TIP]
+Binding a component to a signal avoids this bookkeeping entirely: the binding is active only while the component is attached and is removed automatically on detach. See <<#broadcasting-to-all-users,Broadcasting to All Users>> for the signal-based version of this example.
+
 
 == Avoiding Floods
 
-Another risk you have to manage when updating the user interface in response to events is flooding the user interface with updates. As a rule of thumb, you should not push more than two to four times per second. Pushing more often than that can cause performance issues. Plus, there is a limit to how many updates the human brain is able to register per second.
+Another risk you have to manage when updating the user interface in response to events is flooding the user interface with updates. This applies whether you push through signals or through `UI.access()` directly. As a rule of thumb, you should not push more than two to four times per second. Pushing more often than that can cause performance issues. Plus, there is a limit to how many updates the human brain is able to register per second.
 
-When you know events are coming no faster than two to four events per second, you can push on every event. However, if they're more frequent, you have to buffer events and update the user interface in batches. This is quite easy to do if you're using a `Flux` from https://projectreactor.io/[Reactor]. See the <<reactive#,Consuming Reactive Streams>> documentation page for more information about this.
+When you know events are coming no faster than two to four events per second, you can push on every event. However, if they're more frequent, you have to buffer events and update the user interface in batches — for signals, this means buffering before you write to the signal. This is quite easy to do if you're using a `Flux` from https://projectreactor.io/[Reactor]. See the <<reactive#,Consuming Reactive Streams>> documentation page for more information about this.
 
 The buffering duration depends on the size of the UI update, and the network latency. In some applications, you may need to use a longer buffer duration. In others, a shorter one might work. You should try various durations to see what's best for your application.
 

--- a/articles/building-apps/server-push/updates.adoc
+++ b/articles/building-apps/server-push/updates.adoc
@@ -98,6 +98,9 @@ public class ChatView extends VerticalLayout {
 }
 ----
 
+[IMPORTANT]
+Inside the [methodname]`bindChildren()` factory, pass the child signal straight to a component (as `message.bindText(messageSignal)` does) instead of reading it with [methodname]`get()`. Calling `messageSignal.get()` in the factory throws an exception, because the factory isn't itself a reactive context — let the component create its own binding.
+
 When any user calls `post()`, every open `ChatView` receives the new message. Compare this with the manual approach described in <<#avoiding-memory-leaks,Avoiding Memory Leaks>> below: there's no event bus to subscribe to, no `UI.access()`, and no detach handler to unsubscribe. The signal lives in the bean, so its lifetime is the bean's lifetime, and each view's binding is cleaned up automatically on detach.
 
 [NOTE]

--- a/articles/building-apps/server-push/updates.adoc
+++ b/articles/building-apps/server-push/updates.adoc
@@ -83,7 +83,7 @@ public class ChatView extends VerticalLayout {
         VerticalLayout list = new VerticalLayout();
         list.bindChildren(chatMessages.messages(), messageSignal -> {
             Span message = new Span();
-            message.bindText(messageSignal);
+            message.bindText(messageSignal); // <1>
             return message;
         });
         add(list);
@@ -97,9 +97,7 @@ public class ChatView extends VerticalLayout {
     }
 }
 ----
-
-[IMPORTANT]
-Inside the [methodname]`bindChildren()` factory, pass the child signal straight to a component (as `message.bindText(messageSignal)` does) instead of reading it with [methodname]`get()`. Calling `messageSignal.get()` in the factory throws an exception, because the factory isn't itself a reactive context — let the component create its own binding.
+<1> Pass the child signal straight to a component instead of reading it with [methodname]`get()`. Calling `messageSignal.get()` inside the factory throws an exception, because the factory isn't itself a reactive context — let the component create its own binding.
 
 When any user calls `post()`, every open `ChatView` receives the new message. Compare this with the manual approach described in <<#avoiding-memory-leaks,Avoiding Memory Leaks>> below: there's no event bus to subscribe to, no `UI.access()`, and no detach handler to unsubscribe. The signal lives in the bean, so its lifetime is the bean's lifetime, and each view's binding is cleaned up automatically on detach.
 


### PR DESCRIPTION
## What

Rewrites the **building-apps → Server Push → Pushing** guide (`articles/building-apps/server-push/updates.adoc`) to lead with **signals** as the recommended way to push state-driven UI updates, while keeping the lower-level `UI.access()` material for imperative updates and as the underlying mechanism.

New **"Pushing State with Signals"** section with three worked examples:
- **Updating from a background job** — `ValueSignal` + `bindText`, no `UI.access()` and no captured `UI` instance.
- **Broadcasting to all users** — `SharedListSignal` in a `@Component` singleton + `bindChildren`, replacing the event-bus subscribe / unsubscribe / detach-handler pattern.
- **Highlighting background changes** — `.onChange(ctx -> ctx.isBackgroundChange())` + `flashClass`.

The existing `UI.access()` / `accessLater()` / memory-leak / flood / unnecessary-push sections are preserved and reframed as the imperative path, with `[TIP]` callouts linking the manual bookkeeping to its signal-based equivalent.

## Why

With signals released in 25.2, the framework now updates bound components automatically from any thread (push enabled) and ties binding lifecycle to attach/detach — eliminating the manual `UI.access()` capture and the subscribe/unsubscribe memory-leak handling this guide currently teaches by hand. This was the strongest "rewrite to use signals" candidate among the building-apps articles: it's deep-dive material (so leaning on signals is appropriate) and signals directly solve the pain it documents.

## Notes for reviewers

- Self-contained: the article uses inline code (no `include::` demo sources), so no demo project changes are needed.
- Cross-links follow existing conventions: `<</flow/ui-state#,…>>` for the reference docs and heading-derived `<<#…>>` intra-page anchors.
- API usage verified against the `articles/flow/ui-state/` reference (`bindText`, `bindChildren`, `SharedListSignal`, `.onChange()`/`isBackgroundChange()`, signal scope patterns).
- The flood-control section now notes signals don't rate-limit on their own — buffer before writing to the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)