### PR TITLE
docs: add missing Slider custom CSS properties

### DIFF
--- a/articles/components/slider/styling.adoc
+++ b/articles/components/slider/styling.adoc
@@ -13,6 +13,9 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |===
 | Property | Supported by
 
+|`--vaadin-slider-bubble-arrow-border-radius`
+|Lumo, Aura
+
 |`--vaadin-slider-bubble-arrow-size`
 |Lumo, Aura
 
@@ -52,6 +55,39 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-slider-fill-background`
 |Lumo, Aura
 
+|`--vaadin-slider-fill-border-color`
+|Lumo, Aura
+
+|`--vaadin-slider-fill-border-width`
+|Lumo, Aura
+
+|`--vaadin-slider-marks-color`
+|Lumo, Aura
+
+|`--vaadin-slider-marks-font-size`
+|Lumo, Aura
+
+|`--vaadin-slider-marks-font-weight`
+|Lumo, Aura
+
+|`--vaadin-slider-thumb-background`
+|Lumo, Aura
+
+|`--vaadin-slider-thumb-border-color`
+|Lumo, Aura
+
+|`--vaadin-slider-thumb-border-radius`
+|Lumo, Aura
+
+|`--vaadin-slider-thumb-border-width`
+|Lumo, Aura
+
+|`--vaadin-slider-thumb-cursor`
+|Lumo, Aura
+
+|`--vaadin-slider-thumb-cursor-active`
+|Lumo, Aura
+
 |`--vaadin-slider-thumb-height`
 |Lumo, Aura
 
@@ -61,7 +97,13 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |`--vaadin-slider-track-background`
 |Lumo, Aura
 
+|`--vaadin-slider-track-border-color`
+|Lumo, Aura
+
 |`--vaadin-slider-track-border-radius`
+|Lumo, Aura
+
+|`--vaadin-slider-track-border-width`
 |Lumo, Aura
 
 |`--vaadin-slider-track-height`


### PR DESCRIPTION
Adds `vaadin-slider` custom cSS properties documented in the WC JSDoc but missing from the styling page.


