### PR TITLE
docs: align SwingBridge docs with main (#5807, #5972) (CP: v25.1)

### DIFF
--- a/.github/styles/config/vocabularies/Docs/accept.txt
+++ b/.github/styles/config/vocabularies/Docs/accept.txt
@@ -282,3 +282,6 @@ XSS
 
 # Names of React hooks
 useForm
+appenders?
+Splunk
+[Ii]nterop

--- a/articles/_vaadin-version.adoc
+++ b/articles/_vaadin-version.adoc
@@ -5,4 +5,4 @@
 :vaadin-seven-version: 7.7.49
 :vaadin-eight-version: 8.28.4
 :spring-boot-version: 4.0.7
-:swing-bridge-version: 1.2.0
+:swing-bridge-version: 1.3.0

--- a/articles/tools/modernization-toolkit/swing-bridge/adding-your-app.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/adding-your-app.adoc
@@ -80,7 +80,7 @@ Place a file named `swing-app-jar-list.conf` at the classpath root (`src/main/re
 # My Swing application's classpath (order matters)
 ${maven.multiModuleProjectDirectory}/my-app/target/my-app.jar
 ${maven.multiModuleProjectDirectory}/libs/legacy-utils.jar
-/opt/shared-libs/customer-shared.jar
+/opt/shared-libs/shared-domain.jar
 ----
 
 Path resolution rules:

--- a/articles/tools/modernization-toolkit/swing-bridge/configuration.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/configuration.adoc
@@ -44,6 +44,18 @@ This page lists the runtime knobs SwingBridge reads from JVM system properties, 
 |`swingbridge.errorReporting.enabled`
 |`true`
 |When set to `false`, the launch-failure error view shows only the failure header — the exception type, message, and stack trace are suppressed and the report-submission form is hidden. See <<#swing-bridge.configuration.error-reporting, Launch Failure Error View>> below.
+
+|`swingbridge.consoleLogPrefix`
+|`false`
+|When set to `true`, every console line written by an embedded Swing application is prefixed with that instance's run ID (`[swing:<runId>]`), so concurrent users' output can be told apart in the server console. See <<logging#swing-bridge.logging, Logging & Identifying Logs per User>>.
+
+|`swingbridge.includeUserInLogs`
+|`false`
+|When set to `true`, the logged-in user's name is added to every attributed log line across all channels: the console prefix becomes `[swing:<runId>\|<user>]` and the `%swingUser` / `%X{swingUser}` pattern tokens render the name. Off by default because a user's name is personal data; without it, the name appears only in the per-instance correlation line. Requires an identity to have been published. See <<logging#swing-bridge.logging.identity.per-line, Showing the Name on Every Line>>.
+
+|`swingbridge.log.user`
+|None
+|Not set by the operator: an embedded Swing application sets this property at runtime, after its own login, to publish the authenticated user's name for log attribution. The value is routed per session, so concurrent users can't overwrite each other. See <<logging#swing-bridge.logging.identity, Adding the User's Name to the Logs>>.
 |===
 
 For Spring Boot, set system properties through `<systemPropertyVariables>` on the `spring-boot-maven-plugin` (see <<installation-from-scratch#swing-bridge.installation-from-scratch.project-setup, Project Setup>>) or pass `-D` flags on the command line. For a packaged JAR, pass them with `-D` on the command line:

--- a/articles/tools/modernization-toolkit/swing-bridge/configuration.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/configuration.adoc
@@ -2,7 +2,7 @@
 title: Configuration
 page-title: Configure SwingBridge | Vaadin Tools
 description: System properties and runtime knobs for tuning SwingBridge.
-meta-description: Reference for the system properties that control SwingBridge frame rate, JAR loading, and the launch-failure error view.
+meta-description: Reference for the system properties that control SwingBridge rendering, input, memory, logging, JAR loading, and the launch-failure error view.
 order: 4
 ---
 
@@ -16,6 +16,11 @@ This page lists the runtime knobs SwingBridge reads from JVM system properties, 
 
 [[swing-bridge.configuration.system-properties]]
 == System Properties Reference
+
+Every parameter below is a JVM system property. None of them is required except `java.awt.headless`; the defaults are chosen so that a deployment can leave all of them unset.
+
+[[swing-bridge.configuration.system-properties.core]]
+=== Core
 
 [cols="3,1,5", options="header"]
 |===
@@ -37,17 +42,77 @@ This page lists the runtime knobs SwingBridge reads from JVM system properties, 
 |—
 |*NetBeans RCP only.* Absolute path to a pre-built NetBeans Platform distribution directory; the highest-priority discovery source for `NetBeansRcpBridge`. See <<netbeans-rcp/configuration#swing-bridge.netbeans-rcp.configuration.discovery, NetBeans RCP → Cluster Discovery>>.
 
-|`swingbridge.frameUpdateInterval`
-|`100` (milliseconds, minimum `71`)
-|How often SwingBridge polls each Swing window for changes and pushes the dirty regions to the browser. Lower values feel more responsive at the cost of CPU; higher values save CPU at the cost of perceived latency.
-
 |`swingbridge.errorReporting.enabled`
 |`true`
 |When set to `false`, the launch-failure error view shows only the failure header — the exception type, message, and stack trace are suppressed and the report-submission form is hidden. See <<#swing-bridge.configuration.error-reporting, Launch Failure Error View>> below.
+|===
+
+[[swing-bridge.configuration.system-properties.display]]
+=== Display and Rendering
+
+These decide what the Swing application is told about the screen and how each window's back buffer is allocated. See <<rendering#swing-bridge.rendering, Display and Rendering>> for the accepted values and what they do.
+
+[cols="3,1,5", options="header"]
+|===
+|Property |Default |Description
+
+|`swingbridge.screenSize`
+|`per-user`
+|The screen size reported to the Swing application: derived from each session's own browser, or a fixed `<width>x<height>`.
+
+|`swingbridge.hidpi`
+|`off`
+|Renders the back buffer at the browser's device pixel ratio, for crisp text on Retina and 4K displays. `auto`, or a fixed decimal scale.
+
+|`swingbridge.hidpiMaxScale`
+|`2.0`
+|Upper bound on the HiDPI multiplier, between `1.0` and `4.0`.
+
+|`swingbridge.hidpiMaxBufferPixels`
+|`8000000`
+|Upper bound on a single window's back buffer, in device pixels.
+
+|`swingbridge.backBufferType`
+|`adaptive`
+|Pixel format of each window's back buffer: `adaptive`, `argb`, or `565`.
+|===
+
+[[swing-bridge.configuration.system-properties.input]]
+=== Input
+
+[cols="3,1,5", options="header"]
+|===
+|Property |Default |Description
+
+|`swingbridge.autoFocusOnAttach`
+|`true`
+|The canvas adopts browser focus when it appears, so keystrokes reach the Swing application without the user clicking it first. It only takes focus when nobody else is using it — an unfocused page, another surface of the same bridge, or the navigation control that brought the user to the view; fields and buttons keep their focus, and popup, combo-popup and tooltip canvases never adopt focus at all. Set to `false` to disable it. An unparseable value falls back to enabled.
+
+|`swingbridge.wheel.pixelsPerLine`
+|`40`
+|How many pixels of browser wheel delta count as one Swing line-scroll step, for browsers that report pixel deltas. The fractional remainder is carried per window so high-resolution wheels and trackpads scroll smoothly. A blank, non-numeric or non-positive value falls back to the default. Read once at startup.
+
+|`swingbridge.frameUpdateInterval`
+|`100` (milliseconds, minimum `71`)
+|How often SwingBridge polls each Swing window for changes and pushes the dirty regions to the browser. Lower values feel more responsive at the cost of CPU; higher values save CPU at the cost of perceived latency.
+|===
+
+[[swing-bridge.configuration.system-properties.logging]]
+=== Logging
+
+See <<logging#swing-bridge.logging, Logging & Identifying Logs per User>> for the full picture, including the pattern-layout tokens.
+
+[cols="3,1,5", options="header"]
+|===
+|Property |Default |Description
 
 |`swingbridge.consoleLogPrefix`
 |`false`
-|When set to `true`, every console line written by an embedded Swing application is prefixed with that instance's run ID (`[swing:<runId>]`), so concurrent users' output can be told apart in the server console. See <<logging#swing-bridge.logging, Logging & Identifying Logs per User>>.
+|When set to `true`, every console line written by an embedded Swing application is prefixed with that instance's run ID (`[swing:<runId>]`), so concurrent users' output can be told apart in the server console.
+
+|`swingbridge.consoleLogMirrorFile`
+|—
+|Path to a file that receives a copy of the prefixed console output, for when the server console itself is not retained.
 
 |`swingbridge.includeUserInLogs`
 |`false`
@@ -64,6 +129,35 @@ For Spring Boot, set system properties through `<systemPropertyVariables>` on th
 ----
 java -Dswingbridge.errorReporting.enabled=false -jar my-app.jar
 ----
+
+
+[[swing-bridge.configuration.jvm-tuning]]
+== JVM Tuning for Multiple Sessions
+
+SwingBridge runs every browser session's Swing application inside one JVM, so the host's garbage-collector settings decide how much memory a given number of concurrent sessions needs. The library cannot set these for you — they belong to the host application's launch configuration, alongside the flags in <<installation-from-scratch#swing-bridge.installation-from-scratch.jvm-flags, JVM Flags Reference>>.
+
+The defaults are fine for a handful of sessions. The settings below matter when packing many sessions into one host.
+
+[cols="3,5", options="header"]
+|===
+|Flag |Why
+
+|`-XX:+UseStringDeduplication`
+|Concurrent sessions of the same application load the same strings repeatedly. G1's string deduplication is close to free here and reduces the live set.
+
+|`-XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20`
+|G1 as configured by default does not return a drained session's heap to the operating system: committed heap grows and stays pinned, and an explicit `System.gc()` does not shrink it. These two ratios make G1 uncommit aggressively, which gives the tightest resident footprint of the collectors measured. The cost is more frequent collections; pauses stayed in the single-digit milliseconds, well inside one frame interval. Use `10`/`30` for a gentler throughput trade-off.
+
+|`-XX:+UseShenandoahGC`
+|An alternative when sessions are bursty and memory should come back promptly as they end: sub-millisecond pause times and prompt uncommit. Because it collects concurrently it needs allocation headroom, so budget close to `-Xmx` for the peak rather than the idle figure.
+|===
+
+[CAUTION]
+====
+ZGC is a poor fit for this workload. It has the highest peak footprint of the collectors measured and a large fixed metadata overhead, so its idle resident size lands *above* untuned G1 despite returning the most memory in absolute terms. It is a large-heap collector, and a host running many small Swing sessions is not that regime.
+====
+
+Which of these pays off depends on the Swing application and on how many sessions a host carries, so measure against your own application before adopting one as a default.
 
 
 [[swing-bridge.configuration.error-reporting]]

--- a/articles/tools/modernization-toolkit/swing-bridge/faq.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/faq.adoc
@@ -3,11 +3,16 @@ title: Frequently Asked Questions
 page-title: Frequently Asked Questions for SwingBridge | Vaadin Tools
 description: Frequently Asked Questions for SwingBridge
 meta-description: Frequently Asked Questions for SwingBridge and their answers in a non technical way
-order: 9
+order: 12
 ---
 
+include::{articles}/_vaadin-version.adoc[]
+
+[[swing-bridge.faq]]
+= Frequently Asked Questions
+
 [.collapsible-list]
-== Frequently Asked Questions
+== Questions
 
 .What is SwingBridge?
 [%collapsible]

--- a/articles/tools/modernization-toolkit/swing-bridge/index.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/index.adoc
@@ -12,6 +12,9 @@ include::{articles}/_vaadin-version.adoc[]
 
 pass:[<!-- vale Vaadin.ProductName = NO -->]
 
+:commercial-feature: SwingBridge
+include::{articles}/_commercial-banner.adoc[opts=optional]
+
 Your existing Swing application runs in a web browser without requiring you to rewrite any of your Swing code. Users interact with it through their browser while the actual Swing application runs on the server.
 
 

--- a/articles/tools/modernization-toolkit/swing-bridge/installation-from-scratch.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/installation-from-scratch.adoc
@@ -120,6 +120,9 @@ Add the following parent section, properties, and dependencies to your `pom.xml`
     <artifactId>swing-bridge-graphics</artifactId>
     <version>${swing-bridge.version}</version>
   </dependency>
+  <!-- The exclusion keeps Spring Boot's default Logback as the SLF4J
+       backend. See Logging & Identifying Logs per User for the trade-offs and
+       for standardizing on Log4j2 instead. -->
   <dependency>
     <groupId>com.vaadin</groupId>
     <artifactId>swing-bridge-flow</artifactId>
@@ -147,6 +150,8 @@ Add the following parent section, properties, and dependencies to your `pom.xml`
   </dependency>
 </dependencies>
 ----
+
+The `log4j-slf4j2-impl` exclusion keeps Spring Boot's default Logback as the logging backend. See <<logging#swing-bridge.logging.frameworks.slf4j, Logging & Identifying Logs per User>> for the trade-offs, and for standardizing on Log4j2 instead so that embedded Swing applications' direct Log4j calls end up in the same log files.
 
 SwingBridge requires certain JVM flags so that Maven can access internal Java modules during compilation. Create a `.mvn/jvm.config` file in the project root with the following content:
 

--- a/articles/tools/modernization-toolkit/swing-bridge/installation-from-scratch.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/installation-from-scratch.adoc
@@ -226,6 +226,7 @@ To launch the application through Maven CLI, add the following build plugin to y
           --add-opens=java.desktop/java.awt.event=ALL-UNNAMED
           --add-opens=java.desktop/sun.awt=ALL-UNNAMED
           --add-opens=java.desktop/java.awt.dnd=ALL-UNNAMED
+          --add-opens=java.base/java.lang=ALL-UNNAMED
           -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
         </jvmArguments>
 
@@ -328,8 +329,9 @@ The runtime `<jvmArguments>` block above bundles three categories of flags. The 
 
 |`--add-opens=java.desktop/java.awt.event=ALL-UNNAMED` +
 `--add-opens=java.desktop/sun.awt=ALL-UNNAMED` +
-`--add-opens=java.desktop/java.awt.dnd=ALL-UNNAMED`
-|Reflective access. SwingBridge reads/writes a small number of private fields (focus state, drag flag, event queue) to plumb its multi-tenant model.
+`--add-opens=java.desktop/java.awt.dnd=ALL-UNNAMED` +
+`--add-opens=java.base/java.lang=ALL-UNNAMED`
+|Reflective access. SwingBridge reads/writes a small number of private fields (focus state, drag flag, event queue) to plumb its per-session model.
 |===
 
 The dev-time list in `.mvn/jvm.config` is the same minus `--patch-module` and `-Xbootclasspath/a` — those only apply at runtime.

--- a/articles/tools/modernization-toolkit/swing-bridge/interop/calling-swing-methods.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/interop/calling-swing-methods.adoc
@@ -190,7 +190,7 @@ The bridge resolves to whichever instance of `MainWindow` is currently visible i
 [[swing-bridge.interop.calling-swing-methods.discovery.instance-provider]]
 === `SINGLETON` — `@InstanceProvider` for Long-Lived Panels
 
-For a panel held in a customer-side registry — a common pattern in Swing applications that route between "editors" — declare a static factory and annotate it with `@InstanceProvider`:
+For a panel held in an application-side registry — a common pattern in Swing applications that route between "editors" — declare a static factory and annotate it with `@InstanceProvider`:
 
 [source,java]
 ----

--- a/articles/tools/modernization-toolkit/swing-bridge/interop/index.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/interop/index.adoc
@@ -3,7 +3,7 @@ title: Interoperability
 page-title: SwingBridge Interoperability | Vaadin Tools
 description: Type-safe API and tooling to call between Vaadin and an embedded Swing application.
 meta-description: Type-safe interoperability between Vaadin and an embedded Swing application — call Swing methods, react to Swing events, and share domain types.
-order: 4
+order: 7
 ---
 
 include::{articles}/_vaadin-version.adoc[]
@@ -114,7 +114,7 @@ The annotations live in a single JAR with these coordinates:
 
 The JAR carries only the `@ExposedMethod`, `@VaadinCallback`, and `@InstanceProvider` annotations, plus the `Invocation`, `Dispatch`, and `Discovery` enums. It has no transitive dependencies and no runtime cost — it is *compile-only* on the Swing side. The Swing application does not need it on its runtime classpath; the embedded launch on the Vaadin side supplies the runtime classes.
 
-The JAR is published in Vaadin's public Maven repositories — `https://maven.vaadin.com/vaadin-addons` for stable releases and `https://maven.vaadin.com/vaadin-prereleases` for pre-releases. Downloads are anonymous; the SwingBridge license check happens later, at runtime on the Vaadin side, when the embedded Swing app starts. See <<../installation-from-scratch#swing-bridge.installation-from-scratch.license, License Installation>> for the license setup itself.
+The JAR is published to Maven Central, so a stable release needs no extra repository declaration. Pre-releases come from `https://maven.vaadin.com/vaadin-prereleases`. Downloads are anonymous; the SwingBridge license check happens later, at runtime on the Vaadin side, when the embedded Swing app starts. See <<../installation-from-scratch#swing-bridge.installation-from-scratch.license, License Installation>> for the license setup itself.
 
 Pick the approach that matches your Swing project's build:
 
@@ -123,14 +123,6 @@ Pick the approach that matches your Swing project's build:
 
 [source,xml,subs="+attributes"]
 ----
-<repositories>
-    <repository>
-        <id>vaadin-addons</id>
-        <url>https://maven.vaadin.com/vaadin-addons</url>
-    </repository>
-    <!-- ... existing repositories ... -->
-</repositories>
-
 <dependencies>
     <dependency>
         <groupId>com.vaadin</groupId>
@@ -149,7 +141,7 @@ Pick the approach that matches your Swing project's build:
 [source,groovy,subs="+attributes"]
 ----
 repositories {
-    maven { url = uri("https://maven.vaadin.com/vaadin-addons") }
+    mavenCentral()
     // ... existing repositories ...
 }
 
@@ -167,10 +159,10 @@ Most long-running Swing codebases use Ant, IDE-managed libraries, or no formal b
 
 [source,terminal,subs="+attributes"]
 ----
-curl -O https://maven.vaadin.com/vaadin-addons/com/vaadin/swing-bridge-annotations/{swing-bridge-version}/swing-bridge-annotations-{swing-bridge-version}.jar
+curl -O https://repo1.maven.org/maven2/com/vaadin/swing-bridge-annotations/{swing-bridge-version}/swing-bridge-annotations-{swing-bridge-version}.jar
 ----
 
-For a SwingBridge pre-release, swap `vaadin-addons` for `vaadin-prereleases` in the URL. The download is anonymous — no Vaadin license check at this step.
+For a SwingBridge pre-release, take the JAR from `https://maven.vaadin.com/vaadin-prereleases` instead. The download is anonymous — no Vaadin license check at this step.
 
 Then add the JAR to the Swing project:
 
@@ -194,7 +186,7 @@ import com.vaadin.swingbridge.interop.ExposedMethod;
 [[swing-bridge.interop.status]]
 == What's Shipped Today
 
-The interop runtime, the `generate-bridge` Maven goal, and the by-reference domain-types strategy are production-ready. Two further codegen goals exist as in-progress skeletons and are not recommended for production use yet:
+The interop runtime, the `generate-bridge` Maven goal, and the by-reference domain-types strategy are production-ready. Three further codegen goals exist as in-progress skeletons and are not recommended for production use yet:
 
 [cols="3,1,4", options="header"]
 |===
@@ -219,6 +211,10 @@ The interop runtime, the `generate-bridge` Maven goal, and the by-reference doma
 | Shared domain types by reference (Type 3+)
 | Shipped
 | Add the domain JAR as a Maven `<dependency>` of the Vaadin app. Same `Class<?>` on both sides; no conversion.
+
+| `extract-shared-types` Maven goal
+| Roadmap
+| Extracts the domain classes referenced by `@ExposedMethod` signatures out of a fat Swing JAR into a thin domain JAR — the input to the by-reference strategy above. Present in the plugin but not yet covered by tests; building the domain JAR with your own build is the supported path for now.
 
 | `strip-annotations` Maven goal (Type 1)
 | Roadmap

--- a/articles/tools/modernization-toolkit/swing-bridge/logging.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/logging.adoc
@@ -1,0 +1,468 @@
+---
+title: Logging pass:[&] Identifying Logs per User
+page-title: Identify logs per user in SwingBridge | Vaadin Tools
+description: Attribute server log output to the Swing application user who produced it, and integrate old and new logging frameworks.
+meta-description: Tag SwingBridge log output per user session, publish the logged-in user from Swing or Vaadin, and integrate Log4j, SLF4J, and Spring Boot logging.
+order: 5
+---
+
+include::{articles}/_vaadin-version.adoc[]
+
+[[swing-bridge.logging]]
+= Logging & Identifying Logs per User
+:toc:
+
+_Available since SwingBridge 1.3._
+
+On the desktop, one Swing application serves one user, so its log file belongs to that user. With SwingBridge, many users run the same application inside a single server JVM, and everything they produce (log statements, stack traces, `System.out` output) lands interleaved in one server log. When a user reports a problem, support needs to follow that user's trail through the log.
+
+SwingBridge solves this with automatic log attribution: every application instance gets a short run ID, and each log line it produces is tagged with that ID. Turning it on takes one JVM flag on the server, with no changes to the Swing application. From there you can, step by step, tag your log files too, add the user's name, and reach a full "user reports a bug" support workflow.
+
+If you are new to SwingBridge, read the next section top to bottom: it takes you from nothing to tagged logs in two steps, then points to the optional extras.
+
+In this article:
+
+* <<swing-bridge.logging.quick-setup,Quick Setup>>: the two-step path to tagged logs
+* <<swing-bridge.logging.concepts,How Attribution Works>>: run ID, correlation line, per-thread tagging
+* <<swing-bridge.logging.levels,Choosing an Integration Level>>: how far to go, at a glance
+* <<swing-bridge.logging.channels,What Gets Tagged, and How>>: console vs. log files
+* <<swing-bridge.logging.identity,Adding the User's Name to the Logs>>: publish the user, show it per line
+* <<swing-bridge.logging.support-workflow,Support Workflow>>: the "user reports a bug" flow
+* <<swing-bridge.logging.frameworks,Old and New Logging Frameworks Together>>: Log4j, SLF4J, Spring Boot
+* <<swing-bridge.logging.desktop,Desktop Builds Are Unaffected>>
+* <<swing-bridge.logging.troubleshooting,Troubleshooting>>
+
+[[swing-bridge.logging.quick-setup]]
+== Quick Setup
+
+Everything in this section is configured in the Vaadin application, the server that embeds your Swing application. The Swing code needs no changes to get started.
+
+*Step 1 - Tag console output.* Start the server's JVM with this flag:
+
+[source,terminal]
+----
+-Dswingbridge.consoleLogPrefix=true
+----
+
+Every line an embedded Swing application writes to `System.out` or `System.err`, including `exception.printStackTrace()` and the console output of whatever logging framework it uses, is now prefixed with its run ID:
+
+[source,text]
+----
+[swing:7f3k2a] Loading customer list for account 4711
+----
+
+Server output, and lines from other users, keep their own (different) prefixes, so concurrent users can be told apart at a glance.
+
+*Step 2 (optional) - Tag log files.* Console prefixing can't reach lines written straight to a log file. If your server logs to a file, add one token to its appender pattern. For Log4j2:
+
+[source,xml]
+----
+<PatternLayout pattern="%d %-5p [%X{swingSession}] [%c{1}] %m%n"/>
+----
+
+File lines now carry the run ID in the `%X{swingSession}` column. Other frameworks are covered too, see <<swing-bridge.logging.channels.files,Log Files and Structured Logs>>.
+
+At each application start, SwingBridge also logs one correlation line that ties the run ID to the session and (once known) the user:
+
+[source,text]
+----
+Swing app run 7f3k2a: vaadinSession=57CA0DE6... app=com.example.crm.Main user=alice
+----
+
+The support workflow is then: find the correlation line for the user (or ask the user for the ID, if the application displays it), and search the log for that run ID.
+
+*Step 3 (optional) - Show the user's name on every line.* By default the per-line tag is just the run ID; the user's name appears only in the correlation line. To put the name on every line as well, see <<swing-bridge.logging.identity,Adding the User's Name to the Logs>>. It takes one more flag plus a single line of code (often in the Swing application, sometimes in Vaadin).
+
+[[swing-bridge.logging.concepts]]
+== How Attribution Works
+
+Three concepts appear throughout this page:
+
+Run ID::
+A short random token (for example, `7f3k2a`) assigned to each Swing application instance, one per user session and application. It stays the same for the lifetime of that instance, so one user's continuing work is one search hit. It's deliberately short and free of personal data, making it safe to show to end users and cheap to repeat on every log line.
+
+Correlation line::
+One log line per application start: `Swing app run <runId>: vaadinSession=... app=... [user=...]`. It joins the run ID to the HTTP session and the user, so the per-line tag can stay minimal: just the run ID, unless you opt in to per-line user names (Step 3 above).
+
+Per-thread attribution::
+SwingBridge runs each application instance in an isolated group of threads. Any output produced on those threads, from the Event Dispatch Thread to worker threads the application creates, is attributed to that instance automatically, at the moment of the write. Neither the Swing application nor the Vaadin application does anything to make this work.
+
+[[swing-bridge.logging.levels]]
+== Choosing an Integration Level
+
+The mechanisms on this page form a ladder, from zero cooperation to full use of the interop APIs. Start at the top; descend only as far as your needs require. Most deployments stop at the second or third rung.
+
+[cols="1,2,3,3", options="header"]
+|===
+|Level |Changes required |What you get |Where on this page
+
+|0 - automatic
+|One JVM flag on the server
+|Console output prefixed per user session; correlation lines
+|<<swing-bridge.logging.channels.console,Console Output>>
+
+|1 - configuration only
+|One pattern token in the server's logging configuration
+|Log files and structured logs tagged per session
+|<<swing-bridge.logging.channels.files,Log Files and Structured Logs>>
+
+|2 - one line of code
+|One call after login (Swing or Vaadin side), plus an optional flag
+|The user's name in the correlation lines and, with the flag, on every line
+|<<swing-bridge.logging.identity,Adding the User's Name to the Logs>>
+
+|3 - the log context API
+|Small dependency in the Swing project
+|Support ID in the UI, identity reads, incident reporting
+|<<swing-bridge.logging.identity.swing-side,When Login Happens in the Swing Application>>, <<swing-bridge.logging.support-workflow,Support Workflow>>
+
+|4 - interop cooperation
+|Annotated Swing methods + generated bridges
+|Host-driven initialization of a bespoke logging subsystem
+|<<swing-bridge.logging.identity.interop,Bespoke Logging Subsystems>>
+|===
+
+[[swing-bridge.logging.channels]]
+== What Gets Tagged, and How
+
+Log output leaves a server through two different kinds of channels, and each needs its own mechanism. Both are set up in the Vaadin application; the Swing application is untouched.
+
+[[swing-bridge.logging.channels.console]]
+=== Console Output
+
+With `-Dswingbridge.consoleLogPrefix=true`, SwingBridge wraps `System.out` and `System.err`. Every line written by an application-instance thread is prefixed with `[swing:<runId>]`; server output passes through unchanged. This catches, regardless of the logging framework the Swing application uses:
+
+* plain `System.out.println(...)` and `exception.printStackTrace()`, which is how a lot of legacy Swing code reports problems;
+* console output of any logging framework, old or new, including multi-line stack traces (each line gets the prefix).
+
+The flag is off by default because replacing the process streams is observable behavior; enabling it is a deliberate deployment decision.
+
+When you also opt in to per-line user names (see <<swing-bridge.logging.identity.per-line,Showing the Name on Every Line>>), the prefix carries the user as well, for example `[swing:7f3k2a|alice]`.
+
+[[swing-bridge.logging.channels.files]]
+=== Log Files and Structured Logs
+
+File appenders write straight to disk. They never pass through the console streams, so the prefix above can't reach them. For those, SwingBridge ships logging-framework adapters (inside `swing-bridge-flow`; no extra dependency). They're passive: nothing changes until your pattern references a token.
+
+*Log4j2* is the common case, since `swing-bridge-flow` itself brings Log4j2. Add the token to any pattern:
+
+[source,xml]
+----
+<PatternLayout pattern="%d %-5p [%X{swingSession}] [%c{1}] %m%n"/>
+----
+
+`%X{swingSession}` is filled in automatically: SwingBridge registers a Log4j2 `ContextDataProvider` that captures the run ID at the logging call site, on the calling thread. Because the value travels with the log event, it stays correct even with async appenders, where the actual formatting happens on a background thread. Server lines render an empty value.
+
+Alternatively, `%swingSession` (a pattern converter, discovered automatically) renders the same ID with an explicit `-` for server lines.
+
+To include the user's name, add the parallel `%X{swingUser}` (or `%swingUser`) token and turn on <<swing-bridge.logging.identity.per-line,per-line user names>>. Without that flag the token renders empty (or `-`), so it's safe to leave in a shared pattern:
+
+[source,xml]
+----
+<PatternLayout pattern="%d %-5p [%X{swingSession}] [%X{swingUser}] [%c{1}] %m%n"/>
+----
+
+*Logback* adapter classes ship with `swing-bridge-flow` and activate when Logback is your backend. Register them in `logback.xml`:
+
+[source,xml]
+----
+<turboFilter class="com.vaadin.swingbridge.logging.logback.SwingSessionTurboFilter"/>
+<conversionRule conversionWord="swingSession"
+                converterClass="com.vaadin.swingbridge.logging.logback.SwingSessionConverter"/>
+<conversionRule conversionWord="swingUser"
+                converterClass="com.vaadin.swingbridge.logging.logback.SwingUserConverter"/>
+...
+<pattern>%d %-5level [%swingSession] [%swingUser] %logger - %msg%n</pattern>
+----
+
+The turbo filter stamps the run ID (and, when per-line user names are on, the user) into the Mapped Diagnostic Context (MDC) at the call site, which is required for correctness with `AsyncAppender`. After that, plain `%X{swingSession}` and `%X{swingUser}` work, too. Drop the `swingUser` rule and token if you only want the run ID.
+
+For *`java.util.logging`*, configure the prefixing formatter on a handler:
+
+[source,properties]
+----
+java.util.logging.ConsoleHandler.formatter = com.vaadin.swingbridge.logging.jul.SwingSessionFormatter
+----
+
+The formatter prefixes each record with `[swing:<runId>]`, and with per-line user names on it becomes `[swing:<runId>|<user>]`. There's no separate token to add.
+
+Because the run ID (and user) become normal context fields, they flow into JSON layouts and log aggregation systems such as Elastic, Loki, and Splunk as regular attributes: finding everything for run `7f3k2a`, or everything for `alice`, becomes a filter instead of a text search.
+
+[[swing-bridge.logging.identity]]
+== Adding the User's Name to the Logs
+
+Attribution tags tell log lines apart by run ID; adding the user's name ties that ID to a person. There are two parts to it:
+
+. *Publish the name once.* Someone has to tell SwingBridge who the user is. The rule in one line: whoever learns the user's name calls the method on their side of the bridge. Where that call goes depends on where login happens, and is covered in the subsections below. Once published, the name appears in the correlation line.
+. *Choose where it shows.* By default the name stays in the correlation line only, keeping per-line tags short and free of personal data. Opt in, and it appears on every line as well.
+
+Start with whichever "publish" subsection matches your application; the simplest is a single line in the Swing app.
+
+[[swing-bridge.logging.identity.per-line]]
+=== Showing the Name on Every Line
+
+By default, only the run ID is repeated on each line and the user's name lives in the correlation line. To repeat the name on every line as well, start the server with:
+
+[source,terminal]
+----
+-Dswingbridge.includeUserInLogs=true
+----
+
+Once a user has logged in, log messages are prefixed with `[swing:7f3k2a|alice]`, where `alice` is the name resulting from the `%swingUser` / `%X{swingUser}` tokens (see <<swing-bridge.logging.channels.files,Log Files and Structured Logs>>). Any messages logged before login stay `[swing:7f3k2a]`.
+
+[NOTE]
+====
+This flag is off by default because a user's name is personal data, and repeating it on every line increases what your logs contain and retain. It's a single switch that governs the name across all channels (console prefix and every framework adapter): with it off, the name is emitted nowhere but the correlation line.
+====
+
+[[swing-bridge.logging.identity.swing-side]]
+=== When Login Happens in the Swing Application
+
+In many migrations, the Swing application keeps its own login dialog, and the Vaadin side has no security context yet. The identity is born inside Swing, so it's published from there. There are three options, ordered by how much you can change the Swing code. The first is a one-liner and needs no new dependency.
+
+*Option 1 - one line, no new dependency.* In the Swing application, after a successful login, on any thread the application owns (the Event Dispatch Thread is fine):
+
+[source,java]
+----
+System.setProperty("swingbridge.log.user", loggedInUserName);
+----
+
+This is plain JDK API: the Swing project gains no dependency on SwingBridge and behaves identically as a desktop application (where the property is simply unused). SwingBridge routes the value per session, so concurrent users can't overwrite each other, and logs a correlation line the moment it's set. This is the recommended starting point.
+
+*Option 2 - the log context API (more capabilities).* If the Swing project already depends on `swing-bridge-annotations` (or accepts it, a small JAR with zero transitive dependencies), the `SwingBridgeLogContext` facade offers more than the property, and every method is desktop-safe:
+
+[source,java]
+----
+// in the login-success handler:
+SwingBridgeLogContext.setUser(loggedInUserName);
+
+// show the support ID in an About or error dialog:
+aboutDialog.setSupportId(SwingBridgeLogContext.runId());
+
+// "Report a problem" action (see Support Workflow below):
+SwingBridgeLogContext.reportIncident("Export failed", exception);
+----
+
+Standalone on a desktop, the reads return `null`, `setUser()` does nothing, and `reportIncident()` falls back to `System.err`, so the same JAR works in both worlds. One packaging note: unlike the pure annotations, these are real code references, so the desktop distribution ships the annotations JAR as well.
+
+*Option 3 - zero Swing changes.* When the Swing JAR can't be modified at all, the Vaadin application observes the Swing application's own session state reflectively and attaches the identity once login completes:
+
+[source,java]
+----
+// In the Vaadin view, after the Swing app has initialized: poll every
+// few seconds on a daemon thread until the user has logged in.
+SwingBridge.runInAppContext(component, () -> {
+    ClassLoader appCl = component.getClass().getClassLoader();
+    Class<?> settings = Class.forName("com.example.crm.UserSettings", true, appCl);
+    Field instanceField = settings.getDeclaredField("instance");
+    instanceField.setAccessible(true);
+    Object instance = instanceField.get(null);   // observe; never getInstance()
+    if (instance == null) {
+        return null;                             // not logged in yet
+    }
+    Object user = settings.getMethod("getCurrentUser").invoke(instance);
+    return user == null ? null
+            : (String) user.getClass().getMethod("getName").invoke(user);
+}).get();
+// non-blank result -> bridge.setLogIdentity(result); stop polling
+----
+
+Two rules make this safe: only read existing state, never calling factory methods such as `getInstance()`, whose constructors may have side effects (server connections, file writes); and stop polling when the view detaches.
+
+[[swing-bridge.logging.identity.vaadin-side]]
+=== When Login Happens in Vaadin
+
+The other common shape: authentication and navigation have been modernized into the Vaadin application (for example, with Spring Security), and Vaadin menus open views that each embed a Swing application. Here the identity is born on the server side, so it flows the other way. In each Vaadin view that embeds a Swing application:
+
+[source,java]
+----
+SwingBridge bridge = new MyAppBridge();
+bridge.setLogIdentity(authenticatedPrincipal.getName());
+add(bridge);
+----
+
+Timing is flexible: before adding the bridge to the view or any time later, and a correlation line is logged either way. The identity is keyed per _(server session, Swing application)_ pair, which matters when Vaadin handles navigation: views embedding different Swing applications each call `setLogIdentity()` for their own bridge (typically factored into a base view class), while two views embedding the same application in one session share an instance, so one call covers both. Each opened application gets its own run ID, and all correlation lines carry the same session and user, so support can search by application instance (run ID) or by everything the user did (session ID).
+
+The Swing application needs nothing in this setup, but `SwingBridgeLogContext.runId()` and `reportIncident()` remain fully useful, and `userName()` returns whatever the Vaadin side attached, so the Swing application can display the logged-in user without owning authentication.
+
+[[swing-bridge.logging.identity.interop]]
+=== Bespoke Logging Subsystems
+
+Some Swing applications route everything through a homegrown logging subsystem that needs the identity before first use. There are two directions, depending on where the identity lives.
+
+*Pulling from the Swing side.* The application asks SwingBridge for the values whenever its subsystem initializes:
+
+[source,java]
+----
+// in the Swing application's logging bootstrap:
+MyLegacyLogSystem.setGlobalPrefix(
+        SwingBridgeLogContext.runId() + "/" + SwingBridgeLogContext.userName());
+----
+
+*Pushing from the Vaadin side.* When the identity is host-side and the subsystem must be initialized proactively, use the typed interop APIs: annotate a method in the Swing application and call it from the Vaadin view as soon as the application is ready.
+
+In the Swing application:
+
+[source,java]
+----
+@ExposedMethod
+public void initLogIdentity(String runId, String userName) {
+    MyLegacyLogSystem.setGlobalPrefix(runId + "/" + userName);
+}
+----
+
+In the Vaadin view, through the generated bridge:
+
+[source,java]
+----
+bridge.interop().of(MyAppBridge.class).onReady(app ->
+        app.initLogIdentity(runId, principal.getName()));
+----
+
+The `onReady` callback guarantees the call runs once the application is initialized, before the user interacts with it. See <<interop/index#,Interop APIs>> for setting up the annotation processing and generated bridges.
+
+[[swing-bridge.logging.identity.both]]
+=== Setting the Name from Both Sides
+
+Setting the identity from both sides is allowed and occasionally useful. For example, Vaadin attaches the single-sign-on principal when the view opens, and the Swing application later refines it after a role or mandate selection. The last write wins for that application instance, and each write logs its own correlation line, so the log history shows the transition rather than losing it. A `null` or blank value removes the identity.
+
+[[swing-bridge.logging.support-workflow]]
+== Support Workflow
+
+The pieces above combine into a concrete "user reports a bug" flow:
+
+. The Swing application shows its run ID in an About box or error dialog, using `SwingBridgeLogContext.runId()`. The ID is short, random, and contains no personal data.
+. When something breaks, the user (or the application's error handler) reports it:
++
+[source,java]
+----
+SwingBridgeLogContext.reportIncident("Export to PDF failed", exception);
+----
++
+This writes one warning-level (`WARN`) line to the server log with the full attribution inline, plus the stack trace:
++
+[source,text]
+----
+WARN [7f3k2a] Swing app incident (run=7f3k2a, session=..., user=alice): Export to PDF failed
+java.lang.IllegalStateException: disk full
+    at com.example.crm.export.PdfExporter...
+----
+. Support asks the user for the ID from the dialog, or finds the incident line, and searches the server log for `7f3k2a`. Everything that instance logged, before and after the incident, is on tagged lines.
+
+[[swing-bridge.logging.frameworks]]
+== Old and New Logging Frameworks Together
+
+A migrated deployment typically stacks several logging generations in one JVM: the Swing application may use Log4j 1.x from 2008, the Vaadin application logs through SLF4J, and Spring Boot brings its own opinions. This section describes what actually happens, and the two pitfalls worth knowing.
+
+[[swing-bridge.logging.frameworks.routing]]
+=== Where a Swing Application's Log Statements Go
+
+The Swing application's JARs are loaded by a class loader that delegates to the server's classpath first. Consequences:
+
+* *Bundled frameworks are shadowed.* If the Swing application ships its own `log4j-core` (or Logback) inside its JARs, those copies are ignored whenever the server classpath provides the same classes, which it does for Log4j2, since `swing-bridge-flow` depends on it. The application's log statements execute against the server's Log4j2.
+* *Old APIs are bridged.* Code written against Log4j 1.x (`org.apache.log4j.Logger`) works through the `log4j-1.2-api` bridge and ends up in the same place. A 2008-era Swing codebase needs no logging changes.
+* *The application's own logging configuration is inert.* Because the log statements run against the server's Log4j2 context, the `log4j2.xml` (or `log4j.properties`) bundled inside the Swing JAR, including its file appenders, never activates. If support is used to finding the application's own log file (say, `~/.myapp/log/client.log`), that file doesn't exist in the SwingBridge deployment: the same lines are in the server's log instead, attributed per user. This is the intended outcome, but it's a workflow change worth communicating.
+
+The practical upshot: tag the server's appender patterns (see <<swing-bridge.logging.channels.files,above>>), and every framework generation inside the Swing application is covered.
+
+In the rare setup where the server deliberately excludes Log4j2 and the Swing application runs its own logging context, the adapters still work. Reference them from the application's configuration file instead, or add the forwarding appender to stream its events into the server log, attributed:
+
+[source,xml]
+----
+<!-- in the Swing application's own log4j2.xml (own-context setups only): -->
+<SwingBridgeForward name="FORWARD"/>
+----
+
+In own-context setups, also give each session its own log file path (for example, include the run ID in the file pattern). Many sessions rolling one shared file is a corruption risk regardless of attribution.
+
+[[swing-bridge.logging.frameworks.slf4j]]
+=== SLF4J, Spring Boot, and Provider Selection
+
+SLF4J is a facade: at startup it picks one provider (binding) that decides where all SLF4J log statements go. Two pitfalls in SwingBridge deployments:
+
+*Spring Boot defaults to Logback, SwingBridge brings Log4j2.* Running both backends splits your logs in two. The <<installation-from-scratch#,Installation from Scratch>> template resolves the clash in Logback's favor: it excludes `log4j-slf4j2-impl` from `swing-bridge-flow`, so SLF4J traffic (Spring, SwingBridge itself) goes to Logback. That setup works with the <<swing-bridge.logging.channels.files,Logback adapters>>, with one caveat: a Swing application calling Log4j APIs directly still logs through Log4j2's own default configuration, which writes to the console only (prefixed, but absent from your Logback-managed files).
+
+To get everything (Spring, SwingBridge, and every Swing application) into one set of tagged appenders, standardize on Log4j2 instead: keep the `swing-bridge-flow` binding by removing the template's exclusion, and exclude Logback in the Vaadin application's `pom.xml`:
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.springframework.boot</groupId>
+  <artifactId>spring-boot-starter-validation</artifactId>
+  <exclusions>
+    <exclusion>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-slf4j2-impl</artifactId>
+</dependency>
+----
+
+and configure Log4j2 via `log4j2-spring.xml` on the classpath.
+
+*Multiple providers on the classpath.* SLF4J warns (`Class path contains multiple SLF4J providers`) and then silently picks one, not necessarily the one you want. Notably, Vaadin's development tooling ships a shaded JAR embedding `slf4j-simple`, which can win the auto-selection: the symptom is that SLF4J-routed lines (Spring, SwingBridge's own correlation lines) never reach your Log4j2 appenders, while direct Log4j calls from the Swing application do. The fix is one JVM property that pins the provider explicitly:
+
+[source,terminal]
+----
+-Dslf4j.provider=org.apache.logging.slf4j.SLF4JServiceProvider
+----
+
+[[swing-bridge.logging.frameworks.matrix]]
+=== Coverage Expectations
+
+[cols="3,2,3", options="header"]
+|===
+|How the Swing application logs today |Console (`consoleLogPrefix`) |Log files (pattern token)
+
+|`System.out.println` / `printStackTrace()`
+|Prefixed
+|Not applicable, as raw prints never reach file appenders
+
+|Log4j 1.x API (via bridge)
+|Prefixed
+|Tagged
+
+|Log4j2 / SLF4J / `java.util.logging`
+|Prefixed
+|Tagged
+
+|Bundled framework, own context (server excludes Log4j2)
+|Prefixed (console appenders)
+|Tag in the application's own configuration, or use the forwarding appender
+
+|Homegrown logging subsystem
+|Raw prints prefixed
+|Feed `SwingBridgeLogContext.runId()` / `userName()` into it
+|===
+
+One structural limit applies everywhere: output produced on shared JVM threads that don't belong to any application instance, such as `ForkJoinPool.commonPool()`, can't be attributed to a user.
+
+[[swing-bridge.logging.desktop]]
+== Desktop Builds Are Unaffected
+
+Every mechanism on this page is safe outside SwingBridge. The system properties (`consoleLogPrefix`, `includeUserInLogs`, and the `swingbridge.log.user` value in Option 1) are unused properties on the desktop; `SwingBridgeLogContext` reads return `null`, `setUser()` is a no-op, and `reportIncident()` prints to `System.err`; the pattern tokens live in the server's configuration, which desktop builds never see. One Swing codebase serves both distributions.
+
+[[swing-bridge.logging.troubleshooting]]
+== Troubleshooting
+
+No `[swing:...]` prefixes on the console::
+Check that the JVM was started with `-Dswingbridge.consoleLogPrefix=true`. The flag is off by default.
+
+`%X{swingSession}` stays empty on lines you expected to be tagged::
+The line was probably logged on a server thread (correlation lines, HTTP request handling), and those are intentionally untagged. If application lines stay empty, verify the deployment runs Log4j2 2.13.2 or later; on older versions use `%swingSession` with synchronous appenders.
+
+The user's name isn't on each line (only in the correlation line)::
+Per-line user names are opt-in. Start the server with `-Dswingbridge.includeUserInLogs=true` (it's off by default because the name is personal data), and make sure an identity has been published. See <<swing-bridge.logging.identity,Adding the User's Name to the Logs>>.
+
+Correlation lines and Spring log lines missing from the log file::
+SLF4J is bound to the wrong provider. Look for the `multiple SLF4J providers` warning at startup and pin the provider as shown <<swing-bridge.logging.frameworks.slf4j,above>>.
+
+`user=` never appears in the correlation line::
+The identity call never ran. If login is inside the Swing application, confirm the call happens on an application thread (the Event Dispatch Thread qualifies; a shared server executor does not). If Vaadin owns login, confirm each embedding view calls `setLogIdentity()`.
+
+The Swing application's own log file is missing::
+Expected. See <<swing-bridge.logging.frameworks.routing,Where a Swing Application's Log Statements Go>>. The lines are in the server's log, attributed.

--- a/articles/tools/modernization-toolkit/swing-bridge/logging.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/logging.adoc
@@ -3,7 +3,7 @@ title: Logging pass:[&] Identifying Logs per User
 page-title: Identify logs per user in SwingBridge | Vaadin Tools
 description: Attribute server log output to the Swing application user who produced it, and integrate old and new logging frameworks.
 meta-description: Tag SwingBridge log output per user session, publish the logged-in user from Swing or Vaadin, and integrate Log4j, SLF4J, and Spring Boot logging.
-order: 5
+order: 6
 ---
 
 include::{articles}/_vaadin-version.adoc[]

--- a/articles/tools/modernization-toolkit/swing-bridge/netbeans-rcp/index.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/netbeans-rcp/index.adoc
@@ -3,7 +3,7 @@ title: NetBeans RCP
 page-title: Embed a NetBeans RCP App with SwingBridge | Vaadin Tools
 description: Run a pre-built NetBeans Platform application in the browser with SwingBridge, with no changes to the RCP source.
 meta-description: Embed a pre-built NetBeans Platform (RCP) application in a Vaadin view with SwingBridge — whole shell or a single TopComponent — without rewriting the RCP code.
-order: 5
+order: 8
 ---
 
 include::{articles}/_vaadin-version.adoc[]

--- a/articles/tools/modernization-toolkit/swing-bridge/reference.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/reference.adoc
@@ -3,7 +3,7 @@ title: Reference
 page-title: SwingBridge Reference | Vaadin Tools
 description: Public API summary, lifecycle hooks, and the recommended sample project.
 meta-description: Reference for the SwingBridge public Java API and lifecycle hooks, with a pointer to the SwingBridge skeleton starter project.
-order: 8
+order: 11
 ---
 
 include::{articles}/_vaadin-version.adoc[]
@@ -90,4 +90,7 @@ A custom classloader supplier is contributed via `createClassLoaderSupplier()`, 
 |===
 
 
+[[swing-bridge.reference.next-steps]]
+== Next Steps
 
+- <<configuration#swing-bridge.configuration, Configuration>> for the system properties that control this behavior at deployment level.

--- a/articles/tools/modernization-toolkit/swing-bridge/rendering.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/rendering.adoc
@@ -1,0 +1,117 @@
+---
+title: Display and Rendering
+page-title: SwingBridge Display and Rendering | Vaadin Tools
+description: The virtual screen SwingBridge reports, HiDPI rendering, and the back-buffer format.
+meta-description: Configure the virtual screen SwingBridge advertises to a Swing application, HiDPI oversampling, and the back-buffer pixel format.
+order: 5
+---
+
+include::{articles}/_vaadin-version.adoc[]
+
+[[swing-bridge.rendering]]
+= Display and Rendering
+
+A hosted Swing application still asks AWT how big the screen is and what pixel format to use, and there is no physical screen to answer with. SwingBridge answers on its behalf. Three system properties control those answers; the defaults are chosen so that no deployment has to set any of them.
+
+[cols="3,2,5", options="header"]
+|===
+|Property |Default |What it decides
+
+|`swingbridge.screenSize`
+|`per-user`
+|The screen size reported to the Swing application.
+
+|`swingbridge.hidpi`
+|`off`
+|Whether the back buffer is rendered at the browser's device pixel ratio.
+
+|`swingbridge.backBufferType`
+|`adaptive`
+|The pixel format of each window's back buffer.
+|===
+
+
+[[swing-bridge.rendering.screen-size]]
+== Virtual Screen Size
+
+`swingbridge.screenSize` decides what the Swing application is told when it reads `Toolkit.getScreenSize()`, sizes a window to the screen, or centers a dialog with `setLocationRelativeTo(null)`:
+
+- *`per-user`* (the default, also used when the property is unset) — each session sees a screen derived from that user's own browser.
+- *`<width>x<height>`* — one fixed resolution for every session, for example `1920x1080`. Each edge must be between 240 and 8192. Use `2560x1440` to reproduce the behavior of releases before per-user screens existed.
+- Anything else is logged as a warning and falls back to `2560x1440`.
+
+[source,terminal]
+----
+java -Dswingbridge.screenSize=1920x1080 -jar my-app.jar
+----
+
+Two things this property does *not* do: it never resizes or moves a window — the screen size is information the Swing application may act on — and it does not change rendering resolution.
+
+
+[[swing-bridge.rendering.hidpi]]
+== HiDPI Rendering
+
+`swingbridge.hidpi` renders the back buffer at the browser's device pixel ratio, so text is crisp on Retina and 4K displays instead of being upscaled by the browser:
+
+- *`off`* (the default) — one buffer pixel per logical pixel.
+- *`auto`* — each session follows its own browser's ratio, quantized to 0.25 steps and clamped.
+- *a decimal*, for example `2` or `1.5` — that fixed scale for every session.
+
+Two further properties bound the cost, since heap per window scales with the square of the scale:
+
+[cols="3,1,5", options="header"]
+|===
+|Property |Default |Description
+
+|`swingbridge.hidpiMaxScale`
+|`2.0`
+|Upper bound on the multiplier, between `1.0` and `4.0`.
+
+|`swingbridge.hidpiMaxBufferPixels`
+|`8000000`
+|Upper bound on a single window's back buffer in device pixels. A window over the ceiling renders at a reduced scale rather than being refused.
+|===
+
+[source,terminal]
+----
+java -Dswingbridge.hidpi=auto -jar my-app.jar
+----
+
+Oversampling is invisible to the Swing application: it keeps its logical coordinate space and a 1x default transform, so layout is identical at every scale, pointer coordinates need no translation, and `Toolkit.getScreenResolution()` stays 96. Moving the browser to a display with a different pixel ratio is detected and re-rendered at the new ratio.
+
+Images the Swing application creates itself stay at 1x and are upsampled into the oversampled buffer, so an application that blits its own off-screen image may still look soft.
+
+[[swing-bridge.rendering.hidpi.cost]]
+=== What It Costs
+
+Raising the scale multiplies the pixels in every back buffer. The costs that follow do not all grow at the same rate.
+
+*Memory is where it shows.* A window's buffer grows with the square of the scale, so doubling the scale roughly quadruples it. That is the cost to plan for when many sessions share one host. Setting `swingbridge.backBufferType=565` halves it, and 16-bit color is less noticeable at a higher scale, because the dithering has more pixels to hide in.
+
+*The network sees much less.* Frames are compressed as PNG. Large areas of flat color compress nearly as well at a high scale as at a low one, so only the edges of text carry real extra detail. And only a window's first frame is sent in full — after that SwingBridge sends just the areas that changed, and a small change stays small at any scale.
+
+*Encoding costs more CPU*, roughly in proportion to the pixels. Because the steady state is small updates, this shows when a window first appears or is resized, not while the user works.
+
+HiDPI is therefore limited by memory rather than by bandwidth. On a slow connection it is the first frame of each window that grows; everything after it costs little more than before. Leave `swingbridge.hidpiMaxScale` at its default unless you have measured your own application.
+
+
+[[swing-bridge.rendering.back-buffer]]
+== Back-Buffer Pixel Format
+
+Each bridged window keeps a back buffer sized to the window. It is the dominant per-window allocation and the source of every frame streamed to the browser. `swingbridge.backBufferType` selects its format:
+
+- *`adaptive`* (the default) — opaque windows use 24-bit `TYPE_INT_RGB`; only per-pixel-translucent windows keep 32-bit `TYPE_INT_ARGB`. Same memory as ARGB, smaller frames, and lossless.
+- *`argb`* — 32-bit `TYPE_INT_ARGB` for every window, the behavior of earlier releases.
+- *`565`* — 16-bit `TYPE_USHORT_565_RGB`, halving back-buffer memory at the cost of 16-bit color: banding on gradients and softer text anti-aliasing.
+
+[source,terminal]
+----
+java -Dswingbridge.backBufferType=565 -jar my-app.jar
+----
+
+
+[[swing-bridge.rendering.next-steps]]
+== Next Steps
+
+- <<configuration#swing-bridge.configuration, Configuration>> for every other system property.
+- <<troubleshooting#swing-bridge.troubleshooting, Troubleshooting>> if rendering looks wrong rather than merely soft.

--- a/articles/tools/modernization-toolkit/swing-bridge/running-and-debugging.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/running-and-debugging.adoc
@@ -3,7 +3,7 @@ title: Running and Debugging
 page-title: Run and Debug SwingBridge | Vaadin Tools
 description: Run SwingBridge applications from Maven and attach a remote debugger from IntelliJ IDEA or VS Code.
 meta-description: How to run a SwingBridge application from the command line and attach a remote Java debugger from IntelliJ IDEA or VS Code.
-order: 6
+order: 9
 ---
 
 include::{articles}/_vaadin-version.adoc[]

--- a/articles/tools/modernization-toolkit/swing-bridge/troubleshooting.adoc
+++ b/articles/tools/modernization-toolkit/swing-bridge/troubleshooting.adoc
@@ -3,7 +3,7 @@ title: Troubleshooting
 page-title: Troubleshoot SwingBridge | Vaadin Tools
 description: Common SwingBridge launch failures and how to fix them.
 meta-description: Diagnose and resolve common SwingBridge launch failures, including missing JVM flags, missing main class, and headless toolkit errors.
-order: 7
+order: 10
 ---
 
 include::{articles}/_vaadin-version.adoc[]
@@ -44,4 +44,3 @@ or
 |`License is invalid` or trial key prompt on startup.
 |No valid Vaadin commercial license in `~/.vaadin/` (or `%userprofile%\.vaadin\`). See <<installation-from-scratch#swing-bridge.installation-from-scratch.license, License Installation>>.
 |===
-


### PR DESCRIPTION
## Description

Brings this branch's SwingBridge documentation up to date with `main`, by picking the two changes that never reached it. Both are in one PR because the second modifies a file the first adds.

- **#5807** — the logging and per-user log attribution guide (`logging.adoc`), its three property rows in `configuration.adoc`, and the log4j note in `installation-from-scratch.adoc`. This originally merged to `main` with no `target/*` label, so the bot never picked it.
- **#5972** — the Swing Bridge 1.3.0 configuration surface, the new Display and Rendering page, the switch to Maven Central for the annotations JAR, the interop status-table audit, the missing `--add-opens`, and the nav renumbering.

### Conflicts resolved

**`.github/styles/config/vocabularies/Docs/accept.txt`** — only the three entries `logging.adoc` needs (`appenders?`, `Splunk`, `[Ii]nterop`) are added. The incoming hunk also carried unrelated layout and CSS terms that belong to changes not on this branch; those are deliberately left out.

**`articles/_vaadin-version.adoc`** — this branch had bumped `:spring-boot-version:` on the line directly above `:swing-bridge-version:`, so both sides changed adjacent lines and landed in one hunk. This branch's platform versions are kept untouched; only `:swing-bridge-version:` moves to `1.3.0`.

### Verified

`articles/tools/modernization-toolkit/swing-bridge/` is byte-identical to `main` — 22 files, 0 differing — and `_vaadin-version.adoc` matches this branch except for that one line. Nav order is contiguous with no collisions, and all 158 anchors and every xref in the section resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
