### PR TITLE
docs: add date-picker overlay loader stylable shadow part

### DIFF
--- a/articles/components/date-picker/styling.adoc
+++ b/articles/components/date-picker/styling.adoc
@@ -217,6 +217,7 @@ Modality curtain (backdrop):: `vaadin-date-picker+++<wbr>+++**::part(backdrop)**
 Overlay background:: `vaadin-date-picker+++<wbr>+++**::part(overlay)**`
 Overlay content wrapper:: `vaadin-date-picker-overlay-content`
 Overlay toolbar:: `vaadin-date-picker-overlay-content+++<wbr>+++**::part(toolbar)**`
+[since:com.vaadin:vaadin@V25.3]#Overlay loading indicator#:: `vaadin-date-picker-overlay-content+++<wbr>+++**::part(loader)**`
 Desktop (large viewport) mode:: `vaadin-date-picker-overlay-content+++<wbr>+++**[desktop]**`
 Fullscreen (small viewport) mode:: `vaadin-date-picker-overlay-content+++<wbr>+++**[fullscreen]**`
 Years toggle button:: `vaadin-date-picker-overlay-content+++<wbr>+++**::part(years-toggle-button)**`


### PR DESCRIPTION
Follow-up to https://github.com/vaadin/docs/pull/5909

Added `loader` shadow DOM part used for the overlay loading indicator that I missed to include in the above PR.