### PR TITLE
docs: cover common Vaadin 8 to 25 migration pitfalls

### DIFF
--- a/articles/components/charts/configuration.adoc
+++ b/articles/components/charts/configuration.adoc
@@ -46,6 +46,43 @@ pass:[<!-- vale Vale.Spelling = YES -->]
 For data configuration, see <<data#charts.data,"Chart Data">>.
 For styling, see <<styling#charts.styling,"Chart Styling">>.
 
+
+[[charts.configuration.series-link]]
+== Series and Configuration
+
+A series doesn't know about the chart until it's added to the chart's [classname]`Configuration`. The link is created by [methodname]`addSeries()` and [methodname]`setSeries()`, which are the only methods that set the configuration on a series.
+
+Because of this, [methodname]`getConfiguration()` on a series returns `null` until the series has been added. Calling it earlier -- for example, to reach an axis while building the series -- throws a [classname]`NullPointerException`, and [methodname]`setyAxis(YAxis)` throws an [classname]`IllegalStateException`.
+
+.Reading the configuration too early
+[source,java]
+----
+ListSeries series = new ListSeries("Sales", 49.9, 71.5, 106.4);
+// Throws NullPointerException: the series isn't linked to a
+// configuration yet.
+series.getConfiguration().getyAxis().setTitle("Value");
+configuration.addSeries(series);
+----
+
+.Adding the series first
+[source,java]
+----
+ListSeries series = new ListSeries("Sales", 49.9, 71.5, 106.4);
+configuration.addSeries(series);
+// The series is now linked, so the axis can be reached through it.
+series.getConfiguration().getyAxis().setTitle("Value");
+----
+
+Axes belong to the configuration rather than to an individual series, so a helper method that configures axes should take the [classname]`Configuration` as a parameter instead of reading it back from a series:
+
+[source,java]
+----
+private void configureAxes(Configuration configuration) {
+    configuration.getyAxis().setTitle("Value");
+    configuration.getxAxis().setTitle("Month");
+}
+----
+
 [[charts.configuration.plotoptions]]
 == Plot Options
 

--- a/articles/flow/security/enabling-security.adoc
+++ b/articles/flow/security/enabling-security.adoc
@@ -198,6 +198,19 @@ public class MainLayout extends AppLayout {
 }
 ----
 
+The same component also covers programmatic access checks elsewhere in the application, such as deciding whether to render a navigation item or to enable an action. Roles are given without the role prefix, which [classname]`AuthenticationContext` adds when comparing against the granted authorities (see <<role-prefix, Roles & the Role Prefix>>). An application migrating from a custom security mechanism therefore doesn't need a security utility class of its own:
+
+[source,java]
+----
+SideNav nav = new SideNav();
+nav.addItem(new SideNavItem("Dashboard", DashboardView.class));
+if (authContext.hasRole("ADMIN")) { // Not "ROLE_ADMIN".
+    nav.addItem(new SideNavItem("Administration", AdminView.class));
+}
+----
+
+Hiding a navigation item is a usability measure, not a security measure. The view it points to still needs its own access annotation, since a user can navigate there by entering the URL directly.
+
 
 == Security Configuration Class
 
@@ -264,6 +277,14 @@ The [classname]`VaadinSecurityConfigurer` handles all of the Vaadin-related conf
 
 The log-in view can be configured via the provided [methodname]`loginView()` method on the configurer.
 
+.Configure Form Login Through the Configurer
+[WARNING]
+====
+Configure form login with [methodname]`loginView()` rather than by calling Spring Security's [methodname]`formLogin()` directly. The configurer applies [classname]`FormLoginConfigurer` internally, and at the same time permits Vaadin's internal requests, ignores them in the CSRF check, installs a Vaadin-aware request cache and success handler, and registers the log-in view with navigation access control.
+
+A hand-written [methodname]`formLogin()` configuration does none of that. The internal request that the log-in view itself makes to the server is then treated as an unauthenticated request and redirected back to the log-in view, which produces an endless redirect loop -- typically visible as an `ERR_TOO_MANY_REDIRECTS` page or a "Connection lost" notification instead of a working log-in form.
+====
+
 .Never Use Hard-Coded Credentials in Production
 [WARNING]
 The implementation of the [methodname]`userDetailsService()` method is just an in-memory implementation for the sake of brevity in this documentation. In a normal application, you can change the Spring Security configuration to use an authentication provider for Lightweight Directory Access Protocol (LDAP), JAAS, and other real-world sources. See  https://dzone.com/articles/flow/spring-security-authentication[Spring Security authentication providers] to read more about them.
@@ -328,6 +349,37 @@ This example is using [annotationname]`@RolesAllowed` to enable only the users w
 @RolesAllowed("ADMIN") // <- Should match one of the user's roles (case-sensitive)
 public class AdminView extends VerticalLayout {
     // ...
+}
+----
+
+
+[[role-prefix]]
+=== Roles & the Role Prefix
+
+Spring Security distinguishes between _authorities_, which are arbitrary strings, and _roles_, which are authorities carrying a prefix. The default prefix is `ROLE_`. Role names in [annotationname]`@RolesAllowed` are given without the prefix, and the prefix is added when the granted authorities are checked. So [annotationname]`@RolesAllowed("ADMIN")` matches the granted authority `ROLE_ADMIN`.
+
+This matters when writing a custom [interfacename]`UserDetailsService` or authentication provider, since the authorities have to be created with the prefix included:
+
+[source,java]
+----
+List<GrantedAuthority> authorities = user.getRoles().stream()
+        .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+        .collect(Collectors.toList());
+----
+
+The [methodname]`roles()` builder method of Spring's [classname]`User` class adds the prefix for you, whereas [methodname]`authorities()` doesn't. That's why the examples on this page use `User.withUsername("admin").roles("ADMIN")` to grant the `ROLE_ADMIN` authority.
+
+.Missing Prefixes Fail Silently
+[WARNING]
+If the authority is stored as `ADMIN` instead of `ROLE_ADMIN`, no error is reported. The role check never matches: views annotated with [annotationname]`@RolesAllowed("ADMIN")` become inaccessible, and any menu item shown conditionally on that role disappears. If a role check doesn't behave as expected, log [methodname]`AuthenticationContext.getGrantedAuthorities()` and confirm that the authorities carry the prefix.
+
+To use a prefix other than `ROLE_`, or none at all, define a [classname]`GrantedAuthorityDefaults` bean. Vaadin picks up the configured prefix and applies it to the access annotations and to the role-checking methods of [classname]`AuthenticationContext`:
+
+[source,java]
+----
+@Bean
+static GrantedAuthorityDefaults grantedAuthorityDefaults() {
+    return new GrantedAuthorityDefaults(""); // No prefix.
 }
 ----
 

--- a/articles/upgrading/index.adoc
+++ b/articles/upgrading/index.adoc
@@ -79,6 +79,13 @@ Ensure your application is not using deprecated code fragments.
 Make sure your application runs well on Java 21 runtime.
 
 
+=== Keeping the Upgrade Scoped
+
+An upgrade goes more smoothly when it changes only what the breaking changes require: the platform and dependency versions, the security configuration, theme loading, and the component and API changes listed on this page. Everything else -- the application's architectural patterns, its business logic, its naming conventions, and any custom component hierarchies that still compile and behave correctly -- can be left as it is and revisited separately once the upgraded application has been verified.
+
+Separating the two makes it possible to tell an upgrade regression from an unrelated change when something breaks. This is worth stating explicitly when an AI coding assistant does the upgrade, as such tools tend to modernize surrounding code along the way.
+
+
 == Preparation
 
 Upgrade the Vaadin version in the [filename]`pom.xml` and [filename]`gradle.properties` files to the latest release like so:
@@ -305,6 +312,8 @@ The [annotationname]`@StyleSheet` annotation is now the recommended way to load 
 @StyleSheet("styles.css") // references src/main/resources/META-INF/resources/styles.css
 public class Application implements AppShellConfigurator {}
 ----
+
+Loading a theme is explicit in Vaadin 25: an application class that implements [interfacename]`AppShellConfigurator` without a [annotationname]`@StyleSheet` or [annotationname]`@Theme` annotation gets no theme at all. The application still starts and works, but the components render with only their minimal <<{articles}/styling/themes/base#, base styles>>, which looks unfinished rather than broken. If an upgraded application suddenly loses its styling, this is the first thing to check. Only an application with no [interfacename]`AppShellConfigurator` at all falls back to loading Aura automatically.
 
 Stylesheets referenced by [annotationname]`@StyleSheet` annotation are loaded by the servlet container. [since:com.vaadin:vaadin@V25.2]#Stylesheet URLs are automatically resolved against the servlet context root, so they work also when the application is configured to use a custom URL mapping for the [classname]`VaadinServlet` (e.g. `vaadin.url-mapping` setting in Spring applications).# Prefixing the URL with the `context://` protocol is no longer necessary, but it's still supported.
 
@@ -1034,6 +1043,8 @@ public class SecurityConfiguration {
 }
 ----
 
+Keep form login configured through the configurer's [methodname]`loginView()` method. Replacing it with a direct call to Spring Security's [methodname]`formLogin()` leaves Vaadin's internal requests subject to the authentication entry point, which sends the log-in view into an endless redirect loop -- seen in the browser as `ERR_TOO_MANY_REDIRECTS` or a "Connection lost" notification. See <<{articles}/flow/security/enabling-security#, Enabling Security>> for what the configurer sets up.
+
 
 ==== Restrict Access By Default For Url-Based Security
 URLs not explicitly specified in security configuration changed from being allowed for authenticated users to restricted by default. This requires extra security rules (path matchers) for URLs that were allowed only for authentication users.
@@ -1057,6 +1068,16 @@ public class MainLayout extends AppLayout {
 public class MainLayout extends AppLayout {
 }
 ----
+
+A layout without an annotation falls back to the default [annotationname]`@DenyAll` rule, and every view inside it becomes unreachable. Navigation is then denied with a message such as this one:
+
+----
+Denied access to view 'DashboardView' due to layout 'MainLayout' access rules.
+Consider adding one of the following annotations to make the layout accessible:
+@AnonymousAllowed, @PermitAll, or @RolesAllowed.
+----
+
+Both the layout and the view have to grant access independently, so annotate the layout at least as permissively as the views it hosts. Use [annotationname]`@AnonymousAllowed` for a layout that hosts public views, [annotationname]`@PermitAll` for one that hosts views open to any authenticated user, and [annotationname]`@RolesAllowed` when every view inside is restricted to the same roles. See <<{articles}/flow/security/enabling-security#annotating-the-view-classes, Annotating View Classes>> for details.
 
 
 == Security Defaults in Vaadin 25.2


### PR DESCRIPTION
Based on feedback from a production Vaadin 8 → 25 migration. Each item below caused real debugging time and was either missing from the docs or hard to find from the symptom.

## Charts — `series.getConfiguration()` returns `null`

New [Series and Configuration](https://github.com/vaadin/docs/blob/claude/vaadin-migration-docs-2aa714/articles/components/charts/configuration.adoc) section. A series is linked to a `Configuration` only by `addSeries()`/`setSeries()`, so reading `getConfiguration()` before that throws `NullPointerException`, and `setyAxis(YAxis)` throws `IllegalStateException`.

The feedback reported this as a V25 breaking change. It isn't — `AbstractSeries` behaves identically in 24.9.7 and 25.0.0 — so it's documented as a Charts pitfall rather than in the Upgrading Guide. It still bites when migrating V8 chart code that configures series before adding them.

## Security — form login

Warning against configuring form login with Spring Security's `formLogin()` instead of the configurer's `loginView()`, with the symptom (`ERR_TOO_MANY_REDIRECTS` / "Connection lost"), plus a short pointer from the `VaadinWebSecurity` migration steps in the Upgrading Guide.

## Security — the `ROLE_` prefix

New "Roles & the Role Prefix" section: why `@RolesAllowed("ADMIN")` matches `ROLE_ADMIN`, why `User.roles()` works but `authorities()` doesn't, a warning that a missing prefix fails silently, and `GrantedAuthorityDefaults` for changing it. `GrantedAuthorityDefaults` had no mentions in the docs before this.

## Security — programmatic role checks

The feedback proposed documenting a static `SecurityUtils` helper. `AuthenticationContext` already does that job and, unlike a static helper, strips the configured prefix instead of hardcoding `ROLE_`. Extended the Security Utilities section with the conditional-nav-item example instead, plus a note that hiding a nav item isn't a security measure.

## Upgrading — layout access denied

Quoted the actual message so it's searchable, and explained how to choose the annotation. Correcting the premise slightly: the framework message already suggests the annotations (verified in `AnnotatedViewAccessChecker` for both 25.0.0 and 25.3.0-beta3), so this is about findability. Also, the feedback's advice to always use `@PermitAll` is too narrow — the layout must be at least as permissive as the views it hosts.

## Upgrading — no default theme

Two accuracy adjustments to the reported symptom: the app renders with minimal *base styles*, not raw HTML, and an app with **no** `AppShellConfigurator` still falls back to Aura. The trap is specifically having one without a `@StyleSheet`, which is the upgraded-app case.

## Upgrading — keeping the upgrade scoped

Short subsection in the Overview on changing only what the breaking changes require, including a note that this is worth stating explicitly to AI coding assistants.

---

One feedback item is not addressed here: the primer returned by `get_vaadin_primer` shows `VaadinSecurityConfigurer.apply(http)`, which does not exist — `vaadin()` is the only factory method. That is already fixed in the MCP server release currently in QA, and the endpoint URL isn't changing, so no docs change is needed.

Vale is clean on all three files (remaining alerts are pre-existing) and Asciidoctor reports no new structural warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)