### PR TITLE
fix: related components table syntax

### DIFF
--- a/articles/components/upload/modular-upload.adoc
+++ b/articles/components/upload/modular-upload.adoc
@@ -197,7 +197,9 @@ endif::[]
 
 == Related Components
 
+[cols="1,2"]
 |===
+|Component |Usage Recommendation
 
 |<<index#,Upload>>
 |The default Upload component with built-in drop zone, button, and file list.


### PR DESCRIPTION
Before: 
<img width="803" height="277" alt="Screenshot 2026-07-13 at 10 27 55" src="https://github.com/user-attachments/assets/dcd00345-b0a5-4c2b-a77f-5fddf6a02b76" />

After: 
<img width="782" height="177" alt="Screenshot 2026-07-13 at 10 28 44" src="https://github.com/user-attachments/assets/8ea7166e-7370-49ec-96d3-0bdd195f1705" />
