### PR TITLE
docs: fix incorrect dashboard resize height button parts

### DIFF
--- a/articles/components/dashboard/styling.adoc
+++ b/articles/components/dashboard/styling.adoc
@@ -212,6 +212,6 @@ Move forward button:: `vaadin-dashboard-widget+++<wbr>+++**::part(move-forward-b
 Move apply button:: `vaadin-dashboard-widget+++<wbr>+++**::part(move-apply-button)**`
 Shrink width button:: `vaadin-dashboard-widget+++<wbr>+++**::part(resize-shrink-width-button)**`
 Grow width button:: `vaadin-dashboard-widget+++<wbr>+++**::part(resize-grow-width-button)**`
-Shrink height button:: `vaadin-dashboard-widget+++<wbr>+++**::part(resize-shrink-width-button)**`
-Grow height button:: `vaadin-dashboard-widget+++<wbr>+++**::part(resize-grow-width-button)**`
+Shrink height button:: `vaadin-dashboard-widget+++<wbr>+++**::part(resize-shrink-height-button)**`
+Grow height button:: `vaadin-dashboard-widget+++<wbr>+++**::part(resize-grow-height-button)**`
 Resize apply button:: `vaadin-dashboard-widget+++<wbr>+++**::part(resize-apply-button)**`


### PR DESCRIPTION
Fixed copy-paste issue: `width-button` also used for "height" buttons in Dashboard styling page.