### PR TITLE
docs: add Grid frozen column part names to styling page

### DIFF
--- a/articles/components/grid/styling.adoc
+++ b/articles/components/grid/styling.adoc
@@ -340,6 +340,10 @@ Cell focus ring:: `vaadin-grid+++<wbr>+++**::part(cell)::before**`
 Row focus ring:: `vaadin-grid+++<wbr>+++**::part(row)::before**`
 Collapsed cell:: `vaadin-grid+++<wbr>+++**::part(collapsed-row-cell)**`
 Expanded cell:: `vaadin-grid+++<wbr>+++**::part(expanded-row-cell)**`
+Cell in a column frozen to the start:: `vaadin-grid+++<wbr>+++**::part(frozen-cell)**`
+Cell in a column frozen to the end:: `vaadin-grid+++<wbr>+++**::part(frozen-to-end-cell)**`
+Cell in the last column frozen to the start:: `vaadin-grid+++<wbr>+++**::part(last-frozen-cell)**`
+Cell in the first column frozen to the end:: `vaadin-grid+++<wbr>+++**::part(first-frozen-to-end-cell)**`
 
 You can <<#part-name-generator,style individual cells, rows, and columns>> by applying custom part names to them. Cell padding can be configured using the `--vaadin-grid-cell-padding` style property.
 


### PR DESCRIPTION
Fixes #3655

Added missing grid frozen cells shadow parts.