### PR TITLE
docs: assorted fixes and clarifications from developer feedback

### DIFF
--- a/articles/building-apps/server-push/index.adoc
+++ b/articles/building-apps/server-push/index.adoc
@@ -40,6 +40,9 @@ public class Application implements AppShellConfigurator {
 }
 ----
 
+[NOTE]
+Adding, removing, or changing `@Push` -- like any annotation on the application shell class -- takes effect only when the application starts. During development, hot reload (such as HotswapAgent) doesn't apply the change; you have to restart the application for the new push configuration to take effect.
+
 
 == Push Modes
 

--- a/articles/building-apps/ui-basics/add-drag-and-drop.adoc
+++ b/articles/building-apps/ui-basics/add-drag-and-drop.adoc
@@ -50,8 +50,8 @@ public class DragAndDropExampleView extends HorizontalLayout {
         column.add(new H3(title));
         column.setWidth("300px");
         column.setMinHeight("400px");
-        column.getStyle().set("border", "1px solid var(--lumo-contrast-20pct)");
-        column.getStyle().set("border-radius", "var(--lumo-border-radius-m)");
+        column.getStyle().set("border", "1px solid var(--vaadin-border-color-secondary)");
+        column.getStyle().set("border-radius", "var(--vaadin-radius-m)");
 
         DropTarget<VerticalLayout> dropTarget = DropTarget.create(column);
         dropTarget.setDropEffect(DropEffect.MOVE);
@@ -63,9 +63,9 @@ public class DragAndDropExampleView extends HorizontalLayout {
 
     private Div createDraggableItem(String text) {
         Div item = new Div(new Span(text));
-        item.getStyle().set("padding", "var(--lumo-space-s)");
-        item.getStyle().set("background", "var(--lumo-contrast-5pct)");
-        item.getStyle().set("border-radius", "var(--lumo-border-radius-s)");
+        item.getStyle().set("padding", "var(--vaadin-padding-s)");
+        item.getStyle().set("background", "var(--vaadin-background-container)");
+        item.getStyle().set("border-radius", "var(--vaadin-radius-s)");
         item.getStyle().set("cursor", "grab");
 
         DragSource.create(item);
@@ -140,7 +140,7 @@ Vaadin automatically applies CSS class names during drag operations that you can
 }
 
 .v-drag-over-target {
-    outline: 2px solid var(--lumo-primary-color);
+    outline: 2px solid var(--vaadin-focus-ring-color);
 }
 ----
 

--- a/articles/building-apps/views/add-router-layout.adoc
+++ b/articles/building-apps/views/add-router-layout.adoc
@@ -71,7 +71,9 @@ public class MainLayout extends AppLayout { // <1>
 .Security Annotations Required
 [IMPORTANT]
 ====
-`@Layout` classes need an access annotation such as [annotationname]`@AnonymousAllowed`, [annotationname]`@PermitAll`, or [annotationname]`@RolesAllowed`. Without one, all views rendered inside the layout return a 403 Forbidden error. For most applications, [annotationname]`@PermitAll` is the right choice for the main layout, since it allows all authenticated users to access it:
+When view access control is enabled, a [annotationname]`@Layout` class needs its *own* access annotation -- such as [annotationname]`@AnonymousAllowed`, [annotationname]`@PermitAll`, or [annotationname]`@RolesAllowed` -- in addition to the annotations on the views it renders. Annotating only the views isn't enough: if the layout itself isn't accessible, navigation to any view inside it is denied with a message such as _"Denied access to view 'DirectoryView' due to layout 'MainLayout' access rules."_
+
+For most applications, [annotationname]`@PermitAll` is the right choice for the main layout, since it allows all authenticated users to render it while the per-view annotations still gate each route's content:
 
 [source,java]
 ----

--- a/articles/components/combo-box/index.adoc
+++ b/articles/components/combo-box/index.adoc
@@ -56,6 +56,14 @@ endif::[]
 
 The overlay opens when the user clicks the field using a pointing device. Using the Up/Down arrow keys or typing a character -- found in at least one of the options -- when the field is focused also opens the popup.
 
+.Selection Uses equals() and hashCode()
+[NOTE]
+====
+Combo Box matches the selected value to its items using [methodname]`equals()` and [methodname]`hashCode()`, not reference identity. So [methodname]`setValue()` preselects an item only if the value you pass is _equal_ to one of the items given to [methodname]`setItems()`. The [classname]`Country` class above overrides both methods (based on its `id`), which is why preselection works.
+
+This matters for entity types: a JPA entity that doesn't override [methodname]`equals()` and [methodname]`hashCode()` won't preselect, because a freshly loaded instance isn't equal to the option instance the component holds -- so the field silently stays empty. Either override both methods (for example, based on the entity's ID), or pass the exact item instances the component already holds.
+====
+
 
 == Custom Value Entry
 

--- a/articles/components/combo-box/index.adoc
+++ b/articles/components/combo-box/index.adoc
@@ -59,7 +59,7 @@ The overlay opens when the user clicks the field using a pointing device. Using 
 .Selection Uses equals() and hashCode()
 [NOTE]
 ====
-Combo Box matches the selected value to its items using [methodname]`equals()` and [methodname]`hashCode()`, not reference identity. So [methodname]`setValue()` preselects an item only if the value you pass is _equal_ to one of the items given to [methodname]`setItems()`. The [classname]`Country` class above overrides both methods (based on its `id`), which is why preselection works.
+Combo Box matches the selected value to its items using [methodname]`equals()` and [methodname]`hashCode()`, not reference identity. So [methodname]`setValue()` preselects an item only if the value you pass is _equal_ to one of the items given to [methodname]`setItems()`. The [classname]`Country` class above overrides both methods (based on its `id`), which is why a matching value is preselected.
 
 This matters for entity types: a JPA entity that doesn't override [methodname]`equals()` and [methodname]`hashCode()` won't preselect, because a freshly loaded instance isn't equal to the option instance the component holds -- so the field silently stays empty. Either override both methods (for example, based on the entity's ID), or pass the exact item instances the component already holds.
 ====

--- a/articles/components/horizontal-layout/_troubleshooting.adoc
+++ b/articles/components/horizontal-layout/_troubleshooting.adoc
@@ -297,3 +297,67 @@ endif::[]
 ==== Enable Layout Improvements (Flow only, experimental)
 
 By enabling the `layoutComponentImprovements` <<{articles}/flow/configuration/feature-flags#,feature flag>>, the Flow APIs `setWidthFull`, `setHeightFull` and `setSizeFull` are rewired to also set the minimum size of nested Horizontal and Vertical Layouts to 0, allowing them to shrink below the size of their contents.
+
+
+=== A Nested Layout Takes All the Space
+
+When you nest a Vertical Layout or Horizontal Layout inside another layout, its *default size* -- not just the sizes you set explicitly -- affects how space is shared. A Vertical Layout defaults to `width: 100%`, so when nested as a child of a Horizontal Layout it claims the full width of the row and starves its siblings. (A nested Horizontal Layout defaults to hugging its content instead.)
+
+A typical symptom is a text column that should grow and truncate with an ellipsis, but instead collapses to zero width: a sibling layout's implicit 100% width has consumed the row. Adding the usual `min-width: 0` ellipsis recipe to the text column isn't enough on its own, because the sibling's default width is the real cause.
+
+To fix this, size both children explicitly: let the column that should only take the space it needs hug its content, and give the growing column `flex: 1 1 0` together with `width: 0`, `min-width: 0`, and `overflow: hidden` so it can shrink below its content size and truncate.
+
+[.example]
+--
+ifdef::lit[]
+[source,html]
+----
+<source-info group="Lit"></source-info>
+<vaadin-horizontal-layout>
+  <!-- Grows and truncates -->
+  <vaadin-vertical-layout
+      style="flex: 1 1 0; width: 0; min-width: 0; overflow: hidden;">
+    ...
+  </vaadin-vertical-layout>
+  <!-- Hugs its content (time + badge) -->
+  <vaadin-vertical-layout style="width: auto;">
+    ...
+  </vaadin-vertical-layout>
+</vaadin-horizontal-layout>
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+<source-info group="Flow"></source-info>
+HorizontalLayout row = new HorizontalLayout(textColumn, metaColumn);
+
+// The growing column truncates with an ellipsis
+textColumn.getStyle().set("flex", "1 1 0");
+textColumn.setWidth("0");
+textColumn.setMinWidth("0");
+textColumn.getStyle().setOverflow(Overflow.HIDDEN);
+
+// The meta column hugs its content instead of filling the row
+metaColumn.setWidth(null);
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+<source-info group="React"></source-info>
+<HorizontalLayout>
+  {/* Grows and truncates */}
+  <VerticalLayout style={{ flex: '1 1 0', width: 0, minWidth: 0, overflow: 'hidden' }}>
+    ...
+  </VerticalLayout>
+  {/* Hugs its content (time + badge) */}
+  <VerticalLayout style={{ width: 'auto' }}>
+    ...
+  </VerticalLayout>
+</HorizontalLayout>
+----
+endif::[]
+--

--- a/articles/components/horizontal-layout/_troubleshooting.adoc
+++ b/articles/components/horizontal-layout/_troubleshooting.adoc
@@ -301,7 +301,7 @@ By enabling the `layoutComponentImprovements` <<{articles}/flow/configuration/fe
 
 === A Nested Layout Takes All the Space
 
-When you nest a Vertical Layout or Horizontal Layout inside another layout, its *default size* -- not just the sizes you set explicitly -- affects how space is shared. A Vertical Layout defaults to `width: 100%`, so when nested as a child of a Horizontal Layout it claims the full width of the row and starves its siblings. (A nested Horizontal Layout defaults to hugging its content instead.)
+When you nest a Vertical Layout or Horizontal Layout inside another layout, its *default size* -- not only the sizes you set explicitly -- affects how space is shared. A Vertical Layout defaults to `width: 100%`, so when nested as a child of a Horizontal Layout it claims the full width of the row and starves its siblings. (A nested Horizontal Layout defaults to hugging its content instead.)
 
 A typical symptom is a text column that should grow and truncate with an ellipsis, but instead collapses to zero width: a sibling layout's implicit 100% width has consumed the row. Adding the usual `min-width: 0` ellipsis recipe to the text column isn't enough on its own, because the sibling's default width is the real cause.
 

--- a/articles/components/horizontal-layout/_troubleshooting.adoc
+++ b/articles/components/horizontal-layout/_troubleshooting.adoc
@@ -334,7 +334,9 @@ ifdef::flow[]
 HorizontalLayout row = new HorizontalLayout(textColumn, metaColumn);
 
 // The growing column truncates with an ellipsis
-textColumn.getStyle().set("flex", "1 1 0");
+textColumn.getStyle().setFlexGrow("1");   // grow to fill free space
+textColumn.getStyle().setFlexShrink("1"); // allow shrinking
+textColumn.getStyle().setFlexBasis("0");  // start from zero width
 textColumn.setWidth("0");
 textColumn.setMinWidth("0");
 textColumn.getStyle().setOverflow(Overflow.HIDDEN);

--- a/articles/components/multi-select-combo-box/index.adoc
+++ b/articles/components/multi-select-combo-box/index.adoc
@@ -111,6 +111,14 @@ endif::[]
 
 When the overlay is closed, items can be removed one by one (starting with the most recently selected item) using the kbd:[Backspace] key. The first kbd:[Backspace] press moves focus to the last chip; the second press removes that chip, and the corresponding item, from the selection.
 
+.Selection Uses equals() and hashCode()
+[NOTE]
+====
+Multi-Select Combo Box matches selected values to its items using [methodname]`equals()` and [methodname]`hashCode()`, not reference identity. [methodname]`setValue(Set)` and [methodname]`select()` preselect only items that are _equal_ to those given to [methodname]`setItems()`. The [classname]`Country` class used here overrides both methods (based on its `id`), which is why the preselected chips appear.
+
+This matters for entity types: JPA entities that don't override [methodname]`equals()` and [methodname]`hashCode()` won't preselect, because freshly loaded instances aren't equal to the option instances the component holds -- so the chips silently don't appear. Either override both methods (for example, based on the entity's ID), or select the exact item instances the component already holds.
+====
+
 
 === Selection Change
 

--- a/articles/flow/component-internals/element-api/event-listener.adoc
+++ b/articles/flow/component-internals/element-api/event-listener.adoc
@@ -46,11 +46,11 @@ helloButton.addEventListener("click", this::handleClick)
     .addEventData("element.offsetWidth");
 
 private void handleClick(DomEvent event) {
-    JsonObject eventData = event.getEventData(); // <2>
+    JsonNode eventData = event.getEventData(); // <2>
     boolean shiftKey = eventData
-            .getBoolean("event.shiftKey"); // <3>
+            .get("event.shiftKey").asBoolean(); // <3>
     double width = eventData
-            .getNumber("element.offsetWidth");
+            .get("element.offsetWidth").asDouble();
 
     String text = "Shift " + (shiftKey ? "down" : "up");
     text += " on button whose width is " + width + "px";
@@ -60,11 +60,13 @@ private void handleClick(DomEvent event) {
 }
 ----
 <1> The requested event data values are sent as a JSON object from the client.
-<2> You can retrieve the event data using the [methodname]`DomEvent.getEventData()` method in the listener.
-<3> Make sure that you use:
-* the correct getter based on the data type;
-* the same keys that were provided as parameters in the [methodname]`addEventData()` method.
+<2> You can retrieve the event data using the [methodname]`DomEvent.getEventData()` method in the listener. It returns a Jackson [classname]`JsonNode` (from `tools.jackson.databind`).
+<3> Look up each value by the same key you passed to [methodname]`addEventData()`, then read it with the accessor that matches its type -- for example [methodname]`asBoolean()`, [methodname]`asInt()`, [methodname]`asDouble()`, or [methodname]`asText()`.
 ====
+
+.Return Type Changed in Vaadin 25
+[NOTE]
+In Vaadin 25, [methodname]`DomEvent.getEventData()` returns a Jackson [classname]`JsonNode` (`tools.jackson.databind.JsonNode`) instead of the previous Elemental `JsonObject`. Code written for earlier versions no longer compiles: replace `JsonObject` with [classname]`JsonNode`, and the Elemental getters such as `getString(key)`, `getBoolean(key)`, and `getNumber(key)` with `get(key).asText()`, `get(key).asBoolean()`, and `get(key).asDouble()`. See <<{articles}/upgrading#,the upgrade guide>> for the full list of Elemental-to-Jackson changes.
 
 
 == Filtering and Debouncing

--- a/articles/flow/component-internals/element-api/event-listener.adoc
+++ b/articles/flow/component-internals/element-api/event-listener.adoc
@@ -64,9 +64,9 @@ private void handleClick(DomEvent event) {
 <3> Look up each value by the same key you passed to [methodname]`addEventData()`, then read it with the accessor that matches its type -- for example [methodname]`asBoolean()`, [methodname]`asInt()`, [methodname]`asDouble()`, or [methodname]`asText()`.
 ====
 
-.Return Type Changed in Vaadin 25
+.Return Type Changed from Elemental JSON
 [NOTE]
-In Vaadin 25, [methodname]`DomEvent.getEventData()` returns a Jackson [classname]`JsonNode` (`tools.jackson.databind.JsonNode`) instead of the previous Elemental `JsonObject`. Code written for earlier versions no longer compiles: replace `JsonObject` with [classname]`JsonNode`, and the Elemental getters such as `getString(key)`, `getBoolean(key)`, and `getNumber(key)` with `get(key).asText()`, `get(key).asBoolean()`, and `get(key).asDouble()`. See <<{articles}/upgrading#,the upgrade guide>> for the full list of Elemental-to-Jackson changes.
+[methodname]`DomEvent.getEventData()` now returns a Jackson [classname]`JsonNode` (`tools.jackson.databind.JsonNode`) instead of the previous Elemental `JsonObject`. Code written for earlier versions no longer compiles: replace `JsonObject` with [classname]`JsonNode`, and the Elemental getters such as `getString(key)`, `getBoolean(key)`, and `getNumber(key)` with `get(key).asText()`, `get(key).asBoolean()`, and `get(key).asDouble()`. See <<{articles}/upgrading#,the upgrade guide>> for the full list of Elemental-to-Jackson changes.
 
 
 == Filtering and Debouncing

--- a/articles/flow/configuration/live-reload/hotswap-agent.adoc
+++ b/articles/flow/configuration/live-reload/hotswap-agent.adoc
@@ -95,7 +95,7 @@ The live reload “quiet time” -- which is in milliseconds since the last Java
 
 You should configure the Vaadin Hotswap plugin to watch only for application classes by setting the `vaadin.watched-packages` property in the [filename]`hotswap-agent.properties` file. This improves performance, and prevents unnecessary reloads by limiting the plugin's monitoring to relevant packages. The value given should be a comma-separated list of Java package names (e.g., `com.example.ui,com.example.endpoints`).
 
-Changes to some parts of the Java code, such application startup listeners, won't have any effect until the server is restarted and the startup listeners run again. For these, you need to restart the server.
+Changes to some parts of the Java code, such as application startup listeners or annotations on the application shell class -- for example `@Push`, `@PWA`, and other `AppShellConfigurator` annotations -- won't have any effect until the server is restarted and the startup logic runs again. For these, you need to restart the server.
 
 If you're using the <</flow/advanced/preserving-state-on-refresh#,`@PreserveOnRefresh`>> annotation, the same view instance is reused when the browser is reloaded. That means changes aren't necessarily visible until the view is opened in another browser tab.
 

--- a/articles/flow/testing/browserless/optimizing-tests.adoc
+++ b/articles/flow/testing/browserless/optimizing-tests.adoc
@@ -80,6 +80,15 @@ class ViewTestConfig {
 }
 ----
 
+[NOTE]
+====
+Prefer replacing services this way -- a test [annotationname]`@Configuration` selected with [annotationname]`@ContextConfiguration` -- over bean overrides such as [annotationname]`@MockitoBean` or [annotationname]`@MockBean`, especially when other test classes in the same run authenticate with [annotationname]`@WithUserDetails`, [annotationname]`@WithMockUser`, or a similar annotation.
+
+A bean override changes the context definition, so Spring's test context cache stores a *separate* application context for that test class. In a multi-class run, the resulting context churn can leave the Vaadin and Spring Security integration in a state where the simulated user isn't applied during navigation, causing protected views to redirect to the login view in *unrelated* tests -- a confusing failure that disappears when the affected class is run on its own.
+
+For service-level tests that don't need the Vaadin context, an even simpler option is to construct the service directly with stub collaborators (for example `new ResourceService(repo, id -> 0L)`) instead of overriding a bean. Both approaches keep a single shared context.
+====
+
 
 == [since:com.vaadin:vaadin@V25.2]#Sharing the Vaadin Environment Across Tests#
 

--- a/articles/flow/testing/browserless/spring-security.adoc
+++ b/articles/flow/testing/browserless/spring-security.adoc
@@ -66,6 +66,9 @@ To use Spring Security test annotations, first make sure the dependency is added
 </dependency>
 ----
 
+[CAUTION]
+Overriding beans with [annotationname]`@MockitoBean` or [annotationname]`@MockBean` makes Spring cache a separate application context for that test class. In a multi-class run, this can prevent the simulated user from being applied during navigation, causing protected views to redirect unexpectedly to the login view -- sometimes in *other* test classes. If security navigation tests fail only when the whole suite runs, suspect a bean override elsewhere. See <<optimizing-tests#using-a-reduced-application-context,Using a Reduced Application Context>> for a context-friendly way to replace services.
+
 Then extend [classname]`SpringBrowserlessTest` and annotate test methods to set up an authentication scenario. For the simplest use cases, use [annotationname]`@WithMockUser` or [annotationname]`@WithAnonymousUser`, providing the username and roles that should be granted.
 
 .Tests with Mock Users

--- a/articles/flow/testing/playwright.adoc
+++ b/articles/flow/testing/playwright.adoc
@@ -126,6 +126,37 @@ public class TrivialPlaywrightTest {
 <8> Asserts that there is an element with id `msg` in the page that contains the text, `Clicked!`. If you get instead the text using `+page.locator("#msg").textContent()+` and assert using standard JUnit API, it might fail as the server round-trip response might not yet be completed. Again, using the assertion method from Playwright helpers gives a bit of time for a single-page web application to render the response. Alternatively, you could add, for example, a `+page.getByText("Clicked!").waitFor();+` line before the assertion to ensure the server round-trip has been completed.
 
 
+== Selecting Vaadin Components
+
+Vaadin components are Web Components, so part of their structure lives in shadow DOM and part in slotted light DOM. Because Playwright has no Vaadin-specific element API, a couple of cases trip up hand-written selectors.
+
+=== Dialog Action Buttons Are Slotted
+
+A [classname]`ConfirmDialog`'s confirm, cancel, and reject buttons are *slotted light-DOM children* of `vaadin-confirm-dialog` -- they aren't inside its shadow DOM. Target the slotted button directly:
+
+[source,java]
+----
+page.locator("vaadin-confirm-dialog vaadin-button[slot='confirm-button']").click();
+// also: [slot='cancel-button'] and [slot='reject-button']
+----
+
+A visibility check based on `offsetParent` skips slotted content and misses these buttons, and synthesizing a `click()` on a guessed wrapper element is unreliable -- especially when a confirm dialog is stacked over another overlay, such as an editor, where you need the real button. See <<{articles}/components/confirm-dialog/styling#,ConfirmDialog styling>> for the full list of slot selectors.
+
+=== Grid Cell Content Is Recycled
+
+[classname]`Grid` renders each cell's content into a `vaadin-grid-cell-content` element and *reuses* these elements as rows scroll or the grid refreshes. Detached copies of previously rendered content can linger in the document, so a broad query such as `document.querySelectorAll('vaadin-grid-cell-content')` may report rows that the user no longer sees.
+
+Read grid state from the *live* cells only -- scope the query to the grid and let Playwright match attached, visible elements -- rather than enumerating every cell-content element in the document:
+
+[source,java]
+----
+// Matches only attached, visible cell content within the grid
+Locator cells = page.locator("vaadin-grid vaadin-grid-cell-content:visible");
+----
+
+Alternatively, wait for the refresh to settle (for example, with an explicit `waitFor()`) before asserting, or reload the page to clear detached content.
+
+
 == Running the Test
 
 As the test is annotated with the JUnit 5 @Test annotation, the most natural way to run it is via an IDE. Also, the test is picked up by convention if you call it like so:

--- a/articles/flow/testing/playwright.adoc
+++ b/articles/flow/testing/playwright.adoc
@@ -126,13 +126,13 @@ public class TrivialPlaywrightTest {
 <8> Asserts that there is an element with id `msg` in the page that contains the text, `Clicked!`. If you get instead the text using `+page.locator("#msg").textContent()+` and assert using standard JUnit API, it might fail as the server round-trip response might not yet be completed. Again, using the assertion method from Playwright helpers gives a bit of time for a single-page web application to render the response. Alternatively, you could add, for example, a `+page.getByText("Clicked!").waitFor();+` line before the assertion to ensure the server round-trip has been completed.
 
 
-== Selecting Vaadin Components
+== Selecting Components
 
 Vaadin components are Web Components, so part of their structure lives in shadow DOM and part in slotted light DOM. Because Playwright has no Vaadin-specific element API, a couple of cases trip up hand-written selectors.
 
 === Dialog Action Buttons Are Slotted
 
-A [classname]`ConfirmDialog`'s confirm, cancel, and reject buttons are *slotted light-DOM children* of `vaadin-confirm-dialog` -- they aren't inside its shadow DOM. Target the slotted button directly:
+A [classname]`ConfirmDialog`'s confirm, cancel, and reject buttons are *slotted light-DOM children*, not part of its shadow DOM. Target the slotted button directly:
 
 [source,java]
 ----
@@ -140,7 +140,7 @@ page.locator("vaadin-confirm-dialog vaadin-button[slot='confirm-button']").click
 // also: [slot='cancel-button'] and [slot='reject-button']
 ----
 
-A visibility check based on `offsetParent` skips slotted content and misses these buttons, and synthesizing a `click()` on a guessed wrapper element is unreliable -- especially when a confirm dialog is stacked over another overlay, such as an editor, where you need the real button. See <<{articles}/components/confirm-dialog/styling#,ConfirmDialog styling>> for the full list of slot selectors.
+A visibility check based on `offsetParent` skips slotted content and misses these buttons, and synthesizing a `click()` on a guessed wrapper element is unreliable -- especially when a confirm dialog is stacked over another overlay, such as an editor, where you need the real button. See <<{articles}/components/confirm-dialog/styling#,Confirm Dialog styling>> for the full list of slot selectors.
 
 === Grid Cell Content Is Recycled
 


### PR DESCRIPTION
Draft PR collecting documentation fixes from developer feedback.

## Changes

### 1. `DomEvent.getEventData()` returns a Jackson `JsonNode` (Vaadin 25)
[`event-listener.adoc`](articles/flow/component-internals/element-api/event-listener.adoc)

The example used the old Elemental API (`JsonObject` + `getBoolean()`/`getNumber()`), which no longer compiles in Vaadin 25. Confirmed against the 25.2.0 Javadoc that `getEventData()` now returns `tools.jackson.databind.JsonNode`.

- Snippet rewritten to `JsonNode` with `get(key).asBoolean()` / `.asDouble()` (matching the repo's existing Jackson 3 idiom in `client-server-rpc.adoc`).
- Added a **"Return Type Changed in Vaadin 25"** note mapping the old Elemental getters to the Jackson equivalents, linking to the upgrade guide.

### 2. Nested layout default width can hijack flex sizing
[`_troubleshooting.adoc`](articles/components/horizontal-layout/_troubleshooting.adoc) (shared by the Horizontal & Vertical Layout pages)

New troubleshooting section **"A Nested Layout Takes All the Space"**: a nested Vertical Layout's implicit `width: 100%` claims the whole row and starves a growing text column (so `min-width: 0` alone doesn't restore the ellipsis). Includes the `flex: 1 1 0; width: 0; min-width: 0; overflow: hidden` recipe in Lit / Flow / React.

### 3. Sharpen the `@Layout` access-annotation note
[`add-router-layout.adoc`](articles/building-apps/views/add-router-layout.adoc)

The existing "Security Annotations Required" note described a generic 403. Updated it to match the actual symptom — navigation denied with a *"due to layout access rules"* message — and to clarify that a `@Layout` class needs its **own** access annotation in addition to the view annotations, with `@PermitAll` letting all authenticated users render the layout while per-view annotations still gate each route's content.

### 4. `@Push` changes require an application restart
[`server-push/index.adoc`](articles/building-apps/server-push/index.adoc), [`hotswap-agent.adoc`](articles/flow/configuration/live-reload/hotswap-agent.adoc)

Enabling or changing `@Push` (like any application shell annotation) takes effect only at startup; hot reload such as HotswapAgent does not apply it. Added a note to the **Enabling Push** guide at the point of use, and broadened the HotswapAgent **Additional Considerations** to explicitly name app-shell annotations (`@Push`, `@PWA`, other `AppShellConfigurator` annotations).

### 5. Theme-neutral tokens in the drag-and-drop example
[`add-drag-and-drop.adoc`](articles/building-apps/ui-basics/add-drag-and-drop.adoc)

The "Add Drag and Drop" copy-paste example styled cards/columns with `--lumo-*` variables, which render unstyled in non-Lumo (e.g. Aura) projects. Switched to the theme-neutral `--vaadin-*` base tokens (`--vaadin-border-color-secondary`, `--vaadin-radius-m`/`-s`, `--vaadin-padding-s`, `--vaadin-background-container`, `--vaadin-focus-ring-color`), which resolve correctly in every theme.

### 6. Bean overrides can break `@WithUserDetails` navigation in browserless tests
[`optimizing-tests.adoc`](articles/flow/testing/browserless/optimizing-tests.adoc), [`spring-security.adoc`](articles/flow/testing/browserless/spring-security.adoc)

`@MockitoBean`/`@MockBean` make Spring cache a *separate* application context for the test class; in a multi-class run this can leave the Vaadin + Spring Security integration unable to apply the simulated user, redirecting protected views to the login view in unrelated tests. Documented this in **Optimizing Tests** (alongside the context-friendly `@ContextConfiguration` alternative, and constructor-injected stubs for service-level tests) with a cross-referenced caution on the **Spring Security** testing page.

### 7. Vaadin shadow-DOM gotchas for Playwright tests
[`playwright.adoc`](articles/flow/testing/playwright.adoc)

New **"Selecting Vaadin Components"** section: `ConfirmDialog` action buttons are slotted light-DOM children (`vaadin-button[slot='confirm-button']`), so `offsetParent`-based visibility filters miss them (links to ConfirmDialog styling for all slot selectors); and `Grid` recycles/detaches `vaadin-grid-cell-content` elements on refresh, so a broad `querySelectorAll` can report stale rows — scope to the live grid and match attached, visible cells instead.

### 8. ComboBox / MultiSelectComboBox select by `equals()`/`hashCode()`
[`combo-box/index.adoc`](articles/components/combo-box/index.adoc), [`multi-select-combo-box/index.adoc`](articles/components/multi-select-combo-box/index.adoc)

`setValue()`/`select()` preselect items by `equals`/`hashCode`, not reference identity. Entity items (e.g. JPA beans) without those overrides won't preselect — the field stays empty or chips don't appear. Added a note to both component pages explaining this and calling out why the `Country` example overrides both methods (the docs previously showed the overrides without explaining their relevance to `setValue`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)