### PR TITLE
docs: document opt-in safeUrlSchemes configuration parameter (CP: 24)

### DIFF
--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -353,6 +353,12 @@ Do note that if this parameter is not defined, Vaadin watches for changes under 
 |`false`
 |Build
 
+|`safeUrlSchemes`
+|`vaadin.safeUrlSchemes`
+|Comma-separated list of URL schemes that are considered safe in URLs passed to `Anchor.setHref()`, `IFrame.setSrc()`, and `Page.open()`. URLs whose scheme isn't in the list are rejected with an `IllegalArgumentException`. Relative URLs are always accepted. This validation is opt-in: when the parameter isn't set, every scheme is accepted. An entry of `*` also marks every scheme as safe, disabling the validation. Starting with Vaadin 25.2, this validation is instead enabled by default, accepting the `http`, `https`, `mailto`, `tel`, and `ftp` schemes. URLs with unsafe schemes can still be set through the dedicated unsafe setters, such as `Anchor.setUnsafeHref()`.
+|`*` (validation disabled)
+|Runtime
+
 |`syncIdCheck`
 |`vaadin.syncIdCheck`
 |Enables synchronized ID checking. The synchronized ID is used to handle situations in which the client sends a message to a connector that has been removed from the server. It's set to `true`, by default. You should only disable it if your application doesn't need to stay synchronized, and suffers from a bad network connection.

--- a/articles/flow/security/advanced-topics/vulnerabilities.adoc
+++ b/articles/flow/security/advanced-topics/vulnerabilities.adoc
@@ -154,6 +154,18 @@ div.add(new Html(safeHtml));
 ----
 
 
+=== Unsafe URL Schemes
+
+URLs using a script-capable scheme, such as `javascript:`, are another common XSS vector. Vaadin can validate URLs passed to `Anchor.setHref(String)`, `IFrame.setSrc(String)`, and `Page.open(String)` against a list of safe schemes, rejecting URLs whose scheme isn't considered safe with an `IllegalArgumentException`. Relative URLs have no scheme and are always accepted.
+
+This validation is opt-in and disabled by default, so every URL scheme is accepted unless you enable it. To turn it on, set the `safeUrlSchemes` configuration parameter to a comma-separated list of safe schemes -- for example, `http,https,mailto,tel,ftp`. An entry of `*` marks every scheme as safe, disabling the validation. See <<{articles}/flow/configuration/properties#,Configuration Properties>> for how to set the parameter.
+
+[NOTE]
+Starting with Vaadin 25.2, this validation is enabled by default, accepting the `http`, `https`, `mailto`, `tel`, and `ftp` schemes. In earlier versions it's disabled by default and every scheme is accepted. When upgrading to Vaadin 25.2 or later, URLs with other schemes -- such as `javascript:` -- start to be rejected unless you configure `safeUrlSchemes` accordingly or switch to the unsafe setters.
+
+If a URL is fully under your control and known to be safe, you can bypass the validation for that URL with the dedicated unsafe setters: `Anchor.setUnsafeHref(String)`, `IFrame.setUnsafeSrc(String)`, and `Page.openUnsafe(String)`.
+
+
 === Running Custom JavaScript
 
 Sometimes you may need to run custom scripts inside the application. Running any script is an inherently unsafe operation. Scripts have full access to the entire client side. It's especially dangerous if the script is stored somewhere other than in the application code and loaded dynamically:


### PR DESCRIPTION
Backport of #5775 to the `v24` branch.

As on the 25.1/25.0 backports (#5790, #5791), the URL scheme validation is **opt-in (disabled by default)**: the `safeUrlSchemes` parameter defaults to `*`, so every scheme is accepted unless the parameter is set. There is no `com.vaadin.safeUrlSchemes` legacy name.

Adapted to the `v24` documentation format (five-column property table; plain code spans in `vulnerabilities.adoc`). A note points out that the default flips to **enabled** in Vaadin 25.2 so users are aware of the behavior change when migrating.

Part of vaadin/flow#24924

🤖 Generated with [Claude Code](https://claude.com/claude-code)