### PR TITLE
docs: one section for theme name bindings, and no dark in the examples

### DIFF
--- a/articles/flow/ui-state/building-ui.adoc
+++ b/articles/flow/ui-state/building-ui.adoc
@@ -281,38 +281,6 @@ field.bindRequiredIndicatorVisible(required);
 For more details, see <<element-bindings#required-indicator-binding,Required Indicator Binding>> in Element Bindings.
 
 
-== Binding Theme Variants
-
-Use [methodname]`getThemeList().bind()` to toggle theme variants based on a signal:
-
-[source,java]
-----
-ValueSignal<Boolean> darkMode = new ValueSignal<>(false);
-
-VerticalLayout layout = new VerticalLayout();
-layout.getThemeList().bind("dark", darkMode);
-// Dark theme applied when darkMode is true
-
-Button toggleTheme = new Button("Toggle Dark Mode");
-toggleTheme.addClickListener(e -> darkMode.update(v -> !v));
-----
-
-
-=== Multiple Theme Variants
-
-Bind multiple independent theme variants:
-
-[source,java]
-----
-ValueSignal<Boolean> compact = new ValueSignal<>(false);
-ValueSignal<Boolean> rowStripes = new ValueSignal<>(true);
-
-Grid<Person> grid = new Grid<>();
-grid.getThemeList().bind("compact", compact);
-grid.getThemeList().bind("row-stripes", rowStripes);
-----
-
-
 == Binding Inline Styles
 
 Use [methodname]`getStyle().bind()` to bind CSS properties to signals:
@@ -427,16 +395,18 @@ These are convenience shortcuts for [methodname]`getElement().getClassList().bin
 
 == Binding Theme Names
 
+Theme names select the style variants a component supports, such as `small` on a button or `row-stripes` on a grid.
+
 Use [methodname]`bindThemeName()` and [methodname]`bindThemeNames()` to bind theme names to signals. These are component-level convenience methods available on components that implement [interfacename]`HasTheme`:
 
 [source,java]
 ----
-ValueSignal<Boolean> compact = new ValueSignal<>(false);
+ValueSignal<Boolean> small = new ValueSignal<>(false);
 
-Grid<Person> grid = new Grid<>();
+Button button = new Button("Save");
 
 // Toggle a single theme name based on a boolean signal
-grid.bindThemeName("compact", compact);
+button.bindThemeName("small", small);
 ----
 
 To bind a dynamic list of theme names, use [methodname]`bindThemeNames()`:
@@ -452,8 +422,23 @@ grid.bindThemeNames(themes);
 themes.set(List.of("row-stripes", "compact", "no-border"));
 ----
 
+[methodname]`getThemeList().bind()` does the same at the Element level, which is what to use on components that don't implement [interfacename]`HasTheme`. Each theme name binds independently:
+
+[source,java]
+----
+ValueSignal<Boolean> compact = new ValueSignal<>(false);
+ValueSignal<Boolean> rowStripes = new ValueSignal<>(true);
+
+Grid<Person> grid = new Grid<>();
+grid.getThemeList().bind("compact", compact);
+grid.getThemeList().bind("row-stripes", rowStripes);
+----
+
 [NOTE]
-These are convenience shortcuts for [methodname]`getThemeList().bind()`. For Element-level theme bindings, see <<element-bindings#themelist-binding,ThemeList Binding>>.
+Theme names are per-component style variants. They're not how an application switches between light and dark: use the [annotationname]`ColorScheme` annotation or [methodname]`Page.setColorScheme()` for that, as described in <<{articles}/styling/themes#color-schemes,Light & Dark Color Schemes>>.
+
+[NOTE]
+For Element-level theme bindings, see <<element-bindings#themelist-binding,ThemeList Binding>>.
 
 
 == Rendering Lists of Components

--- a/articles/flow/ui-state/building-ui.adoc
+++ b/articles/flow/ui-state/building-ui.adoc
@@ -395,18 +395,18 @@ These are convenience shortcuts for [methodname]`getElement().getClassList().bin
 
 == Binding Theme Names
 
-Theme names select the style variants a component supports, such as `small` on a button or `row-stripes` on a grid.
+Theme names apply the style variants a component supports, such as `small` on a button or `row-stripes` on a grid.
 
 Use [methodname]`bindThemeName()` and [methodname]`bindThemeNames()` to bind theme names to signals. These are component-level convenience methods available on components that implement [interfacename]`HasTheme`:
 
 [source,java]
 ----
-ValueSignal<Boolean> small = new ValueSignal<>(false);
+ValueSignal<Boolean> smallVariant = new ValueSignal<>(false);
 
 Button button = new Button("Save");
 
 // Toggle a single theme name based on a boolean signal
-button.bindThemeName("small", small);
+button.bindThemeName("small", smallVariant);
 ----
 
 To bind a dynamic list of theme names, use [methodname]`bindThemeNames()`:
@@ -422,7 +422,7 @@ grid.bindThemeNames(themes);
 themes.set(List.of("row-stripes", "compact", "no-border"));
 ----
 
-[methodname]`getThemeList().bind()` does the same at the Element level, which is what to use on components that don't implement [interfacename]`HasTheme`. Each theme name binds independently:
+These methods are convenience shortcuts for [methodname]`getThemeList().bind()`, the Element-level binding described in <<element-bindings#themelist-binding,ThemeList Binding>>. That one is available on every component, including those that don't implement [interfacename]`HasTheme`. Each theme name binds independently:
 
 [source,java]
 ----
@@ -435,10 +435,7 @@ grid.getThemeList().bind("row-stripes", rowStripes);
 ----
 
 [NOTE]
-Theme names are per-component style variants. They're not how an application switches between light and dark: use the [annotationname]`ColorScheme` annotation or [methodname]`Page.setColorScheme()` for that, as described in <<{articles}/styling/themes#color-schemes,Light & Dark Color Schemes>>.
-
-[NOTE]
-For Element-level theme bindings, see <<element-bindings#themelist-binding,ThemeList Binding>>.
+Theme names are per-component style variants. They are not how an application switches between light and dark: use the [annotationname]`ColorScheme` annotation or [methodname]`Page.setColorScheme()` for that, as described in <<{articles}/styling/themes#color-schemes,Light & Dark Color Schemes>>.
 
 
 == Rendering Lists of Components

--- a/articles/flow/ui-state/element-bindings.adoc
+++ b/articles/flow/ui-state/element-bindings.adoc
@@ -273,20 +273,20 @@ span.getElement().getStyle().clear();
 
 == ThemeList Binding
 
+[NOTE]
+Theme names are per-component style variants. They are not how an application switches between light and dark: use the [annotationname]`ColorScheme` annotation or [methodname]`Page.setColorScheme()` for that, as described in <<{articles}/styling/themes#color-schemes,Light & Dark Color Schemes>>.
+
 .`ThemeList#bind(String name, Signal<Boolean> signal)`
 [source,java]
 ----
-ValueSignal<Boolean> small = new ValueSignal<>(false);
+ValueSignal<Boolean> smallVariant = new ValueSignal<>(false);
 
-component.getThemeList().bind("small", small);
-// Theme "small" is applied when small is true
+component.getThemeList().bind("small", smallVariant);
+// Theme "small" is applied when smallVariant is true
 
-small.set(true);
+smallVariant.set(true);
 // Component now has "small" theme applied
 ----
-
-[NOTE]
-Theme names are per-component style variants. They're not how an application switches between light and dark: use the [annotationname]`ColorScheme` annotation or [methodname]`Page.setColorScheme()` for that, as described in <<{articles}/styling/themes#color-schemes,Light & Dark Color Schemes>>.
 
 === Group Binding
 

--- a/articles/flow/ui-state/element-bindings.adoc
+++ b/articles/flow/ui-state/element-bindings.adoc
@@ -276,14 +276,17 @@ span.getElement().getStyle().clear();
 .`ThemeList#bind(String name, Signal<Boolean> signal)`
 [source,java]
 ----
-ValueSignal<Boolean> darkMode = new ValueSignal<>(false);
+ValueSignal<Boolean> small = new ValueSignal<>(false);
 
-component.getThemeList().bind("dark", darkMode);
-// Theme "dark" is applied when darkMode is true
+component.getThemeList().bind("small", small);
+// Theme "small" is applied when small is true
 
-darkMode.set(true);
-// Component now has "dark" theme applied
+small.set(true);
+// Component now has "small" theme applied
 ----
+
+[NOTE]
+Theme names are per-component style variants. They're not how an application switches between light and dark: use the [annotationname]`ColorScheme` annotation or [methodname]`Page.setColorScheme()` for that, as described in <<{articles}/styling/themes#color-schemes,Light & Dark Color Schemes>>.
 
 === Group Binding
 
@@ -302,7 +305,7 @@ themes.set(List.of("no-border"));
 // Component now has only "no-border" theme
 ----
 
-For component-level theme binding examples, see <<building-ui#binding-theme-variants,Binding Theme Variants>>.
+For component-level theme binding examples, see <<building-ui#binding-theme-names,Binding Theme Names>>.
 
 
 == Visibility Binding

--- a/articles/styling/themes/index.adoc
+++ b/articles/styling/themes/index.adoc
@@ -143,6 +143,18 @@ The color scheme can be changed dynamically at runtime using the [methodname]`Pa
 UI.getCurrentOrThrow().getPage().setColorScheme(ColorScheme.Value.DARK);
 ----
 
+Both the annotation and the method set the `theme` attribute and the `color-scheme` CSS property on the `<html>` element. That's why a single call covers both themes: Lumo selects its dark colors with `[theme~="dark"]`, while Aura selects its own through `color-scheme`.
+
+.The `dark` Theme Name Is Not a Second Mechanism
+[CAUTION]
+====
+Adding a `dark` theme name, as in `ui.getElement().getThemeList().add("dark")`, looks like an alternative but isn't one. [methodname]`getThemeList()` is the generic theme name API that every component has, and it's the right tool for variants such as `small` or `contrast`. It only happens to match Lumo's own `[theme~="dark"]` selector.
+
+It writes the attribute on the `<body>` element, since that's the element a [classname]`UI` is. Under Lumo that leaves the `<html>` element light behind whatever the body doesn't cover, and under Aura it has no effect at all. Neither case logs anything or throws, so the page stays light with no indication of why.
+
+In tests, assert on [methodname]`Page.getColorScheme()` rather than on the `theme` attribute. The attribute is only a plain `dark` for [propertyname]`ColorScheme.Value.DARK`. The system preference values write `light-dark` or `dark-light`, which no `[theme~="dark"]` selector matches.
+====
+
 .Testing Color Schemes with Browser DevTools
 [NOTE]
 ====


### PR DESCRIPTION
Fixes #5995

* One section for theme name bindings instead of two.
* No `dark` in the examples: theme names are variants like `small`.
* Theming page: `@ColorScheme` and `Page.setColorScheme()` are the color scheme API, the `dark` theme name is a Lumo selector on `<body>`, and tests assert `getColorScheme()`.
