### PR TITLE
docs: add Accessibility section to Dialog

### DIFF
--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -437,7 +437,7 @@ endif::[]
 --
 
 [NOTE]
-The focus trap setting ([methodname]`setFocusTrap` in Flow, `no-focus-trap` in the web component) is deprecated. Use the autofocus setting for non-modal dialogs instead. Modal dialogs always receive and trap focus.
+The focus trap setting ([methodname]`setFocusTrap` in Flow, `no-focus-trap` in the web component) is deprecated. Use the autofocus setting for non-modal dialogs instead.
 
 === ARIA Role and Accessible Name
 

--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -392,6 +392,89 @@ endif::[]
 --
 
 
+== Accessibility
+
+=== Focus
+
+When a modal dialog opens, keyboard focus moves into it automatically and stays inside: kbd:[Tab] and kbd:[Shift+Tab] cycle through the dialog's content until it's closed. When the dialog closes, focus returns to the element that had it before the dialog opened.
+
+Non-modal dialogs also receive focus when opened, but [since:com.vaadin:vaadin@V25.3]#they don't trap it#. Pressing kbd:[Tab] at the end of the dialog's content moves focus out of the dialog and on through the rest of the page, so the user can keep working with the content below.
+
+[role="since:com.vaadin:vaadin@V25.3"]
+==== Disabling Autofocus
+
+For non-modal dialogs, the automatic focus move can be disabled so that focus stays where it was when the dialog opened. This is useful for auxiliary dialogs, such as a notes panel or a tool palette, that shouldn't interrupt the user's current task.
+
+This setting only applies to non-modal dialogs. Modal dialogs always receive focus when opened.
+
+[.example]
+--
+ifdef::lit[]
+[source,html]
+----
+<source-info group="Lit"></source-info>
+<vaadin-dialog modeless no-autofocus>...</vaadin-dialog>
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+<source-info group="Flow"></source-info>
+Dialog dialog = new Dialog();
+dialog.setModality(ModalityMode.MODELESS);
+dialog.setAutofocus(false);
+----
+endif::[]
+
+ifdef::react[]
+[source,html]
+----
+<source-info group="React"></source-info>
+<Dialog modeless noAutofocus>...</Dialog>
+----
+endif::[]
+--
+
+[NOTE]
+The focus trap setting ([methodname]`setFocusTrap` in Flow, `no-focus-trap` in the web component) is deprecated. Use the autofocus setting for non-modal dialogs instead. Modal dialogs always receive and trap focus.
+
+=== ARIA Role and Accessible Name
+
+The dialog has the ARIA role `dialog` by default, and modal dialogs are marked with `aria-modal`. The role can be changed, for example to `alertdialog` for dialogs that interrupt the user with an error or a warning.
+
+The header title is used as the dialog's accessible name. A dialog whose title is rendered with a custom element in the header (see <<header,Header>>) doesn't get an accessible name automatically. In that case, set `aria-label` or `aria-labelledby` on the dialog element.
+
+[.example]
+--
+ifdef::lit[]
+[source,html]
+----
+<source-info group="Lit"></source-info>
+<vaadin-dialog role="alertdialog" header-title="Unsaved changes">...</vaadin-dialog>
+----
+endif::[]
+
+ifdef::flow[]
+[source,java]
+----
+<source-info group="Flow"></source-info>
+Dialog dialog = new Dialog();
+dialog.setAriaRole("alertdialog");
+dialog.setHeaderTitle("Unsaved changes");
+----
+endif::[]
+
+ifdef::react[]
+[source,html]
+----
+<source-info group="React"></source-info>
+<Dialog role="alertdialog" headerTitle="Unsaved changes">...</Dialog>
+----
+endif::[]
+--
+
+
 == Best Practices
 
 === Use Sparingly

--- a/articles/components/dialog/index.adoc
+++ b/articles/components/dialog/index.adoc
@@ -441,7 +441,7 @@ The focus trap setting ([methodname]`setFocusTrap` in Flow, `no-focus-trap` in t
 
 === ARIA Role and Accessible Name
 
-The dialog has the ARIA role `dialog` by default, and modal dialogs are marked with `aria-modal`. The role can be changed, for example to `alertdialog` for dialogs that interrupt the user with an error or a warning.
+The dialog has the ARIA role `dialog` by default, and modal dialogs are marked with `aria-modal`. The role can be changed, for example to `alertdialog` for dialogs that interrupt a user's workflow to communicate an important message and require a response.
 
 The header title is used as the dialog's accessible name. A dialog whose title is rendered with a custom element in the header (see <<header,Header>>) doesn't get an accessible name automatically. In that case, set `aria-label` or `aria-labelledby` on the dialog element.
 


### PR DESCRIPTION
Adds an Accessibility section to the Dialog component page.

- Focus behavior: modal dialogs receive and trap focus, non-modal dialogs receive focus but don't trap it, focus is restored on close
- New `setAutofocus` / `no-autofocus` / `noAutofocus` setting for non-modal dialogs, with a since badge
- Deprecation note for the focus trap setting
- ARIA role and accessible name: default `dialog` role, `aria-modal`, `setAriaRole`, header title as accessible name

Inline snippets only, no new demo files.

Covers:
- https://github.com/vaadin/web-components/pull/12237
- https://github.com/vaadin/flow-components/pull/9799

🤖 Generated with [Claude Code](https://claude.com/claude-code)