### PR TITLE
docs: link the visibility page to bindVisible signal binding

### DIFF
--- a/articles/flow/component-internals/enabled-state.adoc
+++ b/articles/flow/component-internals/enabled-state.adoc
@@ -26,6 +26,9 @@ The component behaves exactly like an explicitly disabled component, except that
 
 Any component that implements the [interfacename]`HasEnabled` interface can be explicitly enabled or disabled.
 
+[TIP]
+When the enabled state follows application state -- for example, enabling a *Save* button only when a form is valid -- bind it to a signal with [methodname]`bindEnabled()` rather than calling [methodname]`setEnabled()` from listeners. See <<{articles}/flow/ui-state/building-ui#binding-enabled-state,Binding Enabled State>>.
+
 .Disabling a component using the [methodname]`component.setEnabled()` method
 [example]
 ====

--- a/articles/flow/component-internals/visibility.adoc
+++ b/articles/flow/component-internals/visibility.adoc
@@ -2,7 +2,7 @@
 title: Visibility
 page-title: Component Visibility in Vaadin
 description: How component visibility works in Vaadin.
-meta-description: Learn how to manage component visibility in Vaadin applications and its effects on UI rendering and updates.
+meta-description: Learn how to show and hide Vaadin components with setVisible() or a signal binding, and how visibility affects UI rendering and updates.
 order: 21
 ---
 
@@ -10,6 +10,9 @@ order: 21
 = Component Visibility
 
 Invisible components are no longer displayed in the UI, nor do they receive updates from the client side. You make a component invisible by calling [methodname]`Component.setVisible(false)`. Transmission of server-side updates resumes when you make the component visible again.
+
+[TIP]
+When visibility follows application state -- for example, showing a *Done* button only while a row is being edited -- bind it to a signal with [methodname]`Component.bindVisible()` rather than calling [methodname]`setVisible()` from listeners. See <<binding-visibility-to-a-signal,Binding Visibility to a Signal>>.
 
 .Making a component invisible, and visible again
 [example]
@@ -62,3 +65,49 @@ System.out.println("Number of children: " + container.getChildCount());
 If you make an already rendered component invisible, the corresponding element is not removed from the DOM. Instead, it is marked with the `hidden` attribute. Furthermore, the element won't receive any updates from the server. Likewise, the server will ignore any RPCs (Remote Procedure Calls) made from the element.
 
 
+[role="since:com.vaadin:vaadin@V25.1"]
+== Binding Visibility to a Signal
+
+Calling [methodname]`setVisible()` from event listeners works, but every place that changes the underlying state has to remember to update the component. When visibility follows a piece of application state, bind the component to a signal with [methodname]`Component.bindVisible()` and let the framework keep the two synchronized.
+
+.Showing a button only while editing
+[example]
+====
+[source,java]
+----
+import com.vaadin.flow.signals.local.ValueSignal;
+
+ValueSignal<Boolean> editing = new ValueSignal<>(false);
+
+Button done = new Button("Done");
+done.bindVisible(editing);
+// The button is hidden until "editing" becomes true
+
+Button edit = new Button("Edit", evt -> editing.set(true));
+// Clicking Edit makes the Done button appear -
+// no setVisible() call needed
+----
+====
+
+The bound signal can also be a condition computed from other signals, which lets a component react to several pieces of state at once:
+
+.Deriving visibility from several signals
+[example]
+====
+[source,java]
+----
+ValueSignal<Boolean> formDirty = new ValueSignal<>(false);
+ValueSignal<Boolean> submitting = new ValueSignal<>(false);
+
+Button save = new Button("Save");
+save.bindVisible(() -> formDirty.get() && !submitting.get());
+// Visible only while there are unsaved changes
+// and no submission is in progress
+----
+====
+
+While a signal is bound to a component's visibility, calling [methodname]`setVisible()` on that component throws a [classname]`BindingActiveException`. Pass `null` to [methodname]`bindVisible()` to remove the binding if you need to control visibility manually again.
+
+Bound components hide the same way as components hidden with [methodname]`setVisible()`, so <<hiding-before-rendering,Hiding before Rendering>> and <<hiding-after-rendering,Hiding after Rendering>> apply to them as well.
+
+For the full set of binding methods -- text, enabled state, form field values, CSS class names, and more -- see <<{articles}/flow/ui-state/building-ui#binding-visibility,Binding Visibility>> in Component Bindings. For a worked progressive-disclosure form, see <<{articles}/flow/ui-state/usage-examples/conditional-visibility#,Conditional Visibility>>.

--- a/articles/flow/ui-state/building-ui.adoc
+++ b/articles/flow/ui-state/building-ui.adoc
@@ -7,7 +7,7 @@ order: 10
 ---
 
 
-= Component Bindings
+= [since:com.vaadin:vaadin@V25.1]#Component Bindings#
 
 Signals connect directly to Vaadin components through binding methods. When a signal value changes, bound components update automatically without manual listeners or state synchronization.
 
@@ -107,7 +107,7 @@ p.bindText(signal);
 
 == Binding Visibility
 
-Use [methodname]`bindVisible()` to show or hide components based on a boolean signal:
+Use [methodname]`bindVisible()` to show or hide components based on a boolean signal. This is how you express rules such as "show the *Done* button only while a row is being edited" or "hide the *Save* button until the form has unsaved changes": declare the rule once, and the component follows the state instead of being updated from every listener that changes it.
 
 [source,java]
 ----
@@ -122,6 +122,8 @@ Button toggleButton = new Button("Show Details");
 toggleButton.addClickListener(e -> showDetails.update(v -> !v));
 // Clicking toggles panel visibility
 ----
+
+Prefer a binding over calling [methodname]`setVisible()` from listeners whenever visibility follows application state. While a signal is bound, calling [methodname]`setVisible()` on the component throws a [classname]`BindingActiveException`; pass `null` to [methodname]`bindVisible()` to remove the binding. For [methodname]`setVisible()` semantics and how visibility affects the DOM, see <<{articles}/flow/component-internals/visibility#,Component Visibility>>.
 
 
 === Conditional Visibility
@@ -139,6 +141,18 @@ noResults.bindVisible(searchText.map(text -> text.isEmpty()));
 Div results = new Div();
 results.bindVisible(searchText.map(text -> !text.isEmpty()));
 // Shows when search text is not empty
+----
+
+Use a lambda when the condition reads more than one signal:
+
+[source,java]
+----
+ValueSignal<Boolean> formDirty = new ValueSignal<>(false);
+ValueSignal<Boolean> submitting = new ValueSignal<>(false);
+
+Button saveButton = new Button("Save");
+saveButton.bindVisible(() -> formDirty.get() && !submitting.get());
+// Shows only while there are unsaved changes and no submission is in progress
 ----
 
 

--- a/articles/flow/ui-state/usage-examples/conditional-visibility.adoc
+++ b/articles/flow/ui-state/usage-examples/conditional-visibility.adoc
@@ -7,7 +7,7 @@ order: 10
 ---
 
 
-= Conditional Visibility
+= [since:com.vaadin:vaadin@V25.1]#Conditional Visibility#
 
 Progressive disclosure is a design pattern where form fields appear or disappear based on previous user selections. This improves user experience by showing only relevant fields and reducing visual clutter. With Signals, you can implement this pattern declaratively using `bindVisible()`.
 


### PR DESCRIPTION
Fixes vaadin/vaadin-mcp#279

## Problem

`flow/component-internals/visibility.adoc` is the canonical "how do I hide a component" page in the Flow docs, and it contained zero mentions of `bindVisible` or signals. Anyone landing there — a reader or an agent — gets `setVisible()` confirmed as the answer and stops looking. `flow/ui-state/element-bindings.adoc` already linked to `building-ui#binding-visibility`, so the missing link in the other direction looked accidental.

The linked issue measures the agent-facing half of this: task-phrased queries such as *"make the Done button visible only while editing"* return the `setVisible` page at rank 4 with `bindVisible` appearing in none of the results. The binding pages surfaced only for queries containing an abstract term ("signal", "reactively", "conditionally") — not the domain nouns a real task prompt is made of.

## Changes

**`flow/component-internals/visibility.adoc`**
- A `TIP` after the opening paragraph pointing at `bindVisible()`.
- A new `Binding Visibility to a Signal` section: two self-contained examples, the `BindingActiveException` rule (`setVisible()` throws while a signal is bound), a note that the DOM behavior described above applies to bound components too, and links to Component Bindings and the Conditional Visibility guide.
- `meta-description` updated to cover both approaches.

**`flow/ui-state/building-ui.adoc`**
- `[since:com.vaadin:vaadin@V25.1]` badge on the page title.
- The `Binding Visibility` intro now states the rules in concrete terms ("show the **Done** button only while a row is being edited", "hide the **Save** button until the form has unsaved changes") instead of only abstract ones, so the page matches how the task is actually phrased.
- `BindingActiveException` warning and a link back to Component Visibility.
- A multi-signal lambda example (`formDirty && !submitting`) under `Conditional Visibility`.

**`flow/ui-state/usage-examples/conditional-visibility.adoc`**
- `[since:com.vaadin:vaadin@V25.1]` badge on the page title.

**`flow/component-internals/enabled-state.adoc`**
- The same trap exists verbatim for `bindEnabled()`, so this page gets the matching one-line `TIP`. Say the word if you'd rather keep this PR to visibility only and I'll drop the hunk.

## Version check

The `25.1` badges are based on a direct check rather than the issue's assertion: `com.vaadin.flow.signals` has 0 entries in the `flow-server` 25.0.0 javadoc jar and 217 in 25.1.0, and `bindVisible` first appears on `Component` in 25.1.0.

## Verification

- `asciidoctor` parse of all four files: `#binding-visibility-to-a-signal`, `#hiding-before-rendering`, `#hiding-after-rendering`, `#binding-visibility` and `#binding-enabled-state` all resolve to real heading ids, and the `[since:]` spans render as role classes rather than literal brackets.
- Vale reports no new errors or warnings on the four files; the two errors (`RPCs`, `bindChildren`) and three heading-case warnings are pre-existing.

## Note for whoever merges

The MCP docs index is built from the `v25.1` and `v25.2` branches, not `main`. These hunks need cherry-picking to both before the retrieval behavior in vaadin/vaadin-mcp#279 changes — please don't close that issue on this merge alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)