### PR TITLE
docs: document custom AI field marker popover content

### DIFF
--- a/articles/flow/ai-support/ai-powered-form.adoc
+++ b/articles/flow/ai-support/ai-powered-form.adoc
@@ -289,12 +289,12 @@ The texts are applied to every marker the controller puts on a field, so set the
 [role="since:com.vaadin:vaadin@V25.3"]
 === Custom Popover Content
 
-By default the marker's popover holds the explanation message and the revert control. To show what the AI based a value on -- for example the source snippets reported when <<#source-tracking,source tracking>> is enabled -- set a content provider with [methodname]`setFieldMarkerContentProvider()`. The component it returns is shown in the popover between the message and the revert control:
+By default the marker's popover holds the explanation message and the revert control. To show what the AI based a value on -- for example the source snippets reported when <<#source-tracking,source tracking>> is enabled -- set a content provider with [methodname]`setFieldMarkerPopoverContentProvider()`. The component it returns is shown in the popover between the message and the revert control:
 
 [source,java]
 ----
 controller.setSourceTrackingEnabled(true);
-controller.setFieldMarkerContentProvider(change ->
+controller.setFieldMarkerPopoverContentProvider(change ->
         change.getFieldSource()
                 .map(source -> new Div(source.extracts().stream()
                         .map(extract -> new Paragraph(extract.text()))
@@ -302,7 +302,7 @@ controller.setFieldMarkerContentProvider(change ->
                 .orElse(null));
 ----
 
-The provider is called once per field whose value changed during a successful turn, with the same event the <<#reacting-to-ai-changes,change listeners>> receive, before those listeners run. Returning `null` leaves that field's popover without extra content. Return a fresh component on every call; a component that already has a parent is rejected.
+The provider is called once per field whose value changed during a successful turn, with the same event the <<#reacting-to-ai-changes,change listeners>> receive, before those listeners run. Returning `null` leaves that field's popover without extra content. Return a fresh component on every call; a component that already has a parent is rejected -- the controller logs a warning and marks the field without the extra content, without failing the turn.
 
 The controller owns the returned component's lifecycle: the content stays in the popover as long as the mark it belongs to, is replaced when a later turn fills the field again, and goes away with the mark when the user edits or reverts the field. Like the mark itself, the content survives detaching and re-attaching the field. When the marker is <<#disabling-the-marker,disabled>>, the provider is never called.
 

--- a/articles/flow/ai-support/ai-powered-form.adoc
+++ b/articles/flow/ai-support/ai-powered-form.adoc
@@ -252,6 +252,7 @@ The marker needs no application code:
 * The marker clears itself as soon as the user edits or reverts the field, so a stale cue never lingers over a value the user changed.
 * The marker survives detaching and re-attaching the field.
 
+[[disabling-the-marker]]
 === Disabling the Marker
 
 Call [methodname]`setFieldMarkerEnabled(false)` for a form that should carry no trace of the AI's edits:
@@ -284,6 +285,26 @@ Each text has a specific role:
 * [methodname]`setBadgeTooltip()` sets the tooltip text shown when the badge is hovered or focused.
 
 The texts are applied to every marker the controller puts on a field, so set them before the first turn to localize them all. Texts left `null` fall back to the built-in defaults.
+
+[role="since:com.vaadin:vaadin@V25.3"]
+=== Custom Popover Content
+
+By default the marker's popover holds the explanation message and the revert control. To show what the AI based a value on -- for example the source snippets reported when <<#source-tracking,source tracking>> is enabled -- set a content provider with [methodname]`setFieldMarkerContentProvider()`. The component it returns is shown in the popover between the message and the revert control:
+
+[source,java]
+----
+controller.setSourceTrackingEnabled(true);
+controller.setFieldMarkerContentProvider(change ->
+        change.getFieldSource()
+                .map(source -> new Div(source.extracts().stream()
+                        .map(extract -> new Paragraph(extract.text()))
+                        .toArray(Component[]::new)))
+                .orElse(null));
+----
+
+The provider is called once per field whose value changed during a successful turn, with the same event the <<#reacting-to-ai-changes,change listeners>> receive, before those listeners run. Returning `null` leaves that field's popover without extra content. Return a fresh component on every call; a component that already has a parent is rejected.
+
+The controller owns the returned component's lifecycle: the content stays in the popover as long as the mark it belongs to, is replaced when a later turn fills the field again, and goes away with the mark when the user edits or reverts the field. Like the mark itself, the content survives detaching and re-attaching the field. When the marker is <<#disabling-the-marker,disabled>>, the provider is never called.
 
 [[reacting-to-ai-changes]]
 == Reacting to AI Changes


### PR DESCRIPTION
## Summary
- Documents the custom AI field marker popover content provider added in vaadin/flow-components#9922 (web component support in vaadin/web-components#12439)
- Shows the primary use case from the API javadoc: surfacing source-tracking snippets in the popover, alongside the provider's lifecycle rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)