### PR TITLE
docs: document maxRequestBodySize property

### DIFF
--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -252,6 +252,11 @@ Sets the maximum time in `milliseconds` that the client waits for predecessors o
 Default: 5000 ms (i.e., 5 seconds) +
 Mode: Runtime
 
+`**maxRequestBodySize**`::
+Sets the maximum size of a client-to-server UIDL/RPC or push request body that Flow reads before rejecting the request with an HTTP `413` (Request Entity Too Large) response. The value is the number of characters -- individual units of text read from the request body. For the ASCII JSON that Flow sends, one character corresponds to roughly one byte, so `1024` allows a request body of about 1 KB and the default of `10485760` allows about 10 MB. It doesn't affect file uploads, which are streamed in chunks and have their own separate size limits. Set to `-1` to disable the limit. Avoid setting a value too low: protocol overhead and larger component-state changes can cause legitimate interactions to exceed a small limit. +
+Default: 10485760 (i.e., about 10 MB) +
+Mode: Runtime
+
 `**menu.access.control**`::
 Define a menu access control implementation by giving a Fully Qualified Name to the control class. +
 Default: +

--- a/articles/flow/production/troubleshooting.adoc
+++ b/articles/flow/production/troubleshooting.adoc
@@ -82,6 +82,13 @@ When packaging for production, a Vite executable is run. This happens in the `bu
 Note, the hashes differ with each build.
 
 
+== Maximum Request Body Size
+
+Flow limits the size of client-to-server UIDL/RPC and push request bodies. By default, a request whose body exceeds 10 MB is rejected with an HTTP `413` (Request Entity Too Large) response. Normal application interactions stay well below this limit, so reaching it is uncommon -- but a view that sends a very large amount of data to the server in a single request can exceed it.
+
+To allow larger requests, increase the limit -- or set it to `-1` to disable it -- with the `maxRequestBodySize` configuration property. The limit doesn't apply to file uploads, which are streamed in chunks and have their own separate size limits. See <<{articles}/flow/configuration/properties#,Configuration Properties>> for how to set the property.
+
+
 == Common Issues
 
 Below are some common issues faced when attempting to go to production with an application, along with suggestions for resolving them.


### PR DESCRIPTION
Document new `maxRequestBodySize` property in Flow to limit UIDL/RPC and push request body size.

RelatedTo: vaadin/flow#24866