### PR TITLE
docs: add week-numbers part, remove duplicate focused date

### DIFF
--- a/articles/components/date-picker/styling.adoc
+++ b/articles/components/date-picker/styling.adoc
@@ -240,6 +240,7 @@ Week numbers enabled:: `vaadin-month-calendar+++<wbr>+++**[show-week-numbers]**`
 Month header:: `vaadin-month-calendar+++<wbr>+++**::part(month-header)**`
 Weekdays row:: `vaadin-month-calendar+++<wbr>+++**::part(weekdays)**`
 Weekday:: `vaadin-month-calendar+++<wbr>+++**::part(weekday)**`
+Week numbers container:: `vaadin-month-calendar+++<wbr>+++**::part(week-numbers)**`
 Week number:: `vaadin-month-calendar+++<wbr>+++**::part(week-number)**`
 
 ==== Date Cells
@@ -251,6 +252,5 @@ Selected date:: `vaadin-month-calendar+++<wbr>+++**::part(selected date)**`
 Today's date:: `vaadin-month-calendar+++<wbr>+++**::part(today date)**`
 Past date:: `vaadin-month-calendar+++<wbr>+++**::part(past date)**`
 Future date:: `vaadin-month-calendar+++<wbr>+++**::part(future date)**`
-Focused date:: `vaadin-month-calendar+++<wbr>+++**::part(date focused)**`
 Hovered date:: `vaadin-month-calendar+++<wbr>+++**::part(date):hover**`
 Date whose metadata is still loading:: `vaadin-month-calendar+++<wbr>+++**::part(loading date)**`


### PR DESCRIPTION
Updated date-picker Styling page - added missing `week-numbers` part, removed duplicate focused date part.