### PR TITLE
docs: document TextField inputMode

### DIFF
--- a/articles/components/text-field/index.adoc
+++ b/articles/components/text-field/index.adoc
@@ -172,7 +172,7 @@ include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldValue
 
 == [since:com.vaadin:vaadin@V25.3]#Input Mode#
 
-Input mode hints at the type of virtual keyboard to display when the user interacts with the field on a mobile device:
+The input mode is a hint to the browser about which virtual keyboard to display when the user interacts with the field on a mobile device.
 
 [.example]
 --
@@ -180,7 +180,7 @@ ifdef::flow[]
 [source,java]
 ----
 <source-info group="Flow"></source-info>
-textField.setInputMode(InputMode.SEARCH);
+textField.setInputMode(InputMode.URL);
 ----
 endif::[]
 
@@ -188,7 +188,7 @@ ifdef::lit[]
 [source,html]
 ----
 <source-info group="Lit"></source-info>
-<vaadin-text-field .inputMode="search"></vaadin-text-field>
+<vaadin-text-field .inputMode="url"></vaadin-text-field>
 ----
 endif::[]
 
@@ -196,7 +196,7 @@ ifdef::react[]
 [source,tsx]
 ----
 <source-info group="React"></source-info>
-<TextField inputMode="search" />
+<TextField inputMode="url" />
 ----
 endif::[]
 --

--- a/articles/components/text-field/index.adoc
+++ b/articles/components/text-field/index.adoc
@@ -196,7 +196,7 @@ ifdef::react[]
 [source,tsx]
 ----
 <source-info group="React"></source-info>
-<TextField inputMode="url" />
+<TextField inputmode="url" />
 ----
 endif::[]
 --

--- a/articles/components/text-field/index.adoc
+++ b/articles/components/text-field/index.adoc
@@ -177,10 +177,10 @@ Input mode hints at the type of virtual keyboard to display when the user intera
 [.example]
 --
 ifdef::lit[]
-[source,typescript]
+[source,html]
 ----
 <source-info group="Lit"></source-info>
-textField.inputMode = 'numeric';
+<vaadin-text-field .inputMode="search"></vaadin-text-field>
 ----
 endif::[]
 
@@ -188,7 +188,7 @@ ifdef::flow[]
 [source,java]
 ----
 <source-info group="Flow"></source-info>
-textField.setInputMode(InputMode.NUMERIC);
+textField.setInputMode(InputMode.SEARCH);
 ----
 endif::[]
 
@@ -196,7 +196,7 @@ ifdef::react[]
 [source,tsx]
 ----
 <source-info group="React"></source-info>
-<TextField inputMode="numeric" />
+<TextField inputMode="search" />
 ----
 endif::[]
 --

--- a/articles/components/text-field/index.adoc
+++ b/articles/components/text-field/index.adoc
@@ -170,6 +170,39 @@ include::{root}/src/main/java/com/vaadin/demo/component/textfield/TextFieldValue
 ----
 --
 
+== [since:com.vaadin:vaadin@V25.3]#Input Mode#
+
+Input mode hints at the type of virtual keyboard to display when the user interacts with the field on a mobile device:
+
+[.example]
+--
+ifdef::lit[]
+[source,typescript]
+----
+<source-info group="Lit"></source-info>
+textField.inputMode = 'numeric';
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+<source-info group="Flow"></source-info>
+textField.setInputMode(InputMode.NUMERIC);
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+<source-info group="React"></source-info>
+<TextField inputMode="numeric" />
+----
+endif::[]
+--
+
+See the https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode[`inputmode`] attribute on MDN for the list of supported values.
+
 == Related Components
 
 A variety of components are available for different types of input:

--- a/articles/components/text-field/index.adoc
+++ b/articles/components/text-field/index.adoc
@@ -188,7 +188,7 @@ ifdef::lit[]
 [source,html]
 ----
 <source-info group="Lit"></source-info>
-<vaadin-text-field .inputMode="url"></vaadin-text-field>
+<vaadin-text-field inputmode="url"></vaadin-text-field>
 ----
 endif::[]
 

--- a/articles/components/text-field/index.adoc
+++ b/articles/components/text-field/index.adoc
@@ -176,19 +176,19 @@ Input mode hints at the type of virtual keyboard to display when the user intera
 
 [.example]
 --
-ifdef::lit[]
-[source,html]
-----
-<source-info group="Lit"></source-info>
-<vaadin-text-field .inputMode="search"></vaadin-text-field>
-----
-endif::[]
-
 ifdef::flow[]
 [source,java]
 ----
 <source-info group="Flow"></source-info>
 textField.setInputMode(InputMode.SEARCH);
+----
+endif::[]
+
+ifdef::lit[]
+[source,html]
+----
+<source-info group="Lit"></source-info>
+<vaadin-text-field .inputMode="search"></vaadin-text-field>
 ----
 endif::[]
 


### PR DESCRIPTION
dds basic documentation for the `inputMode` API on Text Field, covering Lit, Flow, and React, with a link to MDN for the list of supported values.

Closes https://github.com/vaadin/flow-components/issues/8903