### PR TITLE
docs: add missing has-tooltip state attribute

### DIFF
--- a/articles/components/accordion/styling.adoc
+++ b/articles/components/accordion/styling.adoc
@@ -200,6 +200,7 @@ Opened panel:: `vaadin-accordion-panel+++<wbr>+++**[opened]**`
 Disabled panel:: `vaadin-accordion-panel+++<wbr>+++**[disabled]**`
 Focused panel:: `vaadin-accordion-panel+++<wbr>+++**[focused]**`
 Keyboard focused panel:: `vaadin-accordion-panel+++<wbr>+++**[focus-ring]**`
+Panel with tooltip:: `vaadin-accordion-panel+++<wbr>+++**[has-tooltip]**`
 Panel body content wrapper:: `vaadin-accordion-panel+++<wbr>+++**::part(content)**`
 
 

--- a/articles/components/avatar/styling.adoc
+++ b/articles/components/avatar/styling.adoc
@@ -159,6 +159,7 @@ Root element:: `vaadin-avatar`
 Hovered avatar:: `vaadin-avatar+++<wbr>+++**:hover**`
 Focused avatar:: `vaadin-avatar+++<wbr>+++**[focused]**`
 Keyboard focused avatar:: `vaadin-avatar+++<wbr>+++**[focus-ring]**`
+Avatar with tooltip:: `vaadin-avatar+++<wbr>+++**[has-tooltip]**`
 Avatar with color index:: `vaadin-avatar+++<wbr>+++**[has-color-index]**`
 Overflow avatar:: `vaadin-avatar+++<wbr>+++**[slot="overflow"]**`
 Expanded overflow avatar:: `vaadin-avatar+++<wbr>+++**[aria-expanded="true"]**`

--- a/articles/components/button/styling.adoc
+++ b/articles/components/button/styling.adoc
@@ -402,9 +402,9 @@ Root element:: `vaadin-button`
 Disabled:: `vaadin-button+++<wbr>+++**[disabled]**`
 Focused:: `vaadin-button+++<wbr>+++**[focused]**`
 Keyboard Focused:: `vaadin-button+++<wbr>+++**[focus-ring]**`
+With tooltip:: `vaadin-button+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-button+++<wbr>+++**:hover**`
 Hover Highlight:: `vaadin-button+++<wbr>+++**:hover::before**`
-Button with tooltip:: `vaadin-button+++<wbr>+++**[has-tooltip]**`
 
 
 === Parts

--- a/articles/components/button/styling.adoc
+++ b/articles/components/button/styling.adoc
@@ -404,6 +404,7 @@ Focused:: `vaadin-button+++<wbr>+++**[focused]**`
 Keyboard Focused:: `vaadin-button+++<wbr>+++**[focus-ring]**`
 Hovered:: `vaadin-button+++<wbr>+++**:hover**`
 Hover Highlight:: `vaadin-button+++<wbr>+++**:hover::before**`
+Button with tooltip:: `vaadin-button+++<wbr>+++**[has-tooltip]**`
 
 
 === Parts

--- a/articles/components/checkbox/styling.adoc
+++ b/articles/components/checkbox/styling.adoc
@@ -159,6 +159,7 @@ Focused:: `vaadin-checkbox+++<wbr>+++**[focused]**`
 Keyboard focused:: `vaadin-checkbox+++<wbr>+++**[focus-ring]**`
 Disabled:: `vaadin-checkbox+++<wbr>+++**[disabled]**`
 Read-only:: `vaadin-checkbox+++<wbr>+++**[readonly]**`
+Checkbox with tooltip:: `vaadin-checkbox+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-checkbox+++<wbr>+++**:hover**`
 Pressed:: `vaadin-checkbox+++<wbr>+++**[active]**`
 Checked:: `vaadin-checkbox+++<wbr>+++**[checked]**`
@@ -181,6 +182,7 @@ Disabled:: `vaadin-checkbox-group+++<wbr>+++**[disabled]**`
 Read-only:: `vaadin-checkbox-group+++<wbr>+++**[readonly]**`
 Hovered:: `vaadin-checkbox-group+++<wbr>+++**:hover**`
 One or more checkboxes checked:: `vaadin-checkbox-group+++<wbr>+++**[has-value]**`
+Checkbox group with tooltip:: `vaadin-checkbox-group+++<wbr>+++**[has-tooltip]**`
 
 
 ==== Parts

--- a/articles/components/combo-box/styling.adoc
+++ b/articles/components/combo-box/styling.adoc
@@ -118,6 +118,7 @@ Keyboard focused:: `vaadin-combo-box+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-combo-box+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-combo-box+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-combo-box+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-combo-box+++<wbr>+++**[has-tooltip]**`
 With open overlay:: `vaadin-combo-box+++<wbr>+++**[opened]**`
 Loading items:: `vaadin-combo-box+++<wbr>+++**[loading]**`
 Hovered:: `vaadin-combo-box+++<wbr>+++**:hover**`

--- a/articles/components/combo-box/styling.adoc
+++ b/articles/components/combo-box/styling.adoc
@@ -118,7 +118,7 @@ Keyboard focused:: `vaadin-combo-box+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-combo-box+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-combo-box+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-combo-box+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-combo-box+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-combo-box+++<wbr>+++**[has-tooltip]**`
 With open overlay:: `vaadin-combo-box+++<wbr>+++**[opened]**`
 Loading items:: `vaadin-combo-box+++<wbr>+++**[loading]**`
 Hovered:: `vaadin-combo-box+++<wbr>+++**:hover**`

--- a/articles/components/custom-field/styling.adoc
+++ b/articles/components/custom-field/styling.adoc
@@ -97,7 +97,7 @@ Keyboard focused:: `vaadin-custom-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-custom-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-custom-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-custom-field+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-custom-field+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-custom-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-custom-field+++<wbr>+++**:hover**`
 
 

--- a/articles/components/custom-field/styling.adoc
+++ b/articles/components/custom-field/styling.adoc
@@ -97,6 +97,7 @@ Keyboard focused:: `vaadin-custom-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-custom-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-custom-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-custom-field+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-custom-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-custom-field+++<wbr>+++**:hover**`
 
 

--- a/articles/components/date-picker/styling.adoc
+++ b/articles/components/date-picker/styling.adoc
@@ -176,6 +176,7 @@ Keyboard focused:: `vaadin-date-picker+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-date-picker+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-date-picker+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-date-picker+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-date-picker+++<wbr>+++**[has-tooltip]**`
 With open overlay:: `vaadin-date-picker+++<wbr>+++**[opened]**`
 With week numbers visible:: `vaadin-date-picker+++<wbr>+++**[week-numbers]**`
 Hovered:: `vaadin-date-picker+++<wbr>+++**:hover**`

--- a/articles/components/date-picker/styling.adoc
+++ b/articles/components/date-picker/styling.adoc
@@ -176,7 +176,7 @@ Keyboard focused:: `vaadin-date-picker+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-date-picker+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-date-picker+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-date-picker+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-date-picker+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-date-picker+++<wbr>+++**[has-tooltip]**`
 With open overlay:: `vaadin-date-picker+++<wbr>+++**[opened]**`
 With week numbers visible:: `vaadin-date-picker+++<wbr>+++**[week-numbers]**`
 Hovered:: `vaadin-date-picker+++<wbr>+++**:hover**`

--- a/articles/components/date-time-picker/styling.adoc
+++ b/articles/components/date-time-picker/styling.adoc
@@ -69,6 +69,7 @@ Keyboard focused:: `vaadin-date-time-picker+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-date-time-picker+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-date-time-picker+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-date-time-picker+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-date-time-picker+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-date-time-picker+++<wbr>+++**:hover**`
 
 

--- a/articles/components/date-time-picker/styling.adoc
+++ b/articles/components/date-time-picker/styling.adoc
@@ -69,7 +69,7 @@ Keyboard focused:: `vaadin-date-time-picker+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-date-time-picker+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-date-time-picker+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-date-time-picker+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-date-time-picker+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-date-time-picker+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-date-time-picker+++<wbr>+++**:hover**`
 
 

--- a/articles/components/details/styling.adoc
+++ b/articles/components/details/styling.adoc
@@ -171,6 +171,7 @@ Root element:: `vaadin-details`
 Opened panel:: `vaadin-details+++<wbr>+++**[opened]**`
 Disabled panel:: `vaadin-details+++<wbr>+++**[disabled]**`
 Focused panel:: `vaadin-details+++<wbr>+++**[focused]**`
+Panel with tooltip:: `vaadin-details+++<wbr>+++**[has-tooltip]**`
 Keyboard focused panel:: `vaadin-details+++<wbr>+++**[focus-ring]**`
 
 

--- a/articles/components/email-field/styling.adoc
+++ b/articles/components/email-field/styling.adoc
@@ -60,6 +60,7 @@ Keyboard focused:: `vaadin-email-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-email-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-email-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-email-field+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-email-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-email-field+++<wbr>+++**:hover**`
 
 

--- a/articles/components/email-field/styling.adoc
+++ b/articles/components/email-field/styling.adoc
@@ -60,7 +60,7 @@ Keyboard focused:: `vaadin-email-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-email-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-email-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-email-field+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-email-field+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-email-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-email-field+++<wbr>+++**:hover**`
 
 

--- a/articles/components/icons/styling.adoc
+++ b/articles/components/icons/styling.adoc
@@ -32,3 +32,4 @@ include::../_styling-section-intros.adoc[tag=selectors]
 
 
 Root element:: `vaadin-icon`
+Icon with tooltip:: `vaadin-icon+++<wbr>+++**[has-tooltip]**`

--- a/articles/components/icons/styling.adoc
+++ b/articles/components/icons/styling.adoc
@@ -32,4 +32,4 @@ include::../_styling-section-intros.adoc[tag=selectors]
 
 
 Root element:: `vaadin-icon`
-Icon with tooltip:: `vaadin-icon+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-icon+++<wbr>+++**[has-tooltip]**`

--- a/articles/components/list-box/styling.adoc
+++ b/articles/components/list-box/styling.adoc
@@ -49,7 +49,7 @@ Root element:: `vaadin-list-box`
 === List Box
 
 Multi-select:: `vaadin-list-box+++<wbr>+++**[multiple]**`
-List box with tooltip:: `vaadin-list-box+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-list-box+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-list-box+++<wbr>+++**:hover**`
 Item layout / scroller:: `vaadin-list-box+++<wbr>+++**::part(items)**`
 

--- a/articles/components/list-box/styling.adoc
+++ b/articles/components/list-box/styling.adoc
@@ -49,6 +49,7 @@ Root element:: `vaadin-list-box`
 === List Box
 
 Multi-select:: `vaadin-list-box+++<wbr>+++**[multiple]**`
+List box with tooltip:: `vaadin-list-box+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-list-box+++<wbr>+++**:hover**`
 Item layout / scroller:: `vaadin-list-box+++<wbr>+++**::part(items)**`
 

--- a/articles/components/message-input/styling.adoc
+++ b/articles/components/message-input/styling.adoc
@@ -36,6 +36,7 @@ include::../_styling-section-intros.adoc[tag=selectors]
 
 Root element:: `vaadin-message-input`
 Disabled:: `vaadin-message-input+++<wbr>+++**[disabled]**`
+Message input with tooltip:: `vaadin-message-input+++<wbr>+++**[has-tooltip]**`
 
 === Field
 

--- a/articles/components/message-input/styling.adoc
+++ b/articles/components/message-input/styling.adoc
@@ -36,7 +36,7 @@ include::../_styling-section-intros.adoc[tag=selectors]
 
 Root element:: `vaadin-message-input`
 Disabled:: `vaadin-message-input+++<wbr>+++**[disabled]**`
-Message input with tooltip:: `vaadin-message-input+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-message-input+++<wbr>+++**[has-tooltip]**`
 
 === Field
 

--- a/articles/components/multi-select-combo-box/styling.adoc
+++ b/articles/components/multi-select-combo-box/styling.adoc
@@ -98,6 +98,7 @@ Keyboard focused:: `vaadin-multi-select-combo-box+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-multi-select-combo-box+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-multi-select-combo-box+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-multi-select-combo-box+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-multi-select-combo-box+++<wbr>+++**[has-tooltip]**`
 With open overlay:: `vaadin-multi-select-combo-box+++<wbr>+++**[opened]**`
 Loading items:: `vaadin-multi-select-combo-box+++<wbr>+++**[loading]**`
 Hovered:: `vaadin-multi-select-combo-box+++<wbr>+++**:hover**`

--- a/articles/components/multi-select-combo-box/styling.adoc
+++ b/articles/components/multi-select-combo-box/styling.adoc
@@ -98,7 +98,7 @@ Keyboard focused:: `vaadin-multi-select-combo-box+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-multi-select-combo-box+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-multi-select-combo-box+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-multi-select-combo-box+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-multi-select-combo-box+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-multi-select-combo-box+++<wbr>+++**[has-tooltip]**`
 With open overlay:: `vaadin-multi-select-combo-box+++<wbr>+++**[opened]**`
 Loading items:: `vaadin-multi-select-combo-box+++<wbr>+++**[loading]**`
 Hovered:: `vaadin-multi-select-combo-box+++<wbr>+++**:hover**`

--- a/articles/components/number-field/styling.adoc
+++ b/articles/components/number-field/styling.adoc
@@ -60,6 +60,7 @@ Keyboard focused:: `vaadin-number-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-number-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-number-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-number-field+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-number-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-number-field+++<wbr>+++**:hover**`
 
 

--- a/articles/components/number-field/styling.adoc
+++ b/articles/components/number-field/styling.adoc
@@ -60,7 +60,7 @@ Keyboard focused:: `vaadin-number-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-number-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-number-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-number-field+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-number-field+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-number-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-number-field+++<wbr>+++**:hover**`
 
 

--- a/articles/components/password-field/styling.adoc
+++ b/articles/components/password-field/styling.adoc
@@ -60,7 +60,7 @@ Keyboard focused:: `vaadin-password-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-password-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-password-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-password-field+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-password-field+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-password-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-password-field+++<wbr>+++**:hover**`
 Password visible:: `vaadin-password-field+++<wbr>+++**[password-visible]**`
 Password masked:: `vaadin-password-field+++<wbr>+++**:not([password-visible])**`

--- a/articles/components/password-field/styling.adoc
+++ b/articles/components/password-field/styling.adoc
@@ -60,6 +60,7 @@ Keyboard focused:: `vaadin-password-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-password-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-password-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-password-field+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-password-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-password-field+++<wbr>+++**:hover**`
 Password visible:: `vaadin-password-field+++<wbr>+++**[password-visible]**`
 Password masked:: `vaadin-password-field+++<wbr>+++**:not([password-visible])**`

--- a/articles/components/radio-button/styling.adoc
+++ b/articles/components/radio-button/styling.adoc
@@ -145,6 +145,7 @@ Disabled:: `vaadin-radio-group+++<wbr>+++**[disabled]**`
 Read-only:: `vaadin-radio-group+++<wbr>+++**[readonly]**`
 Hovered:: `vaadin-radio-group+++<wbr>+++**:hover**`
 Has selection:: `vaadin-radio-group+++<wbr>+++**[has-value]**`
+Radio group with tooltip:: `vaadin-radio-group+++<wbr>+++**[has-tooltip]**`
 
 
 ==== Parts

--- a/articles/components/radio-button/styling.adoc
+++ b/articles/components/radio-button/styling.adoc
@@ -145,7 +145,7 @@ Disabled:: `vaadin-radio-group+++<wbr>+++**[disabled]**`
 Read-only:: `vaadin-radio-group+++<wbr>+++**[readonly]**`
 Hovered:: `vaadin-radio-group+++<wbr>+++**:hover**`
 Has selection:: `vaadin-radio-group+++<wbr>+++**[has-value]**`
-Radio group with tooltip:: `vaadin-radio-group+++<wbr>+++**[has-tooltip]**`
+Has tooltip:: `vaadin-radio-group+++<wbr>+++**[has-tooltip]**`
 
 
 ==== Parts

--- a/articles/components/side-nav/styling.adoc
+++ b/articles/components/side-nav/styling.adoc
@@ -151,12 +151,12 @@ Item root element:: `vaadin-side-nav-item`
 Current view/page item:: `vaadin-side-nav-item+++<wbr>+++**[current]**`
 Item with link:: `vaadin-side-nav-item+++<wbr>+++**[path]**`
 Item without link:: `vaadin-side-nav-item+++<wbr>+++**:not([path])**`
+Item with tooltip:: `vaadin-side-nav-item+++<wbr>+++**[has-tooltip]**`
 Item contents (excl. children):: `vaadin-side-nav-item+++<wbr>+++**::part(content)**`
 Link label (incl. prefix/suffix):: `vaadin-side-nav-item+++<wbr>+++**::part(link)**`
 Item prefix element:: `vaadin-side-nav-item+++<wbr>+++** > [slot="prefix"]**`
 Item suffix element:: `vaadin-side-nav-item+++<wbr>+++** > [slot="suffix"]**`
 Item icon:: `vaadin-side-nav-item+++<wbr>+++** > vaadin-icon**`
-Item with tooltip:: `vaadin-side-nav-item+++<wbr>+++**[has-tooltip]**`
 
 
 === Parent and Child Items

--- a/articles/components/side-nav/styling.adoc
+++ b/articles/components/side-nav/styling.adoc
@@ -156,6 +156,7 @@ Link label (incl. prefix/suffix):: `vaadin-side-nav-item+++<wbr>+++**::part(link
 Item prefix element:: `vaadin-side-nav-item+++<wbr>+++** > [slot="prefix"]**`
 Item suffix element:: `vaadin-side-nav-item+++<wbr>+++** > [slot="suffix"]**`
 Item icon:: `vaadin-side-nav-item+++<wbr>+++** > vaadin-icon**`
+Item with tooltip:: `vaadin-side-nav-item+++<wbr>+++**[has-tooltip]**`
 
 
 === Parent and Child Items

--- a/articles/components/switch/styling.adoc
+++ b/articles/components/switch/styling.adoc
@@ -109,7 +109,7 @@ Disabled:: `vaadin-switch+++<wbr>+++**[disabled]**`
 Read-only:: `vaadin-switch+++<wbr>+++**[readonly]**`
 Pressed:: `vaadin-switch+++<wbr>+++**[active]**`
 Checked (on):: `vaadin-switch+++<wbr>+++**[checked]**`
-Switch with tooltip:: `vaadin-switch+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-switch+++<wbr>+++**[has-tooltip]**`
 Track:: `vaadin-switch+++<wbr>+++**::part(switch)**`
 Marker:: `vaadin-switch+++<wbr>+++**::part(marker)**`
 Label:: `vaadin-switch+++<wbr>+++**::part(label)**`

--- a/articles/components/switch/styling.adoc
+++ b/articles/components/switch/styling.adoc
@@ -109,6 +109,7 @@ Disabled:: `vaadin-switch+++<wbr>+++**[disabled]**`
 Read-only:: `vaadin-switch+++<wbr>+++**[readonly]**`
 Pressed:: `vaadin-switch+++<wbr>+++**[active]**`
 Checked (on):: `vaadin-switch+++<wbr>+++**[checked]**`
+Switch with tooltip:: `vaadin-switch+++<wbr>+++**[has-tooltip]**`
 Track:: `vaadin-switch+++<wbr>+++**::part(switch)**`
 Marker:: `vaadin-switch+++<wbr>+++**::part(marker)**`
 Label:: `vaadin-switch+++<wbr>+++**::part(label)**`

--- a/articles/components/tabs/styling.adoc
+++ b/articles/components/tabs/styling.adoc
@@ -350,5 +350,6 @@ Keyboard focused:: `vaadin-tab+++<wbr>+++**[focus-ring]**`
 Pressed:: `vaadin-tab+++<wbr>+++**[active]**`
 Hovered:: `vaadin-tab+++<wbr>+++**:hover**`
 Disabled:: `vaadin-tab+++<wbr>+++**[disabled]**`
+Tab with tooltip:: `vaadin-tab+++<wbr>+++**[has-tooltip]**`
 Selection indicator:: `vaadin-tab+++<wbr>+++**::before**`
 Icon in tab:: `vaadin-tab+++<wbr>+++** > vaadin-icon**`

--- a/articles/components/tabs/styling.adoc
+++ b/articles/components/tabs/styling.adoc
@@ -350,6 +350,6 @@ Keyboard focused:: `vaadin-tab+++<wbr>+++**[focus-ring]**`
 Pressed:: `vaadin-tab+++<wbr>+++**[active]**`
 Hovered:: `vaadin-tab+++<wbr>+++**:hover**`
 Disabled:: `vaadin-tab+++<wbr>+++**[disabled]**`
-Tab with tooltip:: `vaadin-tab+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-tab+++<wbr>+++**[has-tooltip]**`
 Selection indicator:: `vaadin-tab+++<wbr>+++**::before**`
 Icon in tab:: `vaadin-tab+++<wbr>+++** > vaadin-icon**`

--- a/articles/components/text-area/styling.adoc
+++ b/articles/components/text-area/styling.adoc
@@ -60,7 +60,7 @@ Keyboard focused:: `vaadin-text-area+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-text-area+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-text-area+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-text-area+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-text-area+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-text-area+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-text-area+++<wbr>+++**:hover**`
 
 

--- a/articles/components/text-area/styling.adoc
+++ b/articles/components/text-area/styling.adoc
@@ -60,6 +60,7 @@ Keyboard focused:: `vaadin-text-area+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-text-area+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-text-area+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-text-area+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-text-area+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-text-area+++<wbr>+++**:hover**`
 
 

--- a/articles/components/text-field/styling.adoc
+++ b/articles/components/text-field/styling.adoc
@@ -60,6 +60,7 @@ Keyboard focused:: `vaadin-text-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-text-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-text-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-text-field+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-text-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-text-field+++<wbr>+++**:hover**`
 
 

--- a/articles/components/text-field/styling.adoc
+++ b/articles/components/text-field/styling.adoc
@@ -60,7 +60,7 @@ Keyboard focused:: `vaadin-text-field+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-text-field+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-text-field+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-text-field+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-text-field+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-text-field+++<wbr>+++**[has-tooltip]**`
 Hovered:: `vaadin-text-field+++<wbr>+++**:hover**`
 
 

--- a/articles/components/time-picker/styling.adoc
+++ b/articles/components/time-picker/styling.adoc
@@ -98,6 +98,7 @@ Keyboard focused:: `vaadin-time-picker+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-time-picker+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-time-picker+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-time-picker+++<wbr>+++**[has-value]**`
+Field with tooltip:: `vaadin-time-picker+++<wbr>+++**[has-tooltip]**`
 With open overlay:: `vaadin-time-picker+++<wbr>+++**[opened]**`
 Hovered:: `vaadin-time-picker+++<wbr>+++**:hover**`
 

--- a/articles/components/time-picker/styling.adoc
+++ b/articles/components/time-picker/styling.adoc
@@ -98,7 +98,7 @@ Keyboard focused:: `vaadin-time-picker+++<wbr>+++**[focus-ring]**`
 Read-only:: `vaadin-time-picker+++<wbr>+++**[readonly]**`
 Disabled:: `vaadin-time-picker+++<wbr>+++**[disabled]**`
 Not empty:: `vaadin-time-picker+++<wbr>+++**[has-value]**`
-Field with tooltip:: `vaadin-time-picker+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-time-picker+++<wbr>+++**[has-tooltip]**`
 With open overlay:: `vaadin-time-picker+++<wbr>+++**[opened]**`
 Hovered:: `vaadin-time-picker+++<wbr>+++**:hover**`
 

--- a/articles/components/upload/styling.adoc
+++ b/articles/components/upload/styling.adoc
@@ -248,6 +248,7 @@ Disabled:: `vaadin-upload-button+++<wbr>+++**[disabled]**`
 Focused:: `vaadin-upload-button+++<wbr>+++**[focused]**`
 Keyboard focused:: `vaadin-upload-button+++<wbr>+++**[focus-ring]**`
 Maximum files reached:: `vaadin-upload-button+++<wbr>+++**[max-files-reached]**`
+Button with tooltip:: `vaadin-upload-button+++<wbr>+++**[has-tooltip]**`
 
 
 === Upload Drop Zone

--- a/articles/components/upload/styling.adoc
+++ b/articles/components/upload/styling.adoc
@@ -248,7 +248,7 @@ Disabled:: `vaadin-upload-button+++<wbr>+++**[disabled]**`
 Focused:: `vaadin-upload-button+++<wbr>+++**[focused]**`
 Keyboard focused:: `vaadin-upload-button+++<wbr>+++**[focus-ring]**`
 Maximum files reached:: `vaadin-upload-button+++<wbr>+++**[max-files-reached]**`
-Button with tooltip:: `vaadin-upload-button+++<wbr>+++**[has-tooltip]**`
+With tooltip:: `vaadin-upload-button+++<wbr>+++**[has-tooltip]**`
 
 
 === Upload Drop Zone


### PR DESCRIPTION
Documents the `has-tooltip` state attribute on every element that declares it in the web components, but was missing from the styling pages.

Placed in each page's existing states list, using that page's own wording:

- Fields (`Field with tooltip`): Combo Box, Custom Field, Date Picker, Date Time Picker, Email Field, Multi-Select Combo Box, Number Field, Password Field, Text Area, Text Field, Time Picker
- Selection: Checkbox, Checkbox Group, Radio Button Group, Switch
- Buttons: Button, Upload Button
- Others: Accordion Panel, Details, Avatar, Icon, List Box, Message Input, Side Nav Item, Tab

Integer Field also exposes `has-tooltip`, but no page documents `vaadin-integer-field` selectors, so it is left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)