### PR TITLE
chore: fix invalid Vale SourceCode rule on v23

### DIFF
--- a/.github/styles/Vaadin/SourceCode.yml
+++ b/.github/styles/Vaadin/SourceCode.yml
@@ -4,7 +4,6 @@ link: https://vaadin.com/docs/latest/contributing-docs/authoring/formatting/#cod
 nonword: true
 level: suggestion
 scope: raw
-tokens:
 ignorecase: true
 # Checks for the presence of the ; character within source code blocks
 # (java, typescript, javascript, css, html), only if the character is


### PR DESCRIPTION
The `Vaadin.SourceCode` Vale rule on the `v23` branch has a duplicate `tokens:` key -- an empty one followed by the real list:

```yaml
scope: raw
tokens:          # empty (null)
ignorecase: true
# ...
tokens:
  - '(?s)(\[source,...)'
```

An `extends: existence` rule requires a non-empty `tokens` list. Newer Vale versions (pulled by `vale-action`) reject the empty tokens as an invalid rule and abort the whole Vale run with a misleading `E201 … 'extends' key must be one of …`. This blocks the Vale check on every `v23` PR, regardless of the PR content.

This removes the redundant empty `tokens:` line, matching the already-fixed `v24` and `main` branches. Pure config backport; no docs content changes.