### PR TITLE
docs: add Vaadin Agent Marketplace setup and fix Claude Code MCP instructions

### DIFF
--- a/articles/building-apps/mcp/index.adoc
+++ b/articles/building-apps/mcp/index.adoc
@@ -37,6 +37,11 @@ To use the Vaadin MCP server with your AI development tool, follow these steps:
 
 The MCP server automatically provides your AI assistant with access to up-to-date Vaadin documentation.
 
+[TIP]
+====
+If you use Claude Code or Codex, the https://github.com/vaadin/agent-marketplace[Vaadin Agent Marketplace] is the quickest way to get started. A single plugin installs both the Vaadin MCP server and a set of Vaadin development skills, so there's no need to configure the MCP server by hand. See the setup guides for <<{articles}/building-apps/mcp/supported-tools/claude-code# ,Claude Code>> and <<{articles}/building-apps/mcp/supported-tools/codex# ,Codex>> for details.
+====
+
 [.cards]
 == Supported Tools
 
@@ -129,6 +134,13 @@ For stdio-only tools like Junie, you can use https://github.com/pyroprompts/mcp-
 
 [.cards.quiet]
 == Resources
+
+[.card]
+=== Vaadin Agent Marketplace
+
+Install the Vaadin MCP server and development skills as a plugin for Claude Code and Codex.
+
+https://github.com/vaadin/agent-marketplace
 
 [.card]
 === GitHub Repository

--- a/articles/building-apps/mcp/supported-tools/claude-code.adoc
+++ b/articles/building-apps/mcp/supported-tools/claude-code.adoc
@@ -11,49 +11,79 @@ order: 10
 
 Claude Code is Anthropic's official CLI tool for agentic coding. It provides native support for HTTP-based MCP servers, making it straightforward to connect to the Vaadin MCP server.
 
-*Requirements:* Claude Code 0.4.0 or later
+== Recommended: Install via the Vaadin Agent Marketplace
 
-== Configuration
+The easiest way to set up Claude Code for Vaadin development is the https://github.com/vaadin/agent-marketplace[Vaadin Agent Marketplace] plugin. A single plugin installs both the Vaadin MCP server and a set of Vaadin development skills. When you use the plugin, you don't need to configure the MCP server manually as described below.
 
-Add the following to your `~/.config/claude/claude_desktop_config.json`:
+Installing the plugin requires a recent version of Claude Code with plugin support.
+
+. Add the marketplace:
++
+[source,terminal]
+----
+/plugin marketplace add vaadin/agent-marketplace
+----
++
+. Install the plugin:
++
+[source,terminal]
+----
+/plugin install vaadin-skills@vaadin-marketplace
+----
+
+Alternatively, run `/plugin` and select *vaadin-skills* from the marketplace browser.
+
+To update the plugin later, refresh the marketplace and update from the plugin manager:
+
+[source,terminal]
+----
+/plugin marketplace update vaadin-marketplace
+----
+
+If you prefer to connect only the MCP server, without the bundled skills, follow the manual configuration instructions below instead.
+
+== Manual Configuration
+
+The recommended way to add the MCP server on its own is Claude Code's built-in CLI.
+
+=== Global Configuration
+To add the Vaadin MCP server globally (available in all projects):
+
+[source,terminal]
+claude mcp add --transport http vaadin https://mcp.vaadin.com/docs --scope user
+
+=== Project-Scoped Configuration
+To add the server only for the current project, navigate to your project directory and run:
+
+[source,terminal]
+claude mcp add --transport http vaadin https://mcp.vaadin.com/docs --scope project
+
+This creates a `.mcp.json` file in your project root.
+
+[TIP]
+Use `claude mcp add --help` for all available options.
+
+After adding the server, restart Claude Code to load it.
+
+=== Editing the Configuration File
+Alternatively, add the server to Claude Code's configuration directly. User-scoped servers are stored in `~/.claude.json`, while project-scoped servers go in a `.mcp.json` file in your project root. Add a `vaadin` entry under `mcpServers`:
 
 [source,json]
 ----
 {
   "mcpServers": {
     "vaadin": {
+      "type": "http",
       "url": "https://mcp.vaadin.com/docs"
     }
-  },
+  }
 }
 ----
 
-After configuration, restart Claude Code to load the MCP server.
-
 [TIP]
 ====
-You can add multiple MCP servers to the configuration file. Each server should have a unique name in the `mcpServers` object.
+You can add multiple MCP servers to the configuration. Each server needs a unique name in the `mcpServers` object.
 ====
-
-== Alternative: CLI Configuration
-Instead of manually editing configuration files, you can use Claude Code's built-in CLI commands to add the Vaadin MCP server.
-
-=== Global Configuration
-To add the Vaadin MCP server globally (available in all projects):
-
-[source,terminal]
-claude mcp add-json vaadin '{"type":"http","url":"https://mcp.vaadin.com/docs"}' --scope user
-
-=== Project-Scoped Configuration
-To add the server only for the current project, navigate to your project directory and run:
-
-[source,terminal]
-claude mcp add-json vaadin '{"type":"http","url":"https://mcp.vaadin.com/docs"}' --scope project
-
-This creates a .mcp.json file in your project root.
-
-[TIP]
-The CLI approach is recommended for quick setup. Use `claude mcp add --help` for all available options.
 
 == Verify the Setup
 
@@ -63,21 +93,22 @@ After restarting Claude Code:
 . Ask a question about Vaadin development (e.g., "How to create a Button in Vaadin?")
 . Claude Code automatically uses the Vaadin MCP server to fetch relevant documentation
 
-You can verify that the MCP server is connected by checking the status indicators in Claude Code's interface.
+You can verify that the MCP server is connected by running the `/mcp` command in Claude Code, which lists each connected server along with its available tools.
 
 == Useful CLI Commands
 |===
 | Command | Description
 | `claude mcp list`
 | List all configured MCP servers
+| `claude mcp get vaadin`
+| Show details for the Vaadin MCP server
 | `claude mcp remove vaadin`
 | Remove the Vaadin MCP server
-| `claude mcp list-tools`
-| Show available tools from connected servers
 |===
 
 
 == Resources
 
-* https://platform.claude.com/docs/en/home[Claude Code Documentation]
+* https://github.com/vaadin/agent-marketplace[Vaadin Agent Marketplace]
+* https://code.claude.com/docs/en/mcp[Claude Code MCP Documentation]
 * https://github.com/vaadin/vaadin-mcp[Vaadin MCP Server Repository]

--- a/articles/building-apps/mcp/supported-tools/codex.adoc
+++ b/articles/building-apps/mcp/supported-tools/codex.adoc
@@ -13,7 +13,36 @@ OpenAI Codex provides native support for HTTP-based MCP servers, making it strai
 
 *Requirements:* Codex CLI version 0.43 or later
 
-== Configuration
+== Recommended: Install via the Vaadin Agent Marketplace
+
+The easiest way to set up Codex for Vaadin development is the https://github.com/vaadin/agent-marketplace[Vaadin Agent Marketplace] plugin. A single plugin installs both the Vaadin MCP server and a set of Vaadin development skills. When you use the plugin, you don't need to configure the MCP server manually as described below.
+
+. Add the marketplace:
++
+[source,terminal]
+----
+codex plugin marketplace add vaadin/agent-marketplace --ref main
+----
++
+. Install the plugin:
++
+[source,terminal]
+----
+codex plugin add vaadin-skills@vaadin-marketplace
+----
+
+To preview the available plugins before installing, run `codex plugin list --marketplace vaadin-marketplace --available`.
+
+To update the plugin later, upgrade the marketplace:
+
+[source,terminal]
+----
+codex plugin marketplace upgrade
+----
+
+If you prefer to connect only the MCP server, without the bundled skills, follow the manual configuration instructions below instead.
+
+== Manual Configuration
 
 Add the following to `~/.codex/config.toml`:
 
@@ -71,6 +100,7 @@ codex mcp list
 
 == Resources
 
+* https://github.com/vaadin/agent-marketplace[Vaadin Agent Marketplace]
 * https://developers.openai.com/codex/mcp/[Codex MCP Documentation]
 * https://github.com/openai/codex[Codex GitHub Repository]
 * https://github.com/vaadin/vaadin-mcp[Vaadin MCP Server Repository]

--- a/articles/building-apps/mcp/supported-tools/codex.adoc
+++ b/articles/building-apps/mcp/supported-tools/codex.adoc
@@ -17,6 +17,8 @@ OpenAI Codex provides native support for HTTP-based MCP servers, making it strai
 
 The easiest way to set up Codex for Vaadin development is the https://github.com/vaadin/agent-marketplace[Vaadin Agent Marketplace] plugin. A single plugin installs both the Vaadin MCP server and a set of Vaadin development skills. When you use the plugin, you don't need to configure the MCP server manually as described below.
 
+Installing the plugin requires a recent version of Codex with plugin support.
+
 . Add the marketplace:
 +
 [source,terminal]
@@ -31,7 +33,7 @@ codex plugin marketplace add vaadin/agent-marketplace --ref main
 codex plugin add vaadin-skills@vaadin-marketplace
 ----
 
-To preview the available plugins before installing, run `codex plugin list --marketplace vaadin-marketplace --available`.
+To preview the available plugins before installing, run `codex plugin list --marketplace vaadin-marketplace --available --json` (the `--available` flag requires `--json`).
 
 To update the plugin later, upgrade the marketplace:
 

--- a/articles/building-apps/mcp/supported-tools/codex.adoc
+++ b/articles/building-apps/mcp/supported-tools/codex.adoc
@@ -3,7 +3,7 @@ title: Codex
 page-title: Configure OpenAI Codex to Use Vaadin MCP Server
 description: Learn how to configure OpenAI Codex to access Vaadin documentation through the Model Context Protocol server
 meta-description: Setup instructions for connecting OpenAI Codex to the Vaadin MCP server. Enable AI code generation with Vaadin documentation access.
-order: 60
+order: 11
 ---
 
 

--- a/articles/building-apps/mcp/supported-tools/index.adoc
+++ b/articles/building-apps/mcp/supported-tools/index.adoc
@@ -5,7 +5,6 @@ description: Configure your AI development tool to use the Vaadin MCP server for
 meta-description: Setup guide for connecting Claude Code, Cursor, Windsurf, Junie, GitHub Copilot, and other AI tools to the Vaadin MCP server
 order: 101
 tab-title: Overview
-layout: tabbed-page
 ---
 
 
@@ -42,7 +41,16 @@ Most tools follow these general steps:
 
 See the specific instructions for your tool in the tabs above for exact configuration details.
 
+[TIP]
+====
+If you use Claude Code or Codex, you can skip manual configuration. The https://github.com/vaadin/agent-marketplace[Vaadin Agent Marketplace] installs the Vaadin MCP server and Vaadin development skills together as a single plugin. See the <<claude-code# ,Claude Code>> and <<codex# ,Codex>> setup guides for the install commands.
+====
+
 == Resources
+
+=== Vaadin Agent Marketplace
+
+* https://github.com/vaadin/agent-marketplace[Vaadin Agent Marketplace] — MCP server and skills as a plugin for Claude Code and Codex
 
 === Vaadin MCP Server
 


### PR DESCRIPTION
## What

Documents the [Vaadin Agent Marketplace](https://github.com/vaadin/agent-marketplace) as the recommended way to set up **Claude Code** and **Codex** for Vaadin development. A single plugin installs both the Vaadin MCP server and the Vaadin development skills, so users no longer need to configure the MCP server by hand.

It also corrects several outdated/incorrect details in the Claude Code MCP setup guide that surfaced while verifying the page.

## Why

The agent marketplace is a new, lower-friction install path that bundles the skills and MCP server together. The existing Claude Code instructions also pointed at the wrong config file and an invalid command, which would fail if followed.

## Changes

**Agent Marketplace**
- New "Recommended: Install via the Vaadin Agent Marketplace" section in the Claude Code and Codex setup guides, with install/update commands.
- TIP boxes and Resources links in the MCP overview (`mcp/index.adoc`) and setup-guide overview (`supported-tools/index.adoc`).
- The skill list is intentionally described generically (no per-skill breakdown), since the skill set is expected to change frequently.

**Claude Code MCP corrections**
- Config file location fixed: Claude Code uses `~/.claude.json` (user) and `.mcp.json` (project), not the Claude Desktop file `~/.config/claude/claude_desktop_config.json`.
- Removed an invalid trailing comma from the JSON example and added `"type": "http"`.
- Recommend the modern `claude mcp add --transport http` form over `claude mcp add-json`.
- Replaced the non-existent `claude mcp list-tools` command with `claude mcp get`, and use `/mcp` for verifying connected servers.
- Updated broken docs link to `https://code.claude.com/docs/en/mcp`.

## Reviewer notes

- The marketplace and Claude Code commands were verified against the official Claude Code docs. `/plugin marketplace update <name>` is confirmed to exist.
- The Codex commands (`codex plugin add`, `codex plugin marketplace upgrade`) come from the marketplace README and were **not** independently verified against Codex's own docs — worth a second look if a reviewer has a Codex setup handy.
- `package-lock.json` had unrelated lockfile churn in the working tree; it was deliberately excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)