### PR TITLE
docs: correct AI integration docs against current API

### DIFF
--- a/articles/building-apps/ai/index.adoc
+++ b/articles/building-apps/ai/index.adoc
@@ -16,11 +16,11 @@ You'll learn how to:
 * connect your application to an AI client with popular Java libraries such as Spring AI and LangChain4j,
 * use the xref:{articles}/flow/ai-support#[AI support features] to connect LLM providers to Vaadin UI components with minimal boilerplate,
 * choose Vaadin components that create intuitive, AI-powered workflows -- such as `MessageInput`, `MessageList`, and `UploadManager`,
-* let users explore application data through natural language with <<{articles}/flow/ai-support/ai-powered-grid#,AI-powered Grid>> and <<{articles}/flow/ai-support/ai-powered-chart#,AI-powered Chart>>, and
+* let users explore application data through natural language with <<{articles}/flow/ai-support/ai-powered-grid#,AI-powered Grid>> and <<{articles}/flow/ai-support/ai-powered-chart#,AI-powered Chart>>, or fill a form from a prompt or an attached document with the <<{articles}/flow/ai-support/ai-powered-form#,AI Form Filler>>, and
 * deliver real-time updates to users through server push.
 
 [TIP]
-The <<{articles}/flow/ai-support#,AI support features>> eliminate the boilerplate of wiring UI components to LLM frameworks. The [classname]`AIOrchestrator` handles streaming, conversation history, file attachments, and tool calling behind a simple builder API. Ready-made controllers -- [classname]`GridAIController` and [classname]`ChartAIController`, available with a commercial Vaadin subscription -- bring natural-language data exploration to [classname]`Grid` and [classname]`Chart`. See the <<{articles}/flow/ai-support#,documentation>> for the full API reference.
+The <<{articles}/flow/ai-support#,AI support features>> eliminate the boilerplate of wiring UI components to LLM frameworks. The [classname]`AIOrchestrator` handles streaming, conversation history, file attachments, and tool calling behind a simple builder API. Ready-made controllers -- [classname]`GridAIController`, [classname]`ChartAIController`, and [classname]`FormAIController`, available with a commercial Vaadin subscription -- bring natural-language data exploration to [classname]`Grid` and [classname]`Chart`, and form filling to any layout of input fields. See the <<{articles}/flow/ai-support#,documentation>> for the full API reference.
 
 section_outline::[]
 

--- a/articles/building-apps/ai/quickstart-guide.adoc
+++ b/articles/building-apps/ai/quickstart-guide.adoc
@@ -8,7 +8,8 @@ section-nav: badge-preview badge-flow
 ---
 = [since:com.vaadin:vaadin@V25.1]#Quick Start-Guide: Add an AI Chat Bot to a Vaadin + Spring Boot Application# [badge-flow]#Flow#
 
-:preview-banner-content: This guide uses preview versions of AI integration features. This means that they are not yet ready for production usage and may have limitations or bugs. We encourage you to try them out and provide feedback to help us improve them.
+:preview-feature: AI integration features
+:feature-flag: com.vaadin.experimental.aiComponents
 include::{articles}/_preview-banner.adoc[opts=optional]
 
 This guide shows how to connect a Large Language Model (LLM) into a Vaadin application using Spring AI, Spring Boot, and the <<{articles}/flow/ai-support#,AI integration features>>. You'll build a minimal chat UI with **MessageList** and **MessageInput**, stream responses token-by-token, and keep a conversational tone in the dialog with the AI -- all without writing boilerplate wiring code.
@@ -21,6 +22,7 @@ image::images/chatbot-image.png[role=text-center]
 == Prerequisites
 
 * An OpenAI API key (`OPENAI_API_KEY`)
+* The `com.vaadin.experimental.aiComponents` feature flag enabled, as the AI integration features are still a preview. Enable it in Copilot's experimental features tab, or add `com.vaadin.experimental.aiComponents=true` to `src/main/resources/vaadin-featureflags.properties`. Without it, the first prompt fails.
 
 
 == 1. Start from a Vaadin Spring Skeleton
@@ -142,6 +144,8 @@ public class MainView extends Composite<VerticalLayout> {
         // Create UI components
         var messageList = new MessageList();
         messageList.setSizeFull();
+        // LLMs answer in Markdown; render it as rich text
+        messageList.setMarkdown(true);
         var messageInput = new MessageInput();
         messageInput.setWidthFull();
 
@@ -167,8 +171,9 @@ The orchestrator takes care of:
 * **Displaying messages:** user prompts and assistant responses appear in the Message List automatically.
 * **Streaming output:** tokens are pushed to the UI as they arrive from the LLM.
 * **Conversation memory:** the provider maintains a 30-message context window, so the assistant remembers earlier messages.
-* **Markdown rendering:** responses render as rich text (lists, code blocks, links).
 * **Sticky scroll:** the Message List keeps the latest answer in view.
+
+Markdown rendering is not one of them: the Message List renders plain text by default, and the orchestrator doesn't change that. Since LLMs answer in Markdown, call [methodname]`setMarkdown(true)` on the list -- as above -- so that lists, code blocks, and links come out as rich text instead of raw syntax.
 
 
 == 6. Run & Iterate

--- a/articles/flow/ai-support/ai-powered-form.adoc
+++ b/articles/flow/ai-support/ai-powered-form.adoc
@@ -164,6 +164,10 @@ The callback returns domain items; the controller derives the labels through the
 [NOTE]
 Single- and multi-select fields configured with [methodname]`setItems(...)` already share their items with the LLM, so the simple fixed-options case often needs no [methodname]`fieldValueOptions()` call. Use [methodname]`fieldValueOptions()` when items come from a lazy or remote source rather than an in-memory list, or when you want the LLM to fetch options through a filter callback instead of receiving the full set up front.
 
+.At Most 200 Options per Field
+[NOTE]
+A field's option list is capped at 200 entries, whether it comes from eager items, a fixed list, or a query callback, so a longer list is truncated for the LLM. For a large option set, use a query callback and let the model narrow it down with a filter instead of relying on the full list.
+
 === Multi-Select Fields
 
 [classname]`MultiSelectComboBox`, [classname]`CheckboxGroup`, and any other field that implements [classname]`MultiSelect` are supported. Use the component's concrete multi-select type for the field reference so the [methodname]`forField(MultiSelect)` overload is selected:
@@ -221,7 +225,7 @@ The controller sends only a defined subset of the form to the LLM. Knowing where
 The model sees:
 
 * Each visible field's label, helper text, component type, and any [methodname]`describeField()` text or [classname]`Binder` property-name default.
-* The current value of every visible, non-ignored field, so it can decide which entries to overwrite. Disabled and application-set read-only fields are included for context, with a flag telling the model not to write to them.
+* The current value of every visible, non-ignored field, so it can decide which entries to overwrite -- unless <<#hiding-field-values,field values are hidden>>. Disabled and application-set read-only fields are included for context, with a flag telling the model not to write to them.
 * The available labels for a selection field, derived from a combo box or select's eager items, or from the items a [methodname]`fieldValueOptions()` query callback returns for the filter the model supplies.
 
 The model does not see:
@@ -233,7 +237,21 @@ The model does not see:
 
 .Visible Field Values Are Sent to the Model
 [IMPORTANT]
-Every visible field's current value is forwarded to the LLM provider on every turn. Hide fields that carry secrets, identifiers, or personally identifiable information with [methodname]`ignoreField()`, or keep them out of the layout passed to the controller.
+By default, every visible field's current value is forwarded to the LLM provider on every turn. Hide fields that carry secrets, identifiers, or personally identifiable information with [methodname]`ignoreField()`, keep them out of the layout passed to the controller, or hide all values with <<#hiding-field-values,[methodname]`setFieldValuesHidden()`>>.
+
+[[hiding-field-values]]
+=== Hiding Field Values
+
+When the form may already hold values the AI should not read, but should still be able to fill, hide every field's value with [methodname]`setFieldValuesHidden()`:
+
+[source,java]
+----
+controller.setFieldValuesHidden(true);
+----
+
+The model then sees each field with its description, type, and option labels -- everything it needs to fill the field -- but its value always reads as empty, whether one is set or not. The built-in workflow instructions tell the model that such a field may already hold a value, so it writes one only when the user's prompt supplies it.
+
+Only the value is hidden. A field's description, type, and option or `enum` labels still go to the model, so use [methodname]`ignoreField()` for a field whose labels are themselves sensitive, or to hide a single field entirely. Values can also still reach the model through validation rejection messages, which are relayed as written: a message must not embed a field's value.
 
 
 == Field Locking During a Fill Turn
@@ -274,7 +292,11 @@ controller.setFieldMarkerI18n(new FieldMarkerI18n()
         .setMessage("Tekoäly on muuttanut tämän kentän arvoa.")
         .setRevert("Palauta arvo")
         .setBadgeLabel("Tekoälyn tuottama arvo")
-        .setBadgeTooltip("Tekoäly on muuttanut kentän arvoa.\nAvaa lisätiedot napsauttamalla"));
+        .setBadgeTooltip("Tekoäly on muuttanut kentän arvoa.\nAvaa lisätiedot napsauttamalla")
+        .setConfidence(new FieldMarkerI18n.Confidence()
+                .setHigh("Suuri varmuus")
+                .setMedium("Kohtalainen varmuus")
+                .setLow("Pieni varmuus")));
 ----
 
 Each text has a specific role:
@@ -283,6 +305,7 @@ Each text has a specific role:
 * [methodname]`setRevert()` sets the label of the revert control in the popover.
 * [methodname]`setBadgeLabel()` sets the accessible label of the badge button and the popover dialog. The badge itself renders an "AI" icon, so the label is only exposed to assistive technology.
 * [methodname]`setBadgeTooltip()` sets the tooltip text shown when the badge is hovered or focused.
+* [methodname]`setConfidence()` [since:com.vaadin:vaadin@V25.3]#sets the texts of the confidence indicator#, one per level, through a [classname]`FieldMarkerI18n.Confidence` instance with [methodname]`setHigh()`, [methodname]`setMedium()`, and [methodname]`setLow()`. The indicator is shown only when a value's source reports a confidence level -- see <<#confidence-on-the-field-marker,Confidence on the Field Marker>>.
 
 The texts are applied to every marker the controller puts on a field, so set them before the first turn to localize them all. Texts left `null` fall back to the built-in defaults.
 
@@ -400,6 +423,7 @@ controller.describeConfidenceLevel(ConfidenceLevel.MEDIUM,
 
 The description replaces the built-in wording for that level in the LLM-facing instructions. A value reported without a level carries no confidence: it means the model didn't rate the value, not that the value is uncertain.
 
+[[confidence-on-the-field-marker]]
 === Confidence on the Field Marker
 
 While the automatic <<#marking-ai-changes,field marker>> is enabled, a marked field also shows the reported confidence level as an indicator in the field's helper area, so a reviewer can see at a glance which values the model itself was unsure about. A value reported without a confidence level shows no indicator, and a later fill that writes the field without a source clears the indicator. While a fill is in progress, the indicator is hidden, since it describes a value that may be about to be replaced.
@@ -407,7 +431,7 @@ While the automatic <<#marking-ai-changes,field marker>> is enabled, a marked fi
 
 == Reconnecting after Deserialization
 
-[classname]`FormAIController` is not serialized with the orchestrator. After session restore, create a new controller against the same form (and binder, if any), reapply the same [methodname]`describeField()`, [methodname]`fieldValueOptions()`, and [methodname]`ignoreField()` hints, any field-marker and source-tracking configuration, re-register any change listeners, and pass the controller to [methodname]`reconnect()`:
+[classname]`FormAIController` is not serialized with the orchestrator. After session restore, create a new controller against the same form (and binder, if any), reapply the same [methodname]`describeField()`, [methodname]`fieldValueOptions()`, and [methodname]`ignoreField()` hints, any field-marker, value-hiding, and source-tracking configuration, re-register any change listeners, and pass the controller to [methodname]`reconnect()`:
 
 [source,java]
 ----

--- a/articles/flow/ai-support/index.adoc
+++ b/articles/flow/ai-support/index.adoc
@@ -64,6 +64,10 @@ When the user submits a message through the Message Input, the orchestrator auto
 
 By default, user messages are labeled "You" and assistant messages are labeled "Assistant". Use [methodname]`withUserName()` and [methodname]`withAssistantName()` on the builder to customize these display names.
 
+.Render Responses as Markdown
+[TIP]
+LLMs answer in Markdown, but <<{articles}/components/message-list#,Message List>> renders plain text unless asked otherwise, and the orchestrator doesn't change that. Call [methodname]`setMarkdown(true)` on the list so that headings, lists, code blocks, and links come out as rich text instead of raw syntax.
+
 .Always Provide a System Prompt
 [TIP]
 A system prompt is strongly recommended. Without one, the LLM has no guidance beyond your tool descriptions and may behave inconsistently from turn to turn. Use it to set the assistant's role, tone, constraints, and any domain-specific rules -- for example, "You are a helpful customer-support assistant for an online bookstore. Keep answers short and cite order numbers verbatim."

--- a/articles/flow/ai-support/llm-providers.adoc
+++ b/articles/flow/ai-support/llm-providers.adoc
@@ -47,7 +47,7 @@ In synchronous mode, the whole exchange runs in the request that triggered it an
 
 .History Restoration with ChatClient
 [NOTE]
-History restoration via [methodname]`withHistory()` is only supported when creating the provider from a [classname]`ChatModel`. Providers created from a [classname]`ChatClient` do not provide access to internal memory, so calling [methodname]`setHistory()` throws an [classname]`UnsupportedOperationException`. Use `new SpringAILLMProvider(chatModel)` if you need to restore conversation history across sessions.
+A provider created from a [classname]`ChatModel` restores the conversation into its own memory, so [methodname]`withHistory()` and [methodname]`reconnect()` need no extra work. A provider created from a [classname]`ChatClient` cannot do that -- the application owns that client's memory -- so its [methodname]`setHistory()` does nothing beyond logging what it observed: a warning when the client carries no chat memory advisor or no default conversation id, since a restored conversation then never reaches the LLM. Load the conversation into the client's own [classname]`ChatMemory` before passing the client to the provider, or use `new SpringAILLMProvider(chatModel)` and let the provider handle it. The orchestrator's own conversation history and the Message List are restored either way.
 
 
 == LangChain4j

--- a/articles/flow/ai-support/tool-calling.adoc
+++ b/articles/flow/ai-support/tool-calling.adoc
@@ -18,7 +18,8 @@ Register objects with vendor-specific [annotationname]`@Tool` annotations that t
 [source,java]
 ----
 public class WeatherTools {
-    @Tool("Get current weather for a city")
+    // Spring AI: org.springframework.ai.tool.annotation.Tool
+    @Tool(description = "Get current weather for a city")
     public String getWeather(String city) {
         return weatherService.getCurrentWeather(city);
     }
@@ -32,7 +33,16 @@ var orchestrator = AIOrchestrator
         .build();
 ----
 
-For Spring AI, use [annotationname]`@org.springframework.ai.tool.annotation.Tool`. For LangChain4j, use [annotationname]`@dev.langchain4j.agent.tool.Tool`.
+The annotation comes from the framework the provider wraps, and the two spell the description differently. For Spring AI, use [annotationname]`@org.springframework.ai.tool.annotation.Tool` with a `description` attribute, as above. For LangChain4j, use [annotationname]`@dev.langchain4j.agent.tool.Tool`, whose description is the annotation's value:
+
+[source,java]
+----
+// LangChain4j: dev.langchain4j.agent.tool.Tool
+@Tool("Get current weather for a city")
+public String getWeather(String city) {
+    return weatherService.getCurrentWeather(city);
+}
+----
 
 .Tool Threading
 [NOTE]


### PR DESCRIPTION
## Summary
- Several statements in the AI integration docs no longer matched the code: `SpringAILLMProvider.setHistory()` stopped throwing `UnsupportedOperationException` for `ChatClient`-created providers (vaadin/flow-components#9972), the `@Tool` example only compiled against LangChain4j (Spring AI's annotation takes `description`, not a value)...
- The quick start guide claimed the orchestrator renders Markdown. It doesn't — `MessageList` renders plain text unless `setMarkdown(true)` is called, so responses came out as raw Markdown syntax. The guide also never mentioned the `com.vaadin.experimental.aiComponents` feature flag, without which the first prompt fails.
- `FormAIController.setFieldValuesHidden()` (vaadin/flow-components#9527) was undocumented, which left the "field values are sent to the model" guidance incomplete; the marker localization list was likewise missing `FieldMarkerI18n.setConfidence()`, and the 200-option-per-field cap was unstated.