### PR TITLE
docs: add Checkbox small and reverse style variants

### DIFF
--- a/articles/components/checkbox/styling.adoc
+++ b/articles/components/checkbox/styling.adoc
@@ -7,7 +7,33 @@ order: 50
 ---
 = Checkbox Styling
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-start;helper-above-field]
+== Style Variants
+
+The following style variants are supported by the Checkbox:
+
+[cols="1,3,1"]
+|===
+| Variant | Description | Supported by
+
+|[since:com.vaadin:vaadin@V25.3]#`reverse`#
+|Places the label before the checkbox, reversing their order. The label takes up the remaining space, pushing the checkbox to the end.
+|Aura
+
+|`small`
+|Renders a more compact checkbox
+|Aura
+
+|===
+
+The following style variants are supported by the Checkbox Group:
+
+[cols="1,3,1"]
+|===
+| Variant | Description | Supported by
+
+|`helper-above-field`
+|Renders the helper above the field, and below the label
+|Aura, Lumo
 
 |`vertical`
 |Vertical layout for checkbox group items
@@ -17,7 +43,7 @@ include::{articles}/components/_input-field-common-features.adoc[tags=styles-sta
 |Horizontal layout for checkbox group items
 |Aura
 
-include::{articles}/components/_input-field-common-features.adoc[tags=styles-end]
+|===
 
 === Helper Above Field Variant
 


### PR DESCRIPTION
Added Style Variants table with Checkbox variants - `reverse` added in 25.3, and `small` added in 25.2.