### PR TITLE
docs: add DatePicker disabling dates and custom part names

### DIFF
--- a/articles/components/date-picker/index.adoc
+++ b/articles/components/date-picker/index.adoc
@@ -64,6 +64,24 @@ include::{articles}/components/_input-field-common-features.adoc[tags=bad-input;
 The valid input range of Date Picker can be restricted by defining `min` and `max` values. Dates before the `min` and after the `max` are disabled in the overlay. Helper text can be used to inform the user about the accepted range.
 ====
 
+[#disabled-weekdays]
+.Disabled Weekdays
+[%collapsible]
+====
+Whole weekdays can [since:com.vaadin:vaadin@V25.3]#be excluded from selection#, for example to restrict a booking to business days. Dates that fall on a disabled weekday are shown as disabled in the overlay, and typing one into the field makes it invalid.
+====
+
+[#disabled-dates]
+.Disabled Dates
+[%collapsible]
+====
+Individual dates can [since:com.vaadin:vaadin@V25.3]#also be excluded from selection#, for example public holidays. Like disabled weekdays, they're shown as disabled in the overlay, and typing one into the field makes it invalid.
+
+This is meant for a small set of dates that's known in advance. When the set is large, changes while the application runs, or when particular dates should also be styled, use the date metadata callback instead. See <<#configuring-individual-dates,Configuring Individual Dates>>.
+====
+
+All constraints apply together: a date can be selected only if none of them disables it.
+
 The following example demonstrates how to specify these constraints and provide error messages:
 
 [.example,themes="lumo,aura"]
@@ -95,7 +113,7 @@ It's important to ensure an appropriate error message is configured for each con
 
 === Custom Validation
 
-For more complex cases where constraint validation isn't enough, Flow and Hilla offer the Binder API that allows you to define custom validation rules. This is useful, for example, when you want to limit the options to Monday through Friday. In the following example, try selecting a date that's on a Sunday or on a Saturday to see a custom validation message.
+For more complex cases where constraint validation isn't enough, Flow and Hilla offer the Binder API that allows you to define custom validation rules. This is useful, for example, when the rule depends on the value of another field. The following example limits the options to Monday through Friday -- which the <<#disabled-weekdays,Disabled Weekdays>> constraint can also express. Try selecting a date that's on a Sunday or on a Saturday to see a custom validation message.
 
 [.example,themes="lumo,aura"]
 --
@@ -123,6 +141,58 @@ endif::[]
 --
 
 Binder can also be used to organize data binding and validation for multiple fields, creating forms. You can learn more about Binder from the corresponding <<{articles}/flow/binding-data/components-binder-validation#,Flow>> and <<{articles}/hilla/lit/guides/forms/binder-validation#,Hilla>> articles.
+
+
+[[configuring-individual-dates]]
+[role="since:com.vaadin:vaadin@V25.3"]
+== Configuring Individual Dates
+
+Individual dates in the calendar overlay can be given metadata: whether the date can be selected, and custom CSS part names for styling it. The metadata comes from a callback that Date Picker invokes for the dates it's about to render, so the data can be fetched from a backend and can change while the application runs.
+
+Use this when the set of special dates is large, isn't known in advance, or when particular dates should stand out visually. For a small, fixed set of dates, the simpler <<#disabled-dates,Disabled Dates>> and <<#disabled-weekdays,Disabled Weekdays>> constraints are enough, and a continuous range is best expressed with <<#min-and-max-value,Min & Max Values>>.
+
+In the following example, an appointment field marks fully booked dates as unselectable, and highlights the dates that have only a few slots left. Try opening the overlay and navigating between months.
+
+[.example,themes="lumo,aura"]
+--
+
+ifdef::lit[]
+[source,typescript]
+----
+include::{root}/frontend/demo/component/datepicker/date-picker-date-metadata.ts[render,tags=snippet,indent=0,group=Lit]
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+include::{root}/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDateMetadata.java[render,tags=snippet,indent=0,group=Flow]
+----
+endif::[]
+
+ifdef::react[]
+[source,tsx]
+----
+include::{root}/frontend/demo/component/datepicker/react/date-picker-date-metadata.tsx[render,tags=snippet,indent=0,group=React]
+----
+endif::[]
+
+[source,css]
+----
+include::{root}/frontend/themes/docs/date-picker-date-metadata.css[]
+----
+--
+
+
+=== Disabling Individual Dates
+
+A date whose metadata marks it as disabled can't be selected: it's shown as disabled in the overlay, and typing it into the field makes the field invalid. The same error message is used as for the <<#disabled-dates,Disabled Dates>> and <<#disabled-weekdays,Disabled Weekdays>> constraints.
+
+The callback is invoked during server-side validation as well, with the single date being validated, so a disabled date can't be committed even if the browser was never told about it.
+
+=== Custom Part Names
+
+Metadata can add one or more CSS part names to a date, which a style sheet can then target with the `::part()` selector. Part names affect only the appearance of a date; they never change whether it can be selected. This is useful for providing additional information without disabling a date.
 
 
 == Week Numbers

--- a/articles/components/date-picker/index.adoc
+++ b/articles/components/date-picker/index.adoc
@@ -80,8 +80,6 @@ Individual dates can [since:com.vaadin:vaadin@V25.3]#also be excluded from selec
 This is meant for a small set of dates that's known in advance. When the set is large, changes while the application runs, or when particular dates should also be styled, use the date metadata callback instead. See <<#configuring-individual-dates,Configuring Individual Dates>>.
 ====
 
-All constraints apply together: a date can be selected only if none of them disables it.
-
 The following example demonstrates how to specify these constraints and provide error messages:
 
 [.example,themes="lumo,aura"]

--- a/articles/components/date-picker/index.adoc
+++ b/articles/components/date-picker/index.adoc
@@ -65,17 +65,17 @@ The valid input range of Date Picker can be restricted by defining `min` and `ma
 ====
 
 [#disabled-weekdays]
-.Disabled Weekdays
+.[since:com.vaadin:vaadin@V25.3]#Disabled Weekdays#
 [%collapsible]
 ====
-Whole weekdays can [since:com.vaadin:vaadin@V25.3]#be excluded from selection#, for example to restrict a booking to business days. Dates that fall on a disabled weekday are shown as disabled in the overlay, and typing one into the field makes it invalid.
+Whole weekdays can be excluded from selection, for example to restrict a booking to business days. Dates that fall on a disabled weekday are shown as disabled in the overlay, and typing one into the field makes it invalid.
 ====
 
 [#disabled-dates]
-.Disabled Dates
+.[since:com.vaadin:vaadin@V25.3]#Disabled Dates#
 [%collapsible]
 ====
-Individual dates can [since:com.vaadin:vaadin@V25.3]#also be excluded from selection#, for example public holidays. Like disabled weekdays, they're shown as disabled in the overlay, and typing one into the field makes it invalid.
+Individual dates can also be excluded from selection, for example public holidays. Like disabled weekdays, they're shown as disabled in the overlay, and typing one into the field makes it invalid.
 
 This is meant for a small set of dates that's known in advance. When the set is large, changes while the application runs, or when particular dates should also be styled, use the date metadata callback instead. See <<#configuring-individual-dates,Configuring Individual Dates>>.
 ====

--- a/articles/components/date-picker/styling.adoc
+++ b/articles/components/date-picker/styling.adoc
@@ -252,3 +252,4 @@ Past date:: `vaadin-month-calendar+++<wbr>+++**::part(past date)**`
 Future date:: `vaadin-month-calendar+++<wbr>+++**::part(future date)**`
 Focused date:: `vaadin-month-calendar+++<wbr>+++**::part(date focused)**`
 Hovered date:: `vaadin-month-calendar+++<wbr>+++**::part(date):hover**`
+Date whose metadata is still loading:: `vaadin-month-calendar+++<wbr>+++**::part(loading date)**`

--- a/frontend/demo/component/datepicker/date-picker-date-metadata.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-metadata.ts
@@ -1,0 +1,50 @@
+import 'Frontend/demo/init'; // hidden-source-line
+import '@vaadin/date-picker';
+import { eachDayOfInterval, formatISO, parseISO } from 'date-fns';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import type { DatePickerDateMetadata, DatePickerDateMetadataProvider } from '@vaadin/date-picker';
+import { applyTheme } from 'Frontend/demo/theme';
+
+// tag::snippet[]
+// In a real application, these would query a booking service.
+const isFullyBooked = (date: Date) => date.getDate() % 7 === 3;
+const isAlmostFull = (date: Date) => date.getDate() % 5 === 0;
+
+function getMetadata(date: Date): DatePickerDateMetadata | undefined {
+  const isoDate = formatISO(date, { representation: 'date' });
+  if (isFullyBooked(date)) {
+    return { date: isoDate, disabled: true };
+  }
+  if (isAlmostFull(date)) {
+    return { date: isoDate, part: 'limited' };
+  }
+  return undefined;
+}
+
+const dateMetadataProvider: DatePickerDateMetadataProvider = ({ start, end }) =>
+  eachDayOfInterval({ start: parseISO(start), end: parseISO(end) })
+    .map(getMetadata)
+    .filter((metadata) => metadata !== undefined);
+// end::snippet[]
+
+@customElement('date-picker-date-metadata')
+export class Example extends LitElement {
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    applyTheme(root);
+    return root;
+  }
+
+  protected override render() {
+    return html`
+      <!-- tag::snippet[] -->
+      <vaadin-date-picker
+        label="Appointment date"
+        helper-text="Highlighted dates are almost full"
+        .dateMetadataProvider="${dateMetadataProvider}"
+      ></vaadin-date-picker>
+      <!-- end::snippet[] -->
+    `;
+  }
+}

--- a/frontend/demo/component/datepicker/date-picker-date-metadata.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-metadata.ts
@@ -31,7 +31,6 @@ export class Example extends LitElement {
     return undefined;
   };
 
-  // Keep a stable reference: assigning a new function clears the cache.
   private dateMetadataProvider: DatePickerDateMetadataProvider = ({ start, end }) =>
     eachDayOfInterval({ start: parseISO(start), end: parseISO(end) })
       .map(this.getMetadata)

--- a/frontend/demo/component/datepicker/date-picker-date-metadata.ts
+++ b/frontend/demo/component/datepicker/date-picker-date-metadata.ts
@@ -6,28 +6,6 @@ import { customElement } from 'lit/decorators.js';
 import type { DatePickerDateMetadata, DatePickerDateMetadataProvider } from '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/demo/theme';
 
-// tag::snippet[]
-// In a real application, these would query a booking service.
-const isFullyBooked = (date: Date) => date.getDate() % 7 === 3;
-const isAlmostFull = (date: Date) => date.getDate() % 5 === 0;
-
-function getMetadata(date: Date): DatePickerDateMetadata | undefined {
-  const isoDate = formatISO(date, { representation: 'date' });
-  if (isFullyBooked(date)) {
-    return { date: isoDate, disabled: true };
-  }
-  if (isAlmostFull(date)) {
-    return { date: isoDate, part: 'limited' };
-  }
-  return undefined;
-}
-
-const dateMetadataProvider: DatePickerDateMetadataProvider = ({ start, end }) =>
-  eachDayOfInterval({ start: parseISO(start), end: parseISO(end) })
-    .map(getMetadata)
-    .filter((metadata) => metadata !== undefined);
-// end::snippet[]
-
 @customElement('date-picker-date-metadata')
 export class Example extends LitElement {
   protected override createRenderRoot() {
@@ -36,15 +14,37 @@ export class Example extends LitElement {
     return root;
   }
 
+  // tag::snippet[]
+  // In a real application, these would query a booking service.
+  private isFullyBooked = (date: Date) => date.getDate() % 7 === 3;
+
+  private isAlmostFull = (date: Date) => date.getDate() % 5 === 0;
+
+  private getMetadata = (date: Date): DatePickerDateMetadata | undefined => {
+    const isoDate = formatISO(date, { representation: 'date' });
+    if (this.isFullyBooked(date)) {
+      return { date: isoDate, disabled: true };
+    }
+    if (this.isAlmostFull(date)) {
+      return { date: isoDate, part: 'limited' };
+    }
+    return undefined;
+  };
+
+  // Keep a stable reference: assigning a new function clears the cache.
+  private dateMetadataProvider: DatePickerDateMetadataProvider = ({ start, end }) =>
+    eachDayOfInterval({ start: parseISO(start), end: parseISO(end) })
+      .map(this.getMetadata)
+      .filter((metadata) => metadata !== undefined);
+
   protected override render() {
     return html`
-      <!-- tag::snippet[] -->
       <vaadin-date-picker
         label="Appointment date"
         helper-text="Highlighted dates are almost full"
-        .dateMetadataProvider="${dateMetadataProvider}"
+        .dateMetadataProvider="${this.dateMetadataProvider}"
       ></vaadin-date-picker>
-      <!-- end::snippet[] -->
     `;
   }
+  // end::snippet[]
 }

--- a/frontend/demo/component/datepicker/date-picker-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-validation.ts
@@ -6,19 +6,6 @@ import { customElement, state } from 'lit/decorators.js';
 import type { DatePicker, DatePickerDate, DatePickerValidatedEvent } from '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/demo/theme';
 
-// tag::snippet[]
-const closedDates = [3, 4].map((days) =>
-  formatISO(addDays(new Date(), days), { representation: 'date' })
-);
-
-function isOfficeClosed(isoDate: string): boolean {
-  return isWeekend(parseISO(isoDate)) || closedDates.includes(isoDate);
-}
-
-const isDateDisabled = ({ year, month, day }: DatePickerDate) =>
-  isOfficeClosed(formatISO(new Date(year, month, day), { representation: 'date' }));
-// end::snippet[]
-
 @customElement('date-picker-validation')
 export class Example extends LitElement {
   protected override createRenderRoot() {
@@ -36,16 +23,26 @@ export class Example extends LitElement {
   @state()
   private maxDate = addDays(new Date(), 60);
 
+  // tag::snippet[]
+  private closedDates = [3, 4].map((days) =>
+    formatISO(addDays(new Date(), days), { representation: 'date' })
+  );
+
+  private isOfficeClosed = (isoDate: string) =>
+    isWeekend(parseISO(isoDate)) || this.closedDates.includes(isoDate);
+
+  private isDateDisabled = ({ year, month, day }: DatePickerDate) =>
+    this.isOfficeClosed(formatISO(new Date(year, month, day), { representation: 'date' }));
+
   protected override render() {
     return html`
-      <!-- tag::snippet[] -->
       <vaadin-date-picker
         label="Appointment date"
         helper-text="Must be a business day within 60 days from today"
         required
         .min="${formatISO(this.minDate, { representation: 'date' })}"
         .max="${formatISO(this.maxDate, { representation: 'date' })}"
-        .isDateDisabled="${isDateDisabled}"
+        .isDateDisabled="${this.isDateDisabled}"
         .errorMessage="${this.errorMessage}"
         @validated="${(event: DatePickerValidatedEvent) => {
           const field = event.target as DatePicker;
@@ -57,14 +54,14 @@ export class Example extends LitElement {
             this.errorMessage = 'Too early, choose another date';
           } else if (field.value > field.max!) {
             this.errorMessage = 'Too late, choose another date';
-          } else if (isOfficeClosed(field.value)) {
+          } else if (this.isOfficeClosed(field.value)) {
             this.errorMessage = 'The office is closed, choose another date';
           } else {
             this.errorMessage = '';
           }
         }}"
       ></vaadin-date-picker>
-      <!-- end::snippet[] -->
     `;
   }
+  // end::snippet[]
 }

--- a/frontend/demo/component/datepicker/date-picker-validation.ts
+++ b/frontend/demo/component/datepicker/date-picker-validation.ts
@@ -1,10 +1,23 @@
 import 'Frontend/demo/init'; // hidden-source-line
 import '@vaadin/date-picker';
-import { addDays, formatISO } from 'date-fns';
+import { addDays, formatISO, isWeekend, parseISO } from 'date-fns';
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import type { DatePicker, DatePickerValidatedEvent } from '@vaadin/date-picker';
+import type { DatePicker, DatePickerDate, DatePickerValidatedEvent } from '@vaadin/date-picker';
 import { applyTheme } from 'Frontend/demo/theme';
+
+// tag::snippet[]
+const closedDates = [3, 4].map((days) =>
+  formatISO(addDays(new Date(), days), { representation: 'date' })
+);
+
+function isOfficeClosed(isoDate: string): boolean {
+  return isWeekend(parseISO(isoDate)) || closedDates.includes(isoDate);
+}
+
+const isDateDisabled = ({ year, month, day }: DatePickerDate) =>
+  isOfficeClosed(formatISO(new Date(year, month, day), { representation: 'date' }));
+// end::snippet[]
 
 @customElement('date-picker-validation')
 export class Example extends LitElement {
@@ -28,10 +41,11 @@ export class Example extends LitElement {
       <!-- tag::snippet[] -->
       <vaadin-date-picker
         label="Appointment date"
-        helper-text="Must be within 60 days from today"
+        helper-text="Must be a business day within 60 days from today"
         required
         .min="${formatISO(this.minDate, { representation: 'date' })}"
         .max="${formatISO(this.maxDate, { representation: 'date' })}"
+        .isDateDisabled="${isDateDisabled}"
         .errorMessage="${this.errorMessage}"
         @validated="${(event: DatePickerValidatedEvent) => {
           const field = event.target as DatePicker;
@@ -43,6 +57,8 @@ export class Example extends LitElement {
             this.errorMessage = 'Too early, choose another date';
           } else if (field.value > field.max!) {
             this.errorMessage = 'Too late, choose another date';
+          } else if (isOfficeClosed(field.value)) {
+            this.errorMessage = 'The office is closed, choose another date';
           } else {
             this.errorMessage = '';
           }

--- a/frontend/demo/component/datepicker/react/date-picker-date-metadata.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-date-metadata.tsx
@@ -1,0 +1,42 @@
+import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
+import React from 'react'; // hidden-source-line
+import { eachDayOfInterval, formatISO, parseISO } from 'date-fns';
+import {
+  DatePicker,
+  type DatePickerDateMetadata,
+  type DatePickerDateMetadataProvider,
+} from '@vaadin/react-components/DatePicker.js';
+
+// tag::snippet[]
+// In a real application, these would query a booking service.
+const isFullyBooked = (date: Date) => date.getDate() % 7 === 3;
+const isAlmostFull = (date: Date) => date.getDate() % 5 === 0;
+
+function getMetadata(date: Date): DatePickerDateMetadata | undefined {
+  const isoDate = formatISO(date, { representation: 'date' });
+  if (isFullyBooked(date)) {
+    return { date: isoDate, disabled: true };
+  }
+  if (isAlmostFull(date)) {
+    return { date: isoDate, part: 'limited' };
+  }
+  return undefined;
+}
+
+const dateMetadataProvider: DatePickerDateMetadataProvider = ({ start, end }) =>
+  eachDayOfInterval({ start: parseISO(start), end: parseISO(end) })
+    .map(getMetadata)
+    .filter((metadata) => metadata !== undefined);
+
+function Example() {
+  return (
+    <DatePicker
+      label="Appointment date"
+      helperText="Highlighted dates are almost full"
+      dateMetadataProvider={dateMetadataProvider}
+    />
+  );
+}
+// end::snippet[]
+
+export default reactExample(Example); // hidden-source-line

--- a/frontend/demo/component/datepicker/react/date-picker-validation.tsx
+++ b/frontend/demo/component/datepicker/react/date-picker-validation.tsx
@@ -1,9 +1,26 @@
 import { reactExample } from 'Frontend/demo/react-example'; // hidden-source-line
 import React from 'react'; // hidden-source-line
 import { useSignals } from '@preact/signals-react/runtime'; // hidden-source-line
-import { addDays, formatISO } from 'date-fns';
+import { addDays, formatISO, isWeekend, parseISO } from 'date-fns';
 import { useComputed, useSignal } from '@vaadin/hilla-react-signals';
-import { DatePicker, type DatePickerElement } from '@vaadin/react-components/DatePicker.js';
+import {
+  DatePicker,
+  type DatePickerDate,
+  type DatePickerElement,
+} from '@vaadin/react-components/DatePicker.js';
+
+// tag::snippet[]
+const closedDates = [3, 4].map((days) =>
+  formatISO(addDays(new Date(), days), { representation: 'date' })
+);
+
+function isOfficeClosed(isoDate: string): boolean {
+  return isWeekend(parseISO(isoDate)) || closedDates.includes(isoDate);
+}
+
+const isDateDisabled = ({ year, month, day }: DatePickerDate) =>
+  isOfficeClosed(formatISO(new Date(year, month, day), { representation: 'date' }));
+// end::snippet[]
 
 function Example() {
   useSignals(); // hidden-source-line
@@ -15,10 +32,11 @@ function Example() {
     // tag::snippet[]
     <DatePicker
       label="Appointment date"
-      helperText="Must be within 60 days from today"
+      helperText="Must be a business day within 60 days from today"
       required
       min={formatISO(minDate.value, { representation: 'date' })}
       max={formatISO(maxDate.value, { representation: 'date' })}
+      isDateDisabled={isDateDisabled}
       errorMessage={errorMessage.value}
       onValidated={(event) => {
         const field = event.target as DatePickerElement;
@@ -30,6 +48,8 @@ function Example() {
           errorMessage.value = 'Too early, choose another date';
         } else if (field.value > field.max!) {
           errorMessage.value = 'Too late, choose another date';
+        } else if (isOfficeClosed(field.value)) {
+          errorMessage.value = 'The office is closed, choose another date';
         } else {
           errorMessage.value = '';
         }

--- a/frontend/themes/docs/date-picker-date-metadata.css
+++ b/frontend/themes/docs/date-picker-date-metadata.css
@@ -1,0 +1,10 @@
+/* Add this to your global CSS, for example in: */
+/* frontend/theme/[my-theme]/styles.css */
+
+vaadin-month-calendar::part(limited) {
+  background: rgba(255, 201, 102, 0.35);
+}
+
+vaadin-month-calendar::part(limited):hover {
+  background: rgba(255, 201, 102, 0.6);
+}

--- a/frontend/themes/docs/date-picker-date-metadata.css
+++ b/frontend/themes/docs/date-picker-date-metadata.css
@@ -1,5 +1,5 @@
 /* Add this to your global CSS, for example in: */
-/* frontend/theme/[my-theme]/styles.css */
+/* src/main/resources/META-INF/resources/styles.css */
 
 vaadin-month-calendar::part(limited) {
   background: rgba(255, 201, 102, 0.35);

--- a/frontend/themes/docs/styles.css
+++ b/frontend/themes/docs/styles.css
@@ -4,6 +4,7 @@
 @import './context-menu-class-name.css';
 @import './combo-box-item-class-name.css';
 @import './dashboard.css';
+@import './date-picker-date-metadata.css';
 @import './icons.css';
 @import './login-rich-content.css';
 @import './notification-position-example.css';

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDateMetadata.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerDateMetadata.java
@@ -1,0 +1,53 @@
+package com.vaadin.demo.component.datepicker;
+
+import com.vaadin.demo.DemoExporter; // hidden-source-line
+import com.vaadin.flow.component.datepicker.DateMetadata;
+import com.vaadin.flow.component.datepicker.DateMetadataProvider;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+import java.time.LocalDate;
+
+@Route("date-picker-date-metadata")
+public class DatePickerDateMetadata extends Div {
+
+    public DatePickerDateMetadata() {
+        DatePicker datePicker = new DatePicker("Appointment date");
+        // tag::snippet[]
+        datePicker.setHelperText("Highlighted dates are almost full");
+
+        DateMetadataProvider provider = DateMetadataProvider.perDate(date -> {
+            if (isFullyBooked(date)) {
+                return new DateMetadata(date, true);
+            }
+            if (isAlmostFull(date)) {
+                return new DateMetadata(date, "limited");
+            }
+            return null;
+        });
+        datePicker.setDateMetadataProvider(provider);
+
+        datePicker.setI18n(new DatePickerI18n()
+                .setDisabledDateErrorMessage("That date is fully booked"));
+        // end::snippet[]
+
+        add(datePicker);
+    }
+
+    // tag::snippet[]
+
+    // In a real application, these would query a booking service.
+    private static boolean isFullyBooked(LocalDate date) {
+        return date.getDayOfMonth() % 7 == 3;
+    }
+
+    private static boolean isAlmostFull(LocalDate date) {
+        return date.getDayOfMonth() % 5 == 0;
+    }
+    // end::snippet[]
+
+    public static class Exporter extends DemoExporter<DatePickerDateMetadata> { // hidden-source-line
+    } // hidden-source-line
+}

--- a/src/main/java/com/vaadin/demo/component/datepicker/DatePickerValidation.java
+++ b/src/main/java/com/vaadin/demo/component/datepicker/DatePickerValidation.java
@@ -6,8 +6,11 @@ import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.EnumSet;
+import java.util.List;
 
 @Route("date-picker-validation")
 public class DatePickerValidation extends Div {
@@ -20,13 +23,19 @@ public class DatePickerValidation extends Div {
         datePicker.setRequiredIndicatorVisible(true);
         datePicker.setMin(now);
         datePicker.setMax(now.plusDays(60));
-        datePicker.setHelperText("Must be within 60 days from today");
+        datePicker.setDisabledWeekdays(
+                EnumSet.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY));
+        datePicker.setDisabledDates(List.of(now.plusDays(3), now.plusDays(4)));
+        datePicker.setHelperText(
+                "Must be a business day within 60 days from today");
 
         datePicker.setI18n(new DatePickerI18n()
                 .setBadInputErrorMessage("Invalid date format")
                 .setRequiredErrorMessage("Field is required")
                 .setMinErrorMessage("Too early, choose another date")
-                .setMaxErrorMessage("Too late, choose another date"));
+                .setMaxErrorMessage("Too late, choose another date")
+                .setDisabledDateErrorMessage(
+                        "The office is closed, choose another date"));
         // end::snippet[]
 
         add(datePicker);


### PR DESCRIPTION
- Added documentation for DatePicker disabling dates, date metadata and custom part names
- Updated custom validation example which used to show "how to prevent selecting weekends"