### PR TITLE
docs: add Push Transport section to load testing documentation

### DIFF
--- a/articles/flow/testing/load-testing/index.adoc
+++ b/articles/flow/testing/load-testing/index.adoc
@@ -135,6 +135,23 @@ public void deletePatient() {
 }
 ----
 
+[[push-transport]]
+=== Push Transport
+
+Recording captures HTTP traffic into a HAR file, and k6 replays that traffic as HTTP requests. WebSocket connections are not recorded, so applications that use <<{articles}/building-apps/server-push#, server push>> over the default `WEBSOCKET_XHR` (or pure `WEBSOCKET`) transport have their server-to-client push messages missing from the generated load test.
+
+If your scenarios rely on push, switch the application to the HTTP-based long polling transport before recording:
+
+[source,java]
+----
+@Push(transport = Transport.LONG_POLLING)
+public class Application implements AppShellConfigurator {
+    ...
+}
+----
+
+Long polling uses regular HTTP requests, which the recording proxy captures and k6 replays like any other request. See <<{articles}/flow/advanced/server-push#push.configuration.transport, Transport Options>> for details on the available transports.
+
 == Recording and Running Tests
 
 The `loadtest:record` and `loadtest:run` goals require the application server to be running.


### PR DESCRIPTION
New section in load testing documentation explains Push Websocket limitation and adds alternative solution with long polling transport mode.


