### PR TITLE
docs: fix incorrect form layout label width property

### DIFF
--- a/articles/components/form-layout/index.adoc
+++ b/articles/components/form-layout/index.adoc
@@ -131,7 +131,7 @@ When the Form Layout's width isn't sufficient to render labels next to fields, i
 [NOTE]
 Forms with labels next to the fields can be confusing if fields are rendered in multiple columns. Although Form Layout supports combining side-labels with multiple columns, this combination is not recommended.
 
-The width of side labels can be configured with the `--vaadin-form-item-label-width` CSS property. The Flow API also has a dedicated `setLabelWidth` API for this.
+The width of side labels can be configured with the `--vaadin-form-layout-label-width` CSS property. The Flow API also has a dedicated `setLabelWidth` API for this.
 
 === Column Width
 

--- a/frontend/demo/component/formlayout/form-layout-steps-labels-aside.ts
+++ b/frontend/demo/component/formlayout/form-layout-steps-labels-aside.ts
@@ -37,7 +37,7 @@ export class Example extends LitElement {
   // tag::snippet[]
   private renderFormLayout() {
     return html`
-      <vaadin-form-layout style="--vaadin-form-item-label-width: 92px;">
+      <vaadin-form-layout style="--vaadin-form-layout-label-width: 92px;">
         <!-- Wrap fields into form items, which
              displays labels on the side by default -->
         <vaadin-form-item>

--- a/frontend/demo/component/formlayout/react/form-layout-steps-labels-aside.tsx
+++ b/frontend/demo/component/formlayout/react/form-layout-steps-labels-aside.tsx
@@ -13,7 +13,7 @@ function Example() {
 
   function renderFormLayout() {
     return (
-      <FormLayout style={{ '--vaadin-form-item-label-width': '92px' }}>
+      <FormLayout style={{ '--vaadin-form-layout-label-width': '92px' }}>
         {/* Wrap fields into form items, which displays labels on the side by default */}
         <FormItem>
           <label slot="label">First name</label>


### PR DESCRIPTION
Fixed incorrect `--vaadin-form-item-label-width` usage in Styling docs and TS examples.
This property has been removed in V25 and is now only mentioned in the upgrade guide.