### PR TITLE
docs: add missing app-layout shadow part and states

### DIFF
--- a/articles/components/app-layout/styling.adoc
+++ b/articles/components/app-layout/styling.adoc
@@ -127,6 +127,7 @@ Root element:: `vaadin-app-layout`
 Navbar:: `vaadin-app-layout+++<wbr>+++**::part(navbar)**`
 Top navbar:: `vaadin-app-layout+++<wbr>+++**::part(navbar-top)**`
 Bottom "touch optimized" navbar:: `vaadin-app-layout+++<wbr>+++**::part(navbar-bottom)**`
+Modality curtain (backdrop):: `vaadin-app-layout+++<wbr>+++**::part(backdrop)**`
 Content area:: `vaadin-app-layout+++<wbr>+++**::part(content)**`
 Drawer:: `vaadin-app-layout+++<wbr>+++**::part(drawer)**`
 Drawer toggle:: `vaadin-drawer-toggle`
@@ -136,6 +137,8 @@ Drawer toggle icon:: `vaadin-drawer-toggle+++<wbr>+++**::part(icon)::before**`
 
 === States
 
+Layout with navbar content:: `vaadin-app-layout+++<wbr>+++**[has-navbar]**`
+Layout with drawer content:: `vaadin-app-layout+++<wbr>+++**[has-drawer]**`
 Navbar on top of drawer:: `vaadin-app-layout+++<wbr>+++**[primary-section="navbar"]**`
 Navbar next to drawer:: `vaadin-app-layout+++<wbr>+++**[primary-section="drawer"]**`
 Drawer opened:: `vaadin-app-layout+++<wbr>+++**[drawer-opened]**`


### PR DESCRIPTION
Added missing `backdrop` part, `has-navbar` and `has-drawer` state attributes to App Layout styling page.