### PR TITLE
Rephrase `@EnableVaadin` clarification to be Spring Boot centric

### DIFF
--- a/articles/flow/integrations/spring/routing.adoc
+++ b/articles/flow/integrations/spring/routing.adoc
@@ -74,6 +74,6 @@ The https://vaadin.com/directory/component/vaadin-spring/overview[Vaadin Spring 
 - Explicitly specify the packages that should be scanned. You can specify packages to scan using the `value` parameter in the `@EnableVaadin` annotation.
 
 [NOTE]
-You don't need to use the `@EnableVaadin` annotation at all with <<spring-boot#,Spring Boot>>. This annotation is intended to be used with <<spring-mvc#,Spring MVC>> to enable the Vaadin configuration. In Spring Boot, auto-configuration is available, which makes it work out of the box. The only reason to use `@EnableVaadin` is to specify the packages to scan with Spring MVC.
+The `@EnableVaadin` annotation is required when using <<spring-mvc#,Spring MVC>> without <<spring-boot#,Spring Boot>>. When using Spring Boot, auto-configuration automatically enables Vaadin with a default location to scan for Vaadin routes. You can still use the `@EnableVaadin` annotation in a Spring Boot application specifically for the purpose of configuring a custom location.
 
 [discussion-id]`4E7C7193-B3CD-4551-8919-58297836B694`

--- a/articles/flow/integrations/spring/routing.adoc
+++ b/articles/flow/integrations/spring/routing.adoc
@@ -74,6 +74,6 @@ The https://vaadin.com/directory/component/vaadin-spring/overview[Vaadin Spring 
 - Explicitly specify the packages that should be scanned. You can specify packages to scan using the `value` parameter in the `@EnableVaadin` annotation.
 
 [NOTE]
-The `@EnableVaadin` annotation is required when using <<spring-mvc#,Spring MVC>> without <<spring-boot#,Spring Boot>>. When using Spring Boot, auto-configuration automatically enables Vaadin with a default location to scan for Vaadin routes. You can still use the `@EnableVaadin` annotation in a Spring Boot application specifically for the purpose of configuring a custom location.
+The `@EnableVaadin` annotation is required when using <<spring-mvc#,Spring MVC>> without <<spring-boot#,Spring Boot>>. When using Spring Boot, auto-configuration automatically enables Vaadin with a default location to scan for Vaadin routes. You can still use the `@EnableVaadin` annotation in a Spring Boot application specifically for the purpose of replacing the default configuration.
 
 [discussion-id]`4E7C7193-B3CD-4551-8919-58297836B694`


### PR DESCRIPTION
The note about the `@EnableVaadin` annotation being optional originated from a time when Spring Boot wasn't the defacto way of using Spring. That phrasing is confusing nowadays when Spring Boot is the most common way.


