### PR TITLE
docs: SwingBridge config updates and rendering details page (#5972) (CP: v25.2)

### DIFF
--- a/articles/_vaadin-version.adoc
+++ b/articles/_vaadin-version.adoc
@@ -5,4 +5,4 @@
 :vaadin-seven-version: 7.7.49
 :vaadin-eight-version: 8.28.4
 :spring-boot-version: 4.1.1
-:swing-bridge-version: 1.2.0
+:swing-bridge-version: 1.3.0

--- a/articles/tools/modernization-toolkit/swing-bridge/adding-your-app.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/adding-your-app.adoc
@@ -80,7 +80,7 @@ Place a file named `swing-app-jar-list.conf` at the classpath root (`src/main/re
 # My Swing application's classpath (order matters)
 ${maven.multiModuleProjectDirectory}/my-app/target/my-app.jar
 ${maven.multiModuleProjectDirectory}/libs/legacy-utils.jar
-/opt/shared-libs/customer-shared.jar
+/opt/shared-libs/shared-domain.jar
 ----
 
 Path resolution rules:

--- a/articles/tools/modernization-toolkit/swing-bridge/configuration.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/configuration.adoc
@@ -2,7 +2,7 @@
 title: Configuration
 page-title: Configure SwingBridge | Vaadin Tools
 description: System properties and runtime knobs for tuning SwingBridge.
-meta-description: Reference for the system properties that control SwingBridge frame rate, JAR loading, and the launch-failure error view.
+meta-description: Reference for the system properties that control SwingBridge rendering, input, memory, logging, JAR loading, and the launch-failure error view.
 order: 4
 ---
 
@@ -16,6 +16,11 @@ This page lists the runtime knobs SwingBridge reads from JVM system properties, 
 
 [[swing-bridge.configuration.system-properties]]
 == System Properties Reference
+
+Every parameter below is a JVM system property. None of them is required except `java.awt.headless`; the defaults are chosen so that a deployment can leave all of them unset.
+
+[[swing-bridge.configuration.system-properties.core]]
+=== Core
 
 [cols="3,1,5", options="header"]
 |===
@@ -37,17 +42,77 @@ This page lists the runtime knobs SwingBridge reads from JVM system properties, 
 |—
 |*NetBeans RCP only.* Absolute path to a pre-built NetBeans Platform distribution directory; the highest-priority discovery source for `NetBeansRcpBridge`. See <<netbeans-rcp/configuration#swing-bridge.netbeans-rcp.configuration.discovery, NetBeans RCP → Cluster Discovery>>.
 
-|`swingbridge.frameUpdateInterval`
-|`100` (milliseconds, minimum `71`)
-|How often SwingBridge polls each Swing window for changes and pushes the dirty regions to the browser. Lower values feel more responsive at the cost of CPU; higher values save CPU at the cost of perceived latency.
-
 |`swingbridge.errorReporting.enabled`
 |`true`
 |When set to `false`, the launch-failure error view shows only the failure header — the exception type, message, and stack trace are suppressed and the report-submission form is hidden. See <<#swing-bridge.configuration.error-reporting, Launch Failure Error View>> below.
+|===
+
+[[swing-bridge.configuration.system-properties.display]]
+=== Display and Rendering
+
+These decide what the Swing application is told about the screen and how each window's back buffer is allocated. See <<rendering#swing-bridge.rendering, Display and Rendering>> for the accepted values and what they do.
+
+[cols="3,1,5", options="header"]
+|===
+|Property |Default |Description
+
+|`swingbridge.screenSize`
+|`per-user`
+|The screen size reported to the Swing application: derived from each session's own browser, or a fixed `<width>x<height>`.
+
+|`swingbridge.hidpi`
+|`off`
+|Renders the back buffer at the browser's device pixel ratio, for crisp text on Retina and 4K displays. `auto`, or a fixed decimal scale.
+
+|`swingbridge.hidpiMaxScale`
+|`2.0`
+|Upper bound on the HiDPI multiplier, between `1.0` and `4.0`.
+
+|`swingbridge.hidpiMaxBufferPixels`
+|`8000000`
+|Upper bound on a single window's back buffer, in device pixels.
+
+|`swingbridge.backBufferType`
+|`adaptive`
+|Pixel format of each window's back buffer: `adaptive`, `argb`, or `565`.
+|===
+
+[[swing-bridge.configuration.system-properties.input]]
+=== Input
+
+[cols="3,1,5", options="header"]
+|===
+|Property |Default |Description
+
+|`swingbridge.autoFocusOnAttach`
+|`true`
+|The canvas adopts browser focus when it appears, so keystrokes reach the Swing application without the user clicking it first. It only takes focus when nobody else is using it — an unfocused page, another surface of the same bridge, or the navigation control that brought the user to the view; fields and buttons keep their focus, and popup, combo-popup and tooltip canvases never adopt focus at all. Set to `false` to disable it. An unparseable value falls back to enabled.
+
+|`swingbridge.wheel.pixelsPerLine`
+|`40`
+|How many pixels of browser wheel delta count as one Swing line-scroll step, for browsers that report pixel deltas. The fractional remainder is carried per window so high-resolution wheels and trackpads scroll smoothly. A blank, non-numeric or non-positive value falls back to the default. Read once at startup.
+
+|`swingbridge.frameUpdateInterval`
+|`100` (milliseconds, minimum `71`)
+|How often SwingBridge polls each Swing window for changes and pushes the dirty regions to the browser. Lower values feel more responsive at the cost of CPU; higher values save CPU at the cost of perceived latency.
+|===
+
+[[swing-bridge.configuration.system-properties.logging]]
+=== Logging
+
+See <<logging#swing-bridge.logging, Logging & Identifying Logs per User>> for the full picture, including the pattern-layout tokens.
+
+[cols="3,1,5", options="header"]
+|===
+|Property |Default |Description
 
 |`swingbridge.consoleLogPrefix`
 |`false`
-|When set to `true`, every console line written by an embedded Swing application is prefixed with that instance's run ID (`[swing:<runId>]`), so concurrent users' output can be told apart in the server console. See <<logging#swing-bridge.logging, Logging & Identifying Logs per User>>.
+|When set to `true`, every console line written by an embedded Swing application is prefixed with that instance's run ID (`[swing:<runId>]`), so concurrent users' output can be told apart in the server console.
+
+|`swingbridge.consoleLogMirrorFile`
+|—
+|Path to a file that receives a copy of the prefixed console output, for when the server console itself is not retained.
 
 |`swingbridge.includeUserInLogs`
 |`false`
@@ -64,6 +129,35 @@ For Spring Boot, set system properties through `<systemPropertyVariables>` on th
 ----
 java -Dswingbridge.errorReporting.enabled=false -jar my-app.jar
 ----
+
+
+[[swing-bridge.configuration.jvm-tuning]]
+== JVM Tuning for Multiple Sessions
+
+SwingBridge runs every browser session's Swing application inside one JVM, so the host's garbage-collector settings decide how much memory a given number of concurrent sessions needs. The library cannot set these for you — they belong to the host application's launch configuration, alongside the flags in <<installation-from-scratch#swing-bridge.installation-from-scratch.jvm-flags, JVM Flags Reference>>.
+
+The defaults are fine for a handful of sessions. The settings below matter when packing many sessions into one host.
+
+[cols="3,5", options="header"]
+|===
+|Flag |Why
+
+|`-XX:+UseStringDeduplication`
+|Concurrent sessions of the same application load the same strings repeatedly. G1's string deduplication is close to free here and reduces the live set.
+
+|`-XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20`
+|G1 as configured by default does not return a drained session's heap to the operating system: committed heap grows and stays pinned, and an explicit `System.gc()` does not shrink it. These two ratios make G1 uncommit aggressively, which gives the tightest resident footprint of the collectors measured. The cost is more frequent collections; pauses stayed in the single-digit milliseconds, well inside one frame interval. Use `10`/`30` for a gentler throughput trade-off.
+
+|`-XX:+UseShenandoahGC`
+|An alternative when sessions are bursty and memory should come back promptly as they end: sub-millisecond pause times and prompt uncommit. Because it collects concurrently it needs allocation headroom, so budget close to `-Xmx` for the peak rather than the idle figure.
+|===
+
+[CAUTION]
+====
+ZGC is a poor fit for this workload. It has the highest peak footprint of the collectors measured and a large fixed metadata overhead, so its idle resident size lands *above* untuned G1 despite returning the most memory in absolute terms. It is a large-heap collector, and a host running many small Swing sessions is not that regime.
+====
+
+Which of these pays off depends on the Swing application and on how many sessions a host carries, so measure against your own application before adopting one as a default.
 
 
 [[swing-bridge.configuration.error-reporting]]

--- a/articles/tools/modernization-toolkit/swing-bridge/faq.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/faq.adoc
@@ -3,11 +3,16 @@ title: Frequently Asked Questions
 page-title: Frequently Asked Questions for SwingBridge | Vaadin Tools
 description: Frequently Asked Questions for SwingBridge
 meta-description: Frequently Asked Questions for SwingBridge and their answers in a non technical way
-order: 9
+order: 12
 ---
 
+include::{articles}/_vaadin-version.adoc[]
+
+[[swing-bridge.faq]]
+= Frequently Asked Questions
+
 [.collapsible-list]
-== Frequently Asked Questions
+== Questions
 
 .What is SwingBridge?
 [%collapsible]

--- a/articles/tools/modernization-toolkit/swing-bridge/index.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/index.adoc
@@ -12,6 +12,9 @@ include::{articles}/_vaadin-version.adoc[]
 
 pass:[<!-- vale Vaadin.ProductName = NO -->]
 
+:commercial-feature: SwingBridge
+include::{articles}/_commercial-banner.adoc[opts=optional]
+
 Your existing Swing application runs in a web browser without requiring you to rewrite any of your Swing code. Users interact with it through their browser while the actual Swing application runs on the server.
 
 

--- a/articles/tools/modernization-toolkit/swing-bridge/installation-from-scratch.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/installation-from-scratch.adoc
@@ -226,6 +226,7 @@ To launch the application through Maven CLI, add the following build plugin to y
           --add-opens=java.desktop/java.awt.event=ALL-UNNAMED
           --add-opens=java.desktop/sun.awt=ALL-UNNAMED
           --add-opens=java.desktop/java.awt.dnd=ALL-UNNAMED
+          --add-opens=java.base/java.lang=ALL-UNNAMED
           -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         </jvmArguments>
 
@@ -328,8 +329,9 @@ The runtime `<jvmArguments>` block above bundles three categories of flags. The 
 
 |`--add-opens=java.desktop/java.awt.event=ALL-UNNAMED` +
 `--add-opens=java.desktop/sun.awt=ALL-UNNAMED` +
-`--add-opens=java.desktop/java.awt.dnd=ALL-UNNAMED`
-|Reflective access. SwingBridge reads/writes a small number of private fields (focus state, drag flag, event queue) to plumb its multi-tenant model.
+`--add-opens=java.desktop/java.awt.dnd=ALL-UNNAMED` +
+`--add-opens=java.base/java.lang=ALL-UNNAMED`
+|Reflective access. SwingBridge reads/writes a small number of private fields (focus state, drag flag, event queue) to plumb its per-session model.
 |===
 
 The dev-time list in `.mvn/jvm.config` is the same minus `--patch-module` and `-Xbootclasspath/a` — those only apply at runtime.

--- a/articles/tools/modernization-toolkit/swing-bridge/interop/calling-swing-methods.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/interop/calling-swing-methods.adoc
@@ -190,7 +190,7 @@ The bridge resolves to whichever instance of `MainWindow` is currently visible i
 [[swing-bridge.interop.calling-swing-methods.discovery.instance-provider]]
 === `SINGLETON` — `@InstanceProvider` for Long-Lived Panels
 
-For a panel held in a customer-side registry — a common pattern in Swing applications that route between "editors" — declare a static factory and annotate it with `@InstanceProvider`:
+For a panel held in an application-side registry — a common pattern in Swing applications that route between "editors" — declare a static factory and annotate it with `@InstanceProvider`:
 
 [source,java]
 ----

--- a/articles/tools/modernization-toolkit/swing-bridge/interop/index.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/interop/index.adoc
@@ -3,7 +3,7 @@ title: Interoperability
 page-title: SwingBridge Interoperability | Vaadin Tools
 description: Type-safe API and tooling to call between Vaadin and an embedded Swing application.
 meta-description: Type-safe interoperability between Vaadin and an embedded Swing application — call Swing methods, react to Swing events, and share domain types.
-order: 4
+order: 7
 ---
 
 include::{articles}/_vaadin-version.adoc[]
@@ -114,7 +114,7 @@ The annotations live in a single JAR with these coordinates:
 
 The JAR carries only the `@ExposedMethod`, `@VaadinCallback`, and `@InstanceProvider` annotations, plus the `Invocation`, `Dispatch`, and `Discovery` enums. It has no transitive dependencies and no runtime cost — it is *compile-only* on the Swing side. The Swing application does not need it on its runtime classpath; the embedded launch on the Vaadin side supplies the runtime classes.
 
-The JAR is published in Vaadin's public Maven repositories — `https://maven.vaadin.com/vaadin-addons` for stable releases and `https://maven.vaadin.com/vaadin-prereleases` for pre-releases. Downloads are anonymous; the SwingBridge license check happens later, at runtime on the Vaadin side, when the embedded Swing app starts. See <<../installation-from-scratch#swing-bridge.installation-from-scratch.license, License Installation>> for the license setup itself.
+The JAR is published to Maven Central, so a stable release needs no extra repository declaration. Pre-releases come from `https://maven.vaadin.com/vaadin-prereleases`. Downloads are anonymous; the SwingBridge license check happens later, at runtime on the Vaadin side, when the embedded Swing app starts. See <<../installation-from-scratch#swing-bridge.installation-from-scratch.license, License Installation>> for the license setup itself.
 
 Pick the approach that matches your Swing project's build:
 
@@ -123,14 +123,6 @@ Pick the approach that matches your Swing project's build:
 
 [source,xml,subs="+attributes"]
 ----
-<repositories>
-    <repository>
-        <id>vaadin-addons</id>
-        <url>https://maven.vaadin.com/vaadin-addons</url>
-    </repository>
-    <!-- ... existing repositories ... -->
-</repositories>
-
 <dependencies>
     <dependency>
         <groupId>com.vaadin</groupId>
@@ -149,7 +141,7 @@ Pick the approach that matches your Swing project's build:
 [source,groovy,subs="+attributes"]
 ----
 repositories {
-    maven { url = uri("https://maven.vaadin.com/vaadin-addons") }
+    mavenCentral()
     // ... existing repositories ...
 }
 
@@ -167,10 +159,10 @@ Most long-running Swing codebases use Ant, IDE-managed libraries, or no formal b
 
 [source,terminal,subs="+attributes"]
 ----
-curl -O https://maven.vaadin.com/vaadin-addons/com/vaadin/swing-bridge-annotations/{swing-bridge-version}/swing-bridge-annotations-{swing-bridge-version}.jar
+curl -O https://repo1.maven.org/maven2/com/vaadin/swing-bridge-annotations/{swing-bridge-version}/swing-bridge-annotations-{swing-bridge-version}.jar
 ----
 
-For a SwingBridge pre-release, swap `vaadin-addons` for `vaadin-prereleases` in the URL. The download is anonymous — no Vaadin license check at this step.
+For a SwingBridge pre-release, take the JAR from `https://maven.vaadin.com/vaadin-prereleases` instead. The download is anonymous — no Vaadin license check at this step.
 
 Then add the JAR to the Swing project:
 
@@ -194,7 +186,7 @@ import com.vaadin.swingbridge.interop.ExposedMethod;
 [[swing-bridge.interop.status]]
 == What's Shipped Today
 
-The interop runtime, the `generate-bridge` Maven goal, and the by-reference domain-types strategy are production-ready. Two further codegen goals exist as in-progress skeletons and are not recommended for production use yet:
+The interop runtime, the `generate-bridge` Maven goal, and the by-reference domain-types strategy are production-ready. Three further codegen goals exist as in-progress skeletons and are not recommended for production use yet:
 
 [cols="3,1,4", options="header"]
 |===
@@ -219,6 +211,10 @@ The interop runtime, the `generate-bridge` Maven goal, and the by-reference doma
 | Shared domain types by reference (Type 3+)
 | Shipped
 | Add the domain JAR as a Maven `<dependency>` of the Vaadin app. Same `Class<?>` on both sides; no conversion.
+
+| `extract-shared-types` Maven goal
+| Roadmap
+| Extracts the domain classes referenced by `@ExposedMethod` signatures out of a fat Swing JAR into a thin domain JAR — the input to the by-reference strategy above. Present in the plugin but not yet covered by tests; building the domain JAR with your own build is the supported path for now.
 
 | `strip-annotations` Maven goal (Type 1)
 | Roadmap

--- a/articles/tools/modernization-toolkit/swing-bridge/logging.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/logging.adoc
@@ -3,7 +3,7 @@ title: Logging pass:[&] Identifying Logs per User
 page-title: Identify logs per user in SwingBridge | Vaadin Tools
 description: Attribute server log output to the Swing application user who produced it, and integrate old and new logging frameworks.
 meta-description: Tag SwingBridge log output per user session, publish the logged-in user from Swing or Vaadin, and integrate Log4j, SLF4J, and Spring Boot logging.
-order: 5
+order: 6
 ---
 
 include::{articles}/_vaadin-version.adoc[]

--- a/articles/tools/modernization-toolkit/swing-bridge/netbeans-rcp/index.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/netbeans-rcp/index.adoc
@@ -3,7 +3,7 @@ title: NetBeans RCP
 page-title: Embed a NetBeans RCP App with SwingBridge | Vaadin Tools
 description: Run a pre-built NetBeans Platform application in the browser with SwingBridge, with no changes to the RCP source.
 meta-description: Embed a pre-built NetBeans Platform (RCP) application in a Vaadin view with SwingBridge — whole shell or a single TopComponent — without rewriting the RCP code.
-order: 5
+order: 8
 ---
 
 include::{articles}/_vaadin-version.adoc[]

--- a/articles/tools/modernization-toolkit/swing-bridge/reference.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/reference.adoc
@@ -3,7 +3,7 @@ title: Reference
 page-title: SwingBridge Reference | Vaadin Tools
 description: Public API summary, lifecycle hooks, and the recommended sample project.
 meta-description: Reference for the SwingBridge public Java API and lifecycle hooks, with a pointer to the SwingBridge skeleton starter project.
-order: 8
+order: 11
 ---
 
 include::{articles}/_vaadin-version.adoc[]
@@ -90,4 +90,7 @@ A custom classloader supplier is contributed via `createClassLoaderSupplier()`, 
 |===
 
 
+[[swing-bridge.reference.next-steps]]
+== Next Steps
 
+- <<configuration#swing-bridge.configuration, Configuration>> for the system properties that control this behavior at deployment level.

--- a/articles/tools/modernization-toolkit/swing-bridge/rendering.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/rendering.adoc
@@ -1,0 +1,117 @@
+---
+title: Display and Rendering
+page-title: SwingBridge Display and Rendering | Vaadin Tools
+description: The virtual screen SwingBridge reports, HiDPI rendering, and the back-buffer format.
+meta-description: Configure the virtual screen SwingBridge advertises to a Swing application, HiDPI oversampling, and the back-buffer pixel format.
+order: 5
+---
+
+include::{articles}/_vaadin-version.adoc[]
+
+[[swing-bridge.rendering]]
+= Display and Rendering
+
+A hosted Swing application still asks AWT how big the screen is and what pixel format to use, and there is no physical screen to answer with. SwingBridge answers on its behalf. Three system properties control those answers; the defaults are chosen so that no deployment has to set any of them.
+
+[cols="3,2,5", options="header"]
+|===
+|Property |Default |What it decides
+
+|`swingbridge.screenSize`
+|`per-user`
+|The screen size reported to the Swing application.
+
+|`swingbridge.hidpi`
+|`off`
+|Whether the back buffer is rendered at the browser's device pixel ratio.
+
+|`swingbridge.backBufferType`
+|`adaptive`
+|The pixel format of each window's back buffer.
+|===
+
+
+[[swing-bridge.rendering.screen-size]]
+== Virtual Screen Size
+
+`swingbridge.screenSize` decides what the Swing application is told when it reads `Toolkit.getScreenSize()`, sizes a window to the screen, or centers a dialog with `setLocationRelativeTo(null)`:
+
+- *`per-user`* (the default, also used when the property is unset) — each session sees a screen derived from that user's own browser.
+- *`<width>x<height>`* — one fixed resolution for every session, for example `1920x1080`. Each edge must be between 240 and 8192. Use `2560x1440` to reproduce the behavior of releases before per-user screens existed.
+- Anything else is logged as a warning and falls back to `2560x1440`.
+
+[source,terminal]
+----
+java -Dswingbridge.screenSize=1920x1080 -jar my-app.jar
+----
+
+Two things this property does *not* do: it never resizes or moves a window — the screen size is information the Swing application may act on — and it does not change rendering resolution.
+
+
+[[swing-bridge.rendering.hidpi]]
+== HiDPI Rendering
+
+`swingbridge.hidpi` renders the back buffer at the browser's device pixel ratio, so text is crisp on Retina and 4K displays instead of being upscaled by the browser:
+
+- *`off`* (the default) — one buffer pixel per logical pixel.
+- *`auto`* — each session follows its own browser's ratio, quantized to 0.25 steps and clamped.
+- *a decimal*, for example `2` or `1.5` — that fixed scale for every session.
+
+Two further properties bound the cost, since heap per window scales with the square of the scale:
+
+[cols="3,1,5", options="header"]
+|===
+|Property |Default |Description
+
+|`swingbridge.hidpiMaxScale`
+|`2.0`
+|Upper bound on the multiplier, between `1.0` and `4.0`.
+
+|`swingbridge.hidpiMaxBufferPixels`
+|`8000000`
+|Upper bound on a single window's back buffer in device pixels. A window over the ceiling renders at a reduced scale rather than being refused.
+|===
+
+[source,terminal]
+----
+java -Dswingbridge.hidpi=auto -jar my-app.jar
+----
+
+Oversampling is invisible to the Swing application: it keeps its logical coordinate space and a 1x default transform, so layout is identical at every scale, pointer coordinates need no translation, and `Toolkit.getScreenResolution()` stays 96. Moving the browser to a display with a different pixel ratio is detected and re-rendered at the new ratio.
+
+Images the Swing application creates itself stay at 1x and are upsampled into the oversampled buffer, so an application that blits its own off-screen image may still look soft.
+
+[[swing-bridge.rendering.hidpi.cost]]
+=== What It Costs
+
+Raising the scale multiplies the pixels in every back buffer. The costs that follow do not all grow at the same rate.
+
+*Memory is where it shows.* A window's buffer grows with the square of the scale, so doubling the scale roughly quadruples it. That is the cost to plan for when many sessions share one host. Setting `swingbridge.backBufferType=565` halves it, and 16-bit color is less noticeable at a higher scale, because the dithering has more pixels to hide in.
+
+*The network sees much less.* Frames are compressed as PNG. Large areas of flat color compress nearly as well at a high scale as at a low one, so only the edges of text carry real extra detail. And only a window's first frame is sent in full — after that SwingBridge sends just the areas that changed, and a small change stays small at any scale.
+
+*Encoding costs more CPU*, roughly in proportion to the pixels. Because the steady state is small updates, this shows when a window first appears or is resized, not while the user works.
+
+HiDPI is therefore limited by memory rather than by bandwidth. On a slow connection it is the first frame of each window that grows; everything after it costs little more than before. Leave `swingbridge.hidpiMaxScale` at its default unless you have measured your own application.
+
+
+[[swing-bridge.rendering.back-buffer]]
+== Back-Buffer Pixel Format
+
+Each bridged window keeps a back buffer sized to the window. It is the dominant per-window allocation and the source of every frame streamed to the browser. `swingbridge.backBufferType` selects its format:
+
+- *`adaptive`* (the default) — opaque windows use 24-bit `TYPE_INT_RGB`; only per-pixel-translucent windows keep 32-bit `TYPE_INT_ARGB`. Same memory as ARGB, smaller frames, and lossless.
+- *`argb`* — 32-bit `TYPE_INT_ARGB` for every window, the behavior of earlier releases.
+- *`565`* — 16-bit `TYPE_USHORT_565_RGB`, halving back-buffer memory at the cost of 16-bit color: banding on gradients and softer text anti-aliasing.
+
+[source,terminal]
+----
+java -Dswingbridge.backBufferType=565 -jar my-app.jar
+----
+
+
+[[swing-bridge.rendering.next-steps]]
+== Next Steps
+
+- <<configuration#swing-bridge.configuration, Configuration>> for every other system property.
+- <<troubleshooting#swing-bridge.troubleshooting, Troubleshooting>> if rendering looks wrong rather than merely soft.

--- a/articles/tools/modernization-toolkit/swing-bridge/running-and-debugging.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/running-and-debugging.adoc
@@ -3,7 +3,7 @@ title: Running and Debugging
 page-title: Run and Debug SwingBridge | Vaadin Tools
 description: Run SwingBridge applications from Maven and attach a remote debugger from IntelliJ IDEA or VS Code.
 meta-description: How to run a SwingBridge application from the command line and attach a remote Java debugger from IntelliJ IDEA or VS Code.
-order: 6
+order: 9
 ---
 
 include::{articles}/_vaadin-version.adoc[]

--- a/articles/tools/modernization-toolkit/swing-bridge/troubleshooting.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/troubleshooting.adoc
@@ -3,7 +3,7 @@ title: Troubleshooting
 page-title: Troubleshoot SwingBridge | Vaadin Tools
 description: Common SwingBridge launch failures and how to fix them.
 meta-description: Diagnose and resolve common SwingBridge launch failures, including missing JVM flags, missing main class, and headless toolkit errors.
-order: 7
+order: 10
 ---
 
 include::{articles}/_vaadin-version.adoc[]
@@ -44,4 +44,3 @@ or
 |`License is invalid` or trial key prompt on startup.
 |No valid Vaadin commercial license in `~/.vaadin/` (or `%userprofile%\.vaadin\`). See <<installation-from-scratch#swing-bridge.installation-from-scratch.license, License Installation>>.
 |===
-


### PR DESCRIPTION
## Description

Cherry-pick of #5972 to `v25.2`, bringing the Swing Bridge 1.3.0 configuration surface and the new Display and Rendering page to this branch.

**Merge #5981 first.** This PR is stacked on it, so its base is that branch rather than `v25.2` — GitHub retargets this to `v25.2` automatically once #5981 merges. Picking this onto `v25.2` directly fails, because it modifies `logging.adoc`, which #5981 adds.

### One conflict, resolved

`articles/_vaadin-version.adoc` conflicted because `v25.2` had bumped `:spring-boot-version:` on the line directly above `:swing-bridge-version:`, so both sides changed adjacent lines and fell into a single merge hunk. Both sides are kept: this branch's platform versions are untouched and only `:swing-bridge-version:` moves to `1.3.0`. The file's diff against `v25.2` is that one line.

### Verified

With both picks applied, `articles/tools/modernization-toolkit/swing-bridge/` is byte-identical to `main`, and `_vaadin-version.adoc` differs from `main` only in the platform versions that are meant to differ per branch. Nav order is contiguous 1–12 with no collisions, and every xref and anchor in the section resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
