### PR TITLE
docs: mention that an existing X-Frame-Options header is not overwritten

### DIFF
--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -218,7 +218,7 @@ Default: `false` +
 Mode: Runtime
 
 `**frameOptions**`::
-[since:com.vaadin:vaadin@V25.2]#The value of the `X-Frame-Options` HTTP response header# sent with the application page. The header lets the browser protect the application against clickjacking. Common values are `SAMEORIGIN` and `DENY`. Set the parameter to an empty value to disable sending the header, for example for applications that are meant to be embedded in a frame. +
+[since:com.vaadin:vaadin@V25.2]#The value of the `X-Frame-Options` HTTP response header# sent with the application page. The header lets the browser protect the application against clickjacking. Common values are `SAMEORIGIN` and `DENY`. Set the parameter to an empty value to disable sending the header, for example for applications that are meant to be embedded in a frame. The header is only set if the response doesn't already contain an `X-Frame-Options` header set by other means, such as Spring Security or a servlet filter. +
 Default: `SAMEORIGIN` +
 Mode: Runtime
 

--- a/articles/flow/security/advanced-topics/frequent-issues.adoc
+++ b/articles/flow/security/advanced-topics/frequent-issues.adoc
@@ -87,5 +87,7 @@ The `X-Frame-Options` HTTP header is a way for web pages or applications to tell
 
 Vaadin [since:com.vaadin:vaadin@V25.2]#sends the `X-Frame-Options: SAMEORIGIN` header by default# with the application page, so that the application can only be shown in frames on the same origin. The header value can be changed with the `frameOptions` configuration parameter, for example to `DENY` to forbid framing entirely. Applications that are meant to be embedded in a frame on another origin must set the parameter to an empty value to disable the header. See <<{articles}/flow/configuration/properties#,Configuration Properties>> for how to set the parameter.
 
+Vaadin only sets the header if the response doesn't already contain an `X-Frame-Options` header. A header set by other means -- for example, by Spring Security or a servlet filter -- isn't overwritten.
+
 
 [discussion-id]`E609B892-EB97-44B7-AE4B-A3571C62B3F0`

--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -1048,6 +1048,8 @@ If your application needs to set such URLs, either configure the accepted scheme
 
 Starting with Vaadin 25.2, the application page is served with the `X-Frame-Options: SAMEORIGIN` HTTP response header to protect against clickjacking. As a result, browsers refuse to show the application inside a frame on a different origin. Applications that are meant to be embedded in an iframe on another origin must set the `frameOptions` configuration parameter to an empty value to disable the header. The parameter can also be set to another header value, such as `DENY`. See <<{articles}/flow/configuration/properties#,Configuration Properties>> for how to set the parameter.
 
+Vaadin only sets the header if the response doesn't already contain an `X-Frame-Options` header. A header set by other means -- for example, by Spring Security or a servlet filter -- isn't overwritten.
+
 
 == TestBench
 


### PR DESCRIPTION
Addresses review comment on #5661 that arrived after the merge.


