### PR TITLE
docs: markdown line breaks

### DIFF
--- a/articles/components/markdown/index.adoc
+++ b/articles/components/markdown/index.adoc
@@ -43,4 +43,37 @@ endif::[]
 
 --
 
+
+[role="since:com.vaadin:vaadin@V25.3"]
+== Line Breaks
+
+By default, the component follows the original Markdown specification: a single line break within a paragraph is collapsed into a space, and a blank line is needed to start a new paragraph.
+Enabling the line breaks option renders single line breaks (also called _soft breaks_) as actual line breaks, the way chat and message-style Markdown behaves. Blank lines still start a new paragraph.
+
+[.example,themes="lumo,aura"]
+--
+
+ifdef::lit[]
+[source,html]
+----
+include::{root}/frontend/demo/component/markdown/markdown-line-breaks.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/markdown/MarkdownLineBreaks.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/markdown/react/markdown-line-breaks.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+
+--
+
 [discussion-id]`77B51D28-FE42-4829-A315-D0F3C8A55BED`

--- a/articles/components/markdown/index.adoc
+++ b/articles/components/markdown/index.adoc
@@ -48,13 +48,13 @@ endif::[]
 == Line Breaks
 
 By default, the component follows the original Markdown specification: a single line break within a paragraph is collapsed into a space, and a blank line is needed to start a new paragraph.
-Enabling the line breaks option renders single line breaks (also called _soft breaks_) as actual line breaks, the way chat and message-style Markdown behaves. Blank lines still start a new paragraph.
+Enabling the line breaks option renders single line breaks (also called _soft breaks_) as actual line breaks, the way chat and message-style Markdown behaves typically. Blank lines still start a new paragraph.
 
 [.example,themes="lumo,aura"]
 --
 
 ifdef::lit[]
-[source,html]
+[source,typescript]
 ----
 include::{root}/frontend/demo/component/markdown/markdown-line-breaks.ts[render,tags=snippet,indent=0,group=Lit]
 ----

--- a/frontend/demo/component/markdown/markdown-line-breaks.ts
+++ b/frontend/demo/component/markdown/markdown-line-breaks.ts
@@ -1,0 +1,26 @@
+import '@vaadin/markdown';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { applyTheme } from 'Frontend/demo/theme';
+
+@customElement('markdown-line-breaks')
+export class MarkdownLineBreaks extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    applyTheme(root);
+    return root;
+  }
+
+  protected override render() {
+    // tag::snippet[]
+    const markdownText = `
+Deploy checklist for tomorrow:
+Run the test suite
+Bump the version number
+Tag the release
+    `;
+
+    return html`<vaadin-markdown line-breaks .content=${markdownText}></vaadin-markdown>`;
+    // end::snippet[]
+  }
+}

--- a/frontend/demo/component/markdown/markdown-line-breaks.ts
+++ b/frontend/demo/component/markdown/markdown-line-breaks.ts
@@ -14,10 +14,12 @@ export class MarkdownLineBreaks extends LitElement {
   protected override render() {
     // tag::snippet[]
     const markdownText = `
-Deploy checklist for tomorrow:
-Run the test suite
-Bump the version number
-Tag the release
+Hi Maria,
+Your order shipped this morning.
+It should arrive by Thursday.
+
+Best regards,
+Tom
     `;
 
     return html`<vaadin-markdown line-breaks .content=${markdownText}></vaadin-markdown>`;

--- a/frontend/demo/component/markdown/react/markdown-line-breaks.tsx
+++ b/frontend/demo/component/markdown/react/markdown-line-breaks.tsx
@@ -5,10 +5,12 @@ import { Markdown } from '@vaadin/react-components/Markdown.js';
 function Example() {
   // tag::snippet[]
   const markdownText = `
-Deploy checklist for tomorrow:
-Run the test suite
-Bump the version number
-Tag the release
+Hi Maria,
+Your order shipped this morning.
+It should arrive by Thursday.
+
+Best regards,
+Tom
   `;
 
   return <Markdown lineBreaks>{markdownText}</Markdown>;

--- a/frontend/demo/component/markdown/react/markdown-line-breaks.tsx
+++ b/frontend/demo/component/markdown/react/markdown-line-breaks.tsx
@@ -1,0 +1,18 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React from 'react';
+import { Markdown } from '@vaadin/react-components/Markdown.js';
+
+function Example() {
+  // tag::snippet[]
+  const markdownText = `
+Deploy checklist for tomorrow:
+Run the test suite
+Bump the version number
+Tag the release
+  `;
+
+  return <Markdown lineBreaks>{markdownText}</Markdown>;
+  // end::snippet[]
+}
+
+export default reactExample(Example); // hidden-source-line

--- a/src/main/java/com/vaadin/demo/component/markdown/MarkdownLineBreaks.java
+++ b/src/main/java/com/vaadin/demo/component/markdown/MarkdownLineBreaks.java
@@ -1,0 +1,28 @@
+package com.vaadin.demo.component.markdown;
+
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.markdown.Markdown;
+import com.vaadin.flow.router.Route;
+
+@Route("markdown-line-breaks")
+public class MarkdownLineBreaks extends Div {
+
+    public MarkdownLineBreaks() {
+        // tag::snippet[]
+        String markdownText = """
+                Deploy checklist for tomorrow:
+                Run the test suite
+                Bump the version number
+                Tag the release
+                """;
+
+        Markdown markdown = new Markdown(markdownText);
+        markdown.setLineBreaks(true);
+        add(markdown);
+        // end::snippet[]
+    }
+
+    public static class Exporter extends DemoExporter<MarkdownLineBreaks> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/markdown/MarkdownLineBreaks.java
+++ b/src/main/java/com/vaadin/demo/component/markdown/MarkdownLineBreaks.java
@@ -11,16 +11,18 @@ public class MarkdownLineBreaks extends Div {
     public MarkdownLineBreaks() {
         // tag::snippet[]
         String markdownText = """
-                Deploy checklist for tomorrow:
-                Run the test suite
-                Bump the version number
-                Tag the release
+                Hi Maria,
+                Your order shipped this morning.
+                It should arrive by Thursday.
+
+                Best regards,
+                Tom
                 """;
 
         Markdown markdown = new Markdown(markdownText);
         markdown.setLineBreaks(true);
-        add(markdown);
         // end::snippet[]
+        add(markdown);
     }
 
     public static class Exporter extends DemoExporter<MarkdownLineBreaks> { // hidden-source-line


### PR DESCRIPTION
Adds documentation for the Markdown `lineBreaks` API added in:
- https://github.com/vaadin/web-components/pull/12459
- https://github.com/vaadin/flow-components/pull/9930