### PR TITLE
docs: make vaadin.launch-browser findable by search

### DIFF
--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -237,8 +237,13 @@ Sets the fully-qualified name for the internationalization provider class. To tr
 Default: `null` +
 Mode: Runtime
 
+`**launch-browser**`::
+Opens the application in the default browser when the application is started in development mode. A new tab isn't opened on every restart: after a tab has been opened, Vaadin waits for the period defined by `launch-browser-delay` before opening another one. To open a tab on the next start, clean the project (e.g., `mvn clean` or `gradle clean`), or delete the [filename]`tab.launch` file in the build directory. See <<{articles}/flow/integrations/spring/configuration#launch-browser-in-development-mode, Launch Browser in Development Mode>> for Spring-specific instructions. +
+Default: `false` +
+Mode: Development
+
 `**launch-browser-delay**`::
-Defines how long to wait before opening a new browser tab for the staring application. The time is counted always from the latest application start that would try to open a tab. +
+Defines how long to wait before opening a new browser tab for the starting application, when `launch-browser` is enabled. The time is counted always from the latest application start that would try to open a tab. Set to `0` to open a tab on every start. +
 Default: 30 min +
 Mode: Development
 

--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -237,16 +237,6 @@ Sets the fully-qualified name for the internationalization provider class. To tr
 Default: `null` +
 Mode: Runtime
 
-`**launch-browser**`::
-Opens the application in the default browser when the application is started in development mode. Unlike the other properties in this list, this one is available only in Spring Boot applications, where it's set as `vaadin.launch-browser` -- in [filename]`application.properties`, for example. A new tab isn't opened on every restart: after a tab has been opened, Vaadin waits for the period defined by `launch-browser-delay` before opening another one. To open a tab on the next start, clean the project (e.g., `mvn clean` or `gradle clean`), or delete the [filename]`tab.launch` file in the build directory. See <<{articles}/flow/integrations/spring/configuration#launch-browser-in-development-mode, Launch Browser in Development Mode>> for more information. +
-Default: `false` +
-Mode: Development
-
-`**launch-browser-delay**`::
-Defines how long to wait before opening a new browser tab for the starting application. The time is counted always from the latest application start that would try to open a tab. It has an effect only when browser launching is enabled with the Spring Boot `vaadin.launch-browser` property. Set to `0` to open a tab on every start. +
-Default: 30 min +
-Mode: Development
-
 `**maxMessageSuspendTimeout**`::
 Sets the maximum time in `milliseconds` that the client waits for predecessors of an out-of-sequence message, before considering them missing and requesting a full state resynchronization from the server. For example, when a server sends adjacent `XmlHttpRequest` responses and pushes messages over a low-bandwidth connection, the client may receive the messages out of sequence. Increase this value if your application experiences excessive resynchronization requests. However, be aware that it degrades the UX with flickering and loss of client-side-only states, such as scroll position. +
 Default: 5000 ms (i.e., 5 seconds) +

--- a/articles/flow/configuration/properties.adoc
+++ b/articles/flow/configuration/properties.adoc
@@ -238,12 +238,12 @@ Default: `null` +
 Mode: Runtime
 
 `**launch-browser**`::
-Opens the application in the default browser when the application is started in development mode. A new tab isn't opened on every restart: after a tab has been opened, Vaadin waits for the period defined by `launch-browser-delay` before opening another one. To open a tab on the next start, clean the project (e.g., `mvn clean` or `gradle clean`), or delete the [filename]`tab.launch` file in the build directory. See <<{articles}/flow/integrations/spring/configuration#launch-browser-in-development-mode, Launch Browser in Development Mode>> for Spring-specific instructions. +
+Opens the application in the default browser when the application is started in development mode. Unlike the other properties in this list, this one is available only in Spring Boot applications, where it's set as `vaadin.launch-browser` -- in [filename]`application.properties`, for example. A new tab isn't opened on every restart: after a tab has been opened, Vaadin waits for the period defined by `launch-browser-delay` before opening another one. To open a tab on the next start, clean the project (e.g., `mvn clean` or `gradle clean`), or delete the [filename]`tab.launch` file in the build directory. See <<{articles}/flow/integrations/spring/configuration#launch-browser-in-development-mode, Launch Browser in Development Mode>> for more information. +
 Default: `false` +
 Mode: Development
 
 `**launch-browser-delay**`::
-Defines how long to wait before opening a new browser tab for the starting application, when `launch-browser` is enabled. The time is counted always from the latest application start that would try to open a tab. Set to `0` to open a tab on every start. +
+Defines how long to wait before opening a new browser tab for the starting application. The time is counted always from the latest application start that would try to open a tab. It has an effect only when browser launching is enabled with the Spring Boot `vaadin.launch-browser` property. Set to `0` to open a tab on every start. +
 Default: 30 min +
 Mode: Development
 

--- a/articles/flow/integrations/spring/configuration.adoc
+++ b/articles/flow/integrations/spring/configuration.adoc
@@ -70,7 +70,7 @@ This configuration only applies when the Vaadin servlet is mapped to the root ma
 
 === Launch Browser in Development Mode
 
-You can configure a Spring Boot project to launch the default browser when starting the application in development mode by setting the following property:
+You can configure a Spring Boot project to launch the default browser when starting the application in development mode by setting the `vaadin.launch-browser` property to `true`:
 
 .application.properties
 [source,properties]
@@ -99,7 +99,7 @@ During development of a project, Vaadin caches automatically some initialization
 
 Automatic caching won't occur if your application is running in production mode. Plus, it requires that Spring Boot Development Tools be enabled.
 
-Some project resources and classes always need to be scanned, though, and cannot rely on caching. Also, caching can produce unexpected errors after reloads. For these reasons, you may want to disable caching. This can be done using the following property:
+Some project resources and classes always need to be scanned, though, and cannot rely on caching. Also, caching can produce unexpected errors after reloads. For these reasons, you may want to disable caching. This can be done using the `vaadin.devmode-caching` property:
 
 .application.properties
 [source,properties]
@@ -156,7 +156,7 @@ public class OverriddenServletConfiguration {
 
 == Spring Boot Properties
 
-You can set properties for Spring Boot in your [filename]`application.properties` file. An example of this would be setting Spring URL mapping in [filename]`application.properties`:
+You can set properties for Spring Boot in your [filename]`application.properties` file. An example of this would be setting the Vaadin URL mapping with the `vaadin.url-mapping` property:
 
 [source,properties]
 ----


### PR DESCRIPTION
Fixes #5944

`vaadin.launch-browser` is documented, under [Launch Browser in Development Mode](https://vaadin.com/docs/latest/flow/integrations/spring/configuration#launch-browser-in-development-mode) — but it was impossible to find, because the exact name appeared on that page **only inside an `application.properties` code block**. The only occurrences in the page text were the `-delay` variant, so searching for `launch-browser` matched `launch-browser-delay` and never surfaced the property itself.

## Changes

**`articles/flow/integrations/spring/configuration.adoc`** — name the property in the sentence that introduces the code block, which is what the page already does for `vaadin.allowed-packages`, `vaadin.blocked-packages`, and `vaadin.exclude-urls`:

> …by setting the `vaadin.launch-browser` property to `true`:

Two other properties on the same page had the same omission, so they're fixed the same way: `vaadin.devmode-caching` and `vaadin.url-mapping`.

**`articles/flow/configuration/properties.adoc`** — remove the `launch-browser-delay` entry. That page documents properties "set through the system properties, or with the servlet initialization parameters", and its list is scoped to those defined in `DeploymentConfiguration`, `Constants`, and `InitParameters`. Browser launching doesn't work by either means:

- `launch-browser` is not an init parameter at all — it's a field on the Spring `VaadinConfigurationProperties` bean, i.e. the Spring Boot `vaadin.launch-browser` property (default `false`).
- The only code that launches a browser is `DevModeBrowserLauncher` in `vaadin-spring`, a `SpringApplicationRunListener` that calls `DevModeHandlerManager.launchBrowserInDevelopmentMode(url)` from `ready()`, guarded by `properties.isLaunchBrowser()`. It's the sole caller in the codebase.
- `launch-browser-delay` *is* an `InitParameters` constant read via `ApplicationConfiguration`, but since only that Spring listener ever triggers a launch, it has no effect outside a Spring Boot application — and it's meaningless without `launch-browser`.

So the delay entry was both inapplicable on that page and the reason searches for `launch-browser` landed there instead of on the page that actually explains the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9V2HYdj4htGjdh3qW7ZXC