### PR TITLE
docs: fix incorrect details opened grid-pro part names

### DIFF
--- a/articles/components/grid-pro/styling.adoc
+++ b/articles/components/grid-pro/styling.adoc
@@ -164,8 +164,8 @@ Sort order indicator:: `vaadin-grid-sorter+++<wbr>+++**::part(order)**`
 === Item Details
 
 Item details cell (spans entire row):: `vaadin-grid-pro+++<wbr>+++**::part(details-cell)**`
-Cell in row with open details:: `vaadin-grid-pro+++<wbr>+++**::part(details-open-row-cell)**`
-Row with open details:: `vaadin-grid-pro+++<wbr>+++**::part(details-open-row)**`
+Cell in row with open details:: `vaadin-grid-pro+++<wbr>+++**::part(details-opened-row-cell)**`
+Row with open details:: `vaadin-grid-pro+++<wbr>+++**::part(details-opened-row)**`
 
 
 === Editors


### PR DESCRIPTION
Fixed incorrect `details-open-row` in Grid Pro styling page to use `details-opened-row` same as in Grid.