### PR TITLE
docs: replace selectRenderer in TS examples with list-box

### DIFF
--- a/articles/components/select/index.adoc
+++ b/articles/components/select/index.adoc
@@ -413,10 +413,6 @@ ifdef::lit[]
 [source,typescript]
 ----
 include::{root}/frontend/demo/component/select/select-presentation.ts[render,tags=snippet,indent=0,group=Lit]
-
-...
-
-include::{root}/frontend/demo/component/select/select-presentation.ts[tags=renderer,indent=0]
 ----
 endif::[]
 

--- a/frontend/demo/component/select/select-custom-renderer-label.ts
+++ b/frontend/demo/component/select/select-custom-renderer-label.ts
@@ -1,10 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/item';
-import '@vaadin/list-box';
 import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { selectRenderer } from '@vaadin/select/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import { applyTheme } from 'Frontend/demo/theme';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
@@ -28,34 +25,28 @@ export class Example extends LitElement {
 
   protected override render() {
     return html`
-      <vaadin-select
-        label="Assignee"
-        ${selectRenderer(
-          () => html`
-            <vaadin-list-box>
-              ${this.people.map(
-                (person) => html`
-                  <!-- tag::snippet[] -->
-                  <!-- Use the label attribute to display full name of the person as selected value label -->
-                  <vaadin-item value="${person.id}" label="${formatPersonFullName(person)}">
-                    <div class="person-item">
-                      <img
-                        src="${person.pictureUrl}"
-                        alt="Portrait of ${formatPersonFullName(person)}"
-                        style="width: 2.25rem;"
-                      />
-                      <span>${formatPersonFullName(person)}</span>
-                      <span>${person.profession}</span>
-                    </div>
-                  </vaadin-item>
-                  <!-- end::snippet[] -->
-                `
-              )}
-            </vaadin-list-box>
-          `,
-          this.people
-        )}
-      ></vaadin-select>
+      <vaadin-select label="Assignee">
+        <vaadin-select-list-box slot="overlay">
+          ${this.people.map(
+            (person) => html`
+              <!-- tag::snippet[] -->
+              <!-- Use the label attribute to display full name of the person as selected value label -->
+              <vaadin-select-item value="${person.id}" label="${formatPersonFullName(person)}">
+                <div class="person-item">
+                  <img
+                    src="${person.pictureUrl}"
+                    alt="Portrait of ${formatPersonFullName(person)}"
+                    style="width: 2.25rem;"
+                  />
+                  <span>${formatPersonFullName(person)}</span>
+                  <span>${person.profession}</span>
+                </div>
+              </vaadin-select-item>
+              <!-- end::snippet[] -->
+            `
+          )}
+        </vaadin-select-list-box>
+      </vaadin-select>
     `;
   }
 }

--- a/frontend/demo/component/select/select-presentation.ts
+++ b/frontend/demo/component/select/select-presentation.ts
@@ -1,10 +1,7 @@
 import 'Frontend/demo/init'; // hidden-source-line
-import '@vaadin/item';
-import '@vaadin/list-box';
 import '@vaadin/select';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { selectRenderer } from '@vaadin/select/lit.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import { applyTheme } from 'Frontend/demo/theme';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
@@ -31,30 +28,25 @@ export class Example extends LitElement {
       <vaadin-select
         label="Choose doctor"
         style="width: 15em;"
-        ${selectRenderer(this.renderer, this.people)}
-      ></vaadin-select>
+      >
+        <vaadin-select-list-box slot="overlay">
+          ${this.people.map(
+            (person) => html`
+              <vaadin-select-item value="${person.id}">
+                <div class="person-item">
+                  <vaadin-avatar
+                    .img="${person.pictureUrl}"
+                    .name="${`${person.firstName} ${person.lastName}`}"
+                  ></vaadin-avatar>
+                  <span>${person.firstName} ${person.lastName}</span>
+                  <span>${person.profession}</span>
+                </div>
+              </vaadin-select-item>
+            `
+          )}
+        </vaadin-select-list-box>
+      </vaadin-select>
       <!-- end::snippet[] -->
     `;
   }
-
-  // tag::renderer[]
-  private renderer = () => html`
-    <vaadin-list-box>
-      ${this.people.map(
-        (person) => html`
-          <vaadin-item value="${person.id}">
-            <div class="person-item">
-              <vaadin-avatar
-                .img="${person.pictureUrl}"
-                .name="${`${person.firstName} ${person.lastName}`}"
-              ></vaadin-avatar>
-              <span>${person.firstName} ${person.lastName}</span>
-              <span>${person.profession}</span>
-            </div>
-          </vaadin-item>
-        `
-      )}
-    </vaadin-list-box>
-  `;
-  // end::renderer[]
 }


### PR DESCRIPTION
Replaced deprecated `selectRenderer` Lit directive with slotted list-box added in V25.3.