### PR TITLE
Specify how ListBox works with DataProvider

### DIFF
--- a/articles/components/list-box/index.adoc
+++ b/articles/components/list-box/index.adoc
@@ -211,6 +211,9 @@ List Box isn't designed to be used as an input field in forms, and lacks feature
 See related components later for better options for use in forms.
 List Box is best suited for use as a lightweight, scrollable, single-column list for single or multi-selection of items.
 
+The List Box API supports using a [classname]`DataProvider` as its data source. However, List Box does not support lazy loading: all items are fetched from the data provider at once. For large data sets, consider using Virtual List or Grid for displaying items, or Combo Box or Multi-Select Combo Box when selection is required.
+
+
 == Related Components
 
 |===
@@ -222,6 +225,9 @@ List Box is best suited for use as a lightweight, scrollable, single-column list
 |<<../combo-box#,Combo Box>>
 |Select a value from a filterable overlay. Appropriate for large sets of options. Supports lazy loading and entry of custom values.
 
+|<<../multi-select-combo-box#,Multi-Select Combo Box>>
+| Select multiple values from a filterable overlay. Appropriate for large sets of options and supports lazy loading.
+
 |<<../radio-button#,Radio Button Group>>
 |Select a single option from a list. Optimal accessibility, as all options are visible without any user action.
 
@@ -230,6 +236,10 @@ List Box is best suited for use as a lightweight, scrollable, single-column list
 
 |<<../grid#,Grid>>
 |A more advanced list component for cases where multiple columns, filtering or lazy loading is required.
+
+|<<../virtual-list#,Virtual List>>
+| Display a large, scrollable list of items with lazy loading and custom item rendering.
+
 |===
 
 


### PR DESCRIPTION
Solves #81

Adds another paragraph under Best Practices:

> The List Box API supports using a DataProvider as its data source. However, List Box does not support lazy loading: all items are fetched from the data provider at once. For large data sets, consider using Virtual List or Grid for displaying items, or Combo Box or Multi-Select Combo Box when selection is required.

As well as added "Virtual List" under "Related Components" 

> Virtual List | Display a large, scrollable list of items with lazy loading and custom item rendering.