### PR TITLE
docs: add missing RTE indentation stylable shadow parts

### DIFF
--- a/articles/components/rich-text-editor/styling.adoc
+++ b/articles/components/rich-text-editor/styling.adoc
@@ -206,6 +206,9 @@ Superscript button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-
 List button group:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-group-list)**`
 Ordered list button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-list-ordered)**`
 Bullet list button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-list-bullet)**`
+Indentation button group:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-group-indent)**`
+Decrease indentation button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-outdent)**`
+Increase indentation button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-indent)**`
 Alignment button group:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-group-alignment)**`
 Align left button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-align-left)**`
 Align center button:: `vaadin-rich-text-editor+++<wbr>+++**::part(toolbar-button-align-center)**`


### PR DESCRIPTION
Added missing stylable shadow parts for RTE indentation feature introduced in V25.