### PR TITLE
Remove GitHub repository details from index.adoc

### DIFF
--- a/articles/building-apps/mcp/index.adoc
+++ b/articles/building-apps/mcp/index.adoc
@@ -143,13 +143,6 @@ Install the Vaadin MCP server and development skills as a plugin for Claude Code
 https://github.com/vaadin/agent-marketplace
 
 [.card]
-=== GitHub Repository
-
-View source code, report issues, and contribute to the project.
-
-https://github.com/vaadin/vaadin-mcp
-
-[.card]
 === Model Context Protocol
 
 Learn more about the Model Context Protocol standard.


### PR DESCRIPTION
Removed GitHub repository section from the document. The GitHub repo is private nowadays. 


