### PR TITLE
docs: add documentation for the experimental Switch component

### DIFF
--- a/articles/components/switch/index.adoc
+++ b/articles/components/switch/index.adoc
@@ -124,7 +124,7 @@ Switch supports a single constraint: it can be marked as required, in which case
 
 include::{articles}/components/_input-field-common-features.adoc[tags=required]
 
-A required Switch isn't shown as invalid until the user has toggled it, or the application triggers validation, so no error appears before the user has acted. Toggling the switch back on clears the invalid state immediately.
+A required Switch isn't shown as invalid until the user has toggled it, or the application triggers validation, so no error appears before the user has acted. Toggling the switch back on clears the invalid state immediately. Turn off the switch to see the validation message.
 
 [.example,themes="lumo,aura"]
 --

--- a/articles/components/switch/index.adoc
+++ b/articles/components/switch/index.adoc
@@ -51,6 +51,13 @@ endif::[]
 A Switch presents a single setting as a track with a sliding marker. It's toggled by clicking the graphic or the label, or by pressing kbd:[Space] while it's focused, and it defaults to off when no value is set.
 
 
+== When to Use
+
+Use a Switch to show whether a setting, feature, or mode is on -- "Notifications", "Autosave", "Two-factor authentication". Its state is meaningful on its own, independently of the other fields on the page, and users expect toggling it to take effect immediately.
+
+Use a <<../checkbox#,Checkbox>> to mark a selection, such as picking an item, including a row, or agreeing to terms; those values are normally submitted with the rest of a form. A Checkbox also supports indeterminate state, which Switch doesn't have.
+
+
 // Basic Features
 
 include::{articles}/components/_input-field-common-features.adoc[tags=basic-intro;label;helper;tooltip;aria-labels]
@@ -113,11 +120,11 @@ endif::[]
 
 == Validation
 
-Switch supports a single constraint: it can be marked as required, in which case off is invalid and on is valid. This is used most often for confirmations that the user has to accept before proceeding.
+Switch supports a single constraint: it can be marked as required, in which case off is invalid and on is valid. This suits a setting that has to stay on, such as one enforced by a security policy. For a consent that the user has to accept before proceeding, use a <<../checkbox#,Checkbox>> instead.
 
 include::{articles}/components/_input-field-common-features.adoc[tags=required]
 
-A required Switch isn't shown as invalid until the user submits the form or the application triggers validation, so no error appears before the user has acted. Toggling the switch on clears the invalid state immediately.
+A required Switch isn't shown as invalid until the user has toggled it, or the application triggers validation, so no error appears before the user has acted. Toggling the switch back on clears the invalid state immediately.
 
 [.example,themes="lumo,aura"]
 --
@@ -160,6 +167,8 @@ The label, helper, and error message are all associated with the control for ass
 
 == Best Practices
 
+Apply a switch's change as soon as it's toggled. A Switch can take part in a form that's saved with a Save button -- a settings form is a common case -- but users expect a switch to apply right away.
+
 Use short, descriptive labels with positive wording that name the setting being turned on -- for example, "Notifications" rather than "Disable notifications". Negated labels make the off position ambiguous.
 
 Avoid combining read-only with required on a switch that's off, since that leaves the form in a state the user can't correct.
@@ -172,7 +181,7 @@ Avoid combining read-only with required on a switch that's off, since that leave
 |Component |Usage Recommendation
 
 |<<../checkbox#,Checkbox>>
-|Marks a selection -- picking an item, agreeing to terms, or including a row. Use a Switch instead when the control represents the on/off state of a single setting. Unlike Checkbox, Switch has no indeterminate state; if a setting has a third "mixed" state, use a Checkbox.
+|Marks a selection -- picking an item, agreeing to terms, or including a row -- and supports an indeterminate state. See <<#when-to-use,When to Use>> for choosing between the two.
 
 |<<../radio-button#,Radio Button Group>>
 |Picks one of two or more equal options. Use a Switch when one value is clearly the "off" state of a feature, and a two-option radio group when both values are equal labels, such as "Imperial" and "Metric".

--- a/articles/components/switch/index.adoc
+++ b/articles/components/switch/index.adoc
@@ -1,0 +1,182 @@
+---
+title: Switch
+page-title: Switch component | Vaadin components
+description: Switch is an input field for toggling a single setting on or off.
+meta-description: Use the Vaadin Switch component to toggle a single setting on or off, either instantly or as part of a form.
+section-nav: badge-preview
+page-links:
+  - 'API: https://cdn.vaadin.com/vaadin-web-components/{moduleNpmVersion:@vaadin/switch}/elements/vaadin-switch[TypeScript] / https://vaadin.com/api/platform/{moduleMavenVersion:com.vaadin:vaadin}/com/vaadin/flow/component/checkbox/Switch.html[Java]'
+  - 'Source: https://github.com/vaadin/web-components/tree/v{moduleNpmVersion:@vaadin/switch}/packages/switch[TypeScript] / https://github.com/vaadin/flow-components/tree/{moduleMavenVersion:com.vaadin:vaadin}/vaadin-checkbox-flow-parent[Java]'
+---
+
+:tag-name: vaadin-switch
+
+
+= [since:com.vaadin:vaadin@V25.3]#Switch#
+
+// tag::description[]
+Switch is an input field for toggling a single setting on or off.
+// end::description[]
+
+:preview-feature: Switch
+:feature-flag: com.vaadin.experimental.switchComponent
+:ticket-url: https://github.com/vaadin/web-components/issues/new/choose
+include::{articles}/_preview-banner.adoc[opts=optional]
+
+[.example,themes="lumo,aura"]
+--
+
+ifdef::lit[]
+[source,html]
+----
+include::{root}/frontend/demo/component/switch/switch-basic.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchBasic.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/switch/react/switch-basic.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
+
+A Switch presents a single setting as a track with a sliding marker. It's toggled by clicking the graphic or the label, or by pressing kbd:[Space] while it's focused, and it defaults to off when no value is set.
+
+
+// Basic Features
+
+include::{articles}/components/_input-field-common-features.adoc[tags=basic-intro;label;helper;tooltip;aria-labels]
+
+[.example,themes="lumo,aura"]
+--
+ifdef::lit[]
+[source,typescript]
+----
+include::{root}/frontend/demo/component/switch/switch-basic-features.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchBasicFeatures.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/switch/react/switch-basic-features.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
+
+
+// Readonly and disabled
+
+include::{articles}/components/_input-field-common-features.adoc[tag=readonly-and-disabled]
+
+For a setting that the user can see but not change -- one locked by a plan, a policy, or a parent setting -- read-only is preferable to disabled. A read-only Switch remains focusable and announced, and it still accepts programmatic changes, so the application can toggle it for a system-driven update.
+
+[.example,themes="lumo,aura"]
+--
+ifdef::lit[]
+[source,typescript]
+----
+include::{root}/frontend/demo/component/switch/switch-readonly-and-disabled.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchReadonlyAndDisabled.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/switch/react/switch-readonly-and-disabled.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
+
+
+== Validation
+
+Switch supports a single constraint: it can be marked as required, in which case off is invalid and on is valid. This is used most often for confirmations that the user has to accept before proceeding.
+
+include::{articles}/components/_input-field-common-features.adoc[tags=required]
+
+A required Switch isn't shown as invalid until the user submits the form or the application triggers validation, so no error appears before the user has acted. Toggling the switch on clears the invalid state immediately.
+
+[.example,themes="lumo,aura"]
+--
+ifdef::lit[]
+[source,typescript]
+----
+include::{root}/frontend/demo/component/switch/switch-validation.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchValidation.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/switch/react/switch-validation.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
+
+[NOTE]
+====
+The required indicator is visible only when the Switch has a label.
+====
+
+include::{articles}/components/_input-field-common-features.adoc[tags=binder]
+
+
+== Accessibility
+
+Switch uses the WAI-ARIA `switch` role, so screen readers announce it as a switch and read its state as on or off, rather than as a checkbox that is checked or unchecked. The accessible state is kept in sync with the visible state at all times, whether the user toggles the switch, the application updates it programmatically, or a form resets it.
+
+The label, helper, and error message are all associated with the control for assistive technologies, and the read-only and required states are announced as well.
+
+
+== Best Practices
+
+Use short, descriptive labels with positive wording that name the setting being turned on -- for example, "Notifications" rather than "Disable notifications". Negated labels make the off position ambiguous.
+
+Avoid combining read-only with required on a switch that's off, since that leaves the form in a state the user can't correct.
+
+
+== Related Components
+
+[cols="1,2"]
+|===
+|Component |Usage Recommendation
+
+|<<../checkbox#,Checkbox>>
+|Marks a selection -- picking an item, agreeing to terms, or including a row. Use a Switch instead when the control represents the on/off state of a single setting. Unlike Checkbox, Switch has no indeterminate state; if a setting has a third "mixed" state, use a Checkbox.
+
+|<<../radio-button#,Radio Button Group>>
+|Picks one of two or more equal options. Use a Switch when one value is clearly the "off" state of a feature, and a two-option radio group when both values are equal labels, such as "Imperial" and "Metric".
+
+|<<../select#,Select>>
+|Presents options in an overlay. Prefer a Select over a Switch only when the two values need long labels; a Switch shows both states at once and toggles in a single click.
+|===

--- a/articles/components/switch/styling.adoc
+++ b/articles/components/switch/styling.adoc
@@ -1,0 +1,134 @@
+---
+title: Styling
+page-title: How to style the Switch component | Vaadin components
+description: Styling API reference for the Switch component.
+meta-description: Customize the appearance of the Vaadin Switch component to align with your application's theme.
+order: 50
+---
+= Switch Styling
+
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-start]
+
+|`icon`
+|Shows a checkmark inside the marker when on, and a cross when off, for a stronger at-a-glance affordance
+|Aura, Lumo
+
+|`small`
+|Renders a more compact switch
+|Aura
+
+|`reverse`
+|Places the label before the switch, reversing their order
+|Aura
+
+include::{articles}/components/_input-field-common-features.adoc[tags=styles-end]
+
+include::../_styling-section-theming-props.adoc[tag=style-properties]
+
+include::../_styling-section-theming-props.adoc[tag=input-fields]
+
+=== Switch Properties
+
+[cols="3,1"]
+|===
+| Property | Supported by
+
+|`--vaadin-switch-background`
+|Aura, Lumo
+
+|`--vaadin-switch-border-color`
+|Aura, Lumo
+
+|`--vaadin-switch-border-radius`
+|Aura, Lumo
+
+|`--vaadin-switch-border-width`
+|Aura, Lumo
+
+|`--vaadin-switch-gap`
+|Aura, Lumo
+
+|`--vaadin-switch-height`
+|Aura, Lumo
+
+|`--vaadin-switch-width`
+|Aura, Lumo
+
+|`--vaadin-switch-icon-color`
+|Aura, Lumo
+
+|`--vaadin-switch-icon-size`
+|Aura, Lumo
+
+|`--vaadin-switch-label-color`
+|Lumo
+
+|`--vaadin-switch-label-font-size`
+|Lumo
+
+|`--vaadin-switch-label-font-weight`
+|Lumo
+
+|`--vaadin-switch-label-line-height`
+|Lumo
+
+|`--vaadin-switch-marker-border-color`
+|Aura, Lumo
+
+|`--vaadin-switch-marker-border-radius`
+|Aura, Lumo
+
+|`--vaadin-switch-marker-border-width`
+|Aura, Lumo
+
+|`--vaadin-switch-marker-color`
+|Aura, Lumo
+
+|`--vaadin-switch-marker-height`
+|Aura, Lumo
+
+|`--vaadin-switch-marker-scale`
+|Aura, Lumo
+
+|`--vaadin-switch-marker-width`
+|Aura, Lumo
+
+|===
+
+include::../_styling-section-theming-props.adoc[tag=label-helper-error]
+
+include::../_styling-section-intros.adoc[tag=selectors]
+
+
+=== Switch
+
+Root element:: `vaadin-switch`
+Focused:: `vaadin-switch+++<wbr>+++**[focused]**`
+Keyboard focused:: `vaadin-switch+++<wbr>+++**[focus-ring]**`
+Disabled:: `vaadin-switch+++<wbr>+++**[disabled]**`
+Read-only:: `vaadin-switch+++<wbr>+++**[readonly]**`
+Pressed:: `vaadin-switch+++<wbr>+++**[active]**`
+Checked (on):: `vaadin-switch+++<wbr>+++**[checked]**`
+Track:: `vaadin-switch+++<wbr>+++**::part(switch)**`
+Marker:: `vaadin-switch+++<wbr>+++**::part(marker)**`
+Label:: `vaadin-switch+++<wbr>+++**::part(label)**`
+
+
+==== Label
+
+Switch with label:: `vaadin-switch+++<wbr>+++**[has-label]**`
+Label:: `vaadin-switch+++<wbr>+++**::part(label)**`
+Label text:: `vaadin-switch+++<wbr>+++** > label**`
+Required switch:: `vaadin-switch+++<wbr>+++**[required]**`
+Required indicator:: `vaadin-switch+++<wbr>+++**::part(required-indicator)**`
+
+
+==== Helper and Validation Error
+
+Field with helper:: `vaadin-switch+++<wbr>+++**[has-helper]**`
+Helper:: `vaadin-switch+++<wbr>+++**::part(helper-text)**`
+Helper text:: `vaadin-switch+++<wbr>+++** > [slot="helper"]**`
+Invalid field:: `vaadin-switch+++<wbr>+++**[invalid]**`
+Field with error message:: `vaadin-switch+++<wbr>+++**[has-error-message]**`
+Error message:: `vaadin-switch+++<wbr>+++**::part(error-message)**`
+Error message text:: `vaadin-switch+++<wbr>+++** > [slot="error-message"]**`

--- a/articles/flow/configuration/feature-flags.adoc
+++ b/articles/flow/configuration/feature-flags.adoc
@@ -56,7 +56,7 @@ Enables <<{articles}/flow/ai-support#, AI components>> such as `AIOrchestrator`.
 Enables the <<{articles}/components/breadcrumbs#, Breadcrumbs>> component.
 
 `switchComponent`::
-Enables the Switch component.
+Enables the <<{articles}/components/switch#, Switch>> component.
 
 == Legacy Feature Flags
 

--- a/frontend/demo/component/switch/react/switch-basic-features.tsx
+++ b/frontend/demo/component/switch/react/switch-basic-features.tsx
@@ -1,0 +1,16 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React from 'react';
+import { Switch } from '@vaadin/react-components/Switch.js';
+import { Tooltip } from '@vaadin/react-components/Tooltip.js';
+
+function Example() {
+  return (
+    // tag::snippet[]
+    <Switch label="Autosave" helperText="Automatically save changes as you work">
+      <Tooltip slot="tooltip" text="Last saved 5 minutes ago" />
+    </Switch>
+    // end::snippet[]
+  );
+}
+
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/switch/react/switch-basic.tsx
+++ b/frontend/demo/component/switch/react/switch-basic.tsx
@@ -1,0 +1,13 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React from 'react';
+import { Switch } from '@vaadin/react-components/Switch.js';
+
+function Example() {
+  return (
+    // tag::snippet[]
+    <Switch label="Notifications" />
+    // end::snippet[]
+  );
+}
+
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/switch/react/switch-readonly-and-disabled.tsx
+++ b/frontend/demo/component/switch/react/switch-readonly-and-disabled.tsx
@@ -1,0 +1,23 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React from 'react';
+import { Switch } from '@vaadin/react-components/Switch.js';
+import { VerticalLayout } from '@vaadin/react-components/VerticalLayout.js';
+
+function Example() {
+  return (
+    <VerticalLayout theme="spacing">
+      {/* tag::snippet[] */}
+      <Switch
+        label="Audit log retention (90 days)"
+        helperText="Included on the Business plan"
+        readonly
+        checked
+      />
+
+      <Switch label="Daily digest" disabled />
+      {/* end::snippet[] */}
+    </VerticalLayout>
+  );
+}
+
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/switch/react/switch-validation.tsx
+++ b/frontend/demo/component/switch/react/switch-validation.tsx
@@ -7,9 +7,9 @@ function Example() {
     // tag::snippet[]
     <Switch
       label="Two-factor authentication"
-      helperText="Required by your workspace security policy"
       required
-      errorMessage="Two-factor authentication can't be turned off"
+      checked
+      errorMessage="Required by your workplace security policy"
     />
     // end::snippet[]
   );

--- a/frontend/demo/component/switch/react/switch-validation.tsx
+++ b/frontend/demo/component/switch/react/switch-validation.tsx
@@ -1,0 +1,33 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React, { useEffect } from 'react';
+import { Required } from '@vaadin/hilla-lit-form';
+import { useForm, useFormPart } from '@vaadin/hilla-react-form';
+import { Button } from '@vaadin/react-components/Button.js';
+import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
+import { Switch } from '@vaadin/react-components/Switch.js';
+import UserPermissionsModel from 'Frontend/generated/com/vaadin/demo/domain/UserPermissionsModel';
+
+function Example() {
+  const { model, field, validate } = useForm(UserPermissionsModel);
+  const viewField = useFormPart(model.view);
+
+  useEffect(() => {
+    viewField.addValidator(new Required());
+  }, []);
+
+  return (
+    // tag::snippet[]
+    <HorizontalLayout theme="spacing" style={{ alignItems: 'baseline' }}>
+      <Switch
+        label="I confirm the details are correct"
+        required
+        errorMessage="You must confirm to continue"
+        {...field(model.view)}
+      />
+      <Button onClick={validate}>Submit</Button>
+    </HorizontalLayout>
+    // end::snippet[]
+  );
+}
+
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/switch/react/switch-validation.tsx
+++ b/frontend/demo/component/switch/react/switch-validation.tsx
@@ -1,31 +1,16 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
-import React, { useEffect } from 'react';
-import { Required } from '@vaadin/hilla-lit-form';
-import { useForm, useFormPart } from '@vaadin/hilla-react-form';
-import { Button } from '@vaadin/react-components/Button.js';
-import { HorizontalLayout } from '@vaadin/react-components/HorizontalLayout.js';
+import React from 'react';
 import { Switch } from '@vaadin/react-components/Switch.js';
-import UserPermissionsModel from 'Frontend/generated/com/vaadin/demo/domain/UserPermissionsModel';
 
 function Example() {
-  const { model, field, validate } = useForm(UserPermissionsModel);
-  const viewField = useFormPart(model.view);
-
-  useEffect(() => {
-    viewField.addValidator(new Required());
-  }, []);
-
   return (
     // tag::snippet[]
-    <HorizontalLayout theme="spacing" style={{ alignItems: 'baseline' }}>
-      <Switch
-        label="I confirm the details are correct"
-        required
-        errorMessage="You must confirm to continue"
-        {...field(model.view)}
-      />
-      <Button onClick={validate}>Submit</Button>
-    </HorizontalLayout>
+    <Switch
+      label="Two-factor authentication"
+      helperText="Required by your workspace security policy"
+      required
+      errorMessage="Two-factor authentication can't be turned off"
+    />
     // end::snippet[]
   );
 }

--- a/frontend/demo/component/switch/switch-basic-features.ts
+++ b/frontend/demo/component/switch/switch-basic-features.ts
@@ -1,0 +1,25 @@
+import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/switch';
+import '@vaadin/tooltip';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/demo/theme';
+
+@customElement('switch-basic-features')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    applyTheme(root);
+    return root;
+  }
+
+  protected override render() {
+    return html`
+      <!-- tag::snippet[] -->
+      <vaadin-switch label="Autosave" helper-text="Automatically save changes as you work">
+        <vaadin-tooltip slot="tooltip" text="Last saved 5 minutes ago"></vaadin-tooltip>
+      </vaadin-switch>
+      <!-- end::snippet[] -->
+    `;
+  }
+}

--- a/frontend/demo/component/switch/switch-basic.ts
+++ b/frontend/demo/component/switch/switch-basic.ts
@@ -1,0 +1,22 @@
+import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/switch';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/demo/theme';
+
+@customElement('switch-basic')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    applyTheme(root);
+    return root;
+  }
+
+  protected override render() {
+    return html`
+      <!-- tag::snippet[] -->
+      <vaadin-switch label="Notifications"></vaadin-switch>
+      <!-- end::snippet[] -->
+    `;
+  }
+}

--- a/frontend/demo/component/switch/switch-readonly-and-disabled.ts
+++ b/frontend/demo/component/switch/switch-readonly-and-disabled.ts
@@ -1,0 +1,32 @@
+import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/switch';
+import '@vaadin/vertical-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/demo/theme';
+
+@customElement('switch-readonly-and-disabled')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    applyTheme(root);
+    return root;
+  }
+
+  protected override render() {
+    return html`
+      <vaadin-vertical-layout theme="spacing">
+        <!-- tag::snippet[] -->
+        <vaadin-switch
+          label="Audit log retention (90 days)"
+          helper-text="Included on the Business plan"
+          readonly
+          checked
+        ></vaadin-switch>
+
+        <vaadin-switch label="Daily digest" disabled></vaadin-switch>
+        <!-- end::snippet[] -->
+      </vaadin-vertical-layout>
+    `;
+  }
+}

--- a/frontend/demo/component/switch/switch-validation.ts
+++ b/frontend/demo/component/switch/switch-validation.ts
@@ -1,0 +1,44 @@
+import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/button';
+import '@vaadin/switch';
+import '@vaadin/horizontal-layout';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { Binder, field, Required } from '@vaadin/hilla-lit-form';
+import { applyTheme } from 'Frontend/demo/theme';
+import UserPermissionsModel from 'Frontend/generated/com/vaadin/demo/domain/UserPermissionsModel';
+
+@customElement('switch-validation')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    applyTheme(root);
+    return root;
+  }
+
+  private binder = new Binder(this, UserPermissionsModel);
+
+  protected override render() {
+    return html`
+      <vaadin-horizontal-layout theme="spacing" style="align-items: baseline">
+        <!-- tag::snippet[] -->
+        <vaadin-switch
+          label="I confirm the details are correct"
+          required
+          error-message="You must confirm to continue"
+          ${field(this.binder.model.view)}
+        ></vaadin-switch>
+        <!-- end::snippet[] -->
+        <vaadin-button @click="${this.validate}">Submit</vaadin-button>
+      </vaadin-horizontal-layout>
+    `;
+  }
+
+  protected override firstUpdated() {
+    this.binder.for(this.binder.model.view).addValidator(new Required());
+  }
+
+  protected validate() {
+    this.binder.validate();
+  }
+}

--- a/frontend/demo/component/switch/switch-validation.ts
+++ b/frontend/demo/component/switch/switch-validation.ts
@@ -1,12 +1,8 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/button';
 import '@vaadin/switch';
-import '@vaadin/horizontal-layout';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { Binder, field, Required } from '@vaadin/hilla-lit-form';
 import { applyTheme } from 'Frontend/demo/theme';
-import UserPermissionsModel from 'Frontend/generated/com/vaadin/demo/domain/UserPermissionsModel';
 
 @customElement('switch-validation')
 export class Example extends LitElement {
@@ -16,29 +12,16 @@ export class Example extends LitElement {
     return root;
   }
 
-  private binder = new Binder(this, UserPermissionsModel);
-
   protected override render() {
     return html`
-      <vaadin-horizontal-layout theme="spacing" style="align-items: baseline">
-        <!-- tag::snippet[] -->
-        <vaadin-switch
-          label="I confirm the details are correct"
-          required
-          error-message="You must confirm to continue"
-          ${field(this.binder.model.view)}
-        ></vaadin-switch>
-        <!-- end::snippet[] -->
-        <vaadin-button @click="${this.validate}">Submit</vaadin-button>
-      </vaadin-horizontal-layout>
+      <!-- tag::snippet[] -->
+      <vaadin-switch
+        label="Two-factor authentication"
+        helper-text="Required by your workspace security policy"
+        required
+        error-message="Two-factor authentication can't be turned off"
+      ></vaadin-switch>
+      <!-- end::snippet[] -->
     `;
-  }
-
-  protected override firstUpdated() {
-    this.binder.for(this.binder.model.view).addValidator(new Required());
-  }
-
-  protected validate() {
-    this.binder.validate();
   }
 }

--- a/frontend/demo/component/switch/switch-validation.ts
+++ b/frontend/demo/component/switch/switch-validation.ts
@@ -17,9 +17,9 @@ export class Example extends LitElement {
       <!-- tag::snippet[] -->
       <vaadin-switch
         label="Two-factor authentication"
-        helper-text="Required by your workspace security policy"
         required
-        error-message="Two-factor authentication can't be turned off"
+        checked
+        error-message="Required by your workplace security policy"
       ></vaadin-switch>
       <!-- end::snippet[] -->
     `;

--- a/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchBasic.java
+++ b/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchBasic.java
@@ -1,0 +1,21 @@
+package com.vaadin.demo.component.switchcomponent;
+
+import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("switch-basic")
+public class SwitchBasic extends Div {
+
+    public SwitchBasic() {
+        // tag::snippet[]
+        Switch notifications = new Switch("Notifications");
+
+        add(notifications);
+        // end::snippet[]
+    }
+
+    public static class Exporter extends DemoExporter<SwitchBasic> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchBasicFeatures.java
+++ b/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchBasicFeatures.java
@@ -1,0 +1,24 @@
+package com.vaadin.demo.component.switchcomponent;
+
+import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("switch-basic-features")
+public class SwitchBasicFeatures extends Div {
+
+    public SwitchBasicFeatures() {
+        // tag::snippet[]
+        Switch autosave = new Switch("Autosave");
+        autosave.setHelperText("Automatically save changes as you work");
+        autosave.setTooltipText("Last saved 5 minutes ago");
+
+        add(autosave);
+        // end::snippet[]
+    }
+
+    public static class Exporter // hidden-source-line
+            extends DemoExporter<SwitchBasicFeatures> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchReadonlyAndDisabled.java
+++ b/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchReadonlyAndDisabled.java
@@ -1,0 +1,30 @@
+package com.vaadin.demo.component.switchcomponent;
+
+import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("switch-readonly-and-disabled")
+public class SwitchReadonlyAndDisabled extends VerticalLayout {
+
+    public SwitchReadonlyAndDisabled() {
+        setPadding(false); // hidden-source-line
+
+        // tag::snippet[]
+        Switch auditLog = new Switch("Audit log retention (90 days)");
+        auditLog.setValue(true);
+        auditLog.setReadOnly(true);
+        auditLog.setHelperText("Included on the Business plan");
+
+        Switch dailyDigest = new Switch("Daily digest");
+        dailyDigest.setEnabled(false);
+
+        add(auditLog, dailyDigest);
+        // end::snippet[]
+    }
+
+    public static class Exporter // hidden-source-line
+            extends DemoExporter<SwitchReadonlyAndDisabled> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchValidation.java
+++ b/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchValidation.java
@@ -1,0 +1,35 @@
+package com.vaadin.demo.component.switchcomponent;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.checkbox.Switch;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.domain.UserPermissions;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+@Route("switch-validation")
+public class SwitchValidation extends HorizontalLayout {
+
+    public SwitchValidation() {
+        // tag::snippet[]
+        Switch confirmation = new Switch("I confirm the details are correct");
+        confirmation.setRequiredIndicatorVisible(true);
+
+        Binder<UserPermissions> binder = new Binder<>(UserPermissions.class);
+        binder.forField(confirmation).asRequired("You must confirm to continue")
+                .bind(UserPermissions::getView, UserPermissions::setView);
+        // end::snippet[]
+
+        Button button = new Button("Submit", e -> {
+            binder.validate();
+        });
+
+        setAlignItems(FlexComponent.Alignment.BASELINE);
+        add(confirmation, button);
+    }
+
+    public static class Exporter extends DemoExporter<SwitchValidation> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchValidation.java
+++ b/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchValidation.java
@@ -1,33 +1,24 @@
 package com.vaadin.demo.component.switchcomponent;
 
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Switch;
-import com.vaadin.flow.component.orderedlayout.FlexComponent;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.component.checkbox.Switch.SwitchI18n;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
-import com.vaadin.demo.domain.UserPermissions;
 import com.vaadin.demo.DemoExporter; // hidden-source-line
 
 @Route("switch-validation")
-public class SwitchValidation extends HorizontalLayout {
+public class SwitchValidation extends Div {
 
     public SwitchValidation() {
         // tag::snippet[]
-        Switch confirmation = new Switch("I confirm the details are correct");
-        confirmation.setRequiredIndicatorVisible(true);
-
-        Binder<UserPermissions> binder = new Binder<>(UserPermissions.class);
-        binder.forField(confirmation).asRequired("You must confirm to continue")
-                .bind(UserPermissions::getView, UserPermissions::setView);
+        Switch twoFactor = new Switch("Two-factor authentication");
+        twoFactor.setRequiredIndicatorVisible(true);
+        twoFactor.setI18n(new SwitchI18n().setRequiredErrorMessage(
+                "Two-factor authentication can't be turned off"));
         // end::snippet[]
+        twoFactor.setHelperText("Required by your workspace security policy");
 
-        Button button = new Button("Submit", e -> {
-            binder.validate();
-        });
-
-        setAlignItems(FlexComponent.Alignment.BASELINE);
-        add(confirmation, button);
+        add(twoFactor);
     }
 
     public static class Exporter extends DemoExporter<SwitchValidation> { // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchValidation.java
+++ b/src/main/java/com/vaadin/demo/component/switchcomponent/SwitchValidation.java
@@ -12,11 +12,11 @@ public class SwitchValidation extends Div {
     public SwitchValidation() {
         // tag::snippet[]
         Switch twoFactor = new Switch("Two-factor authentication");
+        twoFactor.setValue(true);
         twoFactor.setRequiredIndicatorVisible(true);
         twoFactor.setI18n(new SwitchI18n().setRequiredErrorMessage(
-                "Two-factor authentication can't be turned off"));
+                "Required by your workplace security policy"));
         // end::snippet[]
-        twoFactor.setHelperText("Required by your workspace security policy");
 
         add(twoFactor);
     }

--- a/src/main/resources/vaadin-featureflags.properties
+++ b/src/main/resources/vaadin-featureflags.properties
@@ -1,2 +1,3 @@
 com.vaadin.experimental.aiComponents=true
 com.vaadin.experimental.breadcrumbsComponent=true
+com.vaadin.experimental.switchComponent=true


### PR DESCRIPTION
Added `Switch` component documentation and updated feature flag to link to the new page.

Note: screenshot for the components page is currently missing, I will create one later.

