### PR TITLE
docs: document opt-in safeUrlSchemes configuration parameter (CP: 25.1)

### DIFF
--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -327,6 +327,11 @@ Skip global Node.js lookup and use only Vaadin-managed installations in `~/.vaad
 Default: `false` +
 Mode: Build
 
+`**safeUrlSchemes**`::
+Comma-separated list of URL schemes that are considered safe in URLs passed to [methodname]`Anchor.setHref()`, [methodname]`IFrame.setSrc()`, and [methodname]`Page.open()`. URLs whose scheme isn't in the list are rejected with an `IllegalArgumentException`. Relative URLs are always accepted. This validation is opt-in: when the parameter isn't set, every scheme is accepted. An entry of `*` also marks every scheme as safe, disabling the validation. Starting with Vaadin 25.2, this validation is instead enabled by default, accepting the `http`, `https`, `mailto`, `tel`, and `ftp` schemes. URLs with unsafe schemes can still be set through the dedicated unsafe setters, such as [methodname]`Anchor.setUnsafeHref()`. +
+Default: `*` (all schemes accepted; validation disabled) +
+Mode: Runtime
+
 `**syncIdCheck**`::
 Enables synchronized ID checking. The synchronized ID is used to handle situations in which the client sends a message to a connector that has been removed from the server. It's set to `true`, by default. You should only disable it if your application doesn't need to stay synchronized, and suffers from a bad network connection. +
 Default: `true` +

--- a/articles/flow/security/advanced-topics/vulnerabilities.adoc
+++ b/articles/flow/security/advanced-topics/vulnerabilities.adoc
@@ -154,6 +154,18 @@ div.add(new Html(safeHtml));
 ----
 
 
+=== Unsafe URL Schemes
+
+URLs using a script-capable scheme, such as `javascript:`, are another common XSS vector. Vaadin can validate URLs passed to [methodname]`Anchor.setHref(String)`, [methodname]`IFrame.setSrc(String)`, and [methodname]`Page.open(String)` against a list of safe schemes, rejecting URLs whose scheme isn't considered safe with an [classname]`IllegalArgumentException`. Relative URLs have no scheme and are always accepted.
+
+This validation is opt-in and disabled by default, so every URL scheme is accepted unless you enable it. To turn it on, set the `safeUrlSchemes` configuration parameter to a comma-separated list of safe schemes -- for example, `http,https,mailto,tel,ftp`. An entry of `*` marks every scheme as safe, disabling the validation. See <<{articles}/flow/configuration/properties#,Configuration Properties>> for how to set the parameter.
+
+[NOTE]
+Starting with Vaadin 25.2, this validation is enabled by default, accepting the `http`, `https`, `mailto`, `tel`, and `ftp` schemes. In earlier versions it's disabled by default and every scheme is accepted. When upgrading to Vaadin 25.2 or later, URLs with other schemes -- such as `javascript:` -- start to be rejected unless you configure `safeUrlSchemes` accordingly or switch to the unsafe setters.
+
+If a URL is fully under your control and known to be safe, you can bypass the validation for that URL with the dedicated unsafe setters: [methodname]`Anchor.setUnsafeHref(String)`, [methodname]`IFrame.setUnsafeSrc(String)`, and [methodname]`Page.openUnsafe(String)`.
+
+
 === Running Custom JavaScript
 
 Sometimes you may need to run custom scripts inside the application. Running any script is an inherently unsafe operation. Scripts have full access to the entire client side. It's especially dangerous if the script is stored somewhere other than in the application code and loaded dynamically:


### PR DESCRIPTION
Backport of #5775 to the `v25.1` branch, adapted for the Flow 25.1 backport vaadin/flow#24924.

Two differences from the `main` version:

- **The validation is opt-in (disabled by default).** On 25.1 the `safeUrlSchemes` parameter defaults to `*`, so every URL scheme is accepted unless the parameter is set. The docs describe how to enable it rather than how to relax an already-enabled default.
- **No `com.vaadin.safeUrlSchemes` legacy name.** The 25.1 backport only recognizes `safeUrlSchemes`, so the deprecated-alias note is omitted.

Also adds a note that the default flips to **enabled** in Vaadin 25.2, so users are aware of the behavior change when migrating.

The `upgrading/index.adoc` change from #5775 is intentionally omitted: it documents a breaking change in 25.2, which doesn't apply to the opt-in 25.1 backport.

Part of vaadin/flow#24924

🤖 Generated with [Claude Code](https://claude.com/claude-code)