### PR TITLE
docs: align AI docs with the current AI components module

### DIFF
--- a/articles/building-apps/ai/quickstart-guide.adoc
+++ b/articles/building-apps/ai/quickstart-guide.adoc
@@ -48,7 +48,7 @@ Add the Spring AI BOM and the OpenAI starter to import the necessary dependencie
     <dependency>
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-bom</artifactId>
-      <version>2.0.0-RC2</version><!-- use the latest stable -->
+      <version>2.0.1</version><!-- use the latest stable -->
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/articles/flow/ai-support/ai-powered-chart.adoc
+++ b/articles/flow/ai-support/ai-powered-chart.adoc
@@ -46,7 +46,7 @@ Example prompts:
 
 .Built-In Workflow Instructions
 [TIP]
-The controller already informs the LLM of the workflow it needs. You can focus your own system prompt on application-specific behavior.
+The controller already informs the LLM of the workflow it needs. You can focus your own system prompt on application-specific behavior. Where the system prompt conflicts with a workflow step, the system prompt takes precedence.
 
 .Provider Compatibility
 [NOTE]

--- a/articles/flow/ai-support/ai-powered-form.adoc
+++ b/articles/flow/ai-support/ai-powered-form.adoc
@@ -10,7 +10,7 @@ section-nav: commercial
 = [since:com.vaadin:vaadin@V25.2]#AI Form Filler#
 
 
-[classname]`FormAIController` populates the fields of a <<{articles}/components/form-layout#,[classname]`FormLayout`>> (Vaadin's responsive multi-column form container) or any other layout, using values an LLM extracts from a user prompt or attached files. The controller traverses the layout, discovers every field, and allows the LLM to read the current values, query the available values for selection components like Combo Box or Radio Button Group, and write new values back. Each write is validated through the [classname]`Binder`, or through the component's built-in validators if [classname]`Binder` is not used. Rejected values are reported back so the model can correct them on the next turn.
+[classname]`FormAIController` populates the fields of a <<{articles}/components/form-layout#,[classname]`FormLayout`>> (Vaadin's responsive multi-column form container) or any other layout, using values an LLM extracts from a user prompt or attached files. The controller traverses the layout, discovers every field, and allows the LLM to read the current values, query the available values for selection components like Combo Box or Radio Button Group, and write new values back. Each write is validated through the [classname]`Binder`, or through the component's built-in validators if [classname]`Binder` is not used. Rejected values are reported back so the model can correct them in the same turn.
 
 The controller works with any combination of standard Vaadin field components, such as [classname]`TextField`, [classname]`ComboBox`, [classname]`DatePicker`, [classname]`MultiSelectComboBox`, and [classname]`CheckboxGroup`. No extra wiring is needed beyond constructing the controller around the layout and attaching it to the orchestrator.
 
@@ -51,7 +51,7 @@ Example prompts:
 
 .Built-In Workflow Instructions
 [TIP]
-The controller already informs the LLM of the workflow it needs. You can focus your own system prompt on application-specific behavior, such as tone, naming conventions, or which fields the user may leave blank.
+The controller already informs the LLM of the workflow it needs. You can focus your own system prompt on application-specific behavior, such as tone, naming conventions, or which fields the user may leave blank. Where the system prompt conflicts with a workflow step, the system prompt takes precedence.
 
 
 == Field Discovery
@@ -73,7 +73,7 @@ Ignored fields are hidden from the LLM and stay editable while a fill is in prog
 The controller checks each field's state on every turn:
 
 * A field hidden via [methodname]`setVisible(false)`, or one that sits inside a hidden container, is dropped from the LLM surface entirely. The model cannot read its value and cannot write to it. It reappears the moment a value-change listener or other application code makes it visible again.
-* A field the application has disabled ([methodname]`setEnabled(false)`) or set read-only ([methodname]`setReadOnly(true)`) stays in the form state as read-only context. The model sees its current value -- useful as context for writes to other fields -- but any write is rejected, and the model receives the rejection reason so it can adjust on the next turn.
+* A field the application has disabled ([methodname]`setEnabled(false)`) or set read-only ([methodname]`setReadOnly(true)`) stays in the form state as read-only context. The model sees its current value -- useful as context for writes to other fields -- but any write is rejected, and the model receives the rejection reason so it can adjust in the same turn.
 
 A common case is a conditional field driven by a [interfacename]`ValueChangeListener` -- a "Cost center" enabled only when "Trip type" is set to "Business", or a renewal date enabled by a "Renews automatically" checkbox. The built-in workflow instructions tell the model that a disabled or read-only field is usually waiting on a controlling field, so it sets the controlling field first and writes the dependent one in the same turn.
 
@@ -156,7 +156,7 @@ controller.fieldValueOptions(
                         projectService.search(filter, limit)));
 ----
 
-The callback returns domain items; the controller derives the labels through the field's [methodname]`setItemLabelGenerator()` before showing them to the LLM. If the LLM picks a label and the matching item is no longer available (for example, because the application's data has changed since the search), the write is rejected and the model can try again on the next turn.
+The callback returns domain items; the controller derives the labels through the field's [methodname]`setItemLabelGenerator()` before showing them to the LLM. If the LLM picks a label and the matching item is no longer available (for example, because the application's data has changed since the search), the write is rejected and the model can try again in the same turn.
 
 `projectService` here is a stand-in for whatever your application uses to look up projects: a Spring repository, a REST client, an in-memory list. The controller only needs the callback to return the matching items for the given filter and limit.
 
@@ -260,6 +260,7 @@ While a fill is in progress, every field the AI can write -- visible, enabled, a
 
 
 [[marking-ai-changes]]
+[role="since:com.vaadin:vaadin@V25.3"]
 == Marking AI Changes
 
 When an AI fill changes several fields at once, users benefit from a visual cue that flags which fields the AI wrote. The controller handles this automatically: when a turn ends, every field whose value changed is marked with an "AI" badge. Selecting the badge opens a popover that explains the value was filled by AI and offers a revert control, which restores the field's value from before the AI's first change to it.

--- a/articles/flow/ai-support/ai-powered-grid.adoc
+++ b/articles/flow/ai-support/ai-powered-grid.adoc
@@ -46,14 +46,14 @@ A message list is not required -- the grid itself is the output surface. Example
 
 .Built-In Workflow Instructions
 [TIP]
-The controller already informs the LLM of the workflow it needs. You can focus your own system prompt on application-specific behavior.
+The controller already informs the LLM of the workflow it needs. You can focus your own system prompt on application-specific behavior. Where the system prompt conflicts with a workflow step, the system prompt takes precedence.
 
 
 == Query Validation
 
 Before queueing an update, the controller runs a lightweight probe against the database to validate the LLM's query. If the probe fails, the query is rejected and never reaches the grid.
 
-The LLM can [since:com.vaadin:vaadin@V25.3]#learn why the query failed#, but only if your [classname]`DatabaseProvider` implementation opts in by throwing a [classname]`ToolException` from [methodname]`executeQuery()` -- its message is relayed to the LLM so it can correct the query on the next turn. Any other exception is logged and replaced with a generic error message. See <<controllers#tool-error-handling,Tool Error Handling>>.
+The LLM can [since:com.vaadin:vaadin@V25.3]#learn why the query failed#, but only if your [classname]`DatabaseProvider` implementation opts in by throwing a [classname]`ToolException` from [methodname]`executeQuery()` -- its message is relayed to the LLM so it can correct the query on its next attempt. Any other exception is logged and replaced with a generic error message. See <<controllers#tool-error-handling,Tool Error Handling>>.
 
 
 == Persisting Grid State

--- a/articles/flow/ai-support/file-attachments.adoc
+++ b/articles/flow/ai-support/file-attachments.adoc
@@ -65,6 +65,7 @@ var orchestrator = AIOrchestrator
 [methodname]`saveAttachments` and [methodname]`showAttachment` are placeholders for application code. The former persists the [classname]`AIAttachment` data, while the latter loads it back and displays it.
 
 
+[role="since:com.vaadin:vaadin@V25.2"]
 == Programmatic Attachments
 
 Use [methodname]`prompt(message, attachments)` to send a prompt and attachments from application code -- a file the user dropped on the form, a PDF the application generated, or content fetched from a service. No chat UI is needed.


### PR DESCRIPTION
## Summary
- The form filler returns rejections in the `fill_form` tool result, so the model corrects them within the same turn, not on the next one as the Grid and Form pages claimed.
- The built-in controllers now let the system prompt take precedence over conflicting workflow steps, which the Grid, Chart, and Form workflow tips did not mention.
- The automatic field marker and programmatic attachments lacked since badges, and the quick start pinned a Spring AI BOM release candidate instead of the version the module is built against.