### PR TITLE
docs: add missing checkbox and radio-group readonly state

### DIFF
--- a/articles/components/checkbox/styling.adoc
+++ b/articles/components/checkbox/styling.adoc
@@ -158,6 +158,7 @@ Root element:: `vaadin-checkbox`
 Focused:: `vaadin-checkbox+++<wbr>+++**[focused]**`
 Keyboard focused:: `vaadin-checkbox+++<wbr>+++**[focus-ring]**`
 Disabled:: `vaadin-checkbox+++<wbr>+++**[disabled]**`
+Read-only:: `vaadin-checkbox+++<wbr>+++**[readonly]**`
 Hovered:: `vaadin-checkbox+++<wbr>+++**:hover**`
 Pressed:: `vaadin-checkbox+++<wbr>+++**[active]**`
 Checked:: `vaadin-checkbox+++<wbr>+++**[checked]**`
@@ -177,6 +178,7 @@ Root element:: `vaadin-checkbox-group`
 Focused:: `vaadin-checkbox-group+++<wbr>+++**[focused]**`
 Keyboard focused:: `vaadin-checkbox-group+++<wbr>+++**[focus-ring]**`
 Disabled:: `vaadin-checkbox-group+++<wbr>+++**[disabled]**`
+Read-only:: `vaadin-checkbox-group+++<wbr>+++**[readonly]**`
 Hovered:: `vaadin-checkbox-group+++<wbr>+++**:hover**`
 One or more checkboxes checked:: `vaadin-checkbox-group+++<wbr>+++**[has-value]**`
 

--- a/articles/components/radio-button/styling.adoc
+++ b/articles/components/radio-button/styling.adoc
@@ -142,6 +142,7 @@ Root element:: `vaadin-radio-group`
 Focused:: `vaadin-radio-group+++<wbr>+++**[focused]**`
 Keyboard focused:: `vaadin-radio-group+++<wbr>+++**[focus-ring]**`
 Disabled:: `vaadin-radio-group+++<wbr>+++**[disabled]**`
+Read-only:: `vaadin-radio-group+++<wbr>+++**[readonly]**`
 Hovered:: `vaadin-radio-group+++<wbr>+++**:hover**`
 Has selection:: `vaadin-radio-group+++<wbr>+++**[has-value]**`
 


### PR DESCRIPTION
Added missing `readonly` state for `vaadin-checkbox`, `vaadin-checkbox-group` and `vaadin-radio-group`.