### PR TITLE
docs: rename safeUrlSchemes configuration parameter

### DIFF
--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -137,11 +137,6 @@ Closes the Vaadin session if no UI is active. A UI is considered active if it's 
 Default: `false` +
 Mode: Runtime
 
-`**com.vaadin.safeUrlSchemes**`::
-[since:com.vaadin:vaadin@V25.2]#Comma-separated list of URL schemes that are considered safe# in URLs passed to [methodname]`Anchor.setHref()`, [methodname]`IFrame.setSrc()`, and [methodname]`Page.open()`. URLs whose scheme isn't in the list are rejected with an `IllegalArgumentException`. Relative URLs are always accepted. An entry of `*` marks every scheme as safe, disabling the validation. URLs with unsafe schemes can still be set through the dedicated unsafe setters, such as [methodname]`Anchor.setUnsafeHref()`. +
-Default: `http,https,mailto,tel,ftp` +
-Mode: Runtime
-
 `**devmode.componentTracker.enabled**`::
 Enable component tracking in development mode. +
 Default: `true` +
@@ -346,6 +341,11 @@ Mode: Runtime
 Skip global Node.js lookup and use only Vaadin-managed installations in `~/.vaadin/`. When set to `true`, the global `PATH` is not checked and Node.js is resolved from version-specific directories under `~/.vaadin/` (e.g., `~/.vaadin/node-v24.14.0/`). If a suitable version isn't found, it's downloaded and installed automatically. +
 Default: `false` +
 Mode: Build
+
+`**safeUrlSchemes**`::
+[since:com.vaadin:vaadin@V25.2]#Comma-separated list of URL schemes that are considered safe# in URLs passed to [methodname]`Anchor.setHref()`, [methodname]`IFrame.setSrc()`, and [methodname]`Page.open()`. URLs whose scheme isn't in the list are rejected with an `IllegalArgumentException`. Relative URLs are always accepted. An entry of `*` marks every scheme as safe, disabling the validation. URLs with unsafe schemes can still be set through the dedicated unsafe setters, such as [methodname]`Anchor.setUnsafeHref()`. In Vaadin 25.2.1 this parameter was named `com.vaadin.safeUrlSchemes`; that name is deprecated but still recognized for backwards compatibility. +
+Default: `http,https,mailto,tel,ftp` +
+Mode: Runtime
 
 `**syncIdCheck**`::
 Enables synchronized ID checking. The synchronized ID is used to handle situations in which the client sends a message to a connector that has been removed from the server. It's set to `true`, by default. You should only disable it if your application doesn't need to stay synchronized, and suffers from a bad network connection. +

--- a/articles/flow/security/advanced-topics/vulnerabilities.adoc
+++ b/articles/flow/security/advanced-topics/vulnerabilities.adoc
@@ -169,7 +169,7 @@ Pass a method reference or a lambda that builds the [classname]`Safelist`, rathe
 
 URLs using a script-capable scheme, such as `javascript:`, are another common XSS vector. Vaadin validates URLs passed to [methodname]`Anchor.setHref(String)`, [methodname]`IFrame.setSrc(String)`, and [methodname]`Page.open(String)` against a list of safe schemes, and these methods throw an [classname]`IllegalArgumentException` if the scheme isn't considered safe. By default, the `http`, `https`, `mailto`, `tel`, and `ftp` schemes are accepted. Relative URLs have no scheme and are always accepted.
 
-The set of safe schemes can be customized with the `com.vaadin.safeUrlSchemes` configuration parameter, which takes a comma-separated list of schemes. An entry of `*` marks every scheme as safe, disabling the validation. See <<{articles}/flow/configuration/properties#,Configuration Properties>> for how to set the parameter.
+The set of safe schemes can be customized with the `safeUrlSchemes` configuration parameter, which takes a comma-separated list of schemes. An entry of `*` marks every scheme as safe, disabling the validation. See <<{articles}/flow/configuration/properties#,Configuration Properties>> for how to set the parameter.
 
 If a URL is fully under your control and known to be safe, you can bypass the validation for that URL with the dedicated unsafe setters: [methodname]`Anchor.setUnsafeHref(String)`, [methodname]`IFrame.setUnsafeSrc(String)`, and [methodname]`Page.openUnsafe(String)`.
 

--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -1047,7 +1047,7 @@ Vaadin 25.2 hardens some security-related defaults. These changes may require ac
 
 Starting with Vaadin 25.2, URLs passed to [methodname]`Anchor.setHref(String)`, [methodname]`IFrame.setSrc(String)`, and [methodname]`Page.open(String)` are validated against a list of safe URL schemes. By default, the `http`, `https`, `mailto`, `tel`, and `ftp` schemes are accepted; relative URLs are always accepted. Applications that set URLs with other schemes -- such as `javascript:` -- now get an [classname]`IllegalArgumentException` from these methods.
 
-If your application needs to set such URLs, either configure the accepted schemes with the `com.vaadin.safeUrlSchemes` configuration parameter -- a comma-separated list of schemes, where the value `*` disables the validation -- or use the unsafe setter variants [methodname]`Anchor.setUnsafeHref(String)`, [methodname]`IFrame.setUnsafeSrc(String)`, and [methodname]`Page.openUnsafe(String)` for URLs that are fully under your control. See <<{articles}/flow/security/advanced-topics/vulnerabilities#,Common Vulnerabilities>> for details.
+If your application needs to set such URLs, either configure the accepted schemes with the `safeUrlSchemes` configuration parameter -- a comma-separated list of schemes, where the value `*` disables the validation -- or use the unsafe setter variants [methodname]`Anchor.setUnsafeHref(String)`, [methodname]`IFrame.setUnsafeSrc(String)`, and [methodname]`Page.openUnsafe(String)` for URLs that are fully under your control. See <<{articles}/flow/security/advanced-topics/vulnerabilities#,Common Vulnerabilities>> for details.
 
 === X-Frame-Options Header Sent by Default
 


### PR DESCRIPTION
The `com.vaadin.safeUrlSchemes` init parameter was renamed to `safeUrlSchemes` for consistency with other configuration parameters.

Update the configuration properties, vulnerabilities, and upgrading articles to use the new name, and note the deprecated legacy name in the configuration properties reference.

Part of vaadin/flow#24897


