### PR TITLE
docs: document maxRequestBodySize property (CP: v14)

### DIFF
--- a/articles/flow/configuration/overview.asciidoc
+++ b/articles/flow/configuration/overview.asciidoc
@@ -167,6 +167,16 @@ You may increase this if your application exhibits an undue amount of resynchron
 (as these degrade the UX due to flickering and loss of client-side-only state such as scroll
 position).
 
+|maxRequestBodySize |
+Sets the maximum size of a client-to-server UIDL/RPC or push request body that Flow reads before
+rejecting the request with an HTTP `413` (Request Entity Too Large) response. The value is the
+number of characters -- individual units of text read from the request body. For the ASCII JSON
+that Flow sends, one character corresponds to roughly one byte, so `1024` allows a request body of
+about 1 KB and the default of `10485760` allows about 10 MB. It doesn't affect file uploads, which
+are streamed in chunks and have their own separate size limits. Set to `-1` to disable the limit.
+Avoid setting a value too low: protocol overhead and larger component-state changes can cause
+legitimate interactions to exceed a small limit.
+
 |load.es5.adapters |
 Include polyfills for browsers that do not support ES6 to their initial page. In order for
 web components to work, extra libraries (polyfills) are required to be loaded, can be turned off

--- a/articles/flow/production/troubleshooting.asciidoc
+++ b/articles/flow/production/troubleshooting.asciidoc
@@ -119,6 +119,14 @@ The folder contents should look like this (the hash is going to differ on every 
     └── webcomponents-loader.js
 ----
 
+
+== Maximum Request Body Size
+
+Flow limits the size of client-to-server UIDL/RPC and push request bodies. By default, a request whose body exceeds 10 MB is rejected with an HTTP `413` (Request Entity Too Large) response. Normal application interactions stay well below this limit, so reaching it is uncommon -- but a view that sends a very large amount of data to the server in a single request can exceed it.
+
+To allow larger requests, increase the limit -- or set it to `-1` to disable it -- with the `maxRequestBodySize` configuration property. The limit doesn't apply to file uploads, which are streamed in chunks and have their own separate size limits. See <<{articles}/flow/configuration/overview#, Configuration Properties>> for how to set the property.
+
+
 == Common Issues
 
 After adding the `flow-server-production-mode` dependency, the application no longer starts::


### PR DESCRIPTION
Backport of #5772 to the `v14` branch.

On `v14` the properties are documented in `articles/flow/configuration/overview.asciidoc` (2-column table with no separate default column, so the default is folded into the description) and troubleshooting lives under `articles/flow/production/`. The "Configuration Properties" xref points to the `overview` page.

RelatedTo: vaadin/flow#24866