### PR TITLE
docs: add missing focused and focus-ring state attributes

### DIFF
--- a/articles/components/accordion/styling.adoc
+++ b/articles/components/accordion/styling.adoc
@@ -198,6 +198,8 @@ Root element:: `vaadin-accordion`
 Panel element:: `vaadin-accordion-panel`
 Opened panel:: `vaadin-accordion-panel+++<wbr>+++**[opened]**`
 Disabled panel:: `vaadin-accordion-panel+++<wbr>+++**[disabled]**`
+Focused panel:: `vaadin-accordion-panel+++<wbr>+++**[focused]**`
+Keyboard focused panel:: `vaadin-accordion-panel+++<wbr>+++**[focus-ring]**`
 Panel body content wrapper:: `vaadin-accordion-panel+++<wbr>+++**::part(content)**`
 
 

--- a/articles/components/avatar/styling.adoc
+++ b/articles/components/avatar/styling.adoc
@@ -156,6 +156,7 @@ include::../_styling-section-intros.adoc[tag=selectors]
 Root element:: `vaadin-avatar`
 Hovered avatar:: `vaadin-avatar+++<wbr>+++**:hover**`
 Focused avatar:: `vaadin-avatar+++<wbr>+++**[focused]**`
+Keyboard focused avatar:: `vaadin-avatar+++<wbr>+++**[focus-ring]**`
 Avatar with color index:: `vaadin-avatar+++<wbr>+++**[has-color-index]**`
 Overflow avatar:: `vaadin-avatar+++<wbr>+++**[slot="overflow"]**`
 Expanded overflow avatar:: `vaadin-avatar+++<wbr>+++**[aria-expanded="true"]**`
@@ -177,5 +178,6 @@ Menu inside overlay:: `vaadin-avatar-group-menu`
 Item element:: `vaadin-avatar-group-menu-item`
 Hovered item:: `vaadin-avatar-group-menu-item+++<wbr>+++**:hover**`
 Focused item:: `vaadin-avatar-group-menu-item+++<wbr>+++**[focused]**`
+Keyboard focused item:: `vaadin-avatar-group-menu-item+++<wbr>+++**[focus-ring]**`
 Item content wrapper:: `vaadin-avatar-group-menu-item+++<wbr>+++**::part(content)**`
 Item avatar:: `vaadin-avatar-group-menu-item+++<wbr>+++** > vaadin-avatar**`

--- a/articles/components/breadcrumbs/styling.adoc
+++ b/articles/components/breadcrumbs/styling.adoc
@@ -106,3 +106,5 @@ Item label:: `vaadin-breadcrumbs-item+++<wbr>+++**::part(label)**`
 Item prefix element:: `vaadin-breadcrumbs-item+++<wbr>+++** > [slot="prefix"]**`
 Item with prefix content:: `vaadin-breadcrumbs-item+++<wbr>+++**[has-prefix]**`
 Disabled item:: `vaadin-breadcrumbs-item+++<wbr>+++**[disabled]**`
+Focused item:: `vaadin-breadcrumbs-item+++<wbr>+++**[focused]**`
+Keyboard focused item:: `vaadin-breadcrumbs-item+++<wbr>+++**[focus-ring]**`

--- a/articles/components/context-menu/styling.adoc
+++ b/articles/components/context-menu/styling.adoc
@@ -62,6 +62,7 @@ Separator:: `vaadin-context-menu-list-box+++<wbr>+++** [role="separator"]**`
 
 Selected item:: `vaadin-context-menu-item+++<wbr>+++**[selected]**`
 Focused item:: `vaadin-context-menu-item+++<wbr>+++**[focused]**`
+Keyboard focused item:: `vaadin-context-menu-item+++<wbr>+++**[focus-ring]**`
 Hovered item:: `vaadin-context-menu-item+++<wbr>+++**:hover**`
 Pressed item:: `vaadin-context-menu-item+++<wbr>+++**[active]**`
 Disabled item:: `vaadin-context-menu-item+++<wbr>+++**[disabled]**`

--- a/articles/components/details/styling.adoc
+++ b/articles/components/details/styling.adoc
@@ -170,6 +170,8 @@ Root element:: `vaadin-details`
 
 Opened panel:: `vaadin-details+++<wbr>+++**[opened]**`
 Disabled panel:: `vaadin-details+++<wbr>+++**[disabled]**`
+Focused panel:: `vaadin-details+++<wbr>+++**[focused]**`
+Keyboard focused panel:: `vaadin-details+++<wbr>+++**[focus-ring]**`
 
 
 === Summary

--- a/articles/components/details/styling.adoc
+++ b/articles/components/details/styling.adoc
@@ -180,6 +180,8 @@ Toggle icon:: `vaadin-details-summary+++<wbr>+++**::part(toggle)::before**`
 Summary content wrapper:: `vaadin-details-summary+++<wbr>+++**::part(content)**`
 Opened details summary:: `vaadin-details-summary+++<wbr>+++**[opened]**`
 Disabled details summary:: `vaadin-details-summary+++<wbr>+++**[disabled]**`
+Focused details summary:: `vaadin-details-summary+++<wbr>+++**[focused]**`
+Keyboard focused details summary:: `vaadin-details-summary+++<wbr>+++**[focus-ring]**`
 
 
 === Content

--- a/articles/components/menu-bar/styling.adoc
+++ b/articles/components/menu-bar/styling.adoc
@@ -210,6 +210,7 @@ Button element:: `vaadin-menu-bar-button`
 Button text:: `vaadin-menu-bar-button+++<wbr>+++**::part(label)**`
 Hovered button:: `vaadin-menu-bar-button+++<wbr>+++**:hover**`
 Focused button:: `vaadin-menu-bar-button+++<wbr>+++**[focused]**`
+Keyboard focused button:: `vaadin-menu-bar-button+++<wbr>+++**[focus-ring]**`
 Disabled button:: `vaadin-menu-bar-button+++<wbr>+++**[disabled]**`
 Button with a menu:: `vaadin-menu-bar-button+++<wbr>+++**[aria-haspopup]**`
 Button with opened menu:: `vaadin-menu-bar-button+++<wbr>+++**[expanded]**`
@@ -240,6 +241,7 @@ Separator element:: `vaadin-menu-bar-submenu+++<wbr>+++** [role="separator"]**`
 
 Hovered item:: `vaadin-menu-bar-item+++<wbr>+++**:hover**`
 Focused item:: `vaadin-menu-bar-item+++<wbr>+++**[focused]**`
+Keyboard focused item:: `vaadin-menu-bar-item+++<wbr>+++**[focus-ring]**`
 Disabled item:: `vaadin-menu-bar-item+++<wbr>+++**[disabled]**`
 Item with a nested sub-menu:: `vaadin-menu-bar-item+++<wbr>+++**[aria-haspopup]**`
 Item with expanded sub-menu:: `vaadin-menu-bar-item+++<wbr>+++**[expanded]**`

--- a/articles/components/message-input/styling.adoc
+++ b/articles/components/message-input/styling.adoc
@@ -51,4 +51,5 @@ Send button:: `vaadin-message-input-button**`
 Send button text:: `vaadin-message-input-button+++<wbr>+++**::part(label)**`
 Hovered button:: `vaadin-message-input-button+++<wbr>+++**:hover**`
 Focused button:: `vaadin-message-input-button+++<wbr>+++**[focused]**`
+Keyboard focused button:: `vaadin-message-input-button+++<wbr>+++**[focus-ring]**`
 Button for non-empty field:: `**vaadin-text-area[has-value] ~ vaadin-message-input-button**`

--- a/articles/components/message-list/styling.adoc
+++ b/articles/components/message-list/styling.adoc
@@ -118,6 +118,8 @@ Internal list layout:: `vaadin-message-list+++<wbr>+++**::part(list)**`
 === Message
 
 Root element:: `vaadin-message`
+Focused message:: `vaadin-message+++<wbr>+++**[focused]**`
+Keyboard focused message:: `vaadin-message+++<wbr>+++**[focus-ring]**`
 Text content layout:: `vaadin-message+++<wbr>+++**::part(content)**`
 Header row:: `vaadin-message+++<wbr>+++**::part(header)**`
 Name:: `vaadin-message+++<wbr>+++**::part(name)**`

--- a/articles/components/scroller/styling.adoc
+++ b/articles/components/scroller/styling.adoc
@@ -68,3 +68,5 @@ Content overflow start (left):: `vaadin-scroller+++<wbr>+++**[overflow~="start"]
 Content overflow end (right):: `vaadin-scroller+++<wbr>+++**[overflow~="end"]**`
 Vertical scrolling only:: `vaadin-scroller+++<wbr>+++**[scroll-direction="vertical"]**`
 Horizontal scrolling only:: `vaadin-scroller+++<wbr>+++**[scroll-direction="horizontal"]**`
+Focused scroller:: `vaadin-scroller+++<wbr>+++**[focused]**`
+Keyboard focused scroller:: `vaadin-scroller+++<wbr>+++**[focus-ring]**`

--- a/articles/components/select/styling.adoc
+++ b/articles/components/select/styling.adoc
@@ -137,5 +137,6 @@ Selected item:: `vaadin-select-item+++<wbr>+++**[selected]**`
 Item selection indicator:: `vaadin-select-item+++<wbr>+++**::part(checkmark)**`
 Item selection indicator icon:: `vaadin-select-item+++<wbr>+++**::part(checkmark)::before**`
 Focused item:: `vaadin-select-item+++<wbr>+++**[focused]**`
+Keyboard focused item:: `vaadin-select-item+++<wbr>+++**[focus-ring]**`
 Item content wrapper:: `vaadin-select-item+++<wbr>+++**::part(content)**`
 Hovered item:: `vaadin-select-item+++<wbr>+++**:hover**`

--- a/articles/components/side-nav/styling.adoc
+++ b/articles/components/side-nav/styling.adoc
@@ -141,6 +141,8 @@ Expand/collapse icon:: `vaadin-side-nav+++<wbr>+++**::part(toggle-button)::befor
 
 Collapsible list:: `vaadin-side-nav+++<wbr>+++**[collapsible]**`
 Collapsed list:: `vaadin-side-nav+++<wbr>+++**[collapsed]**`
+Focused label:: `vaadin-side-nav+++<wbr>+++**[focused]**`
+Keyboard focused label:: `vaadin-side-nav+++<wbr>+++**[focus-ring]**`
 
 
 == Navigation Item

--- a/articles/components/split-layout/styling.adoc
+++ b/articles/components/split-layout/styling.adoc
@@ -113,6 +113,8 @@ Root element:: `vaadin-split-layout`
 
 Horizontal split:: `vaadin-split-layout+++<wbr>+++**[orientation="horizontal"]**`
 Vertical split:: `vaadin-split-layout+++<wbr>+++**[orientation="vertical"]**`
+Focused splitter:: `vaadin-split-layout+++<wbr>+++**[focused]**`
+Keyboard focused splitter:: `vaadin-split-layout+++<wbr>+++**[focus-ring]**`
 
 
 === Parts

--- a/articles/components/upload/styling.adoc
+++ b/articles/components/upload/styling.adoc
@@ -207,6 +207,7 @@ Error message:: `vaadin-upload-file+++<wbr>+++**::part(error)**`
 ==== File States
 
 Focused file:: `vaadin-upload-file+++<wbr>+++**[focused]**`
+Keyboard focused file:: `vaadin-upload-file+++<wbr>+++**[focus-ring]**`
 Hovered file:: `vaadin-upload-file+++<wbr>+++**:hover**`
 File uploaded successfully:: `vaadin-upload-file+++<wbr>+++**[complete]**`
 File that failed with an error:: `vaadin-upload-file+++<wbr>+++**[error]**`


### PR DESCRIPTION
Added `focused` and `focus-ring` attributes to styling tables of components missing it:

- `vaadin-accordion-panel`
- `vaadin-avatar` - was missing `focus-ring`
- `vaadin-avatar-group-menu-item` - was missing `focus-ring`
- `vaadin-breadcrumbs-item`
- `vaadin-context-menu-item` - was missing `focus-ring`
- `vaadin-details-summary`
- `vaadin-message`
- `vaadin-side-nav`
- `vaadin-split-layout` - new in Vaadin 25.3