### PR TITLE
docs: Update Gradle frontendOutputDirectory details

### DIFF
--- a/articles/flow/configuration/gradle.adoc
+++ b/articles/flow/configuration/gradle.adoc
@@ -274,7 +274,7 @@ Whether to generate a production bundle even if an existing pre-compiled bundle 
 Enables development using the frontend development server instead of an application bundle. This applies only to development mode. This must be set in the `vaadin {}` block; the Gradle plugin does not read the corresponding `vaadin.frontend.hotdeploy` property from `application.properties`.
 
 `frontendOutputDirectory: File = null`::
-The folder where Vite should output [filename]`index.js` and other generated files. Defaults to `null`, which uses the automatically detected value of the main SourceSet, usually `build/resources/main/META-INF/VAADIN/webapp/`.
+The folder where Vite should output [filename]`index.js` and other generated files. Defaults to `null`, which uses the automatically detected value of the main SourceSet, usually `build/resources/main/META-INF/VAADIN/webapp/`. A custom value must end in `META-INF/VAADIN/webapp` (e.g. `build/my-frontend/META-INF/VAADIN/webapp/`); otherwise the production build fails with an error.
 
 `npmFolder: File = project.projectDir`::
 The folder where the [filename]`package.json` file is located. Defaults to the project root directory.


### PR DESCRIPTION
Clarify the requirements for frontendOutputDirectory in the Gradle configuration.

Related to vaadin/flow#25001

