### PR TITLE
docs: document selectAllUnavailable in Grid i18n

### DIFF
--- a/articles/components/grid/index.adoc
+++ b/articles/components/grid/index.adoc
@@ -787,7 +787,7 @@ gridRef.current!.scrollToColumn(columnRef.current!);
 [role="since:com.vaadin:vaadin@V25.3"]
 == Internationalization (i18n)
 
-Grid provides an i18n API for customizing and translating the accessible names -- the labels announced by screen readers -- for its interactive controls: the Select All checkbox in a selection column header, the per-row selection checkboxes, and the column sorters.
+Grid provides an i18n API for customizing and translating the accessible names -- the labels announced by screen readers -- for its interactive controls: the Select All checkbox in a selection column header, the per-row selection checkboxes, and the column sorters. It also sets the label announced for the selection column header when the Select All checkbox is hidden.
 
 [cols="1,2,3"]
 |===
@@ -796,6 +796,10 @@ Grid provides an i18n API for customizing and translating the accessible names -
 |`selectAll`
 |`Select All`
 |Accessible name for the Select All checkbox in the selection column header.
+
+|`selectAllUnavailable`
+|`Select All unavailable`
+|Accessible name for the selection column header cell when the Select All checkbox is hidden -- for example, when a data provider is used or conditional selection is enabled.
 
 |`selectRow`
 |`Select Row {rowHeader}`
@@ -814,6 +818,7 @@ ifdef::lit[]
 <source-info group="Lit"></source-info>
 grid.i18n = {
   selectAll: 'Select all rows',
+  selectAllUnavailable: 'Select all unavailable',
   selectRow: 'Select row {rowHeader}',
   sorter: 'Sort by {column}',
 };
@@ -826,6 +831,7 @@ ifdef::flow[]
 <source-info group="Flow"></source-info>
 grid.setI18n(new GridI18n()
         .setSelectAll("Select all rows")
+        .setSelectAllUnavailable("Select all unavailable")
         .setSelectRow("Select row {rowHeader}")
         .setSorter("Sort by {column}"));
 ----
@@ -838,6 +844,7 @@ ifdef::react[]
 <Grid
   i18n={{
     selectAll: 'Select all rows',
+    selectAllUnavailable: 'Select all unavailable',
     selectRow: 'Select row {rowHeader}',
     sorter: 'Sort by {column}',
   }}


### PR DESCRIPTION
Adds the `selectAllUnavailable` accessible-name key to the Grid **Internationalization (i18n)** section in `articles/components/grid/index.adoc`.

`selectAllUnavailable` sets the label announced by screen readers for the selection column header cell when the Select All checkbox is hidden — for example, when a data provider is used or conditional selection is enabled. Default: `Select All unavailable`.

Added to the key/default table (after `selectAll`) and to the Flow, Lit, and React examples, matching the existing `GridI18n` documentation. Ships in the same 25.3 release covered by the section's existing `since` badge.

**Source PRs:**
- Flow: vaadin/flow-components#9729
- Web component: vaadin/web-components#12080

🤖 Generated with [Claude Code](https://claude.com/claude-code)