### PR TITLE
docs: style property updates

### DIFF
--- a/articles/components/_styling-section-theming-props.adoc
+++ b/articles/components/_styling-section-theming-props.adoc
@@ -270,9 +270,6 @@ endif::include-item-overlay-props[]
 |`--vaadin-icon-size`
 |Aura
 
-|`--vaadin-icon-visual-size`
-|Aura
-
 |`--vaadin-item-gap`
 |Aura
 

--- a/articles/components/dashboard/styling.adoc
+++ b/articles/components/dashboard/styling.adoc
@@ -96,7 +96,7 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |Aura, Lumo
 
 |`--vaadin-dashboard-widget-padding`
-|Lumo
+|Aura, Lumo
 
 |`--vaadin-dashboard-widget-header-padding`
 |Aura
@@ -120,10 +120,10 @@ include::../_styling-section-theming-props.adoc[tag=style-properties]
 |Aura, Lumo
 
 |`--vaadin-dashboard-drop-target-background-color`
-|Lumo
+|Aura,Lumo
 
 |`--vaadin-dashboard-drop-target-border`
-|Lumo
+|Aura, Lumo
 
 |===
 


### PR DESCRIPTION
- Mark several dashboard properties as supported in Aura that have been fixed as part of https://github.com/vaadin/web-components/issues/11163
- Remove `--vaadin-icon-visual-size` from overlay item props. According to https://github.com/vaadin/web-components/issues/11163 this is only intended to be used on `vaadin-icon`. `--vaadin-icon-size` works for changing the size of icons in overlay items.