### PR TITLE
fix: pin eslint-config-vaadin to the version the lockfile resolves

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@vitejs/plugin-react": "6.0.5",
     "commander": "^9.4.1",
     "eslint": "^9.39.1",
-    "eslint-config-vaadin": "^1.0.0-beta.4",
+    "eslint-config-vaadin": "1.0.0-beta.6",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^16.5.0",


### PR DESCRIPTION
## Summary

* `eslint-config-vaadin@1.0.0-beta.7` raised its peer to `eslint@^10` while this project stays on `eslint@^9.39.1`, and the `^1.0.0-beta.4` range let it in.
* Pins the exact version the lockfile already installs, so a resolution from scratch picks the same tree as `npm ci`.
* No change to what gets installed here: `npm ci` resolves `beta.6` before and after, and `npm run lint` reports the same 451 problems either way.

## Context

`npm ci` is unaffected because the lockfile pins `beta.6`, which is why this repository's own CI stays green. The platform release build is not: Flow's `build-frontend` regenerates `package.json` with the `@NpmPackage` dependencies before installing, the lockfile no longer matches, and npm resolves from scratch and pulls `beta.7`.

That is what fails the `Update vaadin version used in docs` step, which aborts `UpdateDocsToUseTheLatestPlatform` and leaves every platform release needing a manual resume from `UpdateMavenStarters`. It hit 25.3.0-alpha9 today and would hit each of the five stable lines due for a release.