### PR TITLE
docs: add missing field error messages to Login i18n examples

### DIFF
--- a/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginInternationalization.java
@@ -28,6 +28,8 @@ public class LoginInternationalization extends Div {
         i18nErrorMessage.setTitle("Väärä käyttäjätunnus tai salasana");
         i18nErrorMessage.setMessage(
                 "Tarkista että käyttäjätunnus ja salasana ovat oikein ja yritä uudestaan.");
+        i18nErrorMessage.setUsername("Käyttäjätunnus vaaditaan");
+        i18nErrorMessage.setPassword("Salasana vaaditaan");
         i18n.setErrorMessage(i18nErrorMessage);
 
         LoginForm loginForm = new LoginForm();

--- a/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java
+++ b/src/main/java/com/vaadin/demo/component/login/LoginOverlayInternationalization.java
@@ -30,6 +30,8 @@ public class LoginOverlayInternationalization extends Div {
         i18nErrorMessage.setTitle("Väärä käyttäjätunnus tai salasana");
         i18nErrorMessage.setMessage(
                 "Tarkista että käyttäjätunnus ja salasana ovat oikein ja yritä uudestaan.");
+        i18nErrorMessage.setUsername("Käyttäjätunnus vaaditaan");
+        i18nErrorMessage.setPassword("Salasana vaaditaan");
         i18n.setErrorMessage(i18nErrorMessage);
 
         i18n.setAdditionalInformation("Jos tarvitset lisätietoja käyttäjälle.");


### PR DESCRIPTION
LoginI18n.ErrorMessage has setUsername and setPassword for the field-level "required" errors. Both Flow internationalization examples set only the title and message, so an app that follows them keeps the English defaults from createDefault() -- "Username is required" and "Password is required" -- in an otherwise Finnish form.

The Lit and React variants of the same examples already translate both, so this aligns the Java examples with the strings they use.

<img width="369" height="561" alt="image" src="https://github.com/user-attachments/assets/f93a067b-779a-4e79-b6a6-6d52c5025103" />



