### PR TITLE
Added commercial admonitions and badges to AI controller pages

### DIFF
--- a/articles/flow/ai-support/ai-powered-chart.adoc
+++ b/articles/flow/ai-support/ai-powered-chart.adoc
@@ -3,6 +3,7 @@ title: AI-Generated Charts
 description: Use ChartAIController to let users build and update Highcharts visualizations from the application database using natural language.
 meta-description: Learn how to configure the Vaadin ChartAIController to create and update Charts from a database via natural language prompts and persist the resulting state.
 order: 70
+section-nav: commercial
 ---
 
 
@@ -12,6 +13,10 @@ order: 70
 [classname]`ChartAIController` creates and updates a <<{articles}/components/charts#,[classname]`Chart`>> (Vaadin's interactive charting component) visualization based on natural-language requests. Backed by a <<controllers#database-provider,[classname]`DatabaseProvider`>>, the controller lets the LLM inspect the database schema, write SQL queries for one or more series, and update the Highcharts configuration independently of the data.
 
 Data and configuration are kept separate: series data comes from SQL queries, while visual appearance comes from the configuration. Both updates are applied together at the end of the LLM turn, so the user never sees a half-updated chart.
+
+:commercial-feature: ChartAIController
+include::{articles}/_commercial-banner.adoc[opts=optional]
+
 
 == Basic Usage
 

--- a/articles/flow/ai-support/ai-powered-form.adoc
+++ b/articles/flow/ai-support/ai-powered-form.adoc
@@ -3,6 +3,7 @@ title: AI Form Filler
 description: Use FormAIController to let users fill any Vaadin form from natural-language input or attached files.
 meta-description: Configure the Vaadin FormAIController to fill form fields from natural language or attached files, with Binder validation and select-options support.
 order: 80
+section-nav: commercial
 ---
 
 
@@ -12,6 +13,9 @@ order: 80
 [classname]`FormAIController` populates the fields of a <<{articles}/components/form-layout#,[classname]`FormLayout`>> (Vaadin's responsive multi-column form container) or any other layout, using values an LLM extracts from a user prompt or attached files. The controller traverses the layout, discovers every field, and allows the LLM to read the current values, query the available values for selection components like Combo Box or Radio Button Group, and write new values back. Each write is validated through the [classname]`Binder`, or through the component's built-in validators if [classname]`Binder` is not used. Rejected values are reported back so the model can correct them on the next turn.
 
 The controller works with any combination of standard Vaadin field components, such as [classname]`TextField`, [classname]`ComboBox`, [classname]`DatePicker`, [classname]`MultiSelectComboBox`, and [classname]`CheckboxGroup`. No extra wiring is needed beyond constructing the controller around the layout and attaching it to the orchestrator.
+
+:commercial-feature: FormAIController
+include::{articles}/_commercial-banner.adoc[opts=optional]
 
 
 == Basic Usage

--- a/articles/flow/ai-support/ai-powered-grid.adoc
+++ b/articles/flow/ai-support/ai-powered-grid.adoc
@@ -3,6 +3,7 @@ title: AI-Generated Grids
 description: Use GridAIController to let users populate a Grid from the application database using natural language.
 meta-description: Learn how to configure the Vaadin GridAIController to populate a Grid from a database via natural language prompts and persist the resulting state.
 order: 60
+section-nav: commercial
 ---
 
 
@@ -12,6 +13,9 @@ order: 60
 [classname]`GridAIController` populates a <<{articles}/components/grid#,[classname]`Grid`>> (Vaadin's component for displaying tabular data) with data from the application database based on natural-language requests. Backed by a <<controllers#database-provider,[classname]`DatabaseProvider`>>, the controller lets the LLM inspect the database schema and run SQL queries that drive the grid.
 
 When an LLM request completes, the queued query is executed and the grid re-renders with dynamically generated columns, type-appropriate renderers, right-aligned numeric columns, lazy loading via SQL `LIMIT`/`OFFSET`, and optional column grouping.
+
+:commercial-feature: GridAIController
+include::{articles}/_commercial-banner.adoc[opts=optional]
 
 
 == Basic Usage


### PR DESCRIPTION
i.e. Chart, Grid and FormAIController, which will be part of Pro tier

(awaits [moving them to a separate module and adding license check](https://github.com/vaadin/flow-components/issues/9775))
