### PR TITLE
chore: remove no longer needed core-js from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@vaadin/vaadin-lumo-styles": "25.3.0-alpha9",
         "@vaadin/vaadin-themable-mixin": "25.3.0-alpha9",
         "@vaadin/vaadin-usage-statistics": "2.1.3",
-        "core-js": "^3.32.1",
         "date-fns": "4.1.0",
         "iframe-resizer": "^4.3.6",
         "lit": "3.3.3",
@@ -5267,20 +5266,6 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
       "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
       "license": "MIT"
-    },
-    "node_modules/core-js": {
-      "version": "3.50.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
-      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@vaadin/vaadin-lumo-styles": "25.3.0-alpha9",
     "@vaadin/vaadin-themable-mixin": "25.3.0-alpha9",
     "@vaadin/vaadin-usage-statistics": "2.1.3",
-    "core-js": "^3.32.1",
     "date-fns": "4.1.0",
     "iframe-resizer": "^4.3.6",
     "lit": "3.3.3",
@@ -172,7 +171,6 @@
     "@vaadin/vaadin-usage-statistics": "$@vaadin/vaadin-usage-statistics",
     "@vaadin/vertical-layout": "25.3.0-alpha9",
     "@vaadin/virtual-list": "25.3.0-alpha9",
-    "core-js": "$core-js",
     "date-fns": "$date-fns",
     "iframe-resizer": "$iframe-resizer",
     "lit": "$lit",
@@ -255,6 +253,6 @@
       "vite": "8.0.16",
       "vite-plugin-checker": "0.14.5"
     },
-    "hash": "b62b979eb18479bacceced6487af1d6262020761a81a46d2424ff37a84b346f5"
+    "hash": "3472c94cb6b5f6ccc2bc4ddbaa59746e27bb28fa5f3df9deabb23d6ffb70ab98"
   }
 }


### PR DESCRIPTION
Pinning `core-js` was needed as a workaround for an older Flow version. Let's remove it, Vite no longer needs that.