### PR TITLE
docs: update shared Vaadin environment example

### DIFF
--- a/articles/flow/testing/browserless/optimizing-tests.adoc
+++ b/articles/flow/testing/browserless/optimizing-tests.adoc
@@ -85,24 +85,26 @@ class ViewTestConfig {
 
 By default, the Vaadin environment -- the session, the UI, and all routes -- is created before every test method and torn down after. For classes with many tests that navigate to views sharing the same [classname]`MainLayout`, this setup cost can dominate the test runtime.
 
-Annotating the test class with [annotationname]`@TestInstance(Lifecycle.PER_CLASS)` initializes the environment once in [annotationname]`@BeforeAll` and shares the same [classname]`UI` instance across all test methods in the class. This can significantly reduce runtime for suites with hundreds of tests on the same view.
+To reuse a single Vaadin environment across all test methods in a class, register a static [classname]`BrowserlessClassExtension` with [annotationname]`@RegisterExtension`. The extension initializes the environment once before all tests and tears it down after all tests, sharing the same [classname]`UI` instance across every method. Instead of extending [classname]`BrowserlessTest`, implement the [interfacename]`TesterWrappers` and [interfacename]`Locators` interfaces to use the tester and locator DSL directly, and use the extension instance for navigation. This can significantly reduce runtime for suites with hundreds of tests on the same view.
 
-.Per-Class Lifecycle Example
+.Shared Environment Example
 [source,java]
 ----
 @ViewPackages(classes = CartView.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class CartViewTest extends BrowserlessTest {
+class CartViewTest implements TesterWrappers, Locators {
+
+    @RegisterExtension
+    static BrowserlessClassExtension extension = new BrowserlessClassExtension();
 
     @BeforeAll
-    void setup() {
-        navigate(CartView.class);
+    static void setup() {
+        extension.navigate(CartView.class);
     }
 
     @Test
     void addItem_increasesCartSize() {
         // same UI instance as the other tests
-        test(find(Button.class).withText("Add").single()).click();
+        findButton().withText("Add").click();
     }
 
     @Test
@@ -113,10 +115,10 @@ class CartViewTest extends BrowserlessTest {
 ----
 
 [WARNING]
-With a shared environment, state leaks between tests. Tests must either tolerate leftover state or reset it explicitly -- for example, by re-navigating to the view in a [annotationname]`@BeforeEach` method. Prefer per-class lifecycle for read-only or independent interactions; stick with the default per-method lifecycle when tests mutate shared state in conflicting ways.
+With a shared environment, state leaks between tests. Tests must either tolerate leftover state or reset it explicitly -- for example, by re-navigating to the view in a [annotationname]`@BeforeEach` method. Prefer a shared environment for read-only or independent interactions; stick with the default per-method lifecycle when tests mutate shared state in conflicting ways.
 
 [NOTE]
-This optimization applies only to [classname]`BrowserlessTest`. [classname]`SpringBrowserlessTest` and [classname]`QuarkusBrowserlessTest` still reinitialize the Vaadin environment before each test method, so [annotationname]`@TestInstance(PER_CLASS)` on those classes doesn't share the Vaadin environment -- though it can still be useful for sharing other per-class state.
+The base test classes -- [classname]`BrowserlessTest`, [classname]`SpringBrowserlessTest`, and [classname]`QuarkusBrowserlessTest` -- always reinitialize the Vaadin environment before each test method. Annotating them with [annotationname]`@TestInstance(PER_CLASS)` therefore does not share the Vaadin environment, although it can still be useful for sharing other per-class state. Use a static [classname]`BrowserlessClassExtension` as shown above to share the Vaadin environment.
 
 
 [discussion-id]`A3B7E2F1-5D89-4C6A-9E12-7F4A8B3C6D50`


### PR DESCRIPTION
`BrowserlessTest` no longer shares the environment with `@TestInstance(PER_CLASS)`. Show using a static `BrowserlessClassExtension` instead.



