### PR TITLE
docs: mdl animation docs

### DIFF
--- a/articles/components/master-detail-layout/index.adoc
+++ b/articles/components/master-detail-layout/index.adoc
@@ -261,6 +261,36 @@ include::{root}/frontend/demo/component/master-detail-layout/react/PersonDetail.
 endif::[]
 --
 
+== Animation
+
+When detail content is added, replaced, or removed, the layout animates the transition. The detail area slides and fades into place next to the master area, or slides in from the edge with a backdrop when shown as an overlay. Animations are skipped automatically when the user's operating system requests reduced motion.
+
+Animations are enabled by default. They can be disabled, for example to make detail changes apply instantly:
+
+[.example]
+--
+ifdef::flow[]
+[source,Java]
+----
+<source-info group="Flow"></source-info>
+layout.setAnimationEnabled(false);
+----
+endif::[]
+ifdef::react[]
+[source,tsx]
+----
+<source-info group="React"></source-info>
+<MasterDetailLayout noAnimation />
+----
+endif::[]
+--
+
+.Avoiding Animation on Initial Render in React
+[NOTE]
+====
+When detail content is rendered conditionally based on state that is loaded asynchronously, for example in a `useEffect` hook, the detail appears after the layout has already rendered. The layout detects this as a change and animates the detail in, even though it is really the initial content. To avoid this, render the entire layout only once the data is available, instead of rendering the layout first and adding the detail afterwards.
+====
+
 [role="since:com.vaadin:vaadin@V25.2"]
 == Detail Placeholder
 

--- a/frontend/demo/component/master-detail-layout/react/master-detail-layout-nested.tsx
+++ b/frontend/demo/component/master-detail-layout/react/master-detail-layout-nested.tsx
@@ -22,6 +22,7 @@ function Example() {
   const professions = useSignal<string[]>([]);
   const selectedProfession = useSignal<string | null>(null);
   const selectedPerson = useSignal<Person | null>(null);
+  const hasInitialData = useSignal(false);
 
   const persons = useComputed(() => {
     const profession = selectedProfession.value;
@@ -36,10 +37,15 @@ function Example() {
       people.value = allPeople;
       professions.value = [...new Set(allPeople.map((p) => p.profession))].toSorted().slice(0, 4);
       selectedProfession.value = professions.value[0];
+      hasInitialData.value = true;
     });
   }, []);
 
-  return (
+  // For the outer MDL, details can only be rendered after initial data has been loaded. The details
+  // being rendered later than the root component results in an animation for what is practically
+  // the initial rendering of the component. As a workaround, render the whole MDL only after the
+  // initial data has been loaded.
+  return hasInitialData.value ? (
     <SplitLayout style={{ height: '100%' }}>
       {/* tag::snippet[] */}
       <MasterDetailLayout
@@ -113,6 +119,7 @@ function Example() {
           ) : null}
         </MasterDetailLayout.Detail>
       </MasterDetailLayout>
+
       {/* end::snippet[] */}
       <div
         style={{
@@ -130,7 +137,7 @@ function Example() {
         </span>
       </div>
     </SplitLayout>
-  );
+  ) : null;
 }
 
 export default reactExample(Example); // hidden-source-line


### PR DESCRIPTION
Adds an "Animation" section to the MDL docs that explains how animations work and how to disable them. Also explains a workaround for the React component when the initial details are rendered asynchronously and updates the nested MDL example to use it.

Closes https://github.com/vaadin/react-components/issues/379