### PR TITLE
docs: say that chart style properties need styled mode

### DIFF
--- a/articles/components/charts/styling/index.adoc
+++ b/articles/components/charts/styling/index.adoc
@@ -39,6 +39,7 @@ While no error is thrown if different styling methods are used in the same chart
 image::charts_theme_variants.png[]
 
 
+[[java.styling]]
 == Java Styling API in Flow
 The default styling mode in Flow applications uses the Java API.
 See the link:https://vaadin.com/api/platform/com/vaadin/flow/component/charts/model/style/package-summary.html[Java API reference] for details.
@@ -91,11 +92,14 @@ image::../img/flow-styling.png[]
 == CSS Styling
 Chart colors and fonts can be customized in any regular application stylesheet with the CSS style properties listed in <<{articles}/components/charts/styling/styling#,Style Properties>>.
 
+In Flow, CSS styling requires styled mode. See <<css.styling.mode>>.
+
 Styling individual chart elements with Highcharts CSS class names requires the styles to be injected into the chart's shadow DOM: create a [filename]`vaadin-chart.css` file in your theme's [filename]`components` folder, and place the styles there. This mechanism is disabled by default, and must be enabled with the `themeComponentStyles` <<{articles}/flow/configuration/feature-flags#,feature flag>>.
 See the link:https://www.highcharts.com/docs/chart-design-and-style/style-by-css[Highcharts styling documentation] for details on the available class names.
 
+[[css.styling.mode]]
 === CSS Styling Mode for Flow
-Flow applications can use CSS styling by enabling "styled mode" in the Chart configuration:
+To style a chart with CSS in Flow, enable "styled mode" in the Chart configuration:
 
 [source,java]
 ----
@@ -103,6 +107,10 @@ var chart = new Chart();
 var conf = chart.getConfiguration();
 conf.getChart().setStyledMode(true);
 ----
+
+Styled mode is required for all CSS styling of a chart: the style properties, CSS class names, and the rules in a [filename]`vaadin-chart.css` file.
+Without it, the chart is styled through the <<java.styling,Java API>> instead, and doesn't follow the application's theme.
+In Lit and React, styled mode is enabled by default.
 
 === CSS Styling Example
 In this example, CSS is used to change the color of point markers to yellow, their outlines to purple, data labels to red, and the series colors to shades of green.

--- a/articles/components/charts/styling/styling.adoc
+++ b/articles/components/charts/styling/styling.adoc
@@ -17,6 +17,12 @@ ifdef::flow,lit[]
 See <<{articles}/styling/styling-components#component-style-properties,Component Style Properties>> for more information on style properties.
 endif::[]
 
+.Flow Requires Styled Mode
+[IMPORTANT]
+In Flow, these properties have no effect until styled mode is enabled with `configuration.getChart().setStyledMode(true)`.
+See <<{articles}/components/charts/styling/#css.styling.mode,CSS Styling Mode for Flow>>.
+In Lit and React, styled mode is enabled by default.
+
 === Common Properties
 
 [cols="1,2,2"]


### PR DESCRIPTION
Charts ignore the application's theme in Flow until styled mode is turned on, and the styling docs never said so. Reported as vaadin/web-components#12700.

`ChartModel` defaults `styledMode` to `false`, and every themed rule in `vaadin-chart-base-styles.js` is guarded by `:where([styled-mode])`, so none of the `--vaadin-charts-*` properties do anything until it's enabled. The web component defaults it to `true`, so Lit and React users never hit this.

- **`styling/index.adoc`** — the styled-mode section now says what styled mode covers, and that without it the chart is styled through the Java API instead. Adds a forward pointer from the top of CSS Styling, plus anchors for both sections.
- **`styling/styling.adoc`** — an `IMPORTANT` admonition above the property tables, since that's where a reader meets the properties this governs.

The property tables are wrong in ways the ticket also flags (dead properties, missing ones, `--lumo-*` defaults under Aura); that's a bigger diff and lands separately. Flipping the Flow default is the product half of the ticket.

Part of vaadin/web-components#12700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
