### PR TITLE
docs: add keep filter example to MultiSelectComboBox

### DIFF
--- a/articles/components/multi-select-combo-box/index.adoc
+++ b/articles/components/multi-select-combo-box/index.adoc
@@ -257,6 +257,33 @@ include::{root}/frontend/demo/component/multi-select-combo-box/react/multi-selec
 endif::[]
 --
 
+== Keep Filter
+
+By default, the filter is cleared after selecting an item, and the overlay shows the full list of items again. The component can be configured to keep the filter instead, which makes it easier to select several items that match the same filter. The filter is still cleared when the overlay is closed.
+
+--
+ifdef::flow[]
+[source,java]
+----
+comboBox.setKeepFilter(true);
+----
+endif::[]
+
+ifdef::lit[]
+[source,html]
+----
+<vaadin-multi-select-combo-box keep-filter>
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+<MultiSelectComboBox keepFilter>
+----
+endif::[]
+--
+
 [role="since:com.vaadin:vaadin@V25.2"]
 == Collapse Chips
 


### PR DESCRIPTION
Added missing docs for MSCB `keepFilter` - see https://github.com/vaadin/web-components/issues/12538.