### PR TITLE
docs: add content shadow part to app-layout styling docs

### DIFF
--- a/articles/components/app-layout/styling.adoc
+++ b/articles/components/app-layout/styling.adoc
@@ -127,6 +127,7 @@ Root element:: `vaadin-app-layout`
 Navbar:: `vaadin-app-layout+++<wbr>+++**::part(navbar)**`
 Top navbar:: `vaadin-app-layout+++<wbr>+++**::part(navbar-top)**`
 Bottom "touch optimized" navbar:: `vaadin-app-layout+++<wbr>+++**::part(navbar-bottom)**`
+Content area:: `vaadin-app-layout+++<wbr>+++**::part(content)**`
 Drawer:: `vaadin-app-layout+++<wbr>+++**::part(drawer)**`
 Drawer toggle:: `vaadin-drawer-toggle`
 Drawer toggle icon wrapper:: `vaadin-drawer-toggle+++<wbr>+++**::part(icon)**`


### PR DESCRIPTION
Added `content` part introduced in https://github.com/vaadin/web-components/pull/11458.