### PR TITLE
docs: prefer role-attribute since badge on section headings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,17 +184,32 @@ The repository uses Vale for automated style checking. Configuration is in `.val
 
 ### Version References
 
-Avoid explicit Vaadin version numbers in text. Instead, use a `since` badge.
+Avoid explicit Vaadin version numbers in text. Instead, use a `since` badge. The badge attaches to a
+section heading or to a phrase in body text, and it is written differently in each case.
 
-The badge is an inline AsciiDoc role. It **must be immediately followed (no space) by a formatted
-text span** that holds the text the badge applies to — usually `#...#`, but any inline formatting
-works (e.g. `*...*`). Without a following span the badge shows up as literal `[since:...]` brackets
-or is dropped entirely. Place it on a heading or wrapping a phrase in body text.
+**Section headings (`==`, `===`, …): use the role attribute.** Put `[role="since:..."]` on its own
+line directly above the heading. This is the preferred form for section headings — keep them
+consistent rather than mixing both styles.
 
 ```asciidoc
-// Correct — on a page title or section heading:
+// Correct — section heading:
+[role="since:com.vaadin:vaadin@V25.2"]
+== Hierarchical Data
+
+// The heading text can still carry other badges:
+[role="since:com.vaadin:vaadin@V25.2"]
+== Focus Selected Item [badge-flow]#Flow#
+```
+
+**Top-level heading (`=`) and body text: use a formatted span.** The role attribute is not allowed on
+the page title (`=`), so there — and when wrapping a phrase in running text — write the badge as an
+inline role **immediately followed (no space) by a formatted text span** that holds the text the badge
+applies to. This is usually `#...#`, but any inline formatting works (e.g. `*...*`). Without a
+following span the badge shows up as literal `[since:...]` brackets or is dropped entirely.
+
+```asciidoc
+// Correct — page title (top-level heading):
 = [since:com.vaadin:vaadin@V25.1]#Slider#
-== [since:com.vaadin:vaadin@V25.2]#Hierarchical Data#
 
 // Correct — wrapping a phrase in body text:
 The component can also [since:com.vaadin:vaadin@V25.2]#do the sanitization itself#.
@@ -204,7 +219,7 @@ The component can also [since:com.vaadin:vaadin@V25.2]#do the sanitization itsel
 // WRONG — badge after the heading text, with no span (renders literal brackets):
 == Hierarchical Data [since:com.vaadin:vaadin@V25.2]
 
-// WRONG — badge alone on its own line (no span to attach to):
+// WRONG — bare inline badge alone on its own line; use the quoted role attribute instead:
 [since:com.vaadin:vaadin@V25.2]
 ```
 

--- a/articles/flow/testing/browserless/optimizing-tests.adoc
+++ b/articles/flow/testing/browserless/optimizing-tests.adoc
@@ -90,7 +90,8 @@ For service-level tests that don't need the Vaadin context, an even simpler opti
 ====
 
 
-== [since:com.vaadin:vaadin@V25.2]#Sharing the Vaadin Environment Across Tests#
+[role="since:com.vaadin:vaadin@V25.2"]
+== Sharing the Vaadin Environment Across Tests
 
 By default, the Vaadin environment -- the session, the UI, and all routes -- is created before every test method and torn down after. For classes with many tests that navigate to views sharing the same [classname]`MainLayout`, this setup cost can dominate the test runtime.
 

--- a/articles/flow/ui-state/building-ui.adoc
+++ b/articles/flow/ui-state/building-ui.adoc
@@ -657,7 +657,8 @@ languageSelect.bindValue(session.localeSignal(), session::setLocale);
 ----
 
 
-=== [since:com.vaadin:vaadin@V25.2]#Router State Signal#
+[role="since:com.vaadin:vaadin@V25.2"]
+=== Router State Signal
 
 Use [methodname]`UI.routerStateSignal()` to get a read-only signal that tracks the UI's navigation state. The signal provides a [classname]`RouterState` record with the current location, route parameters, active route chain, and navigation target. Its value updates whenever a navigation completes, making it useful for reactive breadcrumbs and menus:
 


### PR DESCRIPTION
Follow-up to #5713. Per review feedback, section headings (== / ===) should annotate the since badge with a [role="since:..."] attribute on the line above the heading rather than wrapping the title in a #...# span. The span form remains required only on the top-level (=) heading, where the role attribute is not allowed, and for phrases in body text.

- Convert the two section headings #5713 had rewritten to span form (optimizing-tests, building-ui) to the role-attribute form.
- Update the CLAUDE.md Version References guidance to document both forms and when each applies.


