### PR TITLE
doc: Update load-testing documentation with WebSocket note

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -121,6 +121,9 @@ When it is not -- for example, during normal IDE runs -- the helper is a no-op a
 
 The test body itself is just a regular TestBench test -- see <<{articles}/flow/testing/end-to-end/creating-tests#, Creating Tests>> for the element query and interaction APIs.
 
+[NOTE]
+At the moment the recording proxy does not support WebSockets. Thus you need to configure the application under test to use LONG_POLLING when being tested. 
+
 [[destructive]]
 === Excluding Destructive Tests
 


### PR DESCRIPTION
Added note about recording proxy limitations with WebSockets.


