### PR TITLE
docs: add Date Time Picker default time examples

### DIFF
--- a/articles/components/date-time-picker/index.adoc
+++ b/articles/components/date-time-picker/index.adoc
@@ -286,6 +286,40 @@ endif::[]
 --
 
 
+[role="since:com.vaadin:vaadin@V25.3"]
+== Default Time
+
+Date Time Picker's default time defines the time that's filled in automatically when the user selects a date while the time field is empty. This saves the user from entering a time in applications where a certain time of day is the most likely choice, such as the start of the working day.
+
+The default time is only applied to dates the user selects; it doesn't affect values set programmatically. A time the user has already entered is never overwritten, but clearing the time field and selecting another date applies the default time again.
+
+The applied time follows the precision defined by the step: a more precise default time is truncated. A default time outside the allowed range is applied as it is, which makes the field invalid.
+
+[.example,themes="lumo,aura"]
+--
+ifdef::lit[]
+[source,html]
+----
+include::{root}/frontend/demo/component/datetimepicker/date-time-picker-default-time.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerDefaultTime.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/datetimepicker/react/date-time-picker-default-time.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+--
+
+
 == Internationalization (i18n)
 
 Date Time Picker allows localizing texts and labels, such as month names and button labels.

--- a/frontend/demo/component/datetimepicker/date-time-picker-default-time.ts
+++ b/frontend/demo/component/datetimepicker/date-time-picker-default-time.ts
@@ -1,0 +1,22 @@
+import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/date-time-picker';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/demo/theme';
+
+@customElement('date-time-picker-default-time')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    applyTheme(root);
+    return root;
+  }
+
+  protected override render() {
+    return html`
+      <!-- tag::snippet[] -->
+      <vaadin-date-time-picker label="Appointment" default-time="09:00"></vaadin-date-time-picker>
+      <!-- end::snippet[] -->
+    `;
+  }
+}

--- a/frontend/demo/component/datetimepicker/react/date-time-picker-default-time.tsx
+++ b/frontend/demo/component/datetimepicker/react/date-time-picker-default-time.tsx
@@ -1,0 +1,13 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React from 'react';
+import { DateTimePicker } from '@vaadin/react-components/DateTimePicker.js';
+
+function Example() {
+  return (
+    // tag::snippet[]
+    <DateTimePicker label="Appointment" defaultTime="09:00" />
+    // end::snippet[]
+  );
+}
+
+export default reactExample(Example); // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerDefaultTime.java
+++ b/src/main/java/com/vaadin/demo/component/datetimepicker/DateTimePickerDefaultTime.java
@@ -1,0 +1,24 @@
+package com.vaadin.demo.component.datetimepicker;
+
+import com.vaadin.flow.component.datetimepicker.DateTimePicker;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+
+import java.time.LocalTime;
+
+@Route("date-time-picker-default-time")
+public class DateTimePickerDefaultTime extends Div {
+
+    public DateTimePickerDefaultTime() {
+        // tag::snippet[]
+        DateTimePicker dateTimePicker = new DateTimePicker("Appointment");
+        dateTimePicker.setDefaultTime(LocalTime.of(9, 0));
+        // end::snippet[]
+        add(dateTimePicker);
+    }
+
+    public static class Exporter extends // hidden-source-line
+            DemoExporter<DateTimePickerDefaultTime> { // hidden-source-line
+    } // hidden-source-line
+}


### PR DESCRIPTION
Add a "Default Time" section describing the `defaultTime` property added and `setDefaultTime(LocalTime)` API.

Needs the Flow component PR to be merged and released in a platform alpha:
 
- vaadin/web-components#12451
- vaadin/flow-components#9915


