### PR TITLE
docs: document mid2/offlineKeyV2 + JNA troubleshooting for License Checker 2.3.1 backport (v23)

### DIFF
--- a/.github/styles/Vaadin/Abbr.yml
+++ b/.github/styles/Vaadin/Abbr.yml
@@ -44,6 +44,7 @@ exceptions:
   - JAR
   - JDBC
   - JDK
+  - JNA
   - JPA
   - JRE
   - JSF
@@ -55,6 +56,7 @@ exceptions:
   - MDN
   - MIME
   - MPR
+  - OSHI
   - OSV
   - PATH
   - PDF

--- a/articles/configuration/licenses.adoc
+++ b/articles/configuration/licenses.adoc
@@ -48,6 +48,8 @@ Under the hood, a license key is created on your machine in the following locati
 
 If your local development environment is offline and can't reach vaadin.com, you need to download an offline license key.
 
+pass:[<!-- vale Vaadin.Versions = NO -->]
+
 Each offline license key is tied to a *machine ID*, in the form of `mid-xxxxxxxx-xxxxxxxx` (legacy) or [since:com.vaadin:vaadin@V23.6]##`mid2-xxxxxxxx-xxxxxxxx` (the `V2` key)##, that you submit to https://vaadin.com/myaccount/licenses to download an offline license key.
 
 Once you have downloaded the [filename]`offlineKey` or [filename]`offlineKeyV2` file (remove any [filename]`.txt` suffix), you should place it in your _home_ directory:
@@ -95,6 +97,8 @@ java -jar %userprofile%\.m2\repository\com\vaadin\license-checker-machineid\1.8.
 mvn dependency:get -Dartifact=com.vaadin:license-checker-machineid:1.8.1 && java -jar ~/.m2/repository/com/vaadin/license-checker-machineid/1.8.1/license-checker-machineid-1.8.1.jar
 ----
 --
+
+pass:[<!-- vale Vaadin.Versions = YES -->]
 
 
 [[server-license-key]]
@@ -157,11 +161,15 @@ This is a known error in `SSLHandshakeException` reported by users of WebSphere 
 See the following discussion for more details: https://vaadin.com/forum/t/running-mpr-project-on-websphere-liberty-fails-with-suncertpathbuilderexcep/160675.
 
 === I See "Detected an Offline License Version 1, but Version 2 is Required"
+pass:[<!-- vale Vaadin.Versions = NO -->]
+
 [since:com.vaadin:vaadin@V23.6]##In Vaadin 23.6 and later, this message can appear even when you have a valid version 1 offline key (`mid-xxxxxxxx-xxxxxxxx`) installed.## It's shown when the License Checker can't compute this machine's version 1 machine ID.
 
 The `mid` machine ID is derived from hardware details through the OSHI library and its native JNA component. If the JNA native library (for example, `jna.dll` on Windows) is blocked -- commonly by antivirus or endpoint-security software -- or otherwise fails to load, the version 1 machine ID can't be generated, and this message is shown instead of the real error.
 
 Re-run the build with debug logging (`mvn -X` or `./gradlew --debug`) and look for a `Failed to generate v1 Machine ID` entry to confirm the cause. Then either resolve the JNA or native-library problem, or switch to a version 2 offline key (`mid2-xxxxxxxx-xxxxxxxx`), which doesn't rely on OSHI or JNA -- download it from https://vaadin.com/myaccount/licenses.
+
+pass:[<!-- vale Vaadin.Versions = YES -->]
 
 === Where Can I Get Help with License Related Issues?
 You can contact link:mailto:license@vaadin.com[license@vaadin.com] for further help.

--- a/articles/configuration/licenses.adoc
+++ b/articles/configuration/licenses.adoc
@@ -48,9 +48,9 @@ Under the hood, a license key is created on your machine in the following locati
 
 If your local development environment is offline and can't reach vaadin.com, you need to download an offline license key.
 
-Each offline license key is tied to a *machine ID*, in the form of `mid-xxxxxxxx-xxxxxxxx`, that you submit to https://vaadin.com/myaccount/licenses to download an offline license key.
+Each offline license key is tied to a *machine ID*, in the form of `mid-xxxxxxxx-xxxxxxxx` (legacy) or [since:com.vaadin:vaadin@V23.6]##`mid2-xxxxxxxx-xxxxxxxx` (the `V2` key)##, that you submit to https://vaadin.com/myaccount/licenses to download an offline license key.
 
-Once you have downloaded the [filename]`offlineKey` file (remove any [filename]`.txt` suffix), you should place it in your _home_ directory:
+Once you have downloaded the [filename]`offlineKey` or [filename]`offlineKeyV2` file (remove any [filename]`.txt` suffix), you should place it in your _home_ directory:
 
 [.example]
 --
@@ -58,18 +58,27 @@ Once you have downloaded the [filename]`offlineKey` file (remove any [filename]`
 ----
 <source-info group="Windows"></source-info>
 %userprofile%\.vaadin\offlineKey
+%userprofile%\.vaadin\offlineKeyV2
 ----
 
 [source,filesystem]
 ----
 <source-info group="macOS/Linux"></source-info>
 ~/.vaadin/offlineKey
+~/.vaadin/offlineKeyV2
 ----
 --
 
+[NOTE]
+====
+[since:com.vaadin:vaadin@V23.6]##Vaadin 23.6 adds support for the `mid2`/`offlineKeyV2` key format.## Earlier 23.x versions support only the legacy `mid`/`offlineKey` format. Versions that support the `V2` key still also accept the legacy key.
+====
+
 ==== Machine ID
 
-You can find your machine ID in the logs when you try to use a commercial component or tool offline without an existing license key, or by running the following commands on your machine:
+You can find your machine ID in the logs when you try to use a commercial component or tool offline without an existing license key. On Vaadin 23.6 and later, the logs show a `mid2` machine ID; the command below prints the legacy `mid`.
+
+You can also get your machine ID by running the following commands on your machine:
 
 [.example]
 --

--- a/articles/configuration/licenses.adoc
+++ b/articles/configuration/licenses.adoc
@@ -156,6 +156,13 @@ If not, either your company's license administrator hasn't yet assigned a seat f
 This is a known error in `SSLHandshakeException` reported by users of WebSphere Liberty and WildFly in Docker.
 See the following discussion for more details: https://vaadin.com/forum/t/running-mpr-project-on-websphere-liberty-fails-with-suncertpathbuilderexcep/160675.
 
+=== I See "Detected an Offline License Version 1, but Version 2 is Required"
+[since:com.vaadin:vaadin@V23.6]##In Vaadin 23.6 and later, this message can appear even when you have a valid version 1 offline key (`mid-xxxxxxxx-xxxxxxxx`) installed.## It's shown when the License Checker can't compute this machine's version 1 machine ID.
+
+The `mid` machine ID is derived from hardware details through the OSHI library and its native JNA component. If the JNA native library (for example, `jna.dll` on Windows) is blocked -- commonly by antivirus or endpoint-security software -- or otherwise fails to load, the version 1 machine ID can't be generated, and this message is shown instead of the real error.
+
+Re-run the build with debug logging (`mvn -X` or `./gradlew --debug`) and look for a `Failed to generate v1 Machine ID` entry to confirm the cause. Then either resolve the JNA or native-library problem, or switch to a version 2 offline key (`mid2-xxxxxxxx-xxxxxxxx`), which doesn't rely on OSHI or JNA -- download it from https://vaadin.com/myaccount/licenses.
+
 === Where Can I Get Help with License Related Issues?
 You can contact link:mailto:license@vaadin.com[license@vaadin.com] for further help.
 

--- a/articles/configuration/licenses.adoc
+++ b/articles/configuration/licenses.adoc
@@ -73,7 +73,7 @@ Once you have downloaded the [filename]`offlineKey` or [filename]`offlineKeyV2` 
 
 [NOTE]
 ====
-[since:com.vaadin:vaadin@V23.6]##Vaadin 23.6 adds support for the `mid2`/`offlineKeyV2` key format.## Earlier 23.x versions support only the legacy `mid`/`offlineKey` format. Versions that support the `V2` key still also accept the legacy key.
+[since:com.vaadin:vaadin@V23.6.12]##Vaadin 23.6.12 adds support for the `mid2`/`offlineKeyV2` key format.## Earlier 23.x versions support only the legacy `mid`/`offlineKey` format. Versions that support the `V2` key still also accept the legacy key.
 ====
 
 ==== Machine ID

--- a/articles/configuration/licenses.adoc
+++ b/articles/configuration/licenses.adoc
@@ -163,7 +163,7 @@ See the following discussion for more details: https://vaadin.com/forum/t/runnin
 === I See "Detected an Offline License Version 1, but Version 2 is Required"
 pass:[<!-- vale Vaadin.Versions = NO -->]
 
-[since:com.vaadin:vaadin@V23.6]##In Vaadin 23.6 and later, this message can appear even when you have a valid version 1 offline key (`mid-xxxxxxxx-xxxxxxxx`) installed.## It's shown when the License Checker can't compute this machine's version 1 machine ID.
+[since:com.vaadin:vaadin@V23.6.12]##In Vaadin 23.6.12 and later, this message can appear even when you have a valid version 1 offline key (`mid-xxxxxxxx-xxxxxxxx`) installed.## It's shown when the License Checker can't compute this machine's version 1 machine ID.
 
 The `mid` machine ID is derived from hardware details through the OSHI library and its native JNA component. If the JNA native library (for example, `jna.dll` on Windows) is blocked -- commonly by antivirus or endpoint-security software -- or otherwise fails to load, the version 1 machine ID can't be generated, and this message is shown instead of the real error.
 

--- a/articles/configuration/licenses.adoc
+++ b/articles/configuration/licenses.adoc
@@ -50,7 +50,7 @@ If your local development environment is offline and can't reach vaadin.com, you
 
 pass:[<!-- vale Vaadin.Versions = NO -->]
 
-Each offline license key is tied to a *machine ID*, in the form of `mid-xxxxxxxx-xxxxxxxx` (legacy) or [since:com.vaadin:vaadin@V23.6]##`mid2-xxxxxxxx-xxxxxxxx` (the `V2` key)##, that you submit to https://vaadin.com/myaccount/licenses to download an offline license key.
+Each offline license key is tied to a *machine ID*, in the form of `mid-xxxxxxxx-xxxxxxxx` (legacy) or [since:com.vaadin:vaadin@V23.6.12]##`mid2-xxxxxxxx-xxxxxxxx` (the `V2` key)##, that you submit to https://vaadin.com/myaccount/licenses to download an offline license key.
 
 Once you have downloaded the [filename]`offlineKey` or [filename]`offlineKeyV2` file (remove any [filename]`.txt` suffix), you should place it in your _home_ directory:
 
@@ -78,7 +78,7 @@ Once you have downloaded the [filename]`offlineKey` or [filename]`offlineKeyV2` 
 
 ==== Machine ID
 
-You can find your machine ID in the logs when you try to use a commercial component or tool offline without an existing license key. On Vaadin 23.6 and later, the logs show a `mid2` machine ID; the command below prints the legacy `mid`.
+You can find your machine ID in the logs when you try to use a commercial component or tool offline without an existing license key. On Vaadin 23.6.12 and later, the logs show a `mid2` machine ID; the command below prints the legacy `mid`.
 
 You can also get your machine ID by running the following commands on your machine:
 


### PR DESCRIPTION
Updates the license documentation for the License Checker 2.3.1 backport, which brings `mid2`/`offlineKeyV2` support to Vaadin 23.6.

### Changes
- `articles/configuration/licenses.adoc`:
  - Document the `mid2`/`offlineKeyV2` offline key format (the page previously covered only the legacy `mid`/`offlineKey`), badged `since V23.6`, including the `offlineKeyV2` home-directory path and a note that 23.6+ accepts both formats.
  - Add a troubleshooting entry for "Detected an offline license version 1, but version 2 is required": it can appear with a valid V1 key when the V1 machine ID cannot be computed — commonly a blocked/failed JNA native library — with a `mvn -X` / `./gradlew --debug` diagnosis tip.

Docs issue: #5817
Related License Checker issue: vaadin/license-checker-vaadin10#245