### PR TITLE
docs: mark upload custom CSS properties supported in Lumo

### DIFF
--- a/articles/components/upload/styling.adoc
+++ b/articles/components/upload/styling.adoc
@@ -35,37 +35,40 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 | Property | Supported by
 
 |`--vaadin-upload-background`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-border-color`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-border-radius`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-border-width`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-drop-label-color`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-drop-label-font-size`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-drop-label-font-weight`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-drop-label-gap`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-drop-label-line-height`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-gap`
 |Aura, Lumo
 
-|`--vaadin-upload-padding`
+|`--vaadin-upload-icon-color`
 |Aura
+
+|`--vaadin-upload-padding`
+|Aura, Lumo
 
 |===
 
@@ -76,10 +79,10 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 | Property | Supported by
 
 |`--vaadin-upload-file-list-divider-color`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-file-list-divider-width`
-|Aura
+|Aura, Lumo
 
 |===
 
@@ -90,10 +93,10 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 | Property | Supported by
 
 |`--vaadin-upload-file-border-radius`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-file-button-background`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-file-button-border-color`
 |Aura
@@ -126,7 +129,7 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |Aura
 
 |`--vaadin-upload-file-gap`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-file-name-color`
 |Aura
@@ -141,7 +144,7 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |Aura
 
 |`--vaadin-upload-file-padding`
-|Aura
+|Aura, Lumo
 
 |`--vaadin-upload-file-status-color`
 |Aura


### PR DESCRIPTION
Marked upload custom CSS properties supported in Lumo since these PRs:

- https://github.com/vaadin/web-components/pull/10552
- https://github.com/vaadin/web-components/pull/10272

Also added missing `--vaadin-upload-icon-color` property (Aura only).