### PR TITLE
docs: add missing input field width and gap style properties

### DIFF
--- a/articles/components/_styling-section-theming-props.adoc
+++ b/articles/components/_styling-section-theming-props.adoc
@@ -25,6 +25,9 @@ Style properties whose names start with `--vaadin-input-field` are shared among 
 |===
 | Property | Supported by
 
+|`--vaadin-field-default-width`
+|Aura, Lumo
+
 |`--vaadin-input-field-background`
 |Aura, Lumo
 
@@ -44,6 +47,9 @@ Style properties whose names start with `--vaadin-input-field` are shared among 
 |Aura, Lumo
 
 |`--vaadin-input-field-container-gap`
+|Aura
+
+|`--vaadin-input-field-gap`
 |Aura
 
 |`--vaadin-input-field-height`


### PR DESCRIPTION
Added missing `--vaadin-field-default-width` and `--vaadin-input-field-gap` custom CSS properties.

Note: technically, gap isn't quite about "field surface" but I couldn't find a better place where to place it.