### PR TITLE
Update minimum Spring Boot requirement to 4.1 for Vaadin 25.2

### DIFF
--- a/articles/_vaadin-version.adoc
+++ b/articles/_vaadin-version.adoc
@@ -4,5 +4,5 @@
 :vaadin-flow-version: 25.1.4
 :vaadin-seven-version: 7.7.49
 :vaadin-eight-version: 8.28.4
-:spring-boot-version: 4.0.6
+:spring-boot-version: 4.1.0
 :swing-bridge-version: 1.2.0

--- a/articles/_vaadin-version.adoc
+++ b/articles/_vaadin-version.adoc
@@ -1,7 +1,7 @@
-:vaadin-version: 25.1.4
-:vaadin-start-platform-version: v25.1
+:vaadin-version: 25.2.0
+:vaadin-start-platform-version: v25.2
 :vaadin-start-java-version: 21
-:vaadin-flow-version: 25.1.4
+:vaadin-flow-version: 25.2.0
 :vaadin-seven-version: 7.7.49
 :vaadin-eight-version: 8.28.4
 :spring-boot-version: 4.1.0

--- a/articles/compatibility.adoc
+++ b/articles/compatibility.adoc
@@ -16,7 +16,7 @@ This page shows the minimum required versions of supported technologies for Vaad
 |Technology|Version
 
 | Java| 21 or later
-| Spring Boot| 4.0 or later
+| Spring Boot| 4.1 or later
 | Node.js| 24 or later
 | Maven| 3.8 or later
 | Gradle| 8.14 or later

--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -161,7 +161,7 @@ You'll need to upgrade Spring to the latest versions, including the starter pare
 <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
 </parent>
 ----
 
@@ -174,7 +174,7 @@ Before migrating, find the corresponding version of the Jakarta EE 11-compatible
 Ensure that the Maven plugins which are explicitly defined in your project, are compatible with Java 21.
 A safe choice: Maven 3.9.11 (or the latest in the 3.9 line) or Maven 4.0.x (once stable) if you are comfortable with that.
 
-To run Gradle on top of Java 21 and latest Spring Boot 4 versions, you'll need to use version 8.14 or later. See the link:https://docs.gradle.org/8.14/release-notes.html[Gradle release notes] for further details. If your project uses Spring Boot, upgrade the plugin `org.springframework.boot` to version 4.0.0.
+To run Gradle on top of Java 21 and latest Spring Boot 4 versions, you'll need to use version 8.14 or later. See the link:https://docs.gradle.org/8.14/release-notes.html[Gradle release notes] for further details. If your project uses Spring Boot, upgrade the plugin `org.springframework.boot` to version 4.1.0 or later.
 
 If you're using a Gradle wrapper, update it to version 8.14 by executing the following from the command line:
 


### PR DESCRIPTION
## What changed

Vaadin 25.2 raises its minimum supported Spring Boot version to **4.1**. This updates the documentation to match:

- **`articles/compatibility.adoc`** — Supported Technologies table: Spring Boot `4.0 or later` → `4.1 or later`.
- **`articles/upgrading/index.adoc`** — bumped the example `spring-boot-starter-parent` version from `4.0.0` to `4.1.0`, and changed the Gradle plugin upgrade instruction from `4.0.0` to `4.1.0 or later`.

## Why

The docs previously listed Spring Boot 4.0 as the minimum, which is no longer accurate as of Vaadin 25.2.

## Notes for reviewers

- An unrelated `package-lock.json` change was present in the working tree (npm install side effect) and was intentionally left out of this PR.
- Companion change to the MCP server primer is in vaadin/vaadin-mcp#143.