### PR TITLE
docs: add AI orchestrator listener docs

### DIFF
--- a/articles/flow/ai-support/controllers.adoc
+++ b/articles/flow/ai-support/controllers.adoc
@@ -126,7 +126,7 @@ The built-in controllers cover grid and chart data exploration. To expose your o
 
 * [methodname]`getTools()` -- returns the list of [classname]`LLMProvider.ToolSpec` instances the controller contributes to each LLM request. Tools are collected before every request, so a controller can vary its tool set based on current state.
 * [methodname]`onRequest()` -- runs on the UI thread right before the LLM stream opens. Use it to lock UI surfaces, snapshot state the tool definitions depend on, or otherwise prepare for the turn. Since tools may execute on a background thread, this is also the place to capture anything that depends on Vaadin thread locals, such as [methodname]`UI.getCurrent()`.
-* [methodname]`onResponse(Throwable)` -- called through `ui.access()` once the LLM stream has completed, either successfully (`error` is `null`) or with an error, so it can safely update components. Controllers use this hook to commit deferred state changes on success and release any per-turn state captured in [methodname]`onRequest()` on failure.
+* [methodname]`onResponse(ResponseListener.ResponseEvent)` -- called through `ui.access()` once the LLM stream has completed, either successfully ([methodname]`event.getError()` is empty) or with an error, so it can safely update components. Controllers use this hook to commit deferred state changes on success and release any per-turn state captured in [methodname]`onRequest()` on failure. The event also carries the provider's [since:com.vaadin:vaadin@V25.3]#response metadata#, which tells a completed turn from one truncated at the model's output limit -- a truncated turn ends without an error, so a controller that commits staged state should check it. See <<listeners#response-metadata,Response Metadata>>.
 
 Each tool is an implementation of [classname]`LLMProvider.ToolSpec`, which has four methods:
 
@@ -175,8 +175,8 @@ public class WeatherController implements AIController {
     }
 
     @Override
-    public void onResponse(Throwable error) {
-        if (error != null) {
+    public void onResponse(ResponseListener.ResponseEvent event) {
+        if (event.getError().isPresent()) {
             return;
         }
         // Apply any deferred state changes here.

--- a/articles/flow/ai-support/conversation-history.adoc
+++ b/articles/flow/ai-support/conversation-history.adoc
@@ -35,7 +35,7 @@ var orchestrator = AIOrchestrator
 
 [methodname]`saveToDatabase` is a placeholder for application code. Write the [classname]`ChatMessage` list to whichever storage the application uses, so the history can be loaded again later.
 
-The listener fires once per turn for both successful and failed exchanges -- check [methodname]`event.getError()` to tell them apart. It is not called when history is restored via [methodname]`withHistory()`, and empty responses (turns where the model emitted only tool calls or no visible content) are not appended to history.
+The listener fires once per turn for both successful and failed exchanges -- check [methodname]`event.getError()` to tell them apart. It is not called when history is restored via [methodname]`withHistory()`, and empty responses (turns where the model emitted only tool calls or no visible content) are not appended to history. The event also carries the [since:com.vaadin:vaadin@V25.3]#finish reason and token usage# of the turn -- see <<listeners#response-metadata,Response Metadata>>.
 
 .UI Updates from ResponseListener
 [IMPORTANT]

--- a/articles/flow/ai-support/file-attachments.adoc
+++ b/articles/flow/ai-support/file-attachments.adoc
@@ -40,7 +40,7 @@ Uploading multiple files with the same name in a single batch throws an [classna
 
 == Persisting Attachments
 
-The orchestrator passes attachments to the LLM with each request but does not store them afterward. To save attachments to your own storage and look them up later -- for example when the user clicks one in the message list -- use [methodname]`withRequestListener()` and [methodname]`withAttachmentClickListener()`:
+The orchestrator passes attachments to the LLM with each request but does not store them afterward. To save attachments to your own storage and look them up later -- for example when the user clicks one in the message list -- use [methodname]`withRequestListener()` (see <<listeners#,Request & Response Listeners>>) and [methodname]`withAttachmentClickListener()`:
 
 [source,java]
 ----

--- a/articles/flow/ai-support/listeners.adoc
+++ b/articles/flow/ai-support/listeners.adoc
@@ -47,7 +47,7 @@ The response listener is called when the turn ends -- normally when the assistan
 
 The event carries:
 
-* [methodname]`getResponse()` -- the assistant's response text. On success, it may be empty when the model emitted only tool calls; on failure, it's whatever partial response was received before the error. Empty responses are not appended to the conversation history.
+* [methodname]`getResponse()` -- the assistant's response text. On success, it may be empty when the model emitted only tool calls; on failure, it's always empty -- partial text received before the error isn't passed on, and the Message List shows a generic error message in its place. Empty responses are not appended to the conversation history.
 * [methodname]`getError()` -- the failure cause, or an empty optional on success.
 * [methodname]`getMetadata()` -- the provider's metadata for the turn; see <<#response-metadata,Response Metadata>>.
 
@@ -77,15 +77,16 @@ When a turn contains <<tool-calling#,tool-call>> round trips, the finish reason 
 [[truncated-responses]]
 === Truncated Responses
 
-A response cut off at the model's output limit is not an error: the turn ends normally, the partial text stays in the Message List and the conversation history, and [methodname]`event.getError()` is empty. The finish reason is what tells a completed turn from a truncated one. A truncated turn reports the model's word for the output limit -- for example, `length` on OpenAI or `max_tokens` on Anthropic -- instead of its word for a natural stop:
+A response cut off at the model's output limit is not an error: the turn ends normally, the partial text stays in the Message List and the conversation history, and [methodname]`event.getError()` is empty. The finish reason is what tells a completed turn from a truncated one: a truncated turn reports the underlying framework's value for the output limit instead of its value for a natural stop. With the built-in providers, that value is `LENGTH` for OpenAI models through Spring AI and for every model through LangChain4j, and `max_tokens` for Anthropic models through Spring AI -- see <<#finish-reason-vocabulary,Finish Reason Vocabulary>>:
 
 [source,java]
 ----
 .withResponseListener(event -> {
     boolean truncated = event.getMetadata()
             .map(ResponseMetadata::finishReason)
-            // OpenAI's finish reason for the output limit
-            .filter("length"::equals)
+            // Output-limit reason for OpenAI models through Spring AI,
+            // and for every model through LangChain4j
+            .filter("LENGTH"::equals)
             .isPresent();
     if (truncated) {
         // For example, tell the user the answer was cut short,
@@ -100,19 +101,17 @@ Checking for truncation matters especially for anything that commits state based
 [[finish-reason-vocabulary]]
 === Finish Reason Vocabulary
 
-Finish reasons pass through exactly as the underlying framework reports them; they are never mapped to a fixed set of Vaadin values. Every model vendor words the reason differently and keeps adding values, so any fixed set would go stale. Compare only against the values documented for the model you call, and treat an unrecognized value as unknown rather than as an error.
+Finish reasons pass through exactly as the underlying framework reports them; they are never mapped to a fixed set of Vaadin values. Every model vendor words the reason differently and keeps adding values, so any fixed set would go stale. The frameworks don't always pass the model's own word through either, so the value that arrives depends on both the framework and its integration for the model you call. Compare only against the values that integration reports, and treat an unrecognized value as unknown rather than as an error.
 
-The two built-in providers differ in whose word arrives:
+The two built-in providers relay the following:
 
-* [classname]`SpringAILLMProvider` relays the model's own word: a turn cut off at the output limit reports `length` on OpenAI and `max_tokens` on Anthropic.
-* [classname]`LangChain4JLLMProvider` reports the name of LangChain4j's own five-constant [classname]`FinishReason` enum, onto which LangChain4j collapses the vendor's word before Vaadin sees it -- both examples above arrive as `LENGTH`. The collapsing is done per integration and loses what it doesn't recognize: an unrecognized value arrives as `null` through the OpenAI integration and as `OTHER` through the Anthropic one.
-
-Use [classname]`SpringAILLMProvider` where the application needs the model's own word.
+* [classname]`SpringAILLMProvider` relays the finish reason from Spring AI's generation metadata, and how close that is to the model's own word depends on the Spring AI model integration. The Anthropic integration passes the model's word through, so a turn cut off at the output limit reports `max_tokens`. The OpenAI integration reports the name of the OpenAI SDK's finish reason constant instead -- the same turn reports `LENGTH` -- and drops a value it doesn't recognize, which then arrives as `null`.
+* [classname]`LangChain4JLLMProvider` reports the name of LangChain4j's own five-constant [classname]`FinishReason` enum, onto which LangChain4j collapses the vendor's word before Vaadin sees it -- the output limit arrives as `LENGTH` for OpenAI and Anthropic models alike. The collapsing is done per integration and loses what it doesn't recognize: an unrecognized value arrives as `null` through the OpenAI integration and as `OTHER` through the Anthropic one.
 
 
 === Failed Turns
 
-The built-in providers publish metadata as the turn progresses, and each publication replaces the previous one. A turn that fails or times out midway therefore still reports what was observed before the failure -- for example, the token usage of the tool-call round trips that did complete. On such a turn, [methodname]`event.getError()` carries the cause and the metadata describes the turn as far as it got.
+The built-in providers publish metadata as the turn progresses, and each publication replaces the previous one. A turn that fails or times out midway therefore still reports what was observed before the failure: [methodname]`event.getError()` carries the cause and the metadata describes the turn as far as it got. How far that is depends on which side runs the <<tool-calling#,tool-calling>> loop. [classname]`LangChain4JLLMProvider` runs the loop itself and publishes after every round trip, so a turn that fails after a tool call still reports the token usage of the round trips that did complete. Spring AI runs the loop inside the framework and hands [classname]`SpringAILLMProvider` only the final response, so the round trips before it are never published: a turn that fails before the final response reports nothing, in synchronous and streaming mode alike. In streaming mode, the chunks of the final response that arrived before the failure are still reported.
 
 The built-in providers also log a warning when a turn ends in a state a completed turn can't end in: without a finish reason, or with tool calls still pending.
 

--- a/articles/flow/ai-support/listeners.adoc
+++ b/articles/flow/ai-support/listeners.adoc
@@ -1,0 +1,119 @@
+---
+title: Request & Response Listeners
+description: Observe each prompt and its outcome with orchestrator-level listeners, including the finish reason and token usage of each LLM turn.
+meta-description: Learn how to observe prompts and turn outcomes in the Vaadin AIOrchestrator with request and response listeners, and how to read response metadata.
+order: 38
+---
+
+
+= [since:com.vaadin:vaadin@V25.2]#Request & Response Listeners#
+
+The orchestrator notifies the application at two moments of every prompt: just before the request goes to the LLM, and when the turn ends. Register the hooks with [methodname]`withRequestListener()` and [methodname]`withResponseListener()` on the builder:
+
+[source,java]
+----
+var orchestrator = AIOrchestrator
+        .builder(provider, systemPrompt)
+        .withMessageList(messageList)
+        .withInput(messageInput)
+        .withRequestListener(event -> logOutbound(
+                event.getMessageId(), event.getUserMessage()))
+        .withResponseListener(event -> logOutcome(
+                event.getResponse(), event.getError(), event.getMetadata()))
+        .build();
+----
+
+[methodname]`logOutbound` and [methodname]`logOutcome` are placeholders for application code.
+
+The listeners observe the turn without changing it. To validate, modify, or reject the prompt before it goes out, use a <<request-interception#,request interceptor>> instead. An <<controllers#,[classname]`AIController`>> receives the same two lifecycle moments through its [methodname]`onRequest()` and [methodname]`onResponse()` hooks -- use a controller to package such behavior reusably, together with tools.
+
+
+== Request Listener
+
+The request listener is called on every prompt, just before the LLM stream opens. By then the <<request-interception#,request interceptor>> has run -- the listener sees the prompt as it actually goes out -- and the user's message already appears in the Message List. A prompt rejected by the interceptor never reaches the listener.
+
+The event carries:
+
+* [methodname]`getUserMessage()` -- the message text sent to the LLM.
+* [methodname]`getMessageId()` -- the unique id assigned to the message. The same id appears on the resulting [classname]`ChatMessage` in the conversation history and in attachment click events, so the listener is the place to correlate them -- see <<file-attachments#,File Attachments>> for an example that persists attachments under this id.
+* [methodname]`getAttachments()` -- the attachments included with the message; an empty list when there are none.
+
+The listener runs on the UI thread under the session lock: components can be updated directly, and long-running work should be offloaded to a worker thread.
+
+
+== Response Listener
+
+The response listener is called when the turn ends -- normally when the assistant's response has completed, successfully or with an error, but also when the turn fails before a response ever starts. It fires at most once per prompt, and not at all for a prompt rejected by the interceptor or for history restored via [methodname]`withHistory()`.
+
+The event carries:
+
+* [methodname]`getResponse()` -- the assistant's response text. On success, it may be empty when the model emitted only tool calls; on failure, it's whatever partial response was received before the error. Empty responses are not appended to the conversation history.
+* [methodname]`getError()` -- the failure cause, or an empty optional on success.
+* [methodname]`getMetadata()` -- the provider's metadata for the turn; see <<#response-metadata,Response Metadata>>.
+
+A typical use is persisting the conversation after each exchange -- see <<conversation-history#,Conversation History & Session Persistence>>.
+
+.UI Updates from ResponseListener
+[IMPORTANT]
+The listener is called from whichever thread ends the turn. With a streaming provider, or when <<llm-providers#background-execution,background execution>> is enabled, that's a background thread, where blocking I/O (such as database writes) is safe. With a synchronous provider in the default execution mode, the whole turn -- this listener included -- runs in the request that triggered the prompt. To update Vaadin UI components from this callback, wrap the update in `ui.access()`.
+
+
+[[response-metadata]]
+[role="since:com.vaadin:vaadin@V25.3"]
+== Response Metadata
+
+Alongside the response text, the model reports metadata about each turn: a finish reason that tells why it stopped, and the token usage of the turn. [classname]`ResponseMetadata` exposes both, so the application can tell a completed response from one cut off at the model's output limit, and can track what each turn costs.
+
+Call [methodname]`event.getMetadata()` on the response event -- in this listener or in <<controllers#,[methodname]`AIController.onResponse()`>> alike. It returns an empty optional when the provider reported no metadata: a <<llm-providers#custom-llm-providers,custom provider>> that doesn't publish it, or a turn that failed before any was observed.
+
+[classname]`ResponseMetadata` is a record with two components:
+
+* [methodname]`finishReason()` -- why the model stopped, worded as the underlying framework reports it, or `null` when no reason was reported. See <<#finish-reason-vocabulary,Finish Reason Vocabulary>>.
+* [methodname]`tokenUsage()` -- a [classname]`TokenUsage` record with [methodname]`inputTokens()`, [methodname]`outputTokens()`, and [methodname]`totalTokens()`, each `null` when unknown. The whole record is `null` when the framework reported no usage.
+
+When a turn contains <<tool-calling#,tool-call>> round trips, the finish reason is the latest one observed, and the token usage covers the round trips so far, as far as the underlying framework reports them. On a turn that completes normally, the metadata therefore describes the whole turn.
+
+
+[[truncated-responses]]
+=== Truncated Responses
+
+A response cut off at the model's output limit is not an error: the turn ends normally, the partial text stays in the Message List and the conversation history, and [methodname]`event.getError()` is empty. The finish reason is what tells a completed turn from a truncated one. A truncated turn reports the model's word for the output limit -- for example, `length` on OpenAI or `max_tokens` on Anthropic -- instead of its word for a natural stop:
+
+[source,java]
+----
+.withResponseListener(event -> {
+    boolean truncated = event.getMetadata()
+            .map(ResponseMetadata::finishReason)
+            // OpenAI's finish reason for the output limit
+            .filter("length"::equals)
+            .isPresent();
+    if (truncated) {
+        // For example, tell the user the answer was cut short,
+        // or flag the turn for review.
+    }
+})
+----
+
+Checking for truncation matters especially for anything that commits state based on the turn. A custom <<controllers#,controller>> that applies staged changes in [methodname]`onResponse()` on success would otherwise commit work the model never finished describing.
+
+
+[[finish-reason-vocabulary]]
+=== Finish Reason Vocabulary
+
+Finish reasons pass through exactly as the underlying framework reports them; they are never mapped to a fixed set of Vaadin values. Every model vendor words the reason differently and keeps adding values, so any fixed set would go stale. Compare only against the values documented for the model you call, and treat an unrecognized value as unknown rather than as an error.
+
+The two built-in providers differ in whose word arrives:
+
+* [classname]`SpringAILLMProvider` relays the model's own word: a turn cut off at the output limit reports `length` on OpenAI and `max_tokens` on Anthropic.
+* [classname]`LangChain4JLLMProvider` reports the name of LangChain4j's own five-constant [classname]`FinishReason` enum, onto which LangChain4j collapses the vendor's word before Vaadin sees it -- both examples above arrive as `LENGTH`. The collapsing is done per integration and loses what it doesn't recognize: an unrecognized value arrives as `null` through the OpenAI integration and as `OTHER` through the Anthropic one.
+
+Use [classname]`SpringAILLMProvider` where the application needs the model's own word.
+
+
+=== Failed Turns
+
+The built-in providers publish metadata as the turn progresses, and each publication replaces the previous one. A turn that fails or times out midway therefore still reports what was observed before the failure -- for example, the token usage of the tool-call round trips that did complete. On such a turn, [methodname]`event.getError()` carries the cause and the metadata describes the turn as far as it got.
+
+The built-in providers also log a warning when a turn ends in a state a completed turn can't end in: without a finish reason, or with tool calls still pending.
+
+A custom [classname]`LLMProvider` decides itself what metadata to publish -- see <<llm-providers#custom-llm-providers,Custom LLM Providers>>.

--- a/articles/flow/ai-support/llm-providers.adoc
+++ b/articles/flow/ai-support/llm-providers.adoc
@@ -100,6 +100,7 @@ The orchestrator processes one prompt at a time. In the default synchronous mode
 If the user closes or reloads the browser tab while a turn is running, the turn still completes on the server: the response is recorded in the conversation history and the [classname]`ResponseListener` fires as usual. Only the UI updates are skipped, along with [methodname]`AIController.onResponse()`, which needs an attached UI. The setting itself lives on the provider and is not serialized with the session -- apply it again to the recreated provider after a session restore, before passing it to [methodname]`reconnect()`. See <<conversation-history#,Conversation History & Session Persistence>>.
 
 
+[[custom-llm-providers]]
 == Custom LLM Providers
 
 Implement the [classname]`LLMProvider` interface to connect to any LLM framework:
@@ -115,6 +116,7 @@ public class MyLLMProvider implements LLMProvider {
         // request.attachments()  -- any file attachments
         // request.systemPrompt() -- the system prompt
         // request.tools()        -- registered tool objects
+        // request.metadataSink() -- consumer for response metadata
     }
 
     @Override
@@ -124,6 +126,8 @@ public class MyLLMProvider implements LLMProvider {
     }
 }
 ----
+
+The response stream carries text only. The provider can also [since:com.vaadin:vaadin@V25.3]#publish the finish reason and token usage# of the turn through the [methodname]`metadataSink()` consumer on the request. Each call carries everything observed so far and replaces the value of any earlier call, so publish whenever the provider learns more -- a turn that fails midway has then still reported what was observed. Pass `null` for any value the framework doesn't report; a provider that observes no metadata never calls the consumer. See <<listeners#response-metadata,Response Metadata>> for how applications read it.
 
 The orchestrator calls [methodname]`stream()` on the thread that triggers the prompt and subscribes to the returned stream on that same thread -- whether a turn runs in the background is decided entirely by the implementation. An implementation whose LLM call blocks should schedule that call itself; otherwise it occupies the request thread and holds the session lock for the whole turn. See <<#background-execution,Background Execution>> for how the built-in providers expose this as a setting.
 


### PR DESCRIPTION
## Summary
- Documents the AI orchestrator's request/response listeners on a dedicated page; their contracts (timing, event contents, threading) were previously only shown in passing in the File Attachments and Conversation History use cases.
- Documents the response metadata added in vaadin/flow-components#9995 (finish reason and token usage, since 25.3), so applications can tell completed turns from truncated ones and track token consumption.
- Updates the `AIController.onResponse` reference for the changed signature, and the custom `LLMProvider` docs for publishing metadata via `metadataSink()`.