### PR TITLE
chore: work around Flow i18n startup regression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,35 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!--
+                      Workaround for a Flow regression: the production build
+                      emits a vaadin-i18n folder into the packaged jar, whose
+                      presence makes the application fail to start. This app has
+                      no translation bundles, so the folder is safe to drop.
+                      Remove this once the regression is fixed in Flow
+                      (fixed by flow#25282, not yet in any published release).
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>drop-empty-i18n-manifest</id>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>${project.build.outputDirectory}/vaadin-i18n</directory>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
## Summary
- The packaged production app fails to start with the current Flow prerelease because the build emits a `vaadin-i18n` folder into the jar, which trips a Flow regression at servlet init.
- This app has no translation bundles, so dropping the empty folder at packaging time is safe and restores previous behavior.
- Temporary workaround — remove once a Flow release containing the fix ([flow#25282](https://github.com/vaadin/flow/pull/25282)) is picked up.
- This fixes the latest `main` revision not getting deployed to https://vaadin.com/docs/next/