### PR TITLE
docs: document opt-in safeUrlSchemes configuration parameter (CP: 14)

### DIFF
--- a/articles/flow/advanced/framework-security.asciidoc
+++ b/articles/flow/advanced/framework-security.asciidoc
@@ -173,6 +173,17 @@ String safeHtml = Jsoup.clean(dangerousText, Whitelist.relaxed());
 new Checkbox().setLabelAsHtml(safeHtml);
 ----
 
+=== Unsafe URL Schemes
+
+URLs using a script-capable scheme, such as `javascript:`, are another common XSS vector. Vaadin can validate URLs passed to `Anchor.setHref(String)`, `IFrame.setSrc(String)` and `Page.open(String)` against a list of safe schemes, rejecting URLs whose scheme is not considered safe with an `IllegalArgumentException`. Relative URLs have no scheme and are always accepted.
+
+This validation is opt-in and disabled by default, so every URL scheme is accepted unless you enable it. To turn it on, set the `safeUrlSchemes` configuration parameter to a comma-separated list of safe schemes, for example `http,https,mailto,tel,ftp`. An entry of `*` marks every scheme as safe, disabling the validation. See <<{articles}/flow/configuration/overview#, Configuration Properties>> for how to set the parameter.
+
+[NOTE]
+Starting with Vaadin 25.2, this validation is enabled by default, accepting the `http`, `https`, `mailto`, `tel` and `ftp` schemes. In earlier versions it is disabled by default and every scheme is accepted. When upgrading to Vaadin 25.2 or later, URLs with other schemes, such as `javascript:`, start to be rejected unless you configure `safeUrlSchemes` accordingly or switch to the unsafe setters.
+
+If a URL is fully under your control and known to be safe, you can bypass the validation for that URL with the dedicated unsafe setters: `Anchor.setUnsafeHref(String)`, `IFrame.setUnsafeSrc(String)` and `Page.openUnsafe(String)`.
+
 === Running custom JavaScript
 
 Sometimes application developers need to run custom scripts inside the application. Running any script is an inherently unsafe operation because scripts have full access to the entire client side. It is especially dangerous if the script is stored somewhere else than the application code and loaded dynamically: 

--- a/articles/flow/configuration/overview.asciidoc
+++ b/articles/flow/configuration/overview.asciidoc
@@ -144,6 +144,13 @@ The permitted values are "disabled" or "manual". Please consult <<{articles}/flo
 It is the url to use for push requests. Some servers require a predefined URL to push.
 Please consult <<{articles}/flow/advanced/tutorial-push-configuration#, Server Push Configuration>> documentation.
 
+|safeUrlSchemes |
+Comma-separated list of URL schemes that are considered safe in URLs passed to `Anchor.setHref()`, `IFrame.setSrc()` and `Page.open()`.
+URLs whose scheme is not in the list are rejected with an `IllegalArgumentException`; relative URLs are always accepted.
+This validation is opt-in: when the parameter is not set, every scheme is accepted, and an entry of `*` also disables the validation.
+Starting with Vaadin 25.2, this validation is instead enabled by default, accepting the `http`, `https`, `mailto`, `tel` and `ftp` schemes.
+URLs with unsafe schemes can still be set through the dedicated unsafe setters, such as `Anchor.setUnsafeHref()`.
+
 |syncIdCheck |
 Returns whether sync id checking is enabled. The sync id is used to gracefully handle situations
 when the client sends a message to a connector that has recently been removed on the server.


### PR DESCRIPTION
Backport of #5775 to the `v14` branch.

As on the newer backports (#5790, #5791, #5792, #5793), the URL scheme validation is **opt-in (disabled by default)**: the `safeUrlSchemes` parameter defaults to `*`, so every scheme is accepted unless the parameter is set. There is no `com.vaadin.safeUrlSchemes` legacy name.

Adapted to the `v14` documentation layout (`articles/flow/configuration/overview.asciidoc` two-column properties table; `articles/flow/advanced/framework-security.asciidoc` for the *Unsafe URL Schemes* topic). A note points out that the default flips to **enabled** in Vaadin 25.2 so users are aware of the behavior change when migrating.

Part of vaadin/flow#24924

🤖 Generated with [Claude Code](https://claude.com/claude-code)