### PR TITLE
docs: fix missing example for MSCB keep filter section

### DIFF
--- a/articles/components/multi-select-combo-box/index.adoc
+++ b/articles/components/multi-select-combo-box/index.adoc
@@ -261,6 +261,7 @@ endif::[]
 
 By default, the filter is cleared after selecting an item, and the overlay shows the full list of items again. The component can be configured to keep the filter instead, which makes it easier to select several items that match the same filter. The filter is still cleared when the overlay is closed.
 
+[.example]
 --
 ifdef::flow[]
 [source,java]


### PR DESCRIPTION
Missed to check how it rendered after updating manually, sorry about the hassle 🙈 