### PR TITLE
docs: document opt-in safeUrlSchemes configuration parameter (CP: 23)

### DIFF
--- a/articles/configuration/properties.asciidoc
+++ b/articles/configuration/properties.asciidoc
@@ -183,6 +183,10 @@ If you use Spring Boot, you should add the `vaadin.` prefix, for example, `vaadi
 |Enables or disables sending URLs as GET and POST parameters in requests with content-type `application/x-www-form-urlencoded`.
 |`true`
 
+|`safeUrlSchemes`
+|Comma-separated list of URL schemes that are considered safe in URLs passed to `Anchor.setHref()`, `IFrame.setSrc()`, and `Page.open()`. URLs whose scheme isn't in the list are rejected with an `IllegalArgumentException`. Relative URLs are always accepted. This validation is opt-in: when the parameter isn't set, every scheme is accepted. An entry of `*` also marks every scheme as safe, disabling the validation. Starting with Vaadin 25.2, this validation is instead enabled by default, accepting the `http`, `https`, `mailto`, `tel`, and `ftp` schemes. URLs with unsafe schemes can still be set through the dedicated unsafe setters, such as `Anchor.setUnsafeHref()`.
+|`*` (validation disabled)
+
 |`syncIdCheck`
 |Enables or disables sync ID checking. The sync ID is used to handle situations where the client sends a message to a connector that has been removed from the server.
 |`true`

--- a/articles/security/advanced-topics/vulnerabilities.asciidoc
+++ b/articles/security/advanced-topics/vulnerabilities.asciidoc
@@ -110,6 +110,17 @@ String safeHtml = Jsoup.clean(dangerousText, Whitelist.relaxed());
 new Checkbox().setLabelAsHtml(safeHtml);
 ----
 
+=== Unsafe URL Schemes
+
+URLs using a script-capable scheme, such as `javascript:`, are another common XSS vector. Vaadin can validate URLs passed to `Anchor.setHref(String)`, `IFrame.setSrc(String)`, and `Page.open(String)` against a list of safe schemes, rejecting URLs whose scheme isn't considered safe with an `IllegalArgumentException`. Relative URLs have no scheme and are always accepted.
+
+This validation is opt-in and disabled by default, so every URL scheme is accepted unless you enable it. To turn it on, set the `safeUrlSchemes` configuration parameter to a comma-separated list of safe schemes -- for example, `http,https,mailto,tel,ftp`. An entry of `*` marks every scheme as safe, disabling the validation. See <<{articles}/configuration/properties#,Configuration Properties>> for how to set the parameter.
+
+[NOTE]
+Starting with Vaadin 25.2, this validation is enabled by default, accepting the `http`, `https`, `mailto`, `tel`, and `ftp` schemes. In earlier versions it's disabled by default and every scheme is accepted. When upgrading to Vaadin 25.2 or later, URLs with other schemes -- such as `javascript:` -- start to be rejected unless you configure `safeUrlSchemes` accordingly or switch to the unsafe setters.
+
+If a URL is fully under your control and known to be safe, you can bypass the validation for that URL with the dedicated unsafe setters: `Anchor.setUnsafeHref(String)`, `IFrame.setUnsafeSrc(String)`, and `Page.openUnsafe(String)`.
+
 === Running Custom JavaScript
 
 Sometimes application developers need to run custom scripts inside the application.


### PR DESCRIPTION
Backport of #5775 to the `v23` branch.

As on the newer backports (#5790, #5791, #5792), the URL scheme validation is **opt-in (disabled by default)**: the `safeUrlSchemes` parameter defaults to `*`, so every scheme is accepted unless the parameter is set. There is no `com.vaadin.safeUrlSchemes` legacy name.

Adapted to the `v23` documentation layout (`articles/configuration/properties.asciidoc` three-column table; `articles/security/advanced-topics/vulnerabilities.asciidoc` for the *Unsafe URL Schemes* topic, plain code spans). A note points out that the default flips to **enabled** in Vaadin 25.2 so users are aware of the behavior change when migrating.

Part of vaadin/flow#24924

🤖 Generated with [Claude Code](https://claude.com/claude-code)