### PR TITLE
docs: update context-menu TS examples to use item and list-box

### DIFF
--- a/frontend/demo/component/grid/grid-context-menu.ts
+++ b/frontend/demo/component/grid/grid-context-menu.ts
@@ -41,13 +41,21 @@ export class Example extends LitElement {
     };
 
     return html`
-      <vaadin-list-box>
-        <vaadin-item @click="${clickHandler('Edit')}">Edit</vaadin-item>
-        <vaadin-item @click="${clickHandler('Delete')}">Delete</vaadin-item>
+      <vaadin-context-menu-list-box>
+        <vaadin-context-menu-item @click="${clickHandler('Edit')}">
+          Edit
+        </vaadin-context-menu-item>
+        <vaadin-context-menu-item @click="${clickHandler('Delete')}">
+          Delete
+        </vaadin-context-menu-item>
         <hr />
-        <vaadin-item @click="${clickHandler('Email')}">Email (${person.email})</vaadin-item>
-        <vaadin-item @click="${clickHandler('Call')}">Call (${person.address.phone})</vaadin-item>
-      </vaadin-list-box>
+        <vaadin-context-menu-item @click="${clickHandler('Email')}">
+          Email (${person.email})
+        </vaadin-context-menu-item>
+        <vaadin-context-menu-item @click="${clickHandler('Call')}">
+          Call (${person.address.phone})
+        </vaadin-context-menu-item>
+      </vaadin-context-menu-list-box>
     `;
   };
 

--- a/frontend/demo/component/grid/react/grid-context-menu.tsx
+++ b/frontend/demo/component/grid/react/grid-context-menu.tsx
@@ -7,10 +7,10 @@ import {
   type ContextMenuElement,
   type ContextMenuRendererContext,
 } from '@vaadin/react-components/ContextMenu.js';
+import { ContextMenuItem } from '@vaadin/react-components/ContextMenuItem.js';
+import { ContextMenuListBox } from '@vaadin/react-components/ContextMenuListBox.js';
 import { Grid, type GridElement } from '@vaadin/react-components/Grid.js';
 import { GridColumn } from '@vaadin/react-components/GridColumn.js';
-import { Item } from '@vaadin/react-components/Item.js';
-import { ListBox } from '@vaadin/react-components/ListBox.js';
 import { getPeople } from 'Frontend/demo/domain/DataService';
 import type Person from 'Frontend/generated/com/vaadin/demo/domain/Person';
 
@@ -60,13 +60,15 @@ function Example() {
     };
 
     return (
-      <ListBox>
-        <Item onClick={clickHandler('Edit')}>Edit</Item>
-        <Item onClick={clickHandler('Delete')}>Delete</Item>
+      <ContextMenuListBox>
+        <ContextMenuItem onClick={clickHandler('Edit')}>Edit</ContextMenuItem>
+        <ContextMenuItem onClick={clickHandler('Delete')}>Delete</ContextMenuItem>
         <hr />
-        <Item onClick={clickHandler('Email')}>Email ({person.email})</Item>
-        <Item onClick={clickHandler('Call')}>Call ({person.address.phone})</Item>
-      </ListBox>
+        <ContextMenuItem onClick={clickHandler('Email')}>Email ({person.email})</ContextMenuItem>
+        <ContextMenuItem onClick={clickHandler('Call')}>
+          Call ({person.address.phone})
+        </ContextMenuItem>
+      </ContextMenuListBox>
     );
   };
 


### PR DESCRIPTION
Updated grid context menu examples to use `vaadin-context-menu-list-box` and `vaadin-context-menu-item`.
Lit example still uses `contextMenuRenderer` until we add new context API in https://github.com/vaadin/web-components/issues/12557.