### PR TITLE
docs: add drawer toggle section to App Layout styling

### DIFF
--- a/articles/components/app-layout/styling.adoc
+++ b/articles/components/app-layout/styling.adoc
@@ -130,10 +130,6 @@ Bottom "touch optimized" navbar:: `vaadin-app-layout+++<wbr>+++**::part(navbar-b
 Modality curtain (backdrop):: `vaadin-app-layout+++<wbr>+++**::part(backdrop)**`
 Content area:: `vaadin-app-layout+++<wbr>+++**::part(content)**`
 Drawer:: `vaadin-app-layout+++<wbr>+++**::part(drawer)**`
-Drawer toggle:: `vaadin-drawer-toggle`
-Drawer toggle icon wrapper:: `vaadin-drawer-toggle+++<wbr>+++**::part(icon)**`
-Drawer toggle icon:: `vaadin-drawer-toggle+++<wbr>+++**::part(icon)::before**`
-
 
 === States
 
@@ -143,3 +139,12 @@ Navbar on top of drawer:: `vaadin-app-layout+++<wbr>+++**[primary-section="navba
 Navbar next to drawer:: `vaadin-app-layout+++<wbr>+++**[primary-section="drawer"]**`
 Drawer opened:: `vaadin-app-layout+++<wbr>+++**[drawer-opened]**`
 Overlay drawer (small screen) mode:: `vaadin-app-layout+++<wbr>+++**[overlay]**`
+
+=== Drawer Toggle
+
+Root element:: `vaadin-drawer-toggle`
+Toggle icon wrapper:: `vaadin-drawer-toggle+++<wbr>+++**::part(icon)**`
+Toggle icon:: `vaadin-drawer-toggle+++<wbr>+++**::part(icon)::before**`
+Focused:: `vaadin-drawer-toggle+++<wbr>+++**[focused]**`
+Keyboard focused:: `vaadin-drawer-toggle+++<wbr>+++**[focus-ring]**`
+Pressed:: `vaadin-drawer-toggle+++<wbr>+++**[active]**`


### PR DESCRIPTION
- Moved `vaadin-drawer-toggle` into its own sub-section on the Styling page,
- Added missing `focused`, `focus-ring` and `active` state attribute selectors