### PR TITLE
docs: note refreshAll after TreeData.addItem/addRootItems

### DIFF
--- a/articles/components/tree-grid/data-binding.adoc
+++ b/articles/components/tree-grid/data-binding.adoc
@@ -134,6 +134,8 @@ treeData.getChildren(new Folder("Family")); // => empty List
 treeData.getParent(new Folder("Family")); // => null (root item)
 ----
 
+After adding items, make sure to call [methodname]`TreeDataProvider#refreshAll()` to update the Tree Grid UI, as described next in <<#moving-items-within-tree,Moving Items within Tree>>.
+
 === Moving Items within Tree
 
 Once items are added to the [classname]`TreeData`, they can be moved to a different parent within the tree. The next example shows how the [methodname]`TreeData#setParent(item, newParent)` method can be used together with Tree Grid's drag-and-drop events to let users move folders around:


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/19327

The Adding Items, Moving Items within Tree, and Removing Items
sections all mutate TreeData, but only Moving Items and Removing
Items reminded readers to call TreeDataProvider#refreshAll()
afterwards. Adding Items didn't, so following that section alone
left the Tree Grid looking like it ignored the change, same as in
the linked issue.

Added the same reminder to the end of the Adding Items section,
pointing to the fuller explanation in Moving Items within Tree.