### PR TITLE
docs: fix invalid since-badge placement and clarify guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,11 +184,12 @@ The repository uses Vale for automated style checking. Configuration is in `.val
 
 ### Version References
 
-Avoid explicit Vaadin version numbers in text. Instead, use version badges:
+Avoid explicit Vaadin version numbers in text. Instead, use a `since` badge.
 
-```asciidoc
-[since:com.vaadin:vaadin@V25.1]
-```
+The badge is an inline AsciiDoc role: `[since:<coordinates>@<version>]` **must** be immediately
+followed (no space) by a formatted text span that holds the text the badge applies to. The span is
+usually `#...#`, but any inline formatting works (e.g. `*...*`). Without a following span the badge
+does not render — it either shows up as literal `[since:...]` brackets or is silently dropped.
 
 This keeps documentation version-agnostic and maintainable.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,10 +186,27 @@ The repository uses Vale for automated style checking. Configuration is in `.val
 
 Avoid explicit Vaadin version numbers in text. Instead, use a `since` badge.
 
-The badge is an inline AsciiDoc role: `[since:<coordinates>@<version>]` **must** be immediately
-followed (no space) by a formatted text span that holds the text the badge applies to. The span is
-usually `#...#`, but any inline formatting works (e.g. `*...*`). Without a following span the badge
-does not render — it either shows up as literal `[since:...]` brackets or is silently dropped.
+The badge is an inline AsciiDoc role. It **must be immediately followed (no space) by a formatted
+text span** that holds the text the badge applies to — usually `#...#`, but any inline formatting
+works (e.g. `*...*`). Without a following span the badge shows up as literal `[since:...]` brackets
+or is dropped entirely. Place it on a heading or wrapping a phrase in body text.
+
+```asciidoc
+// Correct — on a page title or section heading:
+= [since:com.vaadin:vaadin@V25.1]#Slider#
+== [since:com.vaadin:vaadin@V25.2]#Hierarchical Data#
+
+// Correct — wrapping a phrase in body text:
+The component can also [since:com.vaadin:vaadin@V25.2]#do the sanitization itself#.
+```
+
+```asciidoc
+// WRONG — badge after the heading text, with no span (renders literal brackets):
+== Hierarchical Data [since:com.vaadin:vaadin@V25.2]
+
+// WRONG — badge alone on its own line (no span to attach to):
+[since:com.vaadin:vaadin@V25.2]
+```
 
 This keeps documentation version-agnostic and maintainable.
 

--- a/articles/flow/advanced/browser-access.adoc
+++ b/articles/flow/advanced/browser-access.adoc
@@ -48,9 +48,8 @@ String userAgent = browser.getUserAgent();
 // String os = client.os.family; // "Windows"
 ----
 
-[since:com.vaadin:vaadin@V25]
 [NOTE]
-The browser and OS detection methods in [classname]`WebBrowser` -- such as [methodname]`getBrowserApplication()`, [methodname]`isChrome()`, [methodname]`isWindows()`, and [methodname]`getBrowserMajorVersion()` -- are deprecated. Use [methodname]`getUserAgent()` with a parsing library instead.
+[since:com.vaadin:vaadin@V25]#The browser and OS detection methods# in [classname]`WebBrowser` -- such as [methodname]`getBrowserApplication()`, [methodname]`isChrome()`, [methodname]`isWindows()`, and [methodname]`getBrowserMajorVersion()` -- are deprecated. Use [methodname]`getUserAgent()` with a parsing library instead.
 
 
 == Getting the Extended Client-Side Details

--- a/articles/flow/security/advanced-topics/vulnerabilities.adoc
+++ b/articles/flow/security/advanced-topics/vulnerabilities.adoc
@@ -153,9 +153,7 @@ Div div = new Div();
 div.add(new Html(safeHtml));
 ----
 
-[since:com.vaadin:vaadin@V25.2]
-
-The [classname]`Html` component can also do the sanitization itself. The constructors that take a [classname]`SerializableSupplier<Safelist>` clean the initial content -- and any content applied later -- with the supplied jsoup [classname]`Safelist`:
+The [classname]`Html` component can also [since:com.vaadin:vaadin@V25.2]#do the sanitization itself#. The constructors that take a [classname]`SerializableSupplier<Safelist>` clean the initial content -- and any content applied later -- with the supplied jsoup [classname]`Safelist`:
 
 [source,java]
 ----

--- a/articles/flow/testing/browserless/extensions.adoc
+++ b/articles/flow/testing/browserless/extensions.adoc
@@ -7,9 +7,7 @@ order: 45
 ---
 
 
-= JUnit 6 Extensions
-
-[since:com.vaadin:vaadin@V25.2]
+= [since:com.vaadin:vaadin@V25.2]#JUnit 6 Extensions#
 
 Extending [classname]`BrowserlessTest` is the most compact way to write browserless tests, but it requires your test class to use inheritance for the Vaadin setup. When a project already has its own test base class, or you prefer composition over inheritance, the [classname]`BrowserlessExtension` and [classname]`BrowserlessClassExtension` JUnit 6 extensions provide the same functionality without requiring a specific superclass.
 

--- a/articles/flow/testing/browserless/locators.adoc
+++ b/articles/flow/testing/browserless/locators.adoc
@@ -7,9 +7,7 @@ order: 22
 ---
 
 
-= Component Locators
-
-[since:com.vaadin:vaadin@V25.2]
+= [since:com.vaadin:vaadin@V25.2]#Component Locators#
 
 A *locator* is a fluent object that combines a [classname]`ComponentQuery` filter chain with the actions of a [classname]`ComponentTester`. A single expression replaces the common [methodname]`test(find(...).single())` pattern and the locator is reusable across UI changes -- its resolution cache rewinds automatically when filters are reapplied, or explicitly via [methodname]`invalidate()`.
 

--- a/articles/flow/testing/browserless/multi-user.adoc
+++ b/articles/flow/testing/browserless/multi-user.adoc
@@ -7,9 +7,7 @@ order: 32
 ---
 
 
-= Multi-User and Multi-Window Testing
-
-[since:com.vaadin:vaadin@V25.2]
+= [since:com.vaadin:vaadin@V25.2]#Multi-User and Multi-Window Testing#
 
 [classname]`BrowserlessTest` and the JUnit 6 extensions cover the most common scenario: one user, one window. Some features can only be exercised with multiple participants in the same test -- application-wide singletons observed by two users, per-window UI state of the same user, or security context isolation when switching between authenticated users.
 

--- a/articles/flow/testing/browserless/optimizing-tests.adoc
+++ b/articles/flow/testing/browserless/optimizing-tests.adoc
@@ -81,9 +81,7 @@ class ViewTestConfig {
 ----
 
 
-== Sharing the Vaadin Environment Across Tests
-
-[since:com.vaadin:vaadin@V25.2]
+== [since:com.vaadin:vaadin@V25.2]#Sharing the Vaadin Environment Across Tests#
 
 By default, the Vaadin environment -- the session, the UI, and all routes -- is created before every test method and torn down after. For classes with many tests that navigate to views sharing the same [classname]`MainLayout`, this setup cost can dominate the test runtime.
 

--- a/articles/flow/ui-state/building-ui.adoc
+++ b/articles/flow/ui-state/building-ui.adoc
@@ -657,7 +657,7 @@ languageSelect.bindValue(session.localeSignal(), session::setLocale);
 ----
 
 
-=== Router State Signal [since:com.vaadin:vaadin@V25.2]
+=== [since:com.vaadin:vaadin@V25.2]#Router State Signal#
 
 Use [methodname]`UI.routerStateSignal()` to get a read-only signal that tracks the UI's navigation state. The signal provides a [classname]`RouterState` record with the current location, route parameters, active route chain, and navigation target. Its value updates whenever a navigation completes, making it useful for reactive breadcrumbs and menus:
 


### PR DESCRIPTION
Fixes `since` badges that were authored with invalid AsciiDoc and never
rendered. A `since` badge is an inline role that must be immediately followed by
a formatted text span (e.g. `#...#`); a span-less badge renders as literal
`[since:...]` brackets or silently produces nothing.

- Correct 7 broken usages across 7 articles: a badge trailing a heading
  (`== Title [since:...]`) and badges alone on their own line, rewritten to the
  span form (`== [since:...]#Title#`, or wrapping a phrase in body text).
- Update the CLAUDE.md "Version References" guidance to document the correct
  form so future docs use it.

Note: section-heading badges only become visible together with the dspublisher
fix in vaadin/docs-app#537 -- the build attached the version to the wrong
element (a preceding `[classname]` macro or the heading anchor) and had no CSS
rule for badges in `h2`-`h6` headings. This PR makes the markup correct; #537
makes it render.
