### PR TITLE
docs: document maxRequestBodySize property (CP: v23)

### DIFF
--- a/articles/configuration/properties.asciidoc
+++ b/articles/configuration/properties.asciidoc
@@ -155,6 +155,10 @@ If you use Spring Boot, you should add the `vaadin.` prefix, for example, `vaadi
 |In certain cases, for example, when the server sends adjacent `XmlHttpRequest` responses and pushes messages over a low-bandwidth connection, the messages may be received out of sequence by the client. This property specifies the maximum time in `milliseconds` that the client waits for predecessors of a received out-of-sequence message before considering them missing. It then requests a full resynchronization of the application state from the server. You may increase this if your application experiences an undue quantity of resynchronization requests. However, that degrades the UX due to flickering and loss of client-side-only states, such as scroll position.
 |5000 ms
 
+|`maxRequestBodySize`
+|Sets the maximum size of a client-to-server UIDL/RPC or push request body that Flow reads before rejecting the request with an HTTP `413` (Request Entity Too Large) response. The value is the number of characters -- individual units of text read from the request body. For the ASCII JSON that Flow sends, one character corresponds to roughly one byte, so `1024` allows a request body of about 1 KB and the default of `10485760` allows about 10 MB. It doesn't affect file uploads, which are streamed in chunks and have their own separate size limits. Set to `-1` to disable the limit. Avoid setting a value too low: protocol overhead and larger component-state changes can cause legitimate interactions to exceed a small limit.
+|10485760 (i.e., about 10 MB)
+
 |`pnpm.enable`
 |This flag can be used to enable `pnpm` instead of `npm` to resolve and download front-end dependencies. By default, this flag is set to `false`, and `npm` is used. Setting it to `true` enables `pnpm`. See how to <<npm-pnpm#, switch between npm and pnpm>>.
 |`false`

--- a/articles/production/troubleshooting.asciidoc
+++ b/articles/production/troubleshooting.asciidoc
@@ -115,6 +115,14 @@ The folder contents should look like this (the hashes differ with every build):
     └── webcomponents-loader.js
 ----
 
+
+== Maximum Request Body Size
+
+Flow limits the size of client-to-server UIDL/RPC and push request bodies. By default, a request whose body exceeds 10 MB is rejected with an HTTP `413` (Request Entity Too Large) response. Normal application interactions stay well below this limit, so reaching it is uncommon -- but a view that sends a very large amount of data to the server in a single request can exceed it.
+
+To allow larger requests, increase the limit -- or set it to `-1` to disable it -- with the `maxRequestBodySize` configuration property. The limit doesn't apply to file uploads, which are streamed in chunks and have their own separate size limits. See <<{articles}/configuration/properties#,Configuration Properties>> for how to set the property.
+
+
 == Common Issues
 
 After adding the `flow-server-production-mode` dependency, the application no longer starts::


### PR DESCRIPTION
Backport of #5772 to the `v23` branch.

On `v23` the files live at `articles/configuration/properties.asciidoc` (3-column table) and `articles/production/troubleshooting.asciidoc`, so the content was manually ported to that structure and the xref path adjusted accordingly.

RelatedTo: vaadin/flow#24866